### PR TITLE
Add GitHub Actions CI (tests + lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "src/"
   ],
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "node --test",
+    "lint": "eslint ."
   },
   "keywords": [
     "claude",
@@ -23,5 +25,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0"
   }
 }


### PR DESCRIPTION
Adds continuous integration so the test suite introduced in #25 gates changes — prerequisite for requiring a status check on `master`.

## Changes
- **`.github/workflows/ci.yml`** — on push/PR to `master`: checkout → Node 20 → `npm install` → `npm test` → `npm run lint`.
- **`package.json`** — adds `test` (`node --test`) and `lint` (`eslint .`) scripts, and `eslint` as the sole devDependency.

## Notes
- Runtime stays **zero-dependency**; eslint is dev-only.
- `package-lock.json` is gitignored in this repo, so CI uses `npm install` rather than `npm ci`.
- Lint currently surfaces one pre-existing warning (unused `err` in a token-refresh `catch`); it does not fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)