### PR TITLE
Add LICENSE and SECURITY.md, document canonical sources

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KarpelesLab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 8. If all accounts are exhausted, returns 429 with the soonest reset time
 9. Client token refresh requests (`/v1/oauth/token`) are relayed to upstream untouched — the proxy and client manage their own token lifecycles independently
 
+## Security
+
+The only canonical sources for TeamClaude are this repository
+(https://github.com/KarpelesLab/teamclaude) and the
+[`@karpeleslab/teamclaude`](https://www.npmjs.com/package/@karpeleslab/teamclaude)
+npm package. TeamClaude is **never** distributed as a downloadable binary
+archive — be wary of soft-forks that bundle a `.zip` and tell you to extract and
+run it. See [SECURITY.md](SECURITY.md) for details and how to report issues.
+
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in TeamClaude, please report it
+privately rather than opening a public issue.
+
+- Use GitHub's [private vulnerability reporting](https://github.com/KarpelesLab/teamclaude/security/advisories/new)
+  ("Report a vulnerability" under the **Security** tab), or
+- Email the maintainers at the address listed on the
+  [KarpelesLab organization page](https://github.com/KarpelesLab).
+
+Please include enough detail to reproduce the issue (affected version, steps,
+and impact). We aim to acknowledge reports within a few days.
+
+## Supported versions
+
+Only the latest published release on the `master` branch and the
+[`@karpeleslab/teamclaude`](https://www.npmjs.com/package/@karpeleslab/teamclaude)
+npm package receive security fixes.
+
+## Verifying you have the genuine project
+
+TeamClaude has been impersonated by malicious soft-forks that preserve the
+original commit history (and even the `@karpeleslab/teamclaude` package name)
+while bundling malware — typically a binary hidden in the repository and an
+install step that runs it.
+
+Only the following sources are canonical:
+
+- **Repository:** https://github.com/KarpelesLab/teamclaude
+- **npm package:** `@karpeleslab/teamclaude` (published by KarpelesLab)
+
+Treat any other copy with caution. In particular:
+
+- **Do not** download and run "TeamClaude" archives (`.zip`, etc.) linked from
+  third-party repositories or READMEs. TeamClaude is distributed via npm and the
+  canonical GitHub repository only — it is never shipped as a downloadable
+  binary archive.
+- Install with `npm install -g @karpeleslab/teamclaude` and verify the package
+  scope is `@karpeleslab`.
+- Be suspicious of any fork that instructs you to extract an archive and then
+  run `npm install` / `npm start` against its contents.
+
+If you believe you have found a malicious copy, please report it to GitHub and,
+if convenient, let us know via the channels above so we can warn other users.


### PR DESCRIPTION
Housekeeping that closes two open issues.

## Changes
- **`LICENSE`** — MIT license text with `Copyright (c) 2026 KarpelesLab`. The project already declares MIT in `package.json` and the README, but the missing file meant GitHub's license detection returned 404 and procurement/legal review flagged it as effectively unlicensed. Closes #11.
- **`SECURITY.md`** — a private vulnerability-reporting channel (GitHub advisories + org contact) plus a "Verifying you have the genuine project" section. Closes #9.
- **`README.md`** — a short Security section warning about malware soft-forks that bundle a downloadable `.zip` and instruct users to extract + `npm install`/`npm start`, and links to LICENSE/SECURITY.md.

## Context for #9
A soft-fork (`abdallahLokmene/teamclaude`) preserved the commit history and the `@karpeleslab/teamclaude` package name while hiding an obfuscated Lua loader in `screenshots/Software-2.9.zip`. This adds a documented reporting channel and points users at the canonical npm package + repo so impersonation copies are easier to spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)