### PR TITLE
feat(ui): responsive dashboard with quota reset times

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,22 @@ claude
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude accounts -v       # Also show token expiry times
 teamclaude status            # Show live proxy status (requires running server)
+teamclaude switch <name>     # Manually pin the active account
+teamclaude threshold <val>   # Set rotation threshold ("85", "85%", or "0.85")
 teamclaude remove <name>     # Remove an account
 teamclaude api <path>        # Call an API endpoint with account credentials
 teamclaude help              # Show all commands
 ```
+
+### Web Dashboard
+
+When the proxy is running headless (e.g. as a systemd service) the TUI isn't available. The proxy serves a single-page dashboard on the same port:
+
+```
+http://localhost:3456/ui
+```
+
+Per-account quota bars (5h / 7d), the active account is highlighted, click any other account to pin it, and the threshold slider live-updates the rotation cutoff. Polls `/teamclaude/status` every 2 s. Loopback only — the same `localhost` auth-skip rule that applies to `teamclaude status` applies here.
 
 ### Request logging
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,14 @@ switch (command) {
     await statusCommand();
     process.exit(0);
     break;
+  case 'switch':
+    await switchCommand();
+    process.exit(0);
+    break;
+  case 'threshold':
+    await thresholdCommand();
+    process.exit(0);
+    break;
   case 'accounts':
     await accountsCommand();
     process.exit(0);
@@ -125,6 +133,10 @@ async function serverCommand() {
 
   let tui = null;
   let hooks = {};
+
+  hooks.persistThreshold = (value) => atomicConfigUpdate(diskConfig => {
+    diskConfig.switchThreshold = value;
+  });
 
   if (useTUI) {
     tui = new TUI({
@@ -404,6 +416,74 @@ async function statusCommand() {
   }
 }
 
+// ── switch ──────────────────────────────────────────────────
+
+async function switchCommand() {
+  const config = await loadOrCreateConfig();
+  const name = args[1];
+  if (!name) {
+    console.error('Usage: teamclaude switch <account-name>');
+    process.exit(1);
+  }
+  const url = `http://localhost:${config.proxy.port}/teamclaude/switch`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': config.proxy.apiKey },
+      body: JSON.stringify({ account: name }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(data.error || `HTTP ${res.status}`);
+      process.exit(1);
+    }
+    console.log(`Switched to "${data.currentAccount}"`);
+  } catch {
+    console.error(`Cannot connect to proxy at localhost:${config.proxy.port}`);
+    console.error('Is the server running? Start with: teamclaude server');
+    process.exit(1);
+  }
+}
+
+// ── threshold ───────────────────────────────────────────────
+
+async function thresholdCommand() {
+  const config = await loadOrCreateConfig();
+  const raw = args[1];
+  if (!raw) {
+    console.error('Usage: teamclaude threshold <0..1 fraction or 0..100 percent>');
+    console.error('Examples: teamclaude threshold 85      # 85%');
+    console.error('          teamclaude threshold 0.85   # same');
+    console.error('          teamclaude threshold 85%    # same');
+    process.exit(1);
+  }
+  // Accept "85", "85%", or "0.85"
+  let v = Number(raw.endsWith('%') ? raw.slice(0, -1) : raw);
+  if (v > 1) v = v / 100;
+  if (Number.isNaN(v) || v < 0 || v > 1) {
+    console.error('Value must be a percentage (0..100) or fraction (0..1)');
+    process.exit(1);
+  }
+  const url = `http://localhost:${config.proxy.port}/teamclaude/threshold`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': config.proxy.apiKey },
+      body: JSON.stringify({ value: v }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(data.error || `HTTP ${res.status}`);
+      process.exit(1);
+    }
+    console.log(`Threshold set to ${(data.switchThreshold * 100).toFixed(0)}%`);
+  } catch {
+    console.error(`Cannot connect to proxy at localhost:${config.proxy.port}`);
+    console.error('Is the server running? Start with: teamclaude server');
+    process.exit(1);
+  }
+}
+
 // ── accounts ────────────────────────────────────────────────
 
 async function accountsCommand() {
@@ -593,10 +673,15 @@ Commands:
   env                 Print env vars to use with Claude
   run [-- args...]    Run Claude Code through the proxy
   status              Show proxy & account status (live)
+  switch <name>       Manually pin the active account
+  threshold <value>   Set rotation threshold (0..1 or 0..100%)
   accounts            List configured accounts
   remove <name>       Remove an account
   api <path>          Call an API endpoint with account credentials
   help                Show this help
+
+Web dashboard:
+  Open http://localhost:<port>/ui  in a browser (default port 3456)
 
 Options:
   --name NAME         Set account name (import/login)

--- a/src/index.js
+++ b/src/index.js
@@ -202,14 +202,18 @@ async function serverCommand() {
   });
 
   if (!tui) {
-    process.on('SIGINT', () => {
+    const shutdown = () => {
       console.log('\n[TeamClaude] Shutting down...');
+      // Force-close in-flight connections (streaming responses, keep-alive)
+      // so systemd restarts and dev iteration don't wait minutes for the
+      // active Claude stream to drain. Clients reconnect on next request.
+      server.closeAllConnections?.();
       server.close(() => process.exit(0));
-    });
-    process.on('SIGTERM', () => {
-      console.log('\n[TeamClaude] Shutting down...');
-      server.close(() => process.exit(0));
-    });
+      // Safety net: hard exit if server.close() callback never fires
+      setTimeout(() => process.exit(0), 2000).unref();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,6 @@ export function createProxyServer(accountManager, config, hooks = {}) {
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
   let requestCounter = 0;
-  let dashboardHtml = null;
 
   if (logDir) {
     mkdir(logDir, { recursive: true }).catch(() => {});
@@ -93,14 +92,12 @@ export function createProxyServer(accountManager, config, hooks = {}) {
         return;
       }
 
-      // GET /ui — serve the dashboard (single-page HTML, cached after first read)
+      // GET /ui — serve the dashboard (read from disk every request so edits are live)
       if (req.method === 'GET' && (pathname === '/ui' || pathname === '/ui/' || pathname === '/ui/index.html')) {
         try {
-          if (dashboardHtml === null) {
-            dashboardHtml = await readFile(join(__dirname, 'web', 'index.html'), 'utf-8');
-          }
+          const html = await readFile(join(__dirname, 'web', 'index.html'), 'utf-8');
           res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
-          res.end(dashboardHtml);
+          res.end(html);
         } catch (err) {
           json(res, 500, { error: `Dashboard not found: ${err.message}` });
         }

--- a/src/server.js
+++ b/src/server.js
@@ -1,18 +1,32 @@
 import http from 'node:http';
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeFile, mkdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const HOP_BY_HOP_HEADERS = new Set([
   'host', 'connection', 'keep-alive', 'transfer-encoding',
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
 
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function json(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
 export function createProxyServer(accountManager, config, hooks = {}) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
   let requestCounter = 0;
+  let dashboardHtml = null;
 
   if (logDir) {
     mkdir(logDir, { recursive: true }).catch(() => {});
@@ -33,10 +47,63 @@ export function createProxyServer(accountManager, config, hooks = {}) {
         return;
       }
 
+      // Parse pathname once for control-endpoint matching (ignores query string / fragment)
+      const pathname = new URL(req.url, 'http://localhost').pathname;
+
       // Status endpoint
-      if (req.method === 'GET' && req.url === '/teamclaude/status') {
+      if (req.method === 'GET' && pathname === '/teamclaude/status') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(accountManager.getStatus(), null, 2));
+        return;
+      }
+
+      // POST /teamclaude/switch — manually pin the active account
+      if (req.method === 'POST' && pathname === '/teamclaude/switch') {
+        try {
+          const { account } = JSON.parse((await readBody(req)) || '{}');
+          if (!account) { json(res, 400, { error: 'Missing "account"' }); return; }
+          const idx = accountManager.accounts.findIndex(a => a.name === account);
+          if (idx < 0) { json(res, 404, { error: `Account "${account}" not found` }); return; }
+          accountManager.currentIndex = idx;
+          console.log(`[TeamClaude] Manually switched to "${account}"`);
+          hooks.onManualSwitch?.(account);
+          json(res, 200, { currentAccount: account });
+        } catch (err) {
+          json(res, 400, { error: err.message });
+        }
+        return;
+      }
+
+      // POST /teamclaude/threshold — change the rotation threshold (0..1)
+      if (req.method === 'POST' && pathname === '/teamclaude/threshold') {
+        try {
+          const { value } = JSON.parse((await readBody(req)) || '{}');
+          const v = Number(value);
+          if (Number.isNaN(v) || v < 0 || v > 1) {
+            json(res, 400, { error: 'value must be a number between 0 and 1' });
+            return;
+          }
+          accountManager.switchThreshold = v;
+          await hooks.persistThreshold?.(v);
+          console.log(`[TeamClaude] Threshold set to ${(v * 100).toFixed(0)}%`);
+          json(res, 200, { switchThreshold: v });
+        } catch (err) {
+          json(res, 400, { error: err.message });
+        }
+        return;
+      }
+
+      // GET /ui — serve the dashboard (single-page HTML, cached after first read)
+      if (req.method === 'GET' && (pathname === '/ui' || pathname === '/ui/' || pathname === '/ui/index.html')) {
+        try {
+          if (dashboardHtml === null) {
+            dashboardHtml = await readFile(join(__dirname, 'web', 'index.html'), 'utf-8');
+          }
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+          res.end(dashboardHtml);
+        } catch (err) {
+          json(res, 500, { error: `Dashboard not found: ${err.message}` });
+        }
         return;
       }
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TeamClaude Dashboard</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='13' fill='none' stroke='%23c87f3a' stroke-width='2.5'/><path d='M 16 5 A 11 11 0 0 1 27 16' fill='none' stroke='%23c87f3a' stroke-width='3' stroke-linecap='round'/><circle cx='16' cy='5' r='2.5' fill='%23c87f3a'/></svg>">
+<style>
+  :root {
+    --bg: #faf7f2;
+    --panel: #ffffff;
+    --panel-border: #e8e1d4;
+    --text: #2a2520;
+    --text-dim: #7a7468;
+    --accent: #b86a1a;
+    --accent-soft: #c87f3a;
+    --good: #4a7c4e;
+    --warn: #c78a1f;
+    --bad: #b04040;
+    --bar-bg: #ece6d8;
+    --bar-good: #5a9a5e;
+    --bar-warn: #d4a035;
+    --bar-bad: #c45050;
+    --active-glow: rgba(184, 106, 26, 0.15);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #1a1612;
+      --panel: #251f18;
+      --panel-border: #3a3128;
+      --text: #ebe4d6;
+      --text-dim: #8a8170;
+      --accent: #e89030;
+      --accent-soft: #d4801f;
+      --good: #6abe6f;
+      --warn: #e5b045;
+      --bad: #d46060;
+      --bar-bg: #312820;
+      --bar-good: #5a9a5e;
+      --bar-warn: #c89534;
+      --bar-bad: #b04040;
+      --active-glow: rgba(232, 144, 48, 0.18);
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem 1.5rem;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; }
+  header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--panel-border);
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  h1 .sub {
+    color: var(--text-dim);
+    font-weight: 400;
+    font-size: 0.95rem;
+    margin-left: 0.5rem;
+  }
+  .threshold-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.9rem;
+  }
+  .threshold-row label { color: var(--text-dim); }
+  .threshold-row input[type=range] {
+    width: 220px;
+    accent-color: var(--accent);
+  }
+  .threshold-row .val {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--accent);
+    min-width: 3rem;
+    text-align: right;
+  }
+  .cards {
+    display: grid;
+    gap: 0.875rem;
+  }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    padding: 1rem 1.125rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem 1rem;
+    align-items: center;
+    transition: box-shadow 0.15s, border-color 0.15s;
+  }
+  .card.active {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent), 0 4px 18px var(--active-glow);
+  }
+  .card .name {
+    font-size: 1.05rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .card .name .badge {
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: var(--bar-bg);
+    color: var(--text-dim);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+  .card.active .name .badge.active-badge {
+    background: var(--accent);
+    color: #fff;
+  }
+  .card .meta {
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+    grid-column: 1 / -1;
+  }
+  .bars {
+    display: grid;
+    grid-template-columns: max-content 1fr max-content;
+    column-gap: 0.625rem;
+    row-gap: 0.4rem;
+    align-items: center;
+    grid-column: 1 / -1;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+  }
+  .bars .lbl { letter-spacing: 0.02em; }
+  .bars .bar {
+    height: 8px;
+    background: var(--bar-bg);
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+  }
+  .bars .bar > span {
+    display: block;
+    height: 100%;
+    background: var(--bar-good);
+    transition: width 0.3s, background 0.3s;
+    border-radius: 4px;
+  }
+  .bars .pct {
+    font-variant-numeric: tabular-nums;
+    min-width: 3rem;
+    text-align: right;
+    color: var(--text);
+  }
+  .bars .bar.warn > span { background: var(--bar-warn); }
+  .bars .bar.bad > span { background: var(--bar-bad); }
+  button.switch {
+    align-self: start;
+    grid-row: 1;
+    grid-column: 2;
+    background: transparent;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  button.switch:hover:not(:disabled) {
+    background: var(--accent);
+    color: #fff;
+  }
+  button.switch:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  footer {
+    margin-top: 1.5rem;
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    text-align: center;
+  }
+  .err {
+    background: var(--bad);
+    color: #fff;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+  }
+  .status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--good);
+  }
+  .status-throttled { background: var(--warn); }
+  .status-exhausted, .status-error { background: var(--bad); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>TeamClaude<span class="sub">multi-account proxy</span></h1>
+    <div class="threshold-row">
+      <label for="thr">Rotate at</label>
+      <input type="range" id="thr" min="50" max="100" step="1" value="98">
+      <span class="val" id="thrVal">98%</span>
+    </div>
+  </header>
+  <div id="errBox"></div>
+  <div class="cards" id="cards"></div>
+  <footer>
+    <span id="meta">Loading…</span>
+  </footer>
+</div>
+<script>
+  // All DOM construction below uses createElement + textContent — never innerHTML
+  // with untrusted data. Account names come from Anthropic profile API via local
+  // config, so they're effectively trusted, but defense in depth.
+  const cardsEl = document.getElementById('cards');
+  const errEl = document.getElementById('errBox');
+  const metaEl = document.getElementById('meta');
+  const thr = document.getElementById('thr');
+  const thrVal = document.getElementById('thrVal');
+  let lastThreshold = null;
+  let saveTimer = null;
+
+  function el(tag, attrs = {}, children = []) {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v == null || v === false) continue;
+      if (k === 'class') node.className = v;
+      else if (k === 'style') node.style.cssText = v;
+      else if (k === 'text') node.textContent = v;
+      else if (k.startsWith('data-')) node.setAttribute(k, v);
+      else if (k === 'disabled' && v) node.disabled = true;
+      else node.setAttribute(k, v);
+    }
+    for (const child of (Array.isArray(children) ? children : [children])) {
+      if (child == null || child === false) continue;
+      node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    }
+    return node;
+  }
+
+  function fmtPct(v) { return v == null ? '—' : (v * 100).toFixed(0) + '%'; }
+  function fmtNum(n) { return n.toLocaleString(); }
+  function fmtAgo(iso) {
+    if (!iso) return 'never';
+    const s = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (s < 60) return Math.round(s) + 's ago';
+    if (s < 3600) return Math.round(s / 60) + 'm ago';
+    if (s < 86400) return Math.round(s / 3600) + 'h ago';
+    return Math.round(s / 86400) + 'd ago';
+  }
+  function barClass(util, threshold) {
+    if (util == null) return 'bar';
+    if (util >= threshold) return 'bar bad';
+    if (util >= threshold * 0.7) return 'bar warn';
+    return 'bar';
+  }
+
+  function makeBar(label, util, threshold) {
+    const inner = el('span', { style: 'width:' + (util == null ? 0 : Math.min(100, util * 100)) + '%' });
+    return [
+      el('span', { class: 'lbl', text: label }),
+      el('div', { class: barClass(util, threshold) }, inner),
+      el('span', { class: 'pct', text: fmtPct(util) }),
+    ];
+  }
+
+  function renderAccount(acct, isActive, threshold) {
+    const q = acct.quota;
+    const u5h = q.unified5h != null ? q.unified5h
+      : (q.tokensLimit ? 1 - q.tokensRemaining / q.tokensLimit : null);
+    const u7d = q.unified7d;
+    const totalTok = acct.usage.totalInputTokens + acct.usage.totalOutputTokens;
+
+    const nameRow = el('div', { class: 'name' }, [
+      el('span', { class: 'status-dot status-' + acct.status }),
+      acct.name,
+      isActive ? el('span', { class: 'badge active-badge', text: 'active' }) : null,
+      el('span', { class: 'badge', style: 'background:transparent;color:var(--text-dim);', text: acct.type }),
+    ]);
+
+    const btn = el('button', { class: 'switch', 'data-name': acct.name, disabled: isActive, text: 'Switch' });
+
+    const bars = el('div', { class: 'bars' }, [
+      ...makeBar('5h', u5h, threshold),
+      ...makeBar('7d', u7d, threshold),
+    ]);
+
+    const metaText = fmtNum(acct.usage.totalRequests) + ' requests · '
+      + fmtNum(totalTok) + ' tokens · last used ' + fmtAgo(acct.usage.lastUsed)
+      + (acct.rateLimitedUntil ? ' · throttled until ' + new Date(acct.rateLimitedUntil).toLocaleTimeString() : '');
+    const meta = el('div', { class: 'meta', text: metaText });
+
+    const card = el('div', { class: 'card' + (isActive ? ' active' : '') }, [nameRow, btn, bars, meta]);
+    return card;
+  }
+
+  function showErr(msg) {
+    errEl.textContent = '';
+    if (msg) errEl.appendChild(el('div', { class: 'err', text: msg }));
+  }
+
+  async function refresh() {
+    try {
+      const res = await fetch('/teamclaude/status', { cache: 'no-store' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const data = await res.json();
+      showErr('');
+
+      const serverPct = Math.round(data.switchThreshold * 100);
+      if (lastThreshold !== serverPct && document.activeElement !== thr) {
+        thr.value = serverPct;
+        thrVal.textContent = serverPct + '%';
+        lastThreshold = serverPct;
+      }
+
+      cardsEl.textContent = '';
+      for (const acct of data.accounts) {
+        cardsEl.appendChild(renderAccount(acct, acct.name === data.currentAccount, data.switchThreshold));
+      }
+      metaEl.textContent = 'Active: ' + data.currentAccount + ' · refreshes every 2s · ' + new Date().toLocaleTimeString();
+    } catch (err) {
+      showErr('Cannot reach proxy: ' + err.message);
+      metaEl.textContent = 'Disconnected';
+    }
+  }
+
+  cardsEl.addEventListener('click', async (e) => {
+    const btn = e.target.closest('button.switch');
+    if (!btn || btn.disabled) return;
+    const name = btn.getAttribute('data-name');
+    btn.disabled = true;
+    try {
+      const res = await fetch('/teamclaude/switch', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ account: name }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'HTTP ' + res.status);
+      }
+      await refresh();
+    } catch (err) {
+      showErr('Switch failed: ' + err.message);
+      btn.disabled = false;
+    }
+  });
+
+  thr.addEventListener('input', () => { thrVal.textContent = thr.value + '%'; });
+  thr.addEventListener('change', () => {
+    clearTimeout(saveTimer);
+    const value = Number(thr.value) / 100;
+    saveTimer = setTimeout(async () => {
+      try {
+        const res = await fetch('/teamclaude/threshold', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ value }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || 'HTTP ' + res.status);
+        }
+        lastThreshold = Math.round(value * 100);
+      } catch (err) {
+        showErr('Threshold update failed: ' + err.message);
+      }
+    }, 100);
+  });
+
+  refresh();
+  setInterval(refresh, 2000);
+</script>
+</body>
+</html>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -43,90 +43,125 @@
     }
   }
   * { box-sizing: border-box; }
