### PR TITLE
CI: test across the supported Node range (18–24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,21 @@ on:
     branches: [master]
 
 jobs:
-  test:
-    name: test
+  node:
+    name: node ${{ matrix.node }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover the whole supported range — package.json declares "node >=18".
+        node: [18, 20, 22, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Node.js
+      - name: Set up Node.js ${{ matrix.node }}
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
 
       - name: Install dependencies
         run: npm install
@@ -25,4 +30,21 @@ jobs:
         run: npm test
 
       - name: Lint
+        if: matrix.node == 24
         run: npm run lint
+
+  # Single stable status check for branch protection to require, independent of
+  # how many Node versions the matrix runs. Always runs and fails explicitly if
+  # any matrix job did not succeed (so it is never silently "skipped").
+  test:
+    name: test
+    needs: node
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        if: needs.node.result != 'success'
+        run: |
+          echo "Node matrix did not pass: ${{ needs.node.result }}"
+          exit 1
+      - run: echo "All Node matrix jobs passed"


### PR DESCRIPTION
We advertise **Node.js 18+** (README and `package.json` `engines`), but CI only ran on Node 24 — so the minimum-supported claim was never actually verified.

## Change
- Run the test suite on a **matrix of Node 18, 20, 22, 24**, so 18 (the declared floor) and every maintained line are exercised.
- Lint runs **once** (on Node 24) — it's version-independent, no need to repeat it.
- An aggregate **`test`** job `needs` the matrix and gates on it, so branch protection keeps requiring a single stable `test` check regardless of matrix size. It uses `if: always()` and **fails explicitly** if any matrix job fails, so it can never be silently skipped.

## Why this matters
If Node 18 actually breaks (e.g. a newer API slipped in), this surfaces it — at which point we either fix it or bump the floor honestly. Either way the docs and CI agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)