### PR TITLE
Bound 429 retries and handle listen errors gracefully

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ export default [
         console: 'readonly',
         process: 'readonly',
         setTimeout: 'readonly',
+        clearTimeout: 'readonly',
         clearInterval: 'readonly',
         setInterval: 'readonly',
         setImmediate: 'readonly',

--- a/src/index.js
+++ b/src/index.js
@@ -162,8 +162,17 @@ async function serverCommand() {
   }
 
   const server = createProxyServer(accountManager, config, hooks);
+  // Catch bind-time errors (e.g. EADDRINUSE) only. Once the socket is bound we
+  // remove this handler so a later runtime 'error' isn't misreported as a
+  // listen failure and exit the whole proxy.
+  const onListenError = err => handleServerListenError(err, port);
+  server.once('error', onListenError);
 
   server.listen(port, () => {
+    // Bind succeeded: stop treating errors as listen failures, but keep a
+    // benign runtime handler so a later 'error' is logged rather than thrown.
+    server.removeListener('error', onListenError);
+    server.on('error', err => console.error(`[TeamClaude] Server error: ${err.message}`));
     if (tui) {
       tui.start();
       console.log(`Listening on port ${port} with ${accounts.length} account(s)`);
@@ -764,4 +773,19 @@ async function resolveAccounts(config) {
 function argValue(flag) {
   const i = args.indexOf(flag);
   return (i >= 0 && args[i + 1]) ? args[i + 1] : null;
+}
+
+function handleServerListenError(err, port) {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`[TeamClaude] Port ${port} is already in use.`);
+    console.error('Another TeamClaude proxy may already be running.');
+    console.error('Check the existing server with: teamclaude status');
+    console.error(`Find the listener with: lsof -nP -iTCP:${port} -sTCP:LISTEN`);
+  } else if (err.code === 'EACCES') {
+    console.error(`[TeamClaude] Permission denied while listening on port ${port}.`);
+    console.error('Choose a non-privileged port in the TeamClaude config.');
+  } else {
+    console.error(`[TeamClaude] Failed to listen on port ${port}: ${err.message}`);
+  }
+  process.exit(1);
 }

--- a/src/server.js
+++ b/src/server.js
@@ -244,11 +244,31 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
     accountManager.updateQuota(account.index, rateLimitHeaders);
 
     // On 429, wait the retry-after duration and retry on the same account
-    // (this is a transient rate limit, not quota exhaustion)
+    // (this is a transient rate limit, not quota exhaustion).
     if (upstreamRes.status === 429) {
-      const retryAfter = parseInt(upstreamRes.headers.get('retry-after'), 10) || 60;
+      // Clamp Retry-After to a sane window: missing/invalid falls back to 60s,
+      // and out-of-range values are bounded to [1, 300]. A negative value would
+      // otherwise bypass the retry cap — setTimeout returns immediately and
+      // markRateLimited would set rateLimitedUntil in the past.
+      let retryAfter = parseInt(upstreamRes.headers.get('retry-after'), 10);
+      if (Number.isNaN(retryAfter)) retryAfter = 60;
+      retryAfter = Math.min(Math.max(retryAfter, 1), 300);
       // Discard the 429 response body
       await upstreamRes.body?.cancel();
+
+      // Bound the retries: a persistently-throttled upstream must not loop
+      // forever (that would tie up the client connection indefinitely).
+      // Once retries are exhausted, throttle this account and re-dispatch —
+      // getActiveAccount then picks another account, or returns 429 to the
+      // client if every account is throttled.
+      if (retryCount >= maxRetries) {
+        console.log(`[TeamClaude] Persistent 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching`);
+        accountManager.markRateLimited(account.index, retryAfter);
+        if (logDir) {
+          logSections.push(`=== RESPONSE 429 — capped after ${retryCount} retries, throttling account ===\n${formatHeaders(upstreamRes.headers)}`);
+        }
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
+      }
 
       if (logDir) {
         logSections.push(`=== RESPONSE 429 — waiting ${retryAfter}s ===\n${formatHeaders(upstreamRes.headers)}`);
@@ -257,7 +277,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
       // Client may have disconnected during the wait
       if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir);
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
     }
 
     // Log response headers

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// Drive one request through the proxy against an upstream that always 429s with
+// the given Retry-After header, and report how the request terminated.
+async function runAgainstThrottlingUpstream(retryAfterHeader) {
+  let upstreamHits = 0;
+  const upstream = http.createServer((_req, res) => {
+    upstreamHits++;
+    res.writeHead(429, { 'retry-after': retryAfterHeader, 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }],
+    0.98,
+  );
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    return { status: res.status, upstreamHits, accountStatus: am.accounts[0].status };
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+// Regression: a persistently-throttled upstream must terminate (bounded retries),
+// not loop forever tying up the client connection.
+test('persistent upstream 429 terminates with a bounded number of retries', async () => {
+  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('1');
+  assert.equal(status, 429);                                   // returns 429 instead of hanging
+  assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
+  assert.equal(accountStatus, 'throttled');                    // account throttled, not retried forever
+});
+
+// A negative (or otherwise out-of-range) Retry-After must not bypass the cap:
+// it would make setTimeout return immediately and mark the account rate-limited
+// in the past, reactivating it instantly.
+test('negative Retry-After is clamped and still terminates', async () => {
+  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('-1');
+  assert.equal(status, 429);
+  assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
+  assert.equal(accountStatus, 'throttled');
+});

--- a/test/server-listen-error.test.js
+++ b/test/server-listen-error.test.js
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+}
+
+function close(server) {
+  return new Promise(resolve => server.close(resolve));
+}
+
+function runServer(configPath) {
+  const child = spawn(process.execPath, [cliPath, 'server'], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => { stdout += chunk; });
+  child.stderr.on('data', chunk => { stderr += chunk; });
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('server did not exit after listen error'));
+    }, 5000);
+
+    child.on('error', err => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('exit', code => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test('server exits cleanly when configured port is already in use', async () => {
+  const occupied = http.createServer((_req, res) => res.end('ok'));
+  const port = await listen(occupied);
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-'));
+  const configPath = join(dir, 'config.json');
+  await writeFile(configPath, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' },
+    upstream: 'https://api.anthropic.com',
+    switchThreshold: 0.98,
+    accounts: [{ name: 'api-test', type: 'apikey', apiKey: 'sk-ant-test' }],
+  }));
+
+  try {
+    const result = await runServer(configPath);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, new RegExp(`Port ${port} is already in use`));
+    assert.match(result.stderr, /teamclaude status/);
+    assert.doesNotMatch(result.stderr, /Unhandled 'error' event/);
+  } finally {
+    await close(occupied);
+  }
+});


### PR DESCRIPTION
## Summary

Two small, self-contained robustness fixes for the proxy's request-forwarding and startup paths. They don't touch account rotation/probing, so they apply cleanly on top of `master`.

- **Bound upstream 429 retries.** A persistently-throttled upstream made `forwardRequest` retry the *same* account forever — `retryCount` was never incremented on the 429 path — tying up the client connection. Each 429 retry now counts toward `maxRetries`; once exhausted the account is marked rate-limited and the request is re-dispatched (switching to another account, or returning 429 when all are throttled). `Retry-After` is clamped to `[1, 300]s` (missing/invalid → 60) so an out-of-range value (e.g. a negative one) can't bypass the cap by making `setTimeout` return immediately / marking the account rate-limited in the past.

- **Handle listen errors gracefully.** `server.listen` failures such as `EADDRINUSE`/`EACCES` surfaced as an unhandled `'error'` event and a stack-trace crash. They now print a clear message (pointing at `teamclaude status` / `lsof`) and exit 1. Once the socket is bound, the listen-failure handler is swapped for a benign runtime handler so a later `'error'` is logged rather than thrown.

- Minor: add `clearTimeout` to the eslint globals (it pairs with `setTimeout`, which was already listed).

## Test plan

- `node --test`
  - `test/server-429.test.js` — a persistent 429 terminates with a bounded number of retries and the account ends up throttled; a negative `Retry-After` is clamped and still terminates.
  - `test/server-listen-error.test.js` — the CLI exits cleanly with a clear message when the configured port is already in use.
  - 3/3 passing.
- `npx eslint .` — 0 errors.