### PR TITLE
Make accounts org-aware: dedupe by account + organization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -443,27 +443,33 @@ async function accountsCommand() {
   // Deduplicate by accountUuid — keep the last (most recently added) entry
   const seen = new Map();
   let removed = 0;
+  let normalized = false;
   for (let i = config.accounts.length - 1; i >= 0; i--) {
     const a = config.accounts[i];
     const uuid = profiles[i]?.accountUuid || a.accountUuid;
-    if (uuid) {
-      if (seen.has(uuid)) {
+    const orgUuid = profiles[i]?.orgUuid || a.organizationUuid || '';
+    const key = uuid ? `${uuid}::${orgUuid}` : null;
+    if (key) {
+      if (seen.has(key)) {
         config.accounts.splice(i, 1);
         profiles.splice(i, 1);
         removed++;
       } else {
-        seen.set(uuid, i);
-        // Update stored UUID and name from profile
+        seen.set(key, i);
         if (profiles[i] && !profiles[i].error) {
-          a.accountUuid = profiles[i].accountUuid;
-          if (profiles[i].email) a.name = profiles[i].email;
+          if (a.accountUuid !== profiles[i].accountUuid) { a.accountUuid = profiles[i].accountUuid; normalized = true; }
+          if (profiles[i].orgUuid && a.organizationUuid !== profiles[i].orgUuid) { a.organizationUuid = profiles[i].orgUuid; normalized = true; }
+          if (profiles[i].email) {
+            const newName = profiles[i].orgName ? `${profiles[i].email} (${profiles[i].orgName})` : profiles[i].email;
+            if (a.name !== newName) { a.name = newName; normalized = true; }
+          }
         }
       }
     }
   }
-  if (removed > 0) {
+  if (removed > 0 || normalized) {
     await saveConfig(config);
-    console.log(`Removed ${removed} duplicate account(s)\n`);
+    if (removed > 0) console.log(`Removed ${removed} duplicate account(s)\n`);
   }
 
   for (const [i, a] of config.accounts.entries()) {
@@ -480,8 +486,8 @@ async function accountsCommand() {
     const status = hasProfile ? `Claude ${tier}` : `unknown (${p?.error || 'no token'})`;
     const src = a.source ? `, ${a.source}` : '';
     console.log(`  [${i + 1}] ${a.name} (${status}${src})`);
-    if (hasProfile && p.email && p.email !== a.name) console.log(`       Email: ${p.email}`);
-    if (hasProfile && p.orgName) console.log(`       Org:   ${p.orgName}`);
+    if (hasProfile && p.email) console.log(`       Email: ${p.email}`);
+    if (hasProfile && p.orgName) console.log(`       Org:   ${p.orgName}${p.orgType ? ` (${p.orgType})` : ''}${p.rateLimitTier ? ` — ${p.rateLimitTier}` : ''}`);
     if (verbose && a.expiresAt) {
       const remaining = a.expiresAt - Date.now();
       if (remaining <= 0) {
@@ -620,9 +626,9 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
     console.error(`Warning: could not fetch account profile — ${profile?.error || 'no token'}`);
   }
   if (!name && profile?.email) {
-    name = profile.email;
+    name = profile.orgName ? `${profile.email} (${profile.orgName})` : profile.email;
     const tier = profile.hasClaudeMax ? 'Max' : profile.hasClaudePro ? 'Pro' : null;
-    if (tier) console.log(`Detected Claude ${tier} account: ${profile.email}`);
+    if (tier) console.log(`Detected Claude ${tier} account: ${profile.email}${profile.orgName ? ` — org "${profile.orgName}"` : ''}`);
   }
   if (!name) {
     const n = config.accounts.filter(a => a.name.startsWith('account-')).length + 1;
@@ -634,14 +640,15 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
     type: 'oauth',
     source,
     accountUuid: profile?.accountUuid || null,
+    organizationUuid: profile?.orgUuid || null,
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
   };
 
   // Deduplicate: match by UUID first, then by name
-  let idx = profile?.accountUuid
-    ? config.accounts.findIndex(a => a.accountUuid === profile.accountUuid)
+  let idx = (profile?.accountUuid && profile?.orgUuid)
+    ? config.accounts.findIndex(a => a.accountUuid === profile.accountUuid && a.organizationUuid === profile.orgUuid)
     : -1;
   if (idx < 0) idx = config.accounts.findIndex(a => a.name === name);
 

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -129,8 +129,10 @@ export async function fetchProfile(accessToken) {
       accountUuid: data.account?.uuid,
       email: data.account?.email,
       name: data.account?.display_name,
+      orgUuid: data.organization?.uuid,
       orgName: data.organization?.name,
       orgType: data.organization?.organization_type,
+      rateLimitTier: data.organization?.rate_limit_tier,
       hasClaudeMax: data.account?.has_claude_max,
       hasClaudePro: data.account?.has_claude_pro,
     };

--- a/src/tui.js
+++ b/src/tui.js
@@ -303,9 +303,9 @@ export class TUI {
 
       let name;
       if (profile?.email) {
-        name = profile.email;
+        name = profile.orgName ? `${profile.email} (${profile.orgName})` : profile.email;
         const tier = profile.hasClaudeMax ? 'Max' : profile.hasClaudePro ? 'Pro' : null;
-        if (tier) this._addLog(`Detected Claude ${tier}: ${name}`);
+        if (tier) this._addLog(`Detected Claude ${tier}: ${profile.email}${profile.orgName ? ` — org "${profile.orgName}"` : ''}`);
       } else {
         const n = this.config.accounts.filter(a => a.name.startsWith('account-')).length + 1;
         name = `account-${n}`;
@@ -314,14 +314,16 @@ export class TUI {
       const entry = {
         name, type: 'oauth', source: 'import',
         accountUuid: profile?.accountUuid || null,
+        organizationUuid: profile?.orgUuid || null,
+        orgName: profile?.orgName || null,
         accessToken: creds.accessToken,
         refreshToken: creds.refreshToken,
         expiresAt: creds.expiresAt,
       };
 
-      // Deduplicate: match by UUID first, then by name
-      let idx = profile?.accountUuid
-        ? this.config.accounts.findIndex(a => a.accountUuid === profile.accountUuid)
+      // Deduplicate by (account UUID + organization UUID), then by name
+      let idx = (profile?.accountUuid && profile?.orgUuid)
+        ? this.config.accounts.findIndex(a => a.accountUuid === profile.accountUuid && a.organizationUuid === profile.orgUuid)
         : -1;
       if (idx < 0) idx = this.config.accounts.findIndex(a => a.name === name);
 
@@ -398,8 +400,8 @@ export class TUI {
       lines.push('');
       const showBoth = W >= 70;
       const bw = showBoth
-        ? Math.max(5, Math.min(20, Math.floor((W - 56) / 2)))
-        : Math.max(5, Math.min(20, W - 45));
+        ? Math.max(5, Math.min(20, Math.floor((W - 60) / 2)))
+        : Math.max(5, Math.min(20, W - 49));
 
       for (let i = 0; i < this.am.accounts.length; i++) {
         lines.push(this._renderAcct(i, bw, showBoth));
@@ -456,8 +458,11 @@ export class TUI {
     const sel = isSel ? cyan('>') : ' ';
     const cur = isCur ? green('►') : ' ';
 
-    // Name (bold if selected)
-    const rawName = a.name.slice(0, 12).padEnd(12);
+    // Label: show the ORG (what distinguishes accounts sharing one login/email).
+    // Accounts are stored as "email (Org Name)"; show the org, else the full name (API keys).
+    const orgMatch = /^(.*?) \((.+)\)$/.exec(a.name);
+    const label = orgMatch ? orgMatch[2] : a.name;
+    const rawName = label.slice(0, 16).padEnd(16);
     const name = isSel ? bold(rawName) : rawName;
 
     // Type


### PR DESCRIPTION
A single Claude login can belong to multiple orgs/subscriptions (e.g. a personal Max plan and a Team plan), each with its own quota. The previous code keyed OAuth accounts on account UUID alone, so two such subscriptions collapsed into one entry and could not be rotated between.

- fetchProfile() now also returns the organization UUID and rate-limit tier
- login / import / accounts dedupe on (accountUuid + organizationUuid), falling back to name when org info is unavailable
- accounts are named "email (Org Name)" so multiple orgs stay distinct; `accounts` normalization persists this and backfills the org UUID
- `accounts` listing shows org name, org type, and rate-limit tier
- TUI dashboard shows the org per row (the field that distinguishes accounts sharing one login), and its in-dashboard import is org-aware too