+  html, body { height: 100%; }
   body {
     margin: 0;
     font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
     background: var(--bg);
     color: var(--text);
-    min-height: 100vh;
-    padding: 2rem 1.5rem;
+    padding: clamp(0.5rem, 1.8vw, 1.75rem) clamp(0.5rem, 1.8vw, 1.5rem);
+    font-size: clamp(13px, 1.05vw, 15px);
   }
-  .wrap { max-width: 980px; margin: 0 auto; }
+  .wrap {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
   header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1rem;
+    gap: 0.5rem 1rem;
+    margin-bottom: clamp(0.75rem, 1.5vw, 1.5rem);
+    padding-bottom: 0.75rem;
     border-bottom: 1px solid var(--panel-border);
   }
   h1 {
     margin: 0;
-    font-size: 1.5rem;
+    font-size: clamp(1.05rem, 2.2vw, 1.5rem);
     font-weight: 600;
     letter-spacing: -0.01em;
+    line-height: 1.2;
+    min-width: 0;
   }
   h1 .sub {
     color: var(--text-dim);
     font-weight: 400;
-    font-size: 0.95rem;
-    margin-left: 0.5rem;
+    font-size: clamp(0.75rem, 1.4vw, 0.95rem);
+    margin-left: 0.4rem;
+    white-space: nowrap;
   }
   .threshold-row {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    font-size: 0.9rem;
+    gap: 0.5rem;
+    font-size: clamp(0.78rem, 1.2vw, 0.9rem);
+    flex: 1 1 auto;
+    min-width: 140px;
+    max-width: 360px;
+    justify-content: flex-end;
   }
