### PR TITLE
Org-aware account identity, removal, and rotation priority (#6, #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
 - **Hot-reload accounts** — add accounts via `import` or `login` while the server is running, press **R** to pick them up
-- **Account deduplication** — detects duplicate accounts by UUID and keeps the most recent
+- **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
+- **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
 
@@ -128,10 +129,17 @@ claude
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude accounts -v       # Also show token expiry times
 teamclaude status            # Show live proxy status (requires running server)
-teamclaude remove <name>     # Remove an account
+teamclaude remove <name>     # Remove an account (by name or email)
+teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
 teamclaude api <path>        # Call an API endpoint with account credentials
 teamclaude help              # Show all commands
 ```
+
+When the same email belongs to multiple organizations, accounts are named
+`email (Org)` to keep them distinct. Pass `--org <name|uuid>` to disambiguate a
+bare email, e.g. `teamclaude remove user@example.com --org Acme`. Use
+`teamclaude priority <name> --first` / `--last` to move an account to the front
+or back of the rotation order.
 
 ### Request logging
 
@@ -163,9 +171,12 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
   "switchThreshold": 0.98,
   "accounts": [
     {
-      "name": "user@example.com",
+      "name": "user@example.com (Acme)",
       "type": "oauth",
       "accountUuid": "...",
+      "orgUuid": "...",
+      "orgName": "Acme",
+      "priority": 0,
       "accessToken": "sk-ant-oat01-...",
       "refreshToken": "sk-ant-ort01-...",
       "expiresAt": 1774384968427
@@ -180,6 +191,9 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `proxy.apiKey` | API key clients use to authenticate with the proxy |
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts |
+| `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
+| `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
+| `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
 
 ## How It Works
 

--- a/config.example.json
+++ b/config.example.json
@@ -12,14 +12,19 @@
       "importFrom": "~/.claude/.credentials.json"
     },
     {
-      "name": "secondary-max",
+      "name": "user@example.com (Acme)",
       "type": "oauth",
+      "accountUuid": "optional-account-uuid",
+      "orgUuid": "optional-organization-uuid",
+      "orgName": "Acme",
+      "priority": 0,
       "accessToken": "sk-ant-oat01-your-access-token",
       "refreshToken": "sk-ant-ort01-your-refresh-token"
     },
     {
       "name": "api-fallback",
       "type": "apikey",
+      "priority": 10,
       "apiKey": "sk-ant-api03-your-api-key"
     }
   ]

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -24,6 +24,9 @@ export class AccountManager {
       name: acct.name,
       type: acct.type,
       accountUuid: acct.accountUuid || null,
+      orgUuid: acct.orgUuid || null,
+      orgName: acct.orgName || null,
+      priority: acct.priority || 0,
       credential: acct.accessToken || acct.apiKey,
       refreshToken: acct.refreshToken || null,
       expiresAt: acct.expiresAt || null,
@@ -164,6 +167,8 @@ export class AccountManager {
     for (const acc of candidates) {
       if (acc.index === this.currentIndex) continue;
       if (!this._isAvailable(acc)) continue; // enough session & weekly quota left
+      // Don't demote to a lower-priority (higher value) account on a reset.
+      if ((acc.priority || 0) > (current.priority || 0)) continue;
       const weekly = acc.quota.unified7dReset;
       if (weekly == null) continue; // need a known weekly to compare
       if (weekly < bestWeekly) {
@@ -201,12 +206,17 @@ export class AccountManager {
   }
 
   _selectNext() {
-    // Among all available accounts, prefer the one with no known weekly limit
-    // first — using it lets us discover its quota. Otherwise prefer the account
-    // whose weekly limit expires the soonest: that quota is closest to
-    // refreshing, so spending it first preserves accounts whose weekly window
-    // resets further out.
+    // Selection order among available accounts:
+    //   1. lowest `priority` value (operator-controlled; default 0, lower = preferred)
+    //   2. then the account with no known weekly limit — using it lets us
+    //      discover its quota
+    //   3. then the account whose weekly limit expires soonest: that quota is
+    //      closest to refreshing, so spending it first preserves accounts whose
+    //      weekly window resets further out.
+    // With all priorities at the default 0, this reduces to the original
+    // weekly-reset heuristic.
     let best = null;
+    let bestPriority = Infinity;
     let bestReset = Infinity;
 
     for (let i = 0; i < this.accounts.length; i++) {
@@ -216,9 +226,12 @@ export class AccountManager {
       // is still below 98%.
       if (!this._isAvailable(account)) continue;
 
+      const priority = account.priority || 0;
       // Unknown weekly reset sorts first so we fill it in.
       const weeklyReset = account.quota.unified7dReset || -Infinity;
-      if (weeklyReset < bestReset) {
+      if (priority < bestPriority ||
+          (priority === bestPriority && weeklyReset < bestReset)) {
+        bestPriority = priority;
         bestReset = weeklyReset;
         best = account;
       }
@@ -417,6 +430,9 @@ export class AccountManager {
       name: acctData.name,
       type: acctData.type,
       accountUuid: acctData.accountUuid || null,
+      orgUuid: acctData.orgUuid || null,
+      orgName: acctData.orgName || null,
+      priority: acctData.priority || 0,
       credential: acctData.accessToken || acctData.apiKey,
       refreshToken: acctData.refreshToken || null,
       expiresAt: acctData.expiresAt || null,
@@ -454,6 +470,8 @@ export class AccountManager {
       accounts: this.accounts.map(a => ({
         name: a.name,
         type: a.type,
+        orgName: a.orgName || null,
+        priority: a.priority || 0,
         status: a.status,
         quota: { ...a.quota },
         usage: { ...a.usage },

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,0 +1,65 @@
+// Account identity helpers.
+//
+// An OAuth account is identified by its Anthropic account UUID (the *person*)
+// plus the organization it is scoped to. The same email/person can belong to
+// multiple organizations — e.g. a corporate Pro org and a personal Max org —
+// each with its own OAuth token and quota. The org must therefore be part of
+// the identity; otherwise multi-org logins overwrite each other, removals match
+// the wrong entry, and token rotation persists onto the wrong account.
+//
+// The org discriminator prefers the org UUID but falls back to the org name
+// (the profile endpoint has always returned a name), so identity still works on
+// entries created before org UUIDs were stored.
+
+/** Stable org discriminator for an account record: org UUID, else org name, else null. */
+export function orgKey(acct) {
+  return acct?.orgUuid || acct?.orgName || null;
+}
+
+/**
+ * Whether two account records refer to the same account+org.
+ *
+ * - Both have an accountUuid: it must match. If both org keys are known they
+ *   must also match; but if either side's org is still unknown we treat them as
+ *   the same. This lets a freshly-profiled login backfill a legacy entry (which
+ *   has no stored org) instead of creating a duplicate. Once both sides carry an
+ *   org key, a *different* org is correctly seen as a distinct account.
+ * - Otherwise (API-key accounts, or no UUID yet): fall back to matching by name.
+ */
+export function sameIdentity(a, b) {
+  if (a?.accountUuid && b?.accountUuid) {
+    if (a.accountUuid !== b.accountUuid) return false;
+    const ka = orgKey(a);
+    const kb = orgKey(b);
+    if (ka && kb) return ka === kb;
+    return true;
+  }
+  return a?.name === b?.name;
+}
+
+/** The email portion of a display name, stripping any " (org)" suffix. */
+export function emailOf(acct) {
+  return (acct?.name || '').replace(/ \(.*\)$/, '');
+}
+
+/**
+ * Find accounts matching a name-or-email query, optionally narrowed by org.
+ *
+ * An exact display-name match wins outright. Otherwise match by email (so
+ * `remove user@x.com` finds `user@x.com (Acme)`). `orgFilter` narrows by org
+ * name or org UUID (prefix allowed). Returns the array of matches; the caller
+ * decides what to do with 0, 1, or many.
+ */
+export function matchAccounts(accounts, query, orgFilter) {
+  let matches = accounts.filter(a => a.name === query);
+  if (matches.length === 0) {
+    matches = accounts.filter(a => emailOf(a) === query);
+  }
+  if (orgFilter) {
+    matches = matches.filter(a =>
+      (a.orgName && a.orgName === orgFilter) ||
+      (a.orgUuid && (a.orgUuid === orgFilter || a.orgUuid.startsWith(orgFilter)))
+    );
+  }
+  return matches;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
+import { sameIdentity, orgKey, matchAccounts } from './identity.js';
 import { TUI } from './tui.js';
 
 const args = process.argv.slice(2);
@@ -40,6 +41,10 @@ switch (command) {
     break;
   case 'remove':
     await removeCommand();
+    process.exit(0);
+    break;
+  case 'priority':
+    await priorityCommand();
     process.exit(0);
     break;
   case 'api':
@@ -104,8 +109,7 @@ async function serverCommand() {
       // Pick up any new accounts from disk so index matching stays correct
       // (only add, don't refresh credentials — we're about to write the authoritative tokens)
       for (const diskAcct of diskConfig.accounts) {
-        const known = (diskAcct.accountUuid && config.accounts.some(a => a.accountUuid === diskAcct.accountUuid))
-          || config.accounts.some(a => a.name === diskAcct.name);
+        const known = config.accounts.some(a => sameIdentity(a, diskAcct));
         if (!known) {
           config.accounts.push(diskAcct);
           accountManager.addAccount(diskAcct);
@@ -141,9 +145,7 @@ async function serverCommand() {
             refreshToken: am.refreshToken,
             expiresAt: am.expiresAt,
           } : a;
-          const diskAcct = diskConfig.accounts.find(
-            d => (a.accountUuid && d.accountUuid === a.accountUuid) || d.name === a.name
-          );
+          const diskAcct = diskConfig.accounts.find(d => sameIdentity(d, a));
           return diskAcct ? { ...diskAcct, ...live } : live;
         });
       }),
@@ -450,31 +452,50 @@ async function accountsCommand() {
     )
   );
 
-  // Deduplicate by accountUuid — keep the last (most recently added) entry
+  // Backfill account+org identity from profiles, then deduplicate by
+  // (accountUuid, org): the same person in a different org is a distinct
+  // account, not a duplicate. Keep the last (most recently added) entry.
   const seen = new Map();
   let removed = 0;
+  let touched = false;
   for (let i = config.accounts.length - 1; i >= 0; i--) {
     const a = config.accounts[i];
-    const uuid = profiles[i]?.accountUuid || a.accountUuid;
-    if (uuid) {
-      if (seen.has(uuid)) {
-        config.accounts.splice(i, 1);
-        profiles.splice(i, 1);
-        removed++;
-      } else {
-        seen.set(uuid, i);
-        // Update stored UUID and name from profile
-        if (profiles[i] && !profiles[i].error) {
-          a.accountUuid = profiles[i].accountUuid;
-          if (profiles[i].email) a.name = profiles[i].email;
-        }
-      }
+    const p = profiles[i];
+    if (p && !p.error) {
+      if (p.accountUuid && a.accountUuid !== p.accountUuid) { a.accountUuid = p.accountUuid; touched = true; }
+      if (p.orgUuid && a.orgUuid !== p.orgUuid) { a.orgUuid = p.orgUuid; touched = true; }
+      if (p.orgName && a.orgName !== p.orgName) { a.orgName = p.orgName; touched = true; }
+    }
+    const uuid = a.accountUuid;
+    if (!uuid) continue;
+    const key = `${uuid}::${orgKey(a) || ''}`;
+    if (seen.has(key)) {
+      config.accounts.splice(i, 1);
+      profiles.splice(i, 1);
+      removed++;
+      touched = true;
+    } else {
+      seen.set(key, i);
     }
   }
-  if (removed > 0) {
-    await saveConfig(config);
-    console.log(`Removed ${removed} duplicate account(s)\n`);
+
+  // Name accounts from their email: plain when the person has a single org,
+  // "email (Org)" when the same person spans multiple orgs. Names must stay
+  // unique — they are the user-facing key for remove/api/selection.
+  const orgCount = new Map();
+  for (const a of config.accounts) {
+    if (a.accountUuid) orgCount.set(a.accountUuid, (orgCount.get(a.accountUuid) || 0) + 1);
   }
+  for (const [i, a] of config.accounts.entries()) {
+    const p = profiles[i];
+    const email = (p && !p.error && p.email) ? p.email : null;
+    if (!email) continue;
+    const newName = orgCount.get(a.accountUuid) > 1 ? `${email} (${orgLabel(a)})` : email;
+    if (a.name !== newName) { a.name = newName; touched = true; }
+  }
+
+  if (touched) await saveConfig(config);
+  if (removed > 0) console.log(`Removed ${removed} duplicate account(s)\n`);
 
   for (const [i, a] of config.accounts.entries()) {
     const p = profiles[i];
@@ -526,7 +547,7 @@ async function apiCommand() {
   const accounts = await resolveAccounts(config);
   let account;
   if (accountName) {
-    account = accounts.find(a => a.name === accountName);
+    account = resolveAccount(accounts, accountName, argValue('--org'));
     if (!account) { console.error(`Account "${accountName}" not found`); process.exit(1); }
   } else {
     account = accounts.find(a => a.type === 'oauth') || accounts[0];
@@ -568,24 +589,83 @@ async function apiCommand() {
 
 // ── remove ──────────────────────────────────────────────────
 
+/**
+ * Resolve a single account from a name-or-email query.
+ *
+ * An exact display-name match wins. Otherwise match by email (the part before a
+ * " (org)" suffix), optionally narrowed by --org. If still ambiguous across
+ * orgs, print the candidates and exit so the caller can disambiguate with --org.
+ * Returns the matched account, or null if nothing matched.
+ */
+function resolveAccount(accounts, query, orgFilter) {
+  const matches = matchAccounts(accounts, query, orgFilter);
+  if (matches.length === 1) return matches[0];
+  if (matches.length === 0) return null;
+  console.error(`"${query}" matches ${matches.length} accounts — disambiguate with --org <name|uuid>:`);
+  for (const a of matches) {
+    console.error(`  - ${a.name}${a.orgName ? `  (org: ${a.orgName})` : ''}`);
+  }
+  process.exit(1);
+}
+
 async function removeCommand() {
   const config = await loadOrCreateConfig();
   const name = args[1];
 
   if (!name) {
-    console.error('Usage: teamclaude remove <account-name>');
+    console.error('Usage: teamclaude remove <account-name|email> [--org <name|uuid>]');
     process.exit(1);
   }
 
-  const idx = config.accounts.findIndex(a => a.name === name);
-  if (idx < 0) {
+  const account = resolveAccount(config.accounts, name, argValue('--org'));
+  if (!account) {
     console.error(`Account "${name}" not found`);
     process.exit(1);
   }
 
-  config.accounts.splice(idx, 1);
+  config.accounts.splice(config.accounts.indexOf(account), 1);
   await saveConfig(config);
-  console.log(`Removed account "${name}"`);
+  console.log(`Removed account "${account.name}"`);
+}
+
+// ── priority ────────────────────────────────────────────────
+
+async function priorityCommand() {
+  const config = await loadOrCreateConfig();
+  const name = args[1];
+
+  if (!name) {
+    console.error('Usage: teamclaude priority <account-name|email> <n> [--org <name|uuid>]');
+    console.error('       teamclaude priority <account-name|email> --first | --last');
+    console.error('Lower priority is preferred for rotation (default 0).');
+    process.exit(1);
+  }
+
+  const account = resolveAccount(config.accounts, name, argValue('--org'));
+  if (!account) {
+    console.error(`Account "${name}" not found`);
+    process.exit(1);
+  }
+
+  const priorities = config.accounts.map(a => a.priority || 0);
+  let priority;
+  if (args.includes('--first')) {
+    priority = Math.min(0, ...priorities) - 1;
+  } else if (args.includes('--last')) {
+    priority = Math.max(0, ...priorities) + 1;
+  } else {
+    // Accept the integer in any position (e.g. after --org) — first int-looking token.
+    const numTok = args.slice(2).find(t => /^-?\d+$/.test(t));
+    priority = numTok != null ? parseInt(numTok, 10) : NaN;
+    if (Number.isNaN(priority)) {
+      console.error('Provide an integer priority, or --first / --last.');
+      process.exit(1);
+    }
+  }
+
+  account.priority = priority;
+  await saveConfig(config);
+  console.log(`Set priority of "${account.name}" to ${priority} (lower = preferred)`);
 }
 
 // ── help ────────────────────────────────────────────────────
@@ -604,12 +684,14 @@ Commands:
   run [-- args...]    Run Claude Code through the proxy
   status              Show proxy & account status (live)
   accounts            List configured accounts
-  remove <name>       Remove an account
+  remove <name>       Remove an account (by name or email; --org to disambiguate)
+  priority <name> <n> Set rotation priority (lower = preferred; --first/--last)
   api <path>          Call an API endpoint with account credentials
   help                Show this help
 
 Options:
   --name NAME         Set account name (import/login)
+  --org NAME|UUID     Disambiguate when an email spans multiple orgs (remove/priority/api)
   --from PATH         Credentials path (import, default: ~/.claude/.credentials.json)
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
@@ -621,8 +703,14 @@ Config: ${getConfigPath()}
 
 // ── shared account upsert ────────────────────────────────────
 
+/** Short human label for an account's organization, for disambiguating names. */
+function orgLabel(a) {
+  return a.orgName || (a.orgUuid ? a.orgUuid.slice(0, 8) : 'org');
+}
+
 async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
-  // Fetch profile to auto-name and deduplicate by account UUID
+  // Fetch profile to auto-name and deduplicate by account+org identity.
+  const userNamed = !!name;
   const profile = await fetchProfile(creds.accessToken);
   const profileOk = profile && !profile.error;
 
@@ -644,23 +732,40 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
     type: 'oauth',
     source,
     accountUuid: profile?.accountUuid || null,
+    orgUuid: profile?.orgUuid || null,
+    orgName: profile?.orgName || null,
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
   };
 
-  // Deduplicate: match by UUID first, then by name
-  let idx = profile?.accountUuid
-    ? config.accounts.findIndex(a => a.accountUuid === profile.accountUuid)
-    : -1;
+  // Deduplicate by account+org identity (same email in a different org is a
+  // distinct account), then by name.
+  let idx = config.accounts.findIndex(a => sameIdentity(a, account));
   if (idx < 0) idx = config.accounts.findIndex(a => a.name === name);
 
   if (idx >= 0) {
-    config.accounts[idx] = account;
-    console.log(`Updated account "${name}"`);
+    // Same account+org: refresh credentials and org info, but keep the existing
+    // display name and any disk-only fields (e.g. importFrom).
+    const prev = config.accounts[idx];
+    config.accounts[idx] = { ...prev, ...account, name: prev.name };
+    console.log(`Updated account "${prev.name}"`);
   } else {
+    // New org for this person: if another entry shares the accountUuid, the bare
+    // email name would collide — disambiguate both with " (org)".
+    if (!userNamed && account.accountUuid) {
+      const collisions = config.accounts.filter(
+        a => a.accountUuid === account.accountUuid && !sameIdentity(a, account)
+      );
+      if (collisions.length > 0) {
+        for (const c of collisions) {
+          if (!c.name.includes(' (')) c.name = `${c.name} (${orgLabel(c)})`;
+        }
+        account.name = `${name} (${orgLabel(account)})`;
+      }
+    }
     config.accounts.push(account);
-    console.log(`Added account "${name}"`);
+    console.log(`Added account "${account.name}"`);
   }
 
   await saveConfig(config);
@@ -670,14 +775,10 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
 // ── config sync helpers ─────────────────────────────────────
 
 /**
- * Find a config account entry matching an in-memory account (by UUID, then name).
+ * Find a config account entry matching an in-memory account by account+org identity.
  */
 function findConfigAccount(diskConfig, account) {
-  if (account.accountUuid) {
-    const idx = diskConfig.accounts.findIndex(a => a.accountUuid === account.accountUuid);
-    if (idx >= 0) return idx;
-  }
-  return diskConfig.accounts.findIndex(a => a.name === account.name);
+  return diskConfig.accounts.findIndex(a => sameIdentity(a, account));
 }
 
 /**
@@ -687,20 +788,42 @@ function findConfigAccount(diskConfig, account) {
  */
 async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
   let added = 0;
-  for (const diskAcct of diskConfig.accounts) {
-    const matchByUuid = diskAcct.accountUuid &&
-      memConfig.accounts.findIndex(a => a.accountUuid === diskAcct.accountUuid);
-    const matchByName = memConfig.accounts.findIndex(a => a.name === diskAcct.name);
-    const memIdx = (matchByUuid >= 0 ? matchByUuid : null) ?? (matchByName >= 0 ? matchByName : -1);
+  // Greedy 1:1 pairing of disk entries to in-memory accounts, account+org aware.
+  // Each disk entry claims at most one unclaimed manager account, so multiple
+  // same-person/different-org entries pair correctly instead of all matching the
+  // first one with that accountUuid.
+  const claimed = new Set();
+  const claim = (diskAcct) => {
+    for (let i = 0; i < accountManager.accounts.length; i++) {
+      if (!claimed.has(i) && sameIdentity(accountManager.accounts[i], diskAcct)) {
+        claimed.add(i);
+        return i;
+      }
+    }
+    return -1;
+  };
 
-    if (memIdx < 0) {
+  for (const diskAcct of diskConfig.accounts) {
+    const mgrIdx = claim(diskAcct);
+
+    if (mgrIdx < 0) {
       // New account discovered on disk — add to running server
       memConfig.accounts.push(diskAcct);
       accountManager.addAccount(diskAcct);
+      claimed.add(accountManager.accounts.length - 1);
       added++;
       console.log(`[TeamClaude] Picked up new account "${diskAcct.name}" from config`);
       continue;
     }
+
+    const mgr = accountManager.accounts[mgrIdx];
+
+    // Backfill org identity and pick up renames/priority onto the running
+    // account (e.g. after disk-side org disambiguation or a `priority` change).
+    if (diskAcct.orgUuid && !mgr.orgUuid) mgr.orgUuid = diskAcct.orgUuid;
+    if (diskAcct.orgName && !mgr.orgName) mgr.orgName = diskAcct.orgName;
+    if (diskAcct.name && mgr.name !== diskAcct.name) mgr.name = diskAcct.name;
+    if (diskAcct.priority != null && mgr.priority !== diskAcct.priority) mgr.priority = diskAcct.priority;
 
     // Existing account — resolve fresh credentials from disk
     let freshCred = null;
@@ -718,12 +841,6 @@ async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
     }
 
     if (!freshCred) continue;
-
-    // Find the corresponding AccountManager entry and update credentials
-    const mgr = accountManager.accounts.find(a =>
-      (diskAcct.accountUuid && a.accountUuid === diskAcct.accountUuid) || a.name === diskAcct.name
-    );
-    if (!mgr) continue;
 
     if (freshCred.accessToken) {
       const changed = mgr.credential !== freshCred.accessToken ||

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -129,6 +129,7 @@ export async function fetchProfile(accessToken) {
       accountUuid: data.account?.uuid,
       email: data.account?.email,
       name: data.account?.display_name,
+      orgUuid: data.organization?.uuid,
       orgName: data.organization?.name,
       orgType: data.organization?.organization_type,
       hasClaudeMax: data.account?.has_claude_max,

--- a/src/tui.js
+++ b/src/tui.js
@@ -1,4 +1,5 @@
 import { importCredentials, fetchProfile } from './oauth.js';
+import { sameIdentity } from './identity.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -314,34 +315,50 @@ export class TUI {
       const entry = {
         name, type: 'oauth', source: 'import',
         accountUuid: profile?.accountUuid || null,
+        orgUuid: profile?.orgUuid || null,
+        orgName: profile?.orgName || null,
         accessToken: creds.accessToken,
         refreshToken: creds.refreshToken,
         expiresAt: creds.expiresAt,
       };
 
-      // Deduplicate: match by UUID first, then by name
-      let idx = profile?.accountUuid
-        ? this.config.accounts.findIndex(a => a.accountUuid === profile.accountUuid)
-        : -1;
+      // Deduplicate by account+org identity (same email in a different org is a
+      // distinct account), then by name.
+      let idx = this.config.accounts.findIndex(a => sameIdentity(a, entry));
       if (idx < 0) idx = this.config.accounts.findIndex(a => a.name === name);
 
       if (idx >= 0) {
-        this.config.accounts[idx] = entry;
+        const prev = this.config.accounts[idx];
+        this.config.accounts[idx] = { ...prev, ...entry, name: prev.name };
         // Update the running account manager entry
-        const amAcct = this.am.accounts[idx];
+        const amAcct = this.am.accounts.find(a => sameIdentity(a, entry)) || this.am.accounts[idx];
         if (amAcct) {
           amAcct.credential = creds.accessToken;
           amAcct.refreshToken = creds.refreshToken;
           amAcct.expiresAt = creds.expiresAt;
           amAcct.accountUuid = entry.accountUuid;
-          amAcct.name = name;
+          amAcct.orgUuid = entry.orgUuid;
+          amAcct.orgName = entry.orgName;
           if (amAcct.status === 'error') amAcct.status = 'active';
         }
-        this._addLog(`Updated account "${name}"`);
+        this._addLog(`Updated account "${prev.name}"`);
       } else {
+        // New org for this person: disambiguate colliding email names with " (org)".
+        if (profile?.accountUuid) {
+          const orgLbl = a => a.orgName || (a.orgUuid ? a.orgUuid.slice(0, 8) : 'org');
+          const collisions = this.config.accounts.filter(
+            a => a.accountUuid === entry.accountUuid && !sameIdentity(a, entry)
+          );
+          if (collisions.length > 0) {
+            for (const c of collisions) {
+              if (!c.name.includes(' (')) c.name = `${c.name} (${orgLbl(c)})`;
+            }
+            entry.name = `${name} (${orgLbl(entry)})`;
+          }
+        }
         this.config.accounts.push(entry);
         this.am.addAccount(entry);
-        this._addLog(`Imported account "${name}"`);
+        this._addLog(`Imported account "${entry.name}"`);
       }
 
       await this.saveConfig(this.config);

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { orgKey, sameIdentity, emailOf, matchAccounts } from '../src/identity.js';
+
+test('orgKey prefers orgUuid, falls back to orgName, else null', () => {
+  assert.equal(orgKey({ orgUuid: 'u1', orgName: 'Acme' }), 'u1');
+  assert.equal(orgKey({ orgName: 'Acme' }), 'Acme');
+  assert.equal(orgKey({}), null);
+  assert.equal(orgKey(null), null);
+});
+
+test('same person, same org → same identity', () => {
+  const a = { accountUuid: 'p1', orgUuid: 'o1' };
+  const b = { accountUuid: 'p1', orgUuid: 'o1' };
+  assert.equal(sameIdentity(a, b), true);
+});
+
+test('same person, different org → distinct identities', () => {
+  const a = { accountUuid: 'p1', orgUuid: 'o1' };
+  const b = { accountUuid: 'p1', orgUuid: 'o2' };
+  assert.equal(sameIdentity(a, b), false);
+});
+
+test('different person → distinct identities regardless of org', () => {
+  const a = { accountUuid: 'p1', orgUuid: 'o1' };
+  const b = { accountUuid: 'p2', orgUuid: 'o1' };
+  assert.equal(sameIdentity(a, b), false);
+});
+
+test('legacy entry (no org) matches a freshly-profiled login of the same person (backfill path)', () => {
+  const legacy = { accountUuid: 'p1', name: 'a@x.com' };          // no org stored yet
+  const fresh = { accountUuid: 'p1', orgUuid: 'o1', name: 'a@x.com' };
+  assert.equal(sameIdentity(legacy, fresh), true);
+});
+
+test('orgName falls back as discriminator when orgUuid absent', () => {
+  const a = { accountUuid: 'p1', orgName: 'Acme' };
+  const b = { accountUuid: 'p1', orgName: 'Personal' };
+  assert.equal(sameIdentity(a, b), false);
+  const c = { accountUuid: 'p1', orgName: 'Acme' };
+  assert.equal(sameIdentity(a, c), true);
+});
+
+// The migration scenario end-to-end: a legacy entry exists, then two different
+// orgs for the same person are added in sequence. After the first add backfills
+// the legacy entry's org, the second org must be recognized as distinct.
+test('legacy + two different orgs added in sequence resolves to two distinct accounts', () => {
+  const accounts = [{ accountUuid: 'p1', name: 'a@x.com' }]; // legacy, org unknown
+
+  // First login carries org o1: matches the legacy entry (one org unknown) → backfill in place.
+  const first = { accountUuid: 'p1', orgUuid: 'o1', name: 'a@x.com' };
+  let idx = accounts.findIndex(a => sameIdentity(a, first));
+  assert.equal(idx, 0);
+  accounts[idx] = { ...accounts[idx], ...first };
+
+  // Second login carries org o2: both org keys now known and differ → new account.
+  const second = { accountUuid: 'p1', orgUuid: 'o2', name: 'a@x.com' };
+  idx = accounts.findIndex(a => sameIdentity(a, second));
+  assert.equal(idx, -1);
+  accounts.push(second);
+
+  assert.equal(accounts.length, 2);
+});
+
+test('apikey / no-uuid accounts fall back to name matching', () => {
+  assert.equal(sameIdentity({ name: 'k1' }, { name: 'k1' }), true);
+  assert.equal(sameIdentity({ name: 'k1' }, { name: 'k2' }), false);
+});
+
+test('emailOf strips a " (org)" suffix', () => {
+  assert.equal(emailOf({ name: 'a@x.com (Acme)' }), 'a@x.com');
+  assert.equal(emailOf({ name: 'a@x.com' }), 'a@x.com');
+  assert.equal(emailOf({}), '');
+});
+
+// resolveAccount in index.js is built on matchAccounts; cover the routing here.
+const ACCTS = [
+  { name: 'a@x.com (Acme)', accountUuid: 'p1', orgUuid: 'o-acme', orgName: 'Acme' },
+  { name: 'a@x.com (Personal)', accountUuid: 'p1', orgUuid: 'o-pers', orgName: 'Personal' },
+  { name: 'b@y.com', accountUuid: 'p2', orgUuid: 'o-b', orgName: 'BizCo' },
+];
+
+test('matchAccounts: exact display-name match wins', () => {
+  const m = matchAccounts(ACCTS, 'a@x.com (Acme)');
+  assert.equal(m.length, 1);
+  assert.equal(m[0].orgName, 'Acme');
+});
+
+test('matchAccounts: bare email is ambiguous across orgs', () => {
+  const m = matchAccounts(ACCTS, 'a@x.com');
+  assert.equal(m.length, 2);
+});
+
+test('matchAccounts: --org narrows by org name or uuid prefix', () => {
+  assert.equal(matchAccounts(ACCTS, 'a@x.com', 'Personal').length, 1);
+  assert.equal(matchAccounts(ACCTS, 'a@x.com', 'o-acme').length, 1);
+  assert.equal(matchAccounts(ACCTS, 'a@x.com', 'o-ac')[0].orgName, 'Acme'); // uuid prefix
+});
+
+test('matchAccounts: unique email needs no org', () => {
+  assert.equal(matchAccounts(ACCTS, 'b@y.com').length, 1);
+});
+
+test('matchAccounts: no match returns empty', () => {
+  assert.equal(matchAccounts(ACCTS, 'nobody@z.com').length, 0);
+});

--- a/test/rotation-priority.test.js
+++ b/test/rotation-priority.test.js
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// Make an account "exhausted" so _selectNext skips it, isolating the priority sort.
+function exhaust(am, idx) {
+  am.accounts[idx].status = 'exhausted';
+}
+
+test('default priority (all 0) preserves the existing selection (first available)', () => {
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  // No quota known anywhere → weeklyReset is -Infinity for all, ties on priority 0,
+  // so the first available account is chosen, matching pre-priority behavior.
+  const next = am._selectNext();
+  assert.equal(next.name, 'a');
+});
+
+test('lower priority value is preferred over config order', () => {
+  const am = new AccountManager([
+    oauth('a', { priority: 5 }),
+    oauth('b', { priority: 1 }),
+    oauth('c', { priority: 3 }),
+  ], 0.98);
+  assert.equal(am._selectNext().name, 'b');
+});
+
+test('within the same priority, the existing heuristic breaks the tie', () => {
+  const am = new AccountManager([
+    oauth('a', { priority: 0 }),
+    oauth('b', { priority: 0 }),
+  ], 0.98);
+  // Give both a known weekly reset; the sooner-expiring one should win the tie.
+  am.accounts[0].quota.unified7dReset = 5000;
+  am.accounts[1].quota.unified7dReset = 1000;
+  assert.equal(am._selectNext().name, 'b');
+});
+
+test('priority is respected even when a higher-priority account is also available', () => {
+  const am = new AccountManager([
+    oauth('a', { priority: 0 }),
+    oauth('b', { priority: -1 }), // most preferred
+    oauth('c', { priority: 10 }),
+  ], 0.98);
+  assert.equal(am._selectNext().name, 'b');
+});
+
+test('exhausted highest-priority account is skipped, next priority wins', () => {
+  const am = new AccountManager([
+    oauth('a', { priority: 1 }),
+    oauth('b', { priority: 2 }),
+  ], 0.98);
+  exhaust(am, 0);
+  assert.equal(am._selectNext().name, 'b');
+});


### PR DESCRIPTION
Closes #6, closes #7.

## Problem
One Anthropic account (same email / `accountUuid`) can hold **multiple subscriptions across different organizations** — e.g. a corporate Pro org and a personal Max org. Identity was keyed only on `accountUuid` (with `name` as fallback), so connecting the second org **overwrote** the first (#6), and `--name` didn't help because the UUID check won (#7).

## Approach
Identity is now **`accountUuid` + organization**. This was **re-implemented and reviewed line-by-line against `master`** rather than cherry-picked from the closed fork PRs (#15/#17) — per maintainer policy, and because the repo has already been targeted by a malicious soft-fork (#9), external diffs are treated as untrusted.

## Changes
- **`src/identity.js`** (new) — `orgKey` / `sameIdentity` / `matchAccounts` / `emailOf`. `sameIdentity` treats an *unknown* org on either side as a match, so a freshly-profiled login **backfills a legacy entry** instead of duplicating it; once both orgs are known, a different org is a distinct account.
- **`fetchProfile`** extracts `organization.uuid`; accounts persist `orgUuid`/`orgName`.
- **All ~14 dedup/sync/find match sites** converted to `sameIdentity`. `syncAccountsFromDisk` uses a **greedy 1:1 claim** so multiple same-person/different-org entries pair correctly instead of all matching the first. The `accounts` command dedups by `(accountUuid, org)` and backfills org identity from the profile.
- **Name disambiguation** — single org → `email`; multiple → `email (Org)`, renaming the existing collider too. Names stay unique because they're the user-facing key for `remove`/`api`/selection.
- **Org-aware `remove` + `api`** — resolve by name or email; `--org <name|uuid>` disambiguates; ambiguous queries list the candidates.
- **Rotation priority** — `priority` field (lower = preferred, default `0`) is the primary sort key in `_selectNext`, with the existing weekly-reset heuristic as the tiebreaker (default `0` everywhere ⇒ unchanged behavior). New `teamclaude priority <name> <n>` command (`--first`/`--last`). Session-reset switching won't demote to a worse priority.

## Tests
`npm test` — **22 passing**. New `test/identity.test.js` (sameIdentity incl. legacy-backfill + two-orgs migration; matchAccounts/email/--org routing) and `test/rotation-priority.test.js` (priority ordering, tiebreak, default-0 parity). Lint clean (one pre-existing unrelated warning).

## Backward compatibility
Existing single-account configs (no `orgUuid`) run unchanged; an entry is backfilled with its org after one `accounts`/profile fetch.

## Out of scope (future PRs, from the #18 stack)
- #14 headless mode + reload API + background prober
- #16 usage-endpoint quota + error-state recovery
- #13 429 account-failover — **not taken**: the throttle is IP-based, so the merged #25 back-off is the correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)