### PR TITLE
Headless mode, management/reload API, and background quota prober

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
   },
   "upstream": "https://api.anthropic.com",
   "switchThreshold": 0.98,
+  "pokeIntervalMs": 600000,
   "accounts": [
     {
       "name": "primary-max",

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -327,6 +327,33 @@ export class AccountManager {
   }
 
   /**
+   * Compute remaining quota from a quota object. Fractions are 0-1 (1 = full).
+   * For Claude Max (unified) only utilization is reported, so remaining is a
+   * fraction; for API-key accounts absolute token/request counts are available.
+   */
+  _remainingSummary(q) {
+    const r = {
+      session: null,      // fraction 0-1 (Claude Max 5h)
+      weekly: null,       // fraction 0-1 (Claude Max 7d)
+      tokens: null,       // absolute tokens remaining (API key)
+      tokensFraction: null,
+      requests: null,     // absolute requests remaining (API key)
+      requestsFraction: null,
+    };
+    if (q.unified5h != null) r.session = Math.max(0, 1 - q.unified5h);
+    if (q.unified7d != null) r.weekly = Math.max(0, 1 - q.unified7d);
+    if (q.tokensLimit != null && q.tokensRemaining != null) {
+      r.tokens = q.tokensRemaining;
+      r.tokensFraction = q.tokensLimit > 0 ? q.tokensRemaining / q.tokensLimit : null;
+    }
+    if (q.requestsLimit != null && q.requestsRemaining != null) {
+      r.requests = q.requestsRemaining;
+      r.requestsFraction = q.requestsLimit > 0 ? q.requestsRemaining / q.requestsLimit : null;
+    }
+    return r;
+  }
+
+  /**
    * Return a status summary of all accounts (safe to expose, no credentials).
    */
   getStatus() {
@@ -338,6 +365,7 @@ export class AccountManager {
         type: a.type,
         status: a.status,
         quota: { ...a.quota },
+        remaining: this._remainingSummary(a.quota),
         usage: { ...a.usage },
         rateLimitedUntil: a.rateLimitedUntil
           ? new Date(a.rateLimitedUntil).toISOString()

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -29,6 +29,7 @@ export class AccountManager {
       expiresAt: acct.expiresAt || null,
       status: 'active',
       quota: emptyQuota(),
+      lastQuotaAt: null,
       usage: {
         totalInputTokens: 0,
         totalOutputTokens: 0,
@@ -157,8 +158,10 @@ export class AccountManager {
 
   /**
    * Update an account's quota tracking from upstream response headers.
+   * Set countRequest=false for background probes so they don't inflate the
+   * per-account request/usage totals (which should reflect real client traffic).
    */
-  updateQuota(accountIndex, headers) {
+  updateQuota(accountIndex, headers, { countRequest = true } = {}) {
     const account = this.accounts[accountIndex];
     if (!account) return;
 
@@ -192,8 +195,11 @@ export class AccountManager {
     if (tokensReset) account.quota.resetsAt = tokensReset;
     else if (requestsReset) account.quota.resetsAt = requestsReset;
 
-    account.usage.totalRequests++;
-    account.usage.lastUsed = new Date().toISOString();
+    account.lastQuotaAt = Date.now();
+    if (countRequest) {
+      account.usage.totalRequests++;
+      account.usage.lastUsed = new Date().toISOString();
+    }
 
     // Log when approaching quota
     if (this._isNearQuota(account)) {
@@ -306,6 +312,7 @@ export class AccountManager {
       expiresAt: acctData.expiresAt || null,
       status: 'active',
       quota: emptyQuota(),
+      lastQuotaAt: null,
       usage: { totalInputTokens: 0, totalOutputTokens: 0, totalRequests: 0, lastUsed: null },
       rateLimitedUntil: null,
     });

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ export function createDefaultConfig() {
     },
     upstream: 'https://api.anthropic.com',
     switchThreshold: 0.98,
+    pokeIntervalMs: 600000,
     accounts: [],
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,23 @@ async function serverCommand() {
     }).catch(err => console.error(`[TeamClaude] Failed to save refreshed token: ${err.message}`));
   });
   const port = config.proxy.port;
-  const useTUI = process.stdout.isTTY && process.stdin.isTTY;
+  const headless = args.includes('--headless') || args.includes('--no-tui');
+  const useTUI = !headless && process.stdout.isTTY && process.stdin.isTTY;
+
+  // Live account reload — re-sync from disk config (add new, remove deleted,
+  // refresh credentials) without restarting. Serialized so a SIGHUP and an HTTP
+  // reload arriving together don't race on the shared account arrays.
+  let reloadChain = Promise.resolve();
+  function reloadAccounts() {
+    const run = async () => {
+      const diskConfig = await loadConfig();
+      if (!diskConfig) return { added: 0, removed: 0, refreshed: 0 };
+      return syncAccountsFromDisk(diskConfig, config, accountManager);
+    };
+    const result = reloadChain.then(run, run);
+    reloadChain = result.then(() => {}, () => {});
+    return result;
+  }
 
   let tui = null;
   let hooks = {};
@@ -161,7 +177,7 @@ async function serverCommand() {
     };
   }
 
-  const server = createProxyServer(accountManager, config, hooks);
+  const server = createProxyServer(accountManager, config, hooks, { reload: reloadAccounts });
 
   server.listen(port, () => {
     if (tui) {
@@ -197,6 +213,15 @@ async function serverCommand() {
     process.on('SIGTERM', () => {
       console.log('\n[TeamClaude] Shutting down...');
       server.close(() => process.exit(0));
+    });
+    // SIGHUP → reload accounts from config (systemd `ExecReload`, `kill -HUP`)
+    process.on('SIGHUP', async () => {
+      try {
+        const { added, removed, refreshed } = await reloadAccounts();
+        console.log(`[TeamClaude] Reloaded on SIGHUP — +${added} -${removed} accounts, ${refreshed} refreshed`);
+      } catch (err) {
+        console.error(`[TeamClaude] SIGHUP reload failed: ${err.message}`);
+      }
     });
   }
 }
@@ -300,6 +325,7 @@ async function loginApiCommand() {
   await saveConfig(config);
   console.log(`Added API key account "${name}"`);
   console.log(`Saved to ${getConfigPath()}`);
+  await notifyRunningServer(config);
 }
 
 async function loginOAuthCommand() {
@@ -581,6 +607,7 @@ async function removeCommand() {
   config.accounts.splice(idx, 1);
   await saveConfig(config);
   console.log(`Removed account "${name}"`);
+  await notifyRunningServer(config);
 }
 
 // ── help ────────────────────────────────────────────────────
@@ -609,6 +636,12 @@ Options:
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)
+  --headless          Run the server without the interactive TUI (for backgrounding)
+
+Account changes from import/login/remove apply live to a running server
+(no restart). The server also reloads on SIGHUP. Endpoints:
+  GET  /teamclaude/status     account status + remaining quota (JSON)
+  POST /teamclaude/reload     re-sync accounts from config (add/remove/refresh)
 
 Config: ${getConfigPath()}
 `);
@@ -660,6 +693,26 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
 
   await saveConfig(config);
   console.log(`Saved to ${getConfigPath()}`);
+  await notifyRunningServer(config);
+}
+
+/**
+ * If a server is running on the configured proxy port, ask it to live-reload
+ * accounts from the just-saved config so the change applies without a restart.
+ * Prints a hint if no server is reachable.
+ */
+async function notifyRunningServer(config) {
+  const url = `http://localhost:${config.proxy.port}/teamclaude/reload`;
+  try {
+    const res = await fetch(url, { method: 'POST', headers: { 'x-api-key': config.proxy.apiKey } });
+    if (!res.ok) return false;
+    const data = await res.json();
+    console.log(`Applied to running server (+${data.added} -${data.removed} accounts, ${data.refreshed} refreshed).`);
+    return true;
+  } catch {
+    console.log('No running server detected — change applies on next start.');
+    return false;
+  }
 }
 
 // ── config sync helpers ─────────────────────────────────────
@@ -676,12 +729,14 @@ function findConfigAccount(diskConfig, account) {
 }
 
 /**
- * Sync accounts from disk config: add new accounts and refresh credentials
- * for existing ones (handles re-imported OAuth tokens, rotated API keys, etc.).
- * Returns the number of new accounts added.
+ * Sync accounts from disk config to the running server: add new accounts,
+ * remove ones deleted from disk, and refresh credentials for existing ones
+ * (re-imported OAuth tokens, rotated API keys, etc.). Mutates both memConfig
+ * and accountManager in lockstep. Returns { added, removed, refreshed }.
  */
 async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
   let added = 0;
+  let refreshed = 0;
   for (const diskAcct of diskConfig.accounts) {
     const matchByUuid = diskAcct.accountUuid &&
       memConfig.accounts.findIndex(a => a.accountUuid === diskAcct.accountUuid);
@@ -729,15 +784,37 @@ async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
         freshCred.expiresAt < mgr.expiresAt;
       if (changed && !diskIsStaler) {
         accountManager.updateAccountTokens(mgr.index, freshCred);
+        refreshed++;
         console.log(`[TeamClaude] Refreshed credentials for "${mgr.name}"`);
       }
     } else if (freshCred.apiKey && mgr.credential !== freshCred.apiKey) {
       mgr.credential = freshCred.apiKey;
       if (mgr.status === 'error') mgr.status = 'active';
+      refreshed++;
       console.log(`[TeamClaude] Updated API key for "${mgr.name}"`);
     }
   }
-  return added;
+
+  // Removals — drop accounts no longer present on disk. Match by UUID then name
+  // (indices may differ between memConfig and accountManager), and iterate the
+  // manager backwards so removeAccount's re-indexing stays valid.
+  let removed = 0;
+  const onDisk = (acct) => diskConfig.accounts.some(d =>
+    (acct.accountUuid && d.accountUuid === acct.accountUuid) || d.name === acct.name
+  );
+  for (let i = accountManager.accounts.length - 1; i >= 0; i--) {
+    const am = accountManager.accounts[i];
+    if (onDisk(am)) continue;
+    accountManager.removeAccount(i);
+    const ci = memConfig.accounts.findIndex(a =>
+      (am.accountUuid && a.accountUuid === am.accountUuid) || a.name === am.name
+    );
+    if (ci >= 0) memConfig.accounts.splice(ci, 1);
+    removed++;
+    console.log(`[TeamClaude] Removed account "${am.name}" (deleted from config)`);
+  }
+
+  return { added, removed, refreshed };
 }
 
 // ── helpers ─────────────────────────────────────────────────

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { TUI } from './tui.js';
+import { Prober } from './prober.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -139,6 +140,14 @@ async function serverCommand() {
     return result;
   }
 
+  // Background quota prober — periodically pings idle accounts to learn their
+  // utilization + reset times (config.pokeIntervalMs, default 10 min; 0 = off).
+  const prober = new Prober({
+    accountManager,
+    upstream: config.upstream,
+    intervalMs: config.pokeIntervalMs ?? 600000,
+  });
+
   let tui = null;
   let hooks = {};
 
@@ -168,7 +177,7 @@ async function serverCommand() {
         if (!diskConfig) return 0;
         return syncAccountsFromDisk(diskConfig, config, accountManager);
       },
-      onQuit: () => { server.close(() => process.exit(0)); },
+      onQuit: () => { prober.stop(); server.close(() => process.exit(0)); },
     });
     hooks = {
       onRequestStart: (id, info) => tui.onRequestStart(id, info),
@@ -176,6 +185,10 @@ async function serverCommand() {
       onRequestEnd: (id, info) => tui.onRequestEnd(id, info),
     };
   }
+
+  // Feed real /v1/messages traffic to the prober so it can learn the
+  // OAuth-acceptable request shape (works in both TUI and headless modes).
+  hooks.recordPoke = (headers, body) => prober.recordTemplate(headers, body);
 
   const server = createProxyServer(accountManager, config, hooks, { reload: reloadAccounts });
 
@@ -203,14 +216,17 @@ async function serverCommand() {
       console.log(sep);
       console.log('');
     }
+    prober.start();
   });
 
   if (!tui) {
     process.on('SIGINT', () => {
+      prober.stop();
       console.log('\n[TeamClaude] Shutting down...');
       server.close(() => process.exit(0));
     });
     process.on('SIGTERM', () => {
+      prober.stop();
       console.log('\n[TeamClaude] Shutting down...');
       server.close(() => process.exit(0));
     });

--- a/src/index.js
+++ b/src/index.js
@@ -384,13 +384,17 @@ async function statusCommand() {
       console.log(`    Status:   ${acct.status}`);
 
       if (q.unified5h != null || q.unified7d != null) {
-        const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' : '-';
-        const wk = q.unified7d != null ? (q.unified7d * 100).toFixed(1) + '%' : '-';
-        console.log(`    Session:  ${ses} used    Weekly: ${wk} used`);
+        const sesRst = formatReset(q.unified5hReset);
+        const wkRst = formatReset(q.unified7dReset);
+        const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' + (sesRst ? ` (resets in ${sesRst})` : '') : '-';
+        const wk = q.unified7d != null ? (q.unified7d * 100).toFixed(1) + '%' + (wkRst ? ` (resets in ${wkRst})` : '') : '-';
+        console.log(`    Session:  ${ses}    Weekly: ${wk}`);
       } else {
-        const tok = q.tokensLimit ? ((1 - q.tokensRemaining / q.tokensLimit) * 100).toFixed(1) + '%' : '-';
-        const req = q.requestsLimit ? ((1 - q.requestsRemaining / q.requestsLimit) * 100).toFixed(1) + '%' : '-';
-        console.log(`    Tokens:   ${tok} used    Requests: ${req} used`);
+        const tokRst = formatReset(q.resetsAt ? new Date(q.resetsAt).getTime() : null);
+        const reqRst = tokRst; // APIs share the resetsAt timestamp
+        const tok = q.tokensLimit ? ((1 - q.tokensRemaining / q.tokensLimit) * 100).toFixed(1) + '%' + (tokRst ? ` (resets in ${tokRst})` : '') : '-';
+        const req = q.requestsLimit ? ((1 - q.requestsRemaining / q.requestsLimit) * 100).toFixed(1) + '%' + (reqRst ? ` (resets in ${reqRst})` : '') : '-';
+        console.log(`    Tokens:   ${tok}    Requests: ${req}`);
       }
 
       console.log(`    Total:    ${acct.usage.totalInputTokens + acct.usage.totalOutputTokens} tokens, ${acct.usage.totalRequests} requests`);
@@ -736,6 +740,20 @@ async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
 }
 
 // ── helpers ─────────────────────────────────────────────────
+
+function formatReset(resetTs) {
+  if (!resetTs) return '';
+  const ms = resetTs - Date.now();
+  if (ms <= 0) return '';
+  const mins = Math.ceil(ms / 60000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const rm = mins % 60;
+  if (hrs < 24) return rm > 0 ? `${hrs}h${rm}m` : `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  const rh = hrs % 24;
+  return rh > 0 ? `${days}d${rh}h` : `${days}d`;
+}
 
 async function resolveAccounts(config) {
   const accounts = [];

--- a/src/index.js
+++ b/src/index.js
@@ -378,6 +378,7 @@ async function statusCommand() {
 
     for (const acct of data.accounts) {
       const q = acct.quota;
+      const r = acct.remaining || {};
       const current = acct.name === data.currentAccount ? ' *' : '';
 
       console.log(`  ${acct.name} (${acct.type})${current}`);
@@ -386,14 +387,14 @@ async function statusCommand() {
       if (q.unified5h != null || q.unified7d != null) {
         const sesRst = formatReset(q.unified5hReset);
         const wkRst = formatReset(q.unified7dReset);
-        const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' + (sesRst ? ` (resets in ${sesRst})` : '') : '-';
-        const wk = q.unified7d != null ? (q.unified7d * 100).toFixed(1) + '%' + (wkRst ? ` (resets in ${wkRst})` : '') : '-';
+        const ses = r.session != null ? (r.session * 100).toFixed(1) + '% left' + (sesRst ? ` (resets in ${sesRst})` : '') : '-';
+        const wk = r.weekly != null ? (r.weekly * 100).toFixed(1) + '% left' + (wkRst ? ` (resets in ${wkRst})` : '') : '-';
         console.log(`    Session:  ${ses}    Weekly: ${wk}`);
       } else {
         const tokRst = formatReset(q.resetsAt ? new Date(q.resetsAt).getTime() : null);
         const reqRst = tokRst; // APIs share the resetsAt timestamp
-        const tok = q.tokensLimit ? ((1 - q.tokensRemaining / q.tokensLimit) * 100).toFixed(1) + '%' + (tokRst ? ` (resets in ${tokRst})` : '') : '-';
-        const req = q.requestsLimit ? ((1 - q.requestsRemaining / q.requestsLimit) * 100).toFixed(1) + '%' + (reqRst ? ` (resets in ${reqRst})` : '') : '-';
+        const tok = r.tokens != null ? `${r.tokens} left (${(r.tokensFraction * 100).toFixed(1)}%)` + (tokRst ? ` (resets in ${tokRst})` : '') : '-';
+        const req = r.requests != null ? `${r.requests} left (${(r.requestsFraction * 100).toFixed(1)}%)` + (reqRst ? ` (resets in ${reqRst})` : '') : '-';
         console.log(`    Tokens:   ${tok}    Requests: ${req}`);
       }
 

--- a/src/prober.js
+++ b/src/prober.js
@@ -1,0 +1,155 @@
+// Background quota prober.
+//
+// Quota utilization and reset times are only reported by Anthropic in the
+// `anthropic-ratelimit-*` headers of /v1/messages responses — there is no
+// free "usage" endpoint. So an account that isn't currently serving traffic
+// has stale/unknown quota until it's rotated to. The prober periodically sends
+// a minimal 1-token request to each idle account to harvest those headers.
+//
+// Claude Max (OAuth) tokens are only accepted on requests that look like Claude
+// Code (specific anthropic-beta header + a system prompt whose first block is
+// the Claude Code identity). Rather than hardcode that shape, we learn it from
+// real traffic flowing through the proxy (recordTemplate) and replay a minimal
+// version. API-key accounts need no template.
+
+const CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude.";
+const FALLBACK_MODEL = 'claude-haiku-4-5-20251001';
+// Headers worth replaying from real Claude Code traffic (account-independent).
+const TEMPLATE_HEADERS = ['anthropic-version', 'anthropic-beta', 'user-agent'];
+
+export class Prober {
+  constructor({ accountManager, upstream, intervalMs }) {
+    this.accountManager = accountManager;
+    this.upstream = upstream || 'https://api.anthropic.com';
+    this.intervalMs = intervalMs;
+    this.template = null;   // { headers, model, system } learned from live traffic
+    this._timer = null;
+    this._running = false;
+    this._warnedNoTemplate = false;
+  }
+
+  /** Learn the OAuth-acceptable request shape from a real /v1/messages request. */
+  recordTemplate(headers, bodyBuf) {
+    try {
+      const tplHeaders = {};
+      for (const name of TEMPLATE_HEADERS) {
+        const v = headers[name];
+        if (v) tplHeaders[name] = v;
+      }
+      let model = null;
+      let system = null;
+      if (bodyBuf && bodyBuf.length) {
+        const body = JSON.parse(bodyBuf.toString());
+        if (body.model) model = body.model;
+        system = this._firstSystemBlock(body.system);
+      }
+      this.template = { headers: tplHeaders, model, system };
+    } catch {
+      // Not JSON or unexpected shape — keep any previous template.
+    }
+  }
+
+  _firstSystemBlock(system) {
+    if (Array.isArray(system) && system[0]) {
+      const b = system[0];
+      const text = typeof b === 'string' ? b : b?.text;
+      if (text) return [{ type: 'text', text }];
+    } else if (typeof system === 'string' && system.trim()) {
+      return [{ type: 'text', text: system.split('\n')[0] }];
+    }
+    return null;
+  }
+
+  start() {
+    if (!this.intervalMs || this.intervalMs <= 0) return; // disabled
+    this._timer = setInterval(() => this.pokeStale(), this.intervalMs);
+    this._timer.unref?.(); // don't keep the process alive on our account
+    // First pass shortly after boot: API-key accounts can be probed right away;
+    // OAuth accounts wait until a real request has taught us the template.
+    setTimeout(() => this.pokeStale(), 3000).unref?.();
+  }
+
+  stop() {
+    if (this._timer) clearInterval(this._timer);
+    this._timer = null;
+  }
+
+  /** Probe every account whose quota is stale and that isn't throttled/errored. */
+  async pokeStale() {
+    if (this._running) return; // never overlap passes
+    this._running = true;
+    try {
+      const now = Date.now();
+      for (const account of this.accountManager.accounts) {
+        if (account.status === 'error' || account.status === 'exhausted') continue;
+        if (account.rateLimitedUntil && now < account.rateLimitedUntil) continue;
+        const fresh = account.lastQuotaAt && (now - account.lastQuotaAt) < this.intervalMs;
+        if (fresh) continue;
+        await this._poke(account).catch(() => {});
+      }
+    } finally {
+      this._running = false;
+    }
+  }
+
+  async _poke(account) {
+    const isOAuth = account.type === 'oauth';
+    if (isOAuth && !this.template) {
+      if (!this._warnedNoTemplate) {
+        console.log('[TeamClaude] Quota probe deferred for OAuth accounts until the first request establishes a template');
+        this._warnedNoTemplate = true;
+      }
+      return;
+    }
+
+    await this.accountManager.ensureTokenFresh(account.index);
+
+    const headers = { ...(this.template?.headers || {}), 'content-type': 'application/json' };
+    if (!headers['anthropic-version']) headers['anthropic-version'] = '2023-06-01';
+    if (isOAuth) headers['authorization'] = `Bearer ${account.credential}`;
+    else headers['x-api-key'] = account.credential;
+
+    const body = {
+      model: this.template?.model || FALLBACK_MODEL,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    };
+    if (isOAuth) {
+      body.system = this.template?.system || [{ type: 'text', text: CLAUDE_CODE_IDENTITY }];
+    }
+
+    // Bound each probe so a hung upstream can't stall the whole prober
+    // (pokeStale is guarded by _running and awaits probes sequentially).
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 20000);
+    let res;
+    try {
+      res = await fetch(`${this.upstream}/v1/messages`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch {
+      return; // transient network error or timeout — leave the account untouched
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const rateLimitHeaders = {};
+    for (const [k, v] of res.headers.entries()) {
+      if (k.startsWith('anthropic-ratelimit-')) rateLimitHeaders[k] = v;
+    }
+    // Harvest quota without counting the probe as real client usage.
+    this.accountManager.updateQuota(account.index, rateLimitHeaders, { countRequest: false });
+
+    if (res.status === 429) {
+      const retryAfter = parseInt(res.headers.get('retry-after'), 10) || 60;
+      this.accountManager.markRateLimited(account.index, retryAfter);
+    } else if (res.status === 401 || res.status === 403) {
+      console.log(`[TeamClaude] Quota probe rejected for "${account.name}" (${res.status}) — template may be stale`);
+    }
+
+    await res.body?.cancel();
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,7 @@ const HOP_BY_HOP_HEADERS = new Set([
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
 
-export function createProxyServer(accountManager, config, hooks = {}) {
+export function createProxyServer(accountManager, config, hooks = {}, admin = {}) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
@@ -37,6 +37,28 @@ export function createProxyServer(accountManager, config, hooks = {}) {
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(accountManager.getStatus(), null, 2));
+        return;
+      }
+
+      // Reload endpoint — re-sync accounts from disk config (add new, remove
+      // deleted, refresh credentials) on the running server, no restart.
+      if (req.method === 'POST' && req.url === '/teamclaude/reload') {
+        if (!admin.reload) {
+          res.writeHead(501, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'not_implemented', message: 'Reload not available' } }));
+          return;
+        }
+        // Drain any request body before responding
+        for await (const _chunk of req) { /* ignore */ }
+        try {
+          const summary = await admin.reload();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, ...summary }, null, 2));
+        } catch (err) {
+          console.error('[TeamClaude] Reload failed:', err.message);
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'reload_error', message: err.message } }));
+        }
         return;
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -289,6 +289,14 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
 
     ctx.status = upstreamRes.status;
 
+    // Learn the OAuth-acceptable request shape from successful Claude Code
+    // traffic so the quota prober can replay it against idle accounts. Only on
+    // 2xx, so a rejected model/beta/system never poisons the template.
+    if (upstreamRes.status >= 200 && upstreamRes.status < 300 &&
+        req.method === 'POST' && req.url.startsWith('/v1/messages')) {
+      hooks.recordPoke?.(req.headers, body);
+    }
+
     // Build response headers (skip hop-by-hop and encoding headers)
     const responseHeaders = {};
     for (const [key, value] of upstreamRes.headers.entries()) {

--- a/src/tui.js
+++ b/src/tui.js
@@ -279,12 +279,12 @@ export class TUI {
 
   async _doSync() {
     try {
-      const count = await this.syncAccounts();
-      if (count > 0) {
-        this._addLog(`Synced ${count} new account(s) from config`);
-      } else {
-        this._addLog('Config reloaded, credentials refreshed');
-      }
+      const { added = 0, removed = 0, refreshed = 0 } = await this.syncAccounts() || {};
+      const parts = [];
+      if (added) parts.push(`+${added} added`);
+      if (removed) parts.push(`-${removed} removed`);
+      if (refreshed) parts.push(`${refreshed} refreshed`);
+      this._addLog(parts.length ? `Synced accounts (${parts.join(', ')})` : 'Config reloaded, no changes');
     } catch (e) {
       this._addLog(`Sync failed: ${e.message}`);
     }


### PR DESCRIPTION
**Stack position: 1 of 4** (foundation). The next PRs build on this one — see the tracking issue for the full map and merge order.

## What this adds (net-new vs master)
- **CLI status improvements** — show remaining quota and quota reset times in the status output.
- **Headless mode + management/reload API** — run the proxy without the TUI, plus an HTTP endpoint to reload config and atomically add/remove accounts at runtime (`index.js`, `server.js`, `tui.js`).
- **Background quota prober** — a low-cost background probe that keeps idle accounts' quota fresh so routing decisions don't rely on stale data (`prober.js` (new), `account-manager.js`, `config.js`, `server.js`, `index.js`).

## Why
These are the foundation for running TeamClaude as an always-on, multi-account gateway: you need headless operation, runtime account management, and fresh quota data before org-aware identity and smarter rotation (later PRs in the stack) are useful.

## Test plan
- [ ] Proxy starts in headless mode (no TTY) and serves requests.
- [ ] Reload API picks up config changes and add/remove without restart.
- [ ] Status output shows remaining quota + reset times; prober refreshes idle accounts.