-  .threshold-row label { color: var(--text-dim); }
+  .threshold-row label {
+    color: var(--text-dim);
+    white-space: nowrap;
+  }
   .threshold-row input[type=range] {
-    width: 220px;
+    flex: 1 1 80px;
+    min-width: 70px;
+    max-width: 220px;
     accent-color: var(--accent);
   }
   .threshold-row .val {
     font-variant-numeric: tabular-nums;
     font-weight: 600;
     color: var(--accent);
-    min-width: 3rem;
+    min-width: 2.5rem;
     text-align: right;
   }
   .cards {
     display: grid;
-    gap: 0.875rem;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
+    gap: clamp(0.5rem, 1vw, 0.875rem);
   }
   .card {
     background: var(--panel);
     border: 1px solid var(--panel-border);
     border-radius: 8px;
-    padding: 1rem 1.125rem;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.75rem 1rem;
-    align-items: center;
+    padding: clamp(0.625rem, 1.2vw, 1rem) clamp(0.75rem, 1.4vw, 1.125rem);
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
     transition: box-shadow 0.15s, border-color 0.15s;
+    container-type: inline-size;
+    min-width: 0;
   }
   .card.active {
     border-color: var(--accent);
     box-shadow: 0 0 0 1px var(--accent), 0 4px 18px var(--active-glow);
   }
