### PR TITLE
Resolve `claude` shim on Windows in `run` command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -345,6 +345,7 @@ async function runCommand() {
   // Use spawnSync so the Node process blocks entirely — behaves like execvp.
   const result = spawnSync('claude', claudeArgs, {
     stdio: 'inherit',
+    shell: process.platform === 'win32',
     env: {
       ...process.env,
       ANTHROPIC_BASE_URL: `http://localhost:${config.proxy.port}`,


### PR DESCRIPTION
## Problem
`teamclaude run` fails on Windows with:

```
Claude Code not found in PATH. Install it first.
```

even when `@anthropic-ai/claude-code` is installed globally and `claude --version` works in the same shell.

## Root cause
On Windows, npm installs `claude` as shim files (`claude.cmd`, `claude.ps1`) rather than a bare `.exe`. Since Node.js v18.20.2 / v20.12.2 / v21.7.2 (mitigation for **CVE-2024-27980** — aka "BatBadBut"), `child_process.spawn(Sync)` no longer resolves `.cmd`/`.bat` targets through `PATH` unless `shell: true` is set. `src/index.js` calls:

```js
spawnSync('claude', claudeArgs, { stdio: 'inherit', env: { ... } });
```

so Node returns `ENOENT` and the script prints the misleading "not found" message.

Refs:
- Node.js security release notes (Apr 9 2024) — https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
- CVE-2024-27980 — https://nvd.nist.gov/vuln/detail/CVE-2024-27980

## Fix
Set `shell: process.platform === 'win32'` on the `spawnSync` call. No-op on macOS/Linux; on Windows it routes through `cmd.exe` so the `claude.cmd` shim is found.

## Test plan
- [x] **Windows 11, Node v20.19.6, nvm-windows, `@anthropic-ai/claude-code` installed globally**
  - Before: `teamclaude run --version` → "Claude Code not found in PATH."
  - After: `teamclaude run --version` → prints Claude Code's version banner and exits cleanly.
- [ ] macOS / Linux smoke test — behavior unchanged (still POSIX `execvp`-style spawn).

## Alternatives considered
- `cross-spawn` would also fix this but adds a runtime dependency to an otherwise dep-free package.
- Hard-coding `claude.cmd` on Windows would break installs that expose Claude Code as a bare `.exe`.
- Platform-gated `shell: true` is the idiomatic Node.js fix recommended by the official Node.js docs for this exact scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)