### PR TITLE
Preempt to a higher-priority account when one is available

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -65,7 +65,13 @@ export class AccountManager {
       if (next) return next;
     }
     if (this._isAvailable(current)) {
-      return current;
+      // A strictly higher-priority (lower value) available account preempts a
+      // healthy current one. Within the same priority tier we stay put, so the
+      // common case (all accounts at the default priority 0) is unchanged and
+      // never thrashes — preemption only triggers when priorities differ.
+      const betterExists = this.accounts.some(a =>
+        this._isAvailable(a) && (a.priority || 0) < (current.priority || 0));
+      return betterExists ? this._selectNext() : current;
     }
     return this._selectNext();
   }

--- a/test/rotation-priority.test.js
+++ b/test/rotation-priority.test.js
@@ -56,3 +56,26 @@ test('exhausted highest-priority account is skipped, next priority wins', () => 
   exhaust(am, 0);
   assert.equal(am._selectNext().name, 'b');
 });
+
+test('getActiveAccount preempts a healthy current account for a higher-priority one', () => {
+  const am = new AccountManager([oauth('a', { priority: 0 }), oauth('b', { priority: 1 })], 0.98);
+  am.currentIndex = 1; // currently on the lower-priority account
+  assert.equal(am.getActiveAccount().name, 'a');
+  assert.equal(am.currentIndex, 0);
+});
+
+test('getActiveAccount stays sticky within the same priority tier (no thrash)', () => {
+  const am = new AccountManager([oauth('a', { priority: 0 }), oauth('b', { priority: 0 })], 0.98);
+  am.currentIndex = 0;
+  // b has a sooner weekly reset, but same priority → must NOT switch away from a.
+  am.accounts[0].quota.unified7dReset = 5000;
+  am.accounts[1].quota.unified7dReset = 1000;
+  assert.equal(am.getActiveAccount().name, 'a');
+  assert.equal(am.currentIndex, 0);
+});
+
+test('common case: all-equal priority leaves getActiveAccount on the healthy current account', () => {
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  am.currentIndex = 2;
+  assert.equal(am.getActiveAccount().name, 'c'); // unchanged — no preemption when priorities tie
+});


### PR DESCRIPTION
Follow-up refinement to the `priority` feature from #28.

## Problem
`priority` was only consulted inside `_selectNext`, which runs only when a switch is *forced* (current account exhausted/throttled, or on requalify/session-reset). `getActiveAccount` returns the current account as long as it's available — without checking priority. So if rotation landed on a lower-priority account and your preferred (higher-priority) account recovered, the proxy wouldn't resume it until the current one ran low.

## Change
`getActiveAccount` now preempts a healthy current account when a **strictly higher-priority** (lower value) account is available, while staying **sticky within the same priority tier**:

```js
if (this._isAvailable(current)) {
  const betterExists = this.accounts.some(a =>
    this._isAvailable(a) && (a.priority || 0) < (current.priority || 0));
  return betterExists ? this._selectNext() : current;
}
```

## Why this is safe
- **Common case unchanged:** with all accounts at the default priority `0`, no account is strictly higher than another, so `betterExists` is always false and behavior is identical to today — no extra switching, no thrash.
- **Sticky within a tier:** equal-priority accounts never preempt each other, so the per-request weekly-reset heuristic doesn't cause churn.
- **Exhaustion + weekly heuristic intact:** `_isAvailable` (session/weekly threshold) is still checked first, and `_selectNext` still applies the soonest-weekly-reset tiebreaker within a tier.

## Tests
`test/rotation-priority.test.js` extended: preemption to a higher tier, stickiness within a tier, and the all-equal-priority no-op. 8/8 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)