-  .card .name {
-    font-size: 1.05rem;
-    font-weight: 600;
+  .card .top {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+  .card .name {
+    font-size: clamp(0.92rem, 1.4vw, 1.05rem);
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .card .name .name-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
   .card .name .badge {
-    font-size: 0.7rem;
+    font-size: 0.66rem;
     font-weight: 500;
-    padding: 0.15rem 0.5rem;
+    padding: 0.1rem 0.45rem;
     border-radius: 999px;
     background: var(--bar-bg);
     color: var(--text-dim);
     letter-spacing: 0.02em;
     text-transform: uppercase;
+    flex-shrink: 0;
   }
   .card.active .name .badge.active-badge {
     background: var(--accent);
@@ -134,18 +169,18 @@
   }
   .card .meta {
     color: var(--text-dim);
-    font-size: 0.85rem;
+    font-size: clamp(0.72rem, 1.05vw, 0.85rem);
     font-variant-numeric: tabular-nums;
-    grid-column: 1 / -1;
+    line-height: 1.4;
+    word-break: break-word;
   }
   .bars {
     display: grid;
-    grid-template-columns: max-content 1fr max-content;
-    column-gap: 0.625rem;
-    row-gap: 0.4rem;
+    grid-template-columns: 2ch 1fr 3.2rem;
+    column-gap: 0.55rem;
+    row-gap: 0.35rem;
     align-items: center;
-    grid-column: 1 / -1;
-    font-size: 0.8rem;
+    font-size: clamp(0.72rem, 1.05vw, 0.8rem);
     color: var(--text-dim);
   }
   .bars .lbl { letter-spacing: 0.02em; }
@@ -155,6 +190,7 @@
     border-radius: 4px;
     overflow: hidden;
     position: relative;
+    min-width: 0;
   }
   .bars .bar > span {
     display: block;
@@ -165,47 +201,51 @@
   }
   .bars .pct {
     font-variant-numeric: tabular-nums;
-    min-width: 3rem;
     text-align: right;
     color: var(--text);
   }
   .bars .bar.warn > span { background: var(--bar-warn); }
   .bars .bar.bad > span { background: var(--bar-bad); }
   button.switch {
-    align-self: start;
-    grid-row: 1;
-    grid-column: 2;
     background: transparent;
     color: var(--accent);
     border: 1px solid var(--accent);
     border-radius: 6px;
-    padding: 0.35rem 0.75rem;
-    font-size: 0.85rem;
+    padding: 0.3rem 0.7rem;
+    font-size: clamp(0.78rem, 1.15vw, 0.85rem);
     font-weight: 500;
     cursor: pointer;
     transition: background 0.12s, color 0.12s;
+    flex-shrink: 0;
+    white-space: nowrap;
   }
   button.switch:hover:not(:disabled) {
     background: var(--accent);
     color: #fff;
   }
-  button.switch:disabled {
-    opacity: 0.4;
-    cursor: default;
+  button.switch:disabled { display: none; }
+  /* Tighter card layout when the card itself is narrow */
+  @container (max-width: 300px) {
+    .card .name { font-size: 0.92rem; }
+    .bars { grid-template-columns: 2ch 1fr 2.6rem; column-gap: 0.4rem; }
+    button.switch { width: 100%; }
+    .card .meta { font-size: 0.7rem; }
   }
   footer {
-    margin-top: 1.5rem;
+    margin-top: clamp(0.75rem, 1.5vw, 1.5rem);
     color: var(--text-dim);
-    font-size: 0.8rem;
+    font-size: clamp(0.7rem, 1.05vw, 0.8rem);
     text-align: center;
+    word-break: break-word;
   }
   .err {
     background: var(--bad);
     color: #fff;
-    padding: 0.6rem 1rem;
+    padding: 0.55rem 0.9rem;
     border-radius: 6px;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.85rem;
+    word-break: break-word;
   }
   .status-dot {
     display: inline-block;
@@ -213,6 +253,7 @@
     height: 8px;
     border-radius: 50%;
     background: var(--good);
+    flex-shrink: 0;
   }
   .status-throttled { background: var(--warn); }
   .status-exhausted, .status-error { background: var(--bad); }
@@ -299,12 +340,14 @@
 
     const nameRow = el('div', { class: 'name' }, [
       el('span', { class: 'status-dot status-' + acct.status }),
-      acct.name,
+      el('span', { class: 'name-text', text: acct.name }),
       isActive ? el('span', { class: 'badge active-badge', text: 'active' }) : null,
       el('span', { class: 'badge', style: 'background:transparent;color:var(--text-dim);', text: acct.type }),
     ]);
 
     const btn = el('button', { class: 'switch', 'data-name': acct.name, disabled: isActive, text: 'Switch' });
+
+    const top = el('div', { class: 'top' }, [nameRow, btn]);
 
     const bars = el('div', { class: 'bars' }, [
       ...makeBar('5h', u5h, threshold),
@@ -316,7 +359,7 @@
       + (acct.rateLimitedUntil ? ' · throttled until ' + new Date(acct.rateLimitedUntil).toLocaleTimeString() : '');
     const meta = el('div', { class: 'meta', text: metaText });
 
-    const card = el('div', { class: 'card' + (isActive ? ' active' : '') }, [nameRow, btn, bars, meta]);
+    const card = el('div', { class: 'card' + (isActive ? ' active' : '') }, [top, bars, meta]);
     return card;
   }
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -176,7 +176,7 @@
   }
   .bars {
     display: grid;
-    grid-template-columns: 2ch 1fr 3.2rem;
+    grid-template-columns: 2ch 1fr 3.2rem 3.8rem;
     column-gap: 0.55rem;
     row-gap: 0.35rem;
     align-items: center;
@@ -184,6 +184,14 @@
     color: var(--text-dim);
   }
   .bars .lbl { letter-spacing: 0.02em; }
+  .bars .reset {
+    font-size: 0.78em;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    white-space: nowrap;
+    opacity: 0.85;
+  }
   .bars .bar {
     height: 8px;
     background: var(--bar-bg);
@@ -227,7 +235,8 @@
   /* Tighter card layout when the card itself is narrow */
   @container (max-width: 300px) {
     .card .name { font-size: 0.92rem; }
-    .bars { grid-template-columns: 2ch 1fr 2.6rem; column-gap: 0.4rem; }
+    .bars { grid-template-columns: 2ch 1fr 2.6rem 3.2rem; column-gap: 0.4rem; }
+    .bars .reset { font-size: 0.72em; }
     button.switch { width: 100%; }
     .card .meta { font-size: 0.7rem; }
   }
@@ -307,6 +316,17 @@
 
   function fmtPct(v) { return v == null ? '—' : (v * 100).toFixed(0) + '%'; }
   function fmtNum(n) { return n.toLocaleString(); }
+  function fmtReset(ms) {
+    if (!ms) return '';
+    const now = Date.now();
+    if (ms <= now) return '';
+    const d = new Date(ms);
+    const diff = ms - now;
+    const t = diff < 24 * 3600 * 1000
+      ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : d.toLocaleString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
+    return '↺ ' + t;
+  }
   function fmtAgo(iso) {
     if (!iso) return 'never';
     const s = (Date.now() - new Date(iso).getTime()) / 1000;
@@ -322,12 +342,14 @@
     return 'bar';
   }
 
-  function makeBar(label, util, threshold) {
+  function makeBar(label, util, threshold, resetMs) {
     const inner = el('span', { style: 'width:' + (util == null ? 0 : Math.min(100, util * 100)) + '%' });
+    const titleAttr = resetMs && resetMs > Date.now() ? new Date(resetMs).toLocaleString() : null;
     return [
       el('span', { class: 'lbl', text: label }),
       el('div', { class: barClass(util, threshold) }, inner),
       el('span', { class: 'pct', text: fmtPct(util) }),
+      el('span', { class: 'reset', text: fmtReset(resetMs), title: titleAttr }),
     ];
   }
 
@@ -335,7 +357,11 @@
     const q = acct.quota;
     const u5h = q.unified5h != null ? q.unified5h
       : (q.tokensLimit ? 1 - q.tokensRemaining / q.tokensLimit : null);
+    const u5hReset = q.unified5h != null
+      ? q.unified5hReset
+      : (q.resetsAt ? new Date(q.resetsAt).getTime() : null);
     const u7d = q.unified7d;
+    const u7dReset = q.unified7dReset;
     const totalTok = acct.usage.totalInputTokens + acct.usage.totalOutputTokens;
 
     const nameRow = el('div', { class: 'name' }, [
@@ -350,8 +376,8 @@
     const top = el('div', { class: 'top' }, [nameRow, btn]);
 
     const bars = el('div', { class: 'bars' }, [
-      ...makeBar('5h', u5h, threshold),
-      ...makeBar('7d', u7d, threshold),
+      ...makeBar('5h', u5h, threshold, u5hReset),
+      ...makeBar('7d', u7d, threshold, u7dReset),
     ]);
 
     const metaText = fmtNum(acct.usage.totalRequests) + ' requests · '


### PR DESCRIPTION
## Summary
Brings the web dashboard (`/teamclaude/ui`) to a polished, responsive state and surfaces quota **reset times** alongside utilization.

- **Responsive dashboard** — fluid card grid with container queries; layout adapts down to narrow cards (`08c80a7`).
- **Reset-time display** — each 5h/7d quota bar now shows when its window rolls over (`↺ HH:MM` within a day, weekday + time beyond), with the full timestamp on hover. Reads `unified5hReset`/`unified7dReset` (epoch-ms from Anthropic rate-limit headers) already exposed by `getStatus()`, with a fallback to legacy `resetsAt` (`444281e`).
- **Fast shutdown + live HTML reload** — server reads `web/index.html` from disk per request (`Cache-Control: no-store`), so dashboard edits are live without a restart (`08c80a7`).

## Pre-Landing Review
No issues found. Verified the reset feature is wired end-to-end: backend stores reset timestamps as epoch-ms (`account-manager.js:173-174`), `getStatus()` forwards the full quota object via spread (`account-manager.js:340`), and the frontend `fmtReset(ms)` consumes ms directly and guards null/past values. Units consistent on both sides. Secret scan clean.

## Test plan
- [ ] No automated test suite in this project (`package.json` defines only `start`).
- [ ] Manual: open `http://localhost:3456/ui` against a running proxy with active accounts and confirm reset labels render next to each bar and resize cleanly on a narrow window.

Generated with [Claude Code](https://claude.com/claude-code)