### PR TITLE
Persist observed quota across restarts (state file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Hot-reload accounts** — add accounts via `import` or `login` while the server is running, press **R** to pick them up
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
+- **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
 
@@ -152,6 +153,8 @@ teamclaude server --log-to /tmp/requests
 ## Configuration
 
 Config is stored at `~/.config/teamclaude.json` (or `$XDG_CONFIG_HOME/teamclaude.json`). A random proxy API key is generated on first use.
+
+Volatile runtime state (observed quota) is written separately to `teamclaude.state.json` alongside the config, so the config file stays clean and hand-editable. The state file is safe to delete — quota is simply re-learned from traffic.
 
 Override the config path with `TEAMCLAUDE_CONFIG`:
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,4 +1,13 @@
 import { refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
+import { sameIdentity } from './identity.js';
+
+// Quota fields that survive a restart: utilization levels and their reset
+// windows, learned passively from upstream responses. Transient/derived state
+// (probing, requalify, rateLimitedUntil) is intentionally excluded.
+const PERSISTED_QUOTA_FIELDS = [
+  'unified5h', 'unified7d', 'unified5hReset', 'unified7dReset', 'unifiedStatus',
+  'tokensLimit', 'tokensRemaining', 'requestsLimit', 'requestsRemaining', 'resetsAt',
+];
 
 function emptyQuota() {
   return {
@@ -463,6 +472,36 @@ export class AccountManager {
       this.currentIndex = Math.max(0, this.accounts.length - 1);
     } else if (this.currentIndex > index) {
       this.currentIndex--;
+    }
+  }
+
+  /**
+   * Serialize persistable quota state for all accounts (no credentials), keyed
+   * by account identity so it can be matched back after a restart.
+   */
+  exportQuotaState() {
+    return this.accounts.map(a => {
+      const quota = {};
+      for (const f of PERSISTED_QUOTA_FIELDS) quota[f] = a.quota[f];
+      return { accountUuid: a.accountUuid, orgUuid: a.orgUuid, orgName: a.orgName, name: a.name, quota };
+    });
+  }
+
+  /**
+   * Restore quota learned in a previous run. Matches saved entries to accounts
+   * by identity. Stale windows are not special-cased here — _clearExpiredQuotas
+   * wipes any restored window whose reset time has already passed on first use.
+   */
+  restoreQuotaState(saved) {
+    if (!Array.isArray(saved)) return;
+    for (const account of this.accounts) {
+      const match = saved.find(s => sameIdentity(s, account));
+      if (!match || !match.quota) continue;
+      for (const f of PERSISTED_QUOTA_FIELDS) {
+        if (match.quota[f] != null) account.quota[f] = match.quota[f];
+      }
+      // We already know this account's weekly window, so it isn't "probing".
+      if (account.quota.unified7dReset != null) account.probing = false;
     }
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,32 @@ export function getConfigPath() {
   return join(configDir, 'teamclaude.json');
 }
 
+/**
+ * Path to the runtime state file (a sibling of the config). This holds volatile
+ * data learned at runtime — e.g. quota utilization observed passively from
+ * traffic — kept out of the hand-editable config so config stays clean and
+ * isn't rewritten on every state save.
+ */
+export function getStatePath() {
+  const cfg = getConfigPath();
+  return cfg.endsWith('.json') ? cfg.replace(/\.json$/, '.state.json') : cfg + '.state';
+}
+
+export async function loadState() {
+  try {
+    return JSON.parse(await readFile(getStatePath(), 'utf-8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+export async function saveState(state) {
+  const path = getStatePath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+}
+
 export function createDefaultConfig() {
   return {
     proxy: {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
-import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath } from './config.js';
+import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, loadState, saveState } from './config.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
@@ -94,6 +94,21 @@ async function serverCommand() {
   const threshold = config.switchThreshold || 0.98;
   const accountManager = new AccountManager(accounts, threshold);
 
+  // Restore quota observed in a previous run so a restart doesn't lose rotation
+  // state (passive — we never call the API to re-learn it). Stale windows are
+  // cleared automatically on first use by _clearExpiredQuotas.
+  const savedState = await loadState().catch(err => {
+    console.error(`[TeamClaude] Could not read saved state: ${err.message}`);
+    return null;
+  });
+  if (savedState?.quota) accountManager.restoreQuotaState(savedState.quota);
+
+  // Periodically persist quota (and once more on shutdown) to the state file.
+  const persistQuotaState = () =>
+    saveState({ quota: accountManager.exportQuotaState() })
+      .catch(err => console.error(`[TeamClaude] Failed to save quota state: ${err.message}`));
+  let quotaSaveInterval = null;
+
   // Persist refreshed tokens back to config (re-read from disk to avoid clobbering
   // accounts added externally, e.g. by `teamclaude import` while server is running)
   accountManager.onTokenRefresh((idx, newTokens) => {
@@ -154,7 +169,11 @@ async function serverCommand() {
         if (!diskConfig) return 0;
         return syncAccountsFromDisk(diskConfig, config, accountManager);
       },
-      onQuit: () => { server.close(() => process.exit(0)); },
+      onQuit: async () => {
+        if (quotaSaveInterval) clearInterval(quotaSaveInterval);
+        await persistQuotaState();
+        server.close(() => process.exit(0));
+      },
     });
     hooks = {
       onRequestStart: (id, info) => tui.onRequestStart(id, info),
@@ -200,15 +219,19 @@ async function serverCommand() {
     }
   });
 
+  // Persist quota every minute; unref so it never keeps the process alive.
+  quotaSaveInterval = setInterval(persistQuotaState, 60_000);
+  quotaSaveInterval.unref?.();
+
   if (!tui) {
-    process.on('SIGINT', () => {
+    const shutdown = async () => {
       console.log('\n[TeamClaude] Shutting down...');
+      clearInterval(quotaSaveInterval);
+      await persistQuotaState();
       server.close(() => process.exit(0));
-    });
-    process.on('SIGTERM', () => {
-      console.log('\n[TeamClaude] Shutting down...');
-      server.close(() => process.exit(0));
-    });
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   }
 }
 

--- a/test/quota-persistence.test.js
+++ b/test/quota-persistence.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { getStatePath } from '../src/config.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+test('exportQuotaState carries only persistable fields and identity, no credentials', () => {
+  const am = new AccountManager([oauth('a', { accountUuid: 'p1', orgUuid: 'o1', orgName: 'Acme' })], 0.98);
+  am.accounts[0].quota.unified7d = 0.42;
+  const [entry] = am.exportQuotaState();
+
+  assert.deepEqual(Object.keys(entry).sort(), ['accountUuid', 'name', 'orgName', 'orgUuid', 'quota'].sort());
+  assert.equal(entry.accountUuid, 'p1');
+  assert.equal(entry.quota.unified7d, 0.42);
+  // Transient/credential fields must not leak.
+  assert.ok(!('probing' in entry.quota));
+  assert.ok(!('rateLimitedUntil' in entry.quota));
+  assert.ok(!('credential' in entry));
+  assert.ok(!('accessToken' in entry));
+});
+
+test('quota survives an export → restore round-trip', () => {
+  const am1 = new AccountManager([oauth('a', { accountUuid: 'p1', orgUuid: 'o1' })], 0.98);
+  const future = Date.now() + 3600_000;
+  Object.assign(am1.accounts[0].quota, { unified5h: 0.3, unified7d: 0.6, unified7dReset: future });
+
+  const am2 = new AccountManager([oauth('a', { accountUuid: 'p1', orgUuid: 'o1' })], 0.98);
+  am2.restoreQuotaState(am1.exportQuotaState());
+
+  assert.equal(am2.accounts[0].quota.unified5h, 0.3);
+  assert.equal(am2.accounts[0].quota.unified7d, 0.6);
+  assert.equal(am2.accounts[0].quota.unified7dReset, future);
+  assert.equal(am2.accounts[0].probing, false); // weekly window known → not probing
+});
+
+test('restore matches by identity, not array position', () => {
+  const am1 = new AccountManager([
+    oauth('a@x.com (Acme)', { accountUuid: 'p1', orgUuid: 'o1' }),
+    oauth('a@x.com (Personal)', { accountUuid: 'p1', orgUuid: 'o2' }),
+  ], 0.98);
+  am1.accounts[0].quota.unified7d = 0.1; // Acme
+  am1.accounts[1].quota.unified7d = 0.9; // Personal
+  const saved = am1.exportQuotaState();
+
+  // Reverse the order in the new manager — restore must still match by org.
+  const am2 = new AccountManager([
+    oauth('a@x.com (Personal)', { accountUuid: 'p1', orgUuid: 'o2' }),
+    oauth('a@x.com (Acme)', { accountUuid: 'p1', orgUuid: 'o1' }),
+  ], 0.98);
+  am2.restoreQuotaState(saved);
+
+  assert.equal(am2.accounts[0].quota.unified7d, 0.9); // Personal
+  assert.equal(am2.accounts[1].quota.unified7d, 0.1); // Acme
+});
+
+test('a restored window whose reset already passed is cleared on first use', () => {
+  const am = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
+  am.restoreQuotaState([
+    { accountUuid: 'p1', quota: { unified7d: 0.5, unified7dReset: 1000 } }, // reset far in the past
+  ]);
+  assert.equal(am.accounts[0].quota.unified7d, 0.5); // restored...
+  am.refreshExpiredQuotas();
+  assert.equal(am.accounts[0].quota.unified7d, null); // ...then cleared as stale
+});
+
+test('restoreQuotaState ignores a non-array / missing payload', () => {
+  const am = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
+  am.restoreQuotaState(undefined);
+  am.restoreQuotaState(null);
+  assert.equal(am.accounts[0].quota.unified7d, null); // unchanged, no throw
+});
+
+test('getStatePath sits beside the config as a .state.json sibling', () => {
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = '/tmp/teamclaude-xyz.json';
+  try {
+    assert.equal(getStatePath(), '/tmp/teamclaude-xyz.state.json');
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+  }
+});


### PR DESCRIPTION
Adapts the useful half of #4 (quota persistence), reworked to fit the passive-only design and current `master`.

## Problem
Quota is learned passively from upstream response headers. On restart that state was lost, so the proxy re-probed and could mis-rotate until it re-learned each account's window.

## Approach (passive — no API calls)
Persist the observed quota to disk and restore it on startup. Nothing here polls the API; it only serializes what was already learned from traffic.

- **`config.js`** — `getStatePath`/`loadState`/`saveState`. Runtime state lives in a **`teamclaude.state.json` sibling** of the config, so volatile data stays out of the hand-editable config and config isn't rewritten on every save. (This differs from #4, which wrote a `savedQuota` blob into `config.json` every 60s.)
- **`account-manager.js`** — `exportQuotaState`/`restoreQuotaState`, keyed by **account identity** (`sameIdentity`, so it survives reordering and multi-org accounts). Persists only utilization + reset windows (`PERSISTED_QUOTA_FIELDS`); credentials and transient state (`probing`/`requalify`/`rateLimitedUntil`) are excluded. Restored accounts with a known weekly window are no longer flagged `probing`.
- **`index.js`** — restore on startup; persist every 60s (`unref`'d) and once more on `SIGINT`/`SIGTERM`/quit.

## Staleness
A restored window whose reset already passed is wiped on first use by the existing `_clearExpiredQuotas`, so a long downtime can't resurrect an expired window.

## Dropped from #4
The **TUI account-reorder** feature is intentionally not carried over — it's superseded by the `priority` command (#28), and its save path used pre-#28 identity matching that mis-handles org-aware accounts.

## Tests
`test/quota-persistence.test.js` — export/restore round-trip, identity-keyed (not positional) matching, stale-window clearing, bad-payload guard, and state-path derivation. Full suite 28 passing, lint clean.

Credit to @rlawjdghksdlqslek for the original idea in #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)