### PR TITLE
fix: prevent 401s when claude-code drops oauth-2025-04-20 from anthropic-beta

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 D1DX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/server.js
+++ b/src/server.js
@@ -194,6 +194,24 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
     headers[key] = value;
   }
 
+  // Defend against an upstream Claude Code regression: claude-code 2.1.121+
+  // intermittently drops `oauth-2025-04-20` from `anthropic-beta` when
+  // model-level betas are merged in. The Anthropic API then returns 401 with
+  // the misleading `"OAuth authentication is currently not supported"` body.
+  // teamclaude faithfully forwards what claude-code sent, so the failure
+  // surfaces here. Refs: anthropics/claude-code#54235, OpenClaw #41444.
+  // Idempotent (no-op if header already present); gated on isOAuth so
+  // x-api-key flows are untouched.
+  if (isOAuth) {
+    const REQUIRED_OAUTH_BETA = 'oauth-2025-04-20';
+    const betaKey = Object.keys(headers).find(k => k.toLowerCase() === 'anthropic-beta');
+    const existing = betaKey ? String(headers[betaKey]).split(',').map(s => s.trim()).filter(Boolean) : [];
+    if (!existing.includes(REQUIRED_OAUTH_BETA)) {
+      existing.unshift(REQUIRED_OAUTH_BETA);
+      headers[betaKey || 'anthropic-beta'] = existing.join(',');
+    }
+  }
+
   if (isOAuth) {
     headers['authorization'] = `Bearer ${account.credential}`;
   } else {


### PR DESCRIPTION
## Problem

Claude Code 2.1.121+ has an upstream regression where its request-builder occasionally omits `oauth-2025-04-20` from the outgoing `anthropic-beta` header — most reliably on large requests (~280 KB body) with full tool loadout in interactive sessions. When this happens, the Anthropic API responds 401 with the misleading `"OAuth authentication is currently not supported"` body. teamclaude faithfully forwards what claude-code sent, so the failure surfaces here.

References:
- anthropics/claude-code#54235 — upstream regression filing
- OpenClaw #41444 — root-cause analysis (`Object.assign` source-order merge clobbers the OAuth gate)

Anthropic shipped a partial fix in 2.1.123 and refactored the beta system in 2.1.126, but real-world load still reproduces the 401.

## Fix

On OAuth-account requests, ensure `oauth-2025-04-20` is present in `anthropic-beta` before forwarding upstream. Idempotent — no-op when claude-code includes it correctly. Gated on `isOAuth === true` so `x-api-key` flows are untouched. 14 lines (including an 8-line comment block).

```js
if (isOAuth) {
  const REQUIRED_OAUTH_BETA = 'oauth-2025-04-20';
  const betaKey = Object.keys(headers).find(k => k.toLowerCase() === 'anthropic-beta');
  const existing = betaKey ? String(headers[betaKey]).split(',').map(s => s.trim()).filter(Boolean) : [];
  if (!existing.includes(REQUIRED_OAUTH_BETA)) {
    existing.unshift(REQUIRED_OAUTH_BETA);
    headers[betaKey || 'anthropic-beta'] = existing.join(',');
  }
}
```

## Validation

Reproduced + fix verified in production (D1DX):

- **Pre-patch:** first VS Code session request reproduced the 401. Outbound `anthropic-beta` was missing `oauth-2025-04-20`:
  ```
  anthropic-beta: claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advisor-tool-2026-03-01,effort-2025-11-24
  ```
- **Post-patch:** 4 / 5 consecutive responses 200 (the 5th was a 429 rate-limit, unrelated). Header now consistently shows the OAuth gate prepended:
  ```
  anthropic-beta: oauth-2025-04-20,claude-code-20250219,context-1m-2025-08-07,...
  ```

Synthetic-load tests (`claude -p "..."` with small bodies) did not reliably trigger the bug — only real interactive workloads with large bodies + full tool loadout did. Reproduce with a non-trivial VS Code session if you'd like to verify locally.

## Notes

- Cross-repo PR from `D1DX:master` since our git-managed workflow is single-branch. Happy to rebase to a feature branch if preferred.
- Targeting the case where claude-code is the bug source. If/when Anthropic fully fixes their request-builder, this becomes a permanent no-op (idempotent guard).