### PR TITLE
Enable/disable accounts (pause without removing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Hot-reload accounts** — add accounts via `import` or `login` while the server is running, press **R** to pick them up
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
+- **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
@@ -106,6 +107,7 @@ Falls back to plain log output when not a TTY (e.g. running as a service).
 | `s` | Switch active account |
 | `a` | Add account (import or API key) |
 | `r` | Remove an account |
+| `d` | Enable/disable an account |
 | `R` | Reload accounts from config |
 | `q` | Quit |
 
@@ -131,6 +133,8 @@ teamclaude accounts          # List accounts with subscription tier and token st
 teamclaude accounts -v       # Also show token expiry times
 teamclaude status            # Show live proxy status (requires running server)
 teamclaude remove <name>     # Remove an account (by name or email)
+teamclaude disable <name>    # Temporarily exclude an account from rotation
+teamclaude enable <name>     # Re-enable it (also clears a stuck error state)
 teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
 teamclaude api <path>        # Call an API endpoint with account credentials
 teamclaude help              # Show all commands
@@ -197,6 +201,7 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
+| `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
 
 ## How It Works
 

--- a/config.example.json
+++ b/config.example.json
@@ -25,6 +25,7 @@
       "name": "api-fallback",
       "type": "apikey",
       "priority": 10,
+      "disabled": false,
       "apiKey": "sk-ant-api03-your-api-key"
     }
   ]

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -36,6 +36,7 @@ export class AccountManager {
       orgUuid: acct.orgUuid || null,
       orgName: acct.orgName || null,
       priority: acct.priority || 0,
+      disabled: acct.disabled || false,
       credential: acct.accessToken || acct.apiKey,
       refreshToken: acct.refreshToken || null,
       expiresAt: acct.expiresAt || null,
@@ -87,6 +88,9 @@ export class AccountManager {
 
   _isAvailable(account) {
     if (!account) return false;
+
+    // Manually disabled accounts are skipped entirely until re-enabled.
+    if (account.disabled) return false;
 
     // Check rate limit expiry
     if (account.status === 'throttled' && account.rateLimitedUntil) {
@@ -361,6 +365,22 @@ export class AccountManager {
   }
 
   /**
+   * Enable or disable an account. A disabled account is skipped by rotation
+   * until re-enabled. Re-enabling also clears a stuck 'error' state (and any
+   * lingering rate-limit hold) so the account is retried immediately.
+   */
+  setDisabled(accountIndex, disabled) {
+    const account = this.accounts[accountIndex];
+    if (!account) return;
+    account.disabled = disabled;
+    if (!disabled && account.status === 'error') {
+      account.status = 'active';
+      account.rateLimitedUntil = null;
+      console.log(`[TeamClaude] Account "${account.name}" re-enabled — clearing error state`);
+    }
+  }
+
+  /**
    * Mark an account as rate-limited for a given duration.
    */
   markRateLimited(accountIndex, retryAfterSeconds) {
@@ -448,6 +468,7 @@ export class AccountManager {
       orgUuid: acctData.orgUuid || null,
       orgName: acctData.orgName || null,
       priority: acctData.priority || 0,
+      disabled: acctData.disabled || false,
       credential: acctData.accessToken || acctData.apiKey,
       refreshToken: acctData.refreshToken || null,
       expiresAt: acctData.expiresAt || null,
@@ -517,6 +538,7 @@ export class AccountManager {
         type: a.type,
         orgName: a.orgName || null,
         priority: a.priority || 0,
+        disabled: a.disabled || false,
         status: a.status,
         quota: { ...a.quota },
         usage: { ...a.usage },

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,14 @@ switch (command) {
     await priorityCommand();
     process.exit(0);
     break;
+  case 'disable':
+    await setDisabledCommand(true);
+    process.exit(0);
+    break;
+  case 'enable':
+    await setDisabledCommand(false);
+    process.exit(0);
+    break;
   case 'api':
     await apiCommand();
     process.exit(0);
@@ -416,7 +424,7 @@ async function statusCommand() {
       const current = acct.name === data.currentAccount ? ' *' : '';
 
       console.log(`  ${acct.name} (${acct.type})${current}`);
-      console.log(`    Status:   ${acct.status}`);
+      console.log(`    Status:   ${acct.status}${acct.disabled ? ' (disabled)' : ''}`);
 
       if (q.unified5h != null || q.unified7d != null) {
         const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' : '-';
@@ -691,6 +699,36 @@ async function priorityCommand() {
   console.log(`Set priority of "${account.name}" to ${priority} (lower = preferred)`);
 }
 
+// ── enable / disable ────────────────────────────────────────
+
+async function setDisabledCommand(disabled) {
+  const config = await loadOrCreateConfig();
+  const name = args[1];
+  const verb = disabled ? 'disable' : 'enable';
+
+  if (!name) {
+    console.error(`Usage: teamclaude ${verb} <account-name|email> [--org <name|uuid>]`);
+    process.exit(1);
+  }
+
+  const account = resolveAccount(config.accounts, name, argValue('--org'));
+  if (!account) {
+    console.error(`Account "${name}" not found`);
+    process.exit(1);
+  }
+
+  if (disabled) {
+    account.disabled = true;
+  } else {
+    delete account.disabled;
+  }
+  await saveConfig(config);
+  console.log(`${disabled ? 'Disabled' : 'Enabled'} account "${account.name}"`);
+  if (!disabled) {
+    console.log('(restart or reload the running server to retry it if it was in an error state)');
+  }
+}
+
 // ── help ────────────────────────────────────────────────────
 
 function showHelp() {
@@ -708,6 +746,8 @@ Commands:
   status              Show proxy & account status (live)
   accounts            List configured accounts
   remove <name>       Remove an account (by name or email; --org to disambiguate)
+  disable <name>      Temporarily exclude an account from rotation
+  enable <name>       Re-enable a disabled account (also clears a stuck error)
   priority <name> <n> Set rotation priority (lower = preferred; --first/--last)
   api <path>          Call an API endpoint with account credentials
   help                Show this help
@@ -847,6 +887,9 @@ async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
     if (diskAcct.orgName && !mgr.orgName) mgr.orgName = diskAcct.orgName;
     if (diskAcct.name && mgr.name !== diskAcct.name) mgr.name = diskAcct.name;
     if (diskAcct.priority != null && mgr.priority !== diskAcct.priority) mgr.priority = diskAcct.priority;
+    // Pick up enable/disable toggles; re-enabling clears a stuck error state.
+    const wantDisabled = !!diskAcct.disabled;
+    if (mgr.disabled !== wantDisabled) accountManager.setDisabled(mgr.index, wantDisabled);
 
     // Existing account — resolve fresh credentials from disk
     let freshCred = null;

--- a/src/tui.js
+++ b/src/tui.js
@@ -233,6 +233,9 @@ export class TUI {
     else if (k === 'r' && this.am.accounts.length > 0) {
       this.mode = 'select'; this.selAction = 'remove'; this.selIdx = 0;
     }
+    else if (k === 'd' && this.am.accounts.length > 0) {
+      this.mode = 'select'; this.selAction = 'toggle'; this.selIdx = this.am.currentIndex;
+    }
     else if (k === 'a') { this.mode = 'add'; }
     else if (k === 'R') { this._doSync(); }
   }
@@ -245,6 +248,8 @@ export class TUI {
       if (this.selAction === 'switch') {
         this.am.currentIndex = this.selIdx;
         this._addLog(`Switched to "${this.am.accounts[this.selIdx].name}"`);
+      } else if (this.selAction === 'toggle') {
+        this._doToggleDisabled(this.selIdx);
       } else {
         this._doRemove(this.selIdx);
       }
@@ -386,6 +391,18 @@ export class TUI {
     this._addLog(`Removed account "${name}"`);
   }
 
+  async _doToggleDisabled(idx) {
+    if (idx < 0 || idx >= this.am.accounts.length) return;
+    const acct = this.am.accounts[idx];
+    const next = !acct.disabled;
+    this.am.setDisabled(idx, next); // re-enabling also clears a stuck error state
+    // Write an explicit boolean (not delete): saveConfig merges over the on-disk
+    // entry, so a `delete` would leave a stale `disabled: true` from disk intact.
+    if (this.config.accounts[idx]) this.config.accounts[idx].disabled = next;
+    await this.saveConfig(this.config);
+    this._addLog(`${next ? 'Disabled' : 'Enabled'} account "${acct.name}"`);
+  }
+
   // ── rendering ──────────────────────────────────────
 
   render() {
@@ -495,9 +512,11 @@ export class TUI {
     // Type
     const type = gray(a.type.padEnd(7));
 
-    // Status
+    // Status — a disabled account is shown as such regardless of its quota state.
     let status;
-    switch (a.status) {
+    if (a.disabled) {
+      status = gray('disabled');
+    } else switch (a.status) {
       case 'active':    status = isCur ? green('active') : 'active'; break;
       case 'throttled': status = yellow('throttled'); break;
       case 'exhausted': status = red('exhausted'); break;
@@ -536,9 +555,11 @@ export class TUI {
   _renderFooter() {
     switch (this.mode) {
       case 'normal':
-        return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('R')}eload  ${bold('q')}uit`;
+        return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('q')}uit`;
       case 'select': {
-        const act = this.selAction === 'switch' ? 'switch' : 'remove';
+        const act = this.selAction === 'switch' ? 'switch'
+          : this.selAction === 'toggle' ? 'enable/disable'
+          : 'remove';
         return ` ${dim('↑↓')} select  ${bold('Enter')} ${act}  ${bold('Esc')} cancel`;
       }
       case 'add':

--- a/test/account-disable.test.js
+++ b/test/account-disable.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+test('a disabled account is skipped by selection', () => {
+  const am = new AccountManager([oauth('a', { disabled: true }), oauth('b')], 0.98);
+  assert.equal(am._isAvailable(am.accounts[0]), false);
+  assert.equal(am._selectNext().name, 'b');
+});
+
+test('disabling the active account rotates away from it', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.currentIndex = 0;
+  am.setDisabled(0, true);
+  assert.equal(am.getActiveAccount().name, 'b');
+});
+
+test('re-enabling brings the account back into rotation', () => {
+  const am = new AccountManager([oauth('a', { disabled: true }), oauth('b')], 0.98);
+  assert.equal(am._isAvailable(am.accounts[0]), false);
+  am.setDisabled(0, false);
+  assert.equal(am._isAvailable(am.accounts[0]), true);
+});
+
+test('enabling an errored account clears the error so it is retried', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].status = 'error';
+  am.accounts[0].disabled = true;
+  am.setDisabled(0, false);
+  assert.equal(am.accounts[0].status, 'active');
+  assert.equal(am.accounts[0].rateLimitedUntil, null);
+  assert.equal(am._isAvailable(am.accounts[0]), true);
+});
+
+test('disabling does NOT clobber an error state (only enabling resets it)', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].status = 'error';
+  am.setDisabled(0, true);
+  assert.equal(am.accounts[0].status, 'error'); // unchanged
+  assert.equal(am.accounts[0].disabled, true);
+});
+
+test('all accounts disabled → no account available', () => {
+  const am = new AccountManager([oauth('a', { disabled: true }), oauth('b', { disabled: true })], 0.98);
+  assert.equal(am.getActiveAccount(), null);
+});
+
+test('getStatus exposes the disabled flag', () => {
+  const am = new AccountManager([oauth('a', { disabled: true }), oauth('b')], 0.98);
+  const s = am.getStatus();
+  assert.equal(s.accounts[0].disabled, true);
+  assert.equal(s.accounts[1].disabled, false);
+});


### PR DESCRIPTION
Adds a way to temporarily exclude an account from rotation and bring it back later, instead of removing and re-adding it.

## Usage
```bash
teamclaude disable user@example.com          # pause it
teamclaude enable  user@example.com          # resume it
teamclaude disable user@example.com --org Acme   # disambiguate one email across orgs
```
In the TUI, press **`d`** and pick an account to toggle. Disabled accounts render with a `disabled` status; `teamclaude status` shows `(disabled)`.

## Behavior
- A persistent **`disabled`** flag on the account (stored in config). `_isAvailable` skips disabled accounts, so rotation, selection, and preemption all ignore them. If every account is disabled, the proxy returns 429 (all exhausted), same as today.
- **Enable also restarts a stuck account:** re-enabling clears an `error` status (and any lingering rate-limit hold) so the account is retried immediately, rather than staying stuck until something else resets it. (Requested behavior.)
- `syncAccountsFromDisk` picks up enable/disable toggles on reload, including the error-clear on re-enable.

## Notes / edge cases
- Disabling does **not** alter an account's `error`/quota state — only enabling resets it.
- The TUI toggle writes an explicit boolean rather than deleting the key, because the TUI's `saveConfig` merges over the on-disk entry (`{...diskAcct, ...live}`); a `delete` would leave a stale `disabled: true` from disk intact.

## Tests
`test/account-disable.test.js` — skip-from-selection, rotate-away-on-disable, re-enable restores, error-clear on enable, disable-doesn't-clobber-error, all-disabled → none available, and getStatus exposure. Full suite 38 passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)