### PR TITLE
Smart `run` (proxy probe + fallback) and a `claude` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,25 @@ In selection mode, use `j`/`k` or arrow keys to navigate, `Enter` to confirm, `E
 teamclaude run
 ```
 
+`run` probes the proxy first: if it's up, Claude Code is routed through it; if it's **not** running, `claude` is launched directly so nothing breaks.
+
 Or manually set the environment:
 
 ```bash
 eval $(teamclaude env)
 claude
 ```
+
+### Routing plain `claude` automatically (alias)
+
+So you don't have to type `teamclaude run` every time, add a shell alias that makes plain `claude` go through the proxy (and fall back to direct when it's down):
+
+```bash
+teamclaude alias              # print the alias for your shell
+teamclaude alias --install    # or write it to your shell rc (--uninstall to remove)
+```
+
+This is an interactive-shell alias — it affects `claude` typed at a prompt, not `claude` spawned by editors or scripts. It's a thin passthrough to `teamclaude run`, which holds the proxy-up/down logic.
 
 ### Other commands
 
@@ -136,6 +149,7 @@ teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
 teamclaude enable <name>     # Re-enable it (also clears a stuck error state)
 teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
+teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude api <path>        # Call an API endpoint with account credentials
 teamclaude help              # Show all commands
 ```

--- a/src/alias.js
+++ b/src/alias.js
@@ -1,0 +1,100 @@
+// `claude` shell alias — print or install/uninstall.
+//
+// The alias simply routes plain `claude` through `teamclaude run`, which itself
+// probes the proxy and falls back to launching claude directly when it's down.
+// So the alias stays a dumb passthrough and all the smarts live in `run`.
+//
+// This only affects interactive shells (aliases aren't seen by editors/scripts
+// that exec `claude` themselves). It's intentionally lighter than a PATH shim:
+// no binary shadowing, one line per rc, trivially reversible.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+const MARKER = '# teamclaude alias';
+
+/** Basename of the user's login shell, e.g. "zsh". Defaults to bash. */
+export function detectShell() {
+  return (process.env.SHELL || '').split('/').pop() || 'bash';
+}
+
+/** The alias definition for a given shell family. */
+export function aliasLine(shell = detectShell()) {
+  if (shell === 'fish') return "alias claude 'teamclaude run --'";
+  return "alias claude='teamclaude run --'";
+}
+
+/** The rc file an alias for this shell should live in. */
+export function rcPathForShell(shell = detectShell()) {
+  const home = homedir();
+  switch (shell) {
+    case 'zsh':  return join(home, '.zshrc');
+    case 'sh':   return join(home, '.profile');
+    case 'fish': {
+      const cfg = process.env.XDG_CONFIG_HOME || join(home, '.config');
+      return join(cfg, 'fish', 'conf.d', 'teamclaude.fish');
+    }
+    case 'bash':
+    default:     return join(home, '.bashrc');
+  }
+}
+
+export function printAlias({ shell = detectShell() } = {}) {
+  const line = aliasLine(shell);
+  console.log('# Route plain `claude` through the proxy (when it is running; direct otherwise).');
+  console.log('# Add this to your shell config:');
+  console.log('');
+  console.log(`  ${line}`);
+  console.log('');
+  console.log(`# Or install it automatically: teamclaude alias --install`);
+  console.log(`#   → writes to ${rcPathForShell(shell)} (override with --shell <bash|zsh|fish|sh>)`);
+}
+
+export function installAlias({ shell = detectShell(), rcPath = rcPathForShell(shell) } = {}) {
+  const line = aliasLine(shell);
+  mkdirSync(dirname(rcPath), { recursive: true });
+  let text = existsSync(rcPath) ? readFileSync(rcPath, 'utf8') : '';
+
+  if (text.includes(line)) {
+    console.log(`Alias already present in ${rcPath}`);
+    return;
+  }
+  if (text && !text.endsWith('\n')) text += '\n';
+  text += `${MARKER}\n${line}\n`;
+  writeFileSync(rcPath, text);
+  console.log(`Installed alias in ${rcPath}`);
+  console.log('Reload your shell (or open a new terminal) to use it.');
+}
+
+export function uninstallAlias({ shell = detectShell(), rcPath = rcPathForShell(shell) } = {}) {
+  if (!existsSync(rcPath)) {
+    console.log(`Nothing to remove (${rcPath} does not exist)`);
+    return;
+  }
+  const text = readFileSync(rcPath, 'utf8');
+  const line = aliasLine(shell);
+  // Strip our marked block (and tolerate a bare alias line without the marker).
+  const blockRe = new RegExp(`\\n?${escapeRe(MARKER)}\\n${escapeRe(line)}\\n?`, 'g');
+  let cleaned = text.replace(blockRe, '\n');
+  cleaned = cleaned.replace(new RegExp(`\\n?${escapeRe(line)}\\n?`, 'g'), '\n');
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+
+  if (cleaned === text) {
+    console.log(`Alias not found in ${rcPath}`);
+    return;
+  }
+
+  // For the dedicated fish drop-file, remove it entirely if now empty.
+  if (rcPath.endsWith('teamclaude.fish') && cleaned.trim() === '') {
+    rmSync(rcPath);
+    console.log(`Removed ${rcPath}`);
+    return;
+  }
+  writeFileSync(rcPath, cleaned);
+  console.log(`Removed alias from ${rcPath}`);
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/alias.js
+++ b/src/alias.js
@@ -8,7 +8,7 @@
 // that exec `claude` themselves). It's intentionally lighter than a PATH shim:
 // no binary shadowing, one line per rc, trivially reversible.
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -19,10 +19,33 @@ export function detectShell() {
   return (process.env.SHELL || '').split('/').pop() || 'bash';
 }
 
+/** Whether a bare command resolves on the current $PATH. */
+function commandOnPath(cmd) {
+  for (const dir of (process.env.PATH || '').split(':')) {
+    if (dir && existsSync(join(dir, cmd))) return true;
+  }
+  return false;
+}
+
+/**
+ * How the alias should invoke teamclaude. Prefer the bare `teamclaude` when it's
+ * on $PATH; otherwise embed the absolute path to this CLI (quoted) so the alias
+ * still works when teamclaude isn't installed on PATH — e.g. run from a clone.
+ */
+export function teamclaudeRef() {
+  if (commandOnPath('teamclaude')) return 'teamclaude';
+  const entry = process.argv[1];
+  if (!entry) return 'teamclaude';
+  let abs;
+  try { abs = realpathSync(entry); } catch { abs = entry; }
+  return `"${abs}"`;
+}
+
 /** The alias definition for a given shell family. */
-export function aliasLine(shell = detectShell()) {
-  if (shell === 'fish') return "alias claude 'teamclaude run --'";
-  return "alias claude='teamclaude run --'";
+export function aliasLine(shell = detectShell(), ref = teamclaudeRef()) {
+  const body = `${ref} run --`;
+  if (shell === 'fish') return `alias claude '${body}'`;
+  return `alias claude='${body}'`;
 }
 
 /** The rc file an alias for this shell should live in. */
@@ -73,11 +96,11 @@ export function uninstallAlias({ shell = detectShell(), rcPath = rcPathForShell(
     return;
   }
   const text = readFileSync(rcPath, 'utf8');
-  const line = aliasLine(shell);
-  // Strip our marked block (and tolerate a bare alias line without the marker).
-  const blockRe = new RegExp(`\\n?${escapeRe(MARKER)}\\n${escapeRe(line)}\\n?`, 'g');
+  // Strip our marked block: the marker comment + the single line after it.
+  // Matching by marker (not by exact alias text) makes this robust even if the
+  // embedded teamclaude path differs from what's computed now.
+  const blockRe = new RegExp(`\\n?${escapeRe(MARKER)}\\n[^\\n]*\\n?`, 'g');
   let cleaned = text.replace(blockRe, '\n');
-  cleaned = cleaned.replace(new RegExp(`\\n?${escapeRe(line)}\\n?`, 'g'), '\n');
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
 
   if (cleaned === text) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@
 
 import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
+import net from 'node:net';
 import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, loadState, saveState } from './config.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
+import * as alias from './alias.js';
 import { TUI } from './tui.js';
 
 const args = process.argv.slice(2);
@@ -57,6 +59,10 @@ switch (command) {
     break;
   case 'api':
     await apiCommand();
+    process.exit(0);
+    break;
+  case 'alias':
+    aliasCommand();
     process.exit(0);
     break;
   case 'help':
@@ -381,17 +387,25 @@ async function runCommand() {
   const claudeArgs = args.slice(1);
   if (claudeArgs[0] === '--') claudeArgs.shift();
 
-  // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
-  // which the proxy accepts from localhost. Not setting ANTHROPIC_API_KEY
-  // lets Claude Code stay in subscription mode (full model access).
+  // Route through the proxy only when it's actually up; otherwise launch claude
+  // directly so a stopped proxy doesn't break `claude`. This is what lets the
+  // shell alias (`claude='teamclaude run --'`) be a dumb passthrough.
+  const port = config.proxy.port;
+  const env = { ...process.env };
+  if (await isProxyUp(port)) {
+    // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
+    // which the proxy accepts from localhost. Not setting ANTHROPIC_API_KEY
+    // lets Claude Code stay in subscription mode (full model access).
+    env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+  } else {
+    console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (start it with: teamclaude server)`);
+  }
+
   // Use spawnSync so the Node process blocks entirely — behaves like execvp.
   const result = spawnSync('claude', claudeArgs, {
     stdio: 'inherit',
     shell: process.platform === 'win32',
-    env: {
-      ...process.env,
-      ANTHROPIC_BASE_URL: `http://localhost:${config.proxy.port}`,
-    },
+    env,
   });
 
   if (result.error) {
@@ -618,6 +632,19 @@ async function apiCommand() {
   }
 }
 
+// ── alias ───────────────────────────────────────────────────
+
+function aliasCommand() {
+  const shell = argValue('--shell') || undefined;
+  if (args.includes('--uninstall')) {
+    alias.uninstallAlias({ shell });
+  } else if (args.includes('--install')) {
+    alias.installAlias({ shell });
+  } else {
+    alias.printAlias({ shell });
+  }
+}
+
 // ── remove ──────────────────────────────────────────────────
 
 /**
@@ -742,7 +769,9 @@ Commands:
   login               OAuth login via browser
   login --api         Add an API key account
   env                 Print env vars to use with Claude
-  run [-- args...]    Run Claude Code through the proxy
+  run [-- args...]    Run Claude Code through the proxy (direct if it's down)
+  alias               Print a shell alias so plain 'claude' routes via the proxy
+                      (--install to write it to your shell rc; --uninstall to remove)
   status              Show proxy & account status (live)
   accounts            List configured accounts
   remove <name>       Remove an account (by name or email; --org to disambiguate)
@@ -957,6 +986,20 @@ async function resolveAccounts(config) {
 function argValue(flag) {
   const i = args.indexOf(flag);
   return (i >= 0 && args[i + 1]) ? args[i + 1] : null;
+}
+
+// Quick liveness probe: is something listening on the local proxy port?
+// A successful TCP connect is enough (the proxy is local). Times out fast so a
+// down proxy doesn't add noticeable latency to `claude` launches via the alias.
+function isProxyUp(port, timeout = 600) {
+  return new Promise(resolve => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    const done = up => { socket.destroy(); resolve(up); };
+    socket.setTimeout(timeout);
+    socket.once('connect', () => done(true));
+    socket.once('timeout', () => done(false));
+    socket.once('error', () => resolve(false));
+  });
 }
 
 function handleServerListenError(err, port) {

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -1,15 +1,50 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { aliasLine, rcPathForShell, installAlias, uninstallAlias } from '../src/alias.js';
+import { aliasLine, rcPathForShell, teamclaudeRef, installAlias, uninstallAlias } from '../src/alias.js';
 
-test('aliasLine uses the right syntax per shell', () => {
-  assert.equal(aliasLine('bash'), "alias claude='teamclaude run --'");
-  assert.equal(aliasLine('zsh'), "alias claude='teamclaude run --'");
-  assert.equal(aliasLine('fish'), "alias claude 'teamclaude run --'");
+test('aliasLine uses the right syntax per shell (explicit ref)', () => {
+  assert.equal(aliasLine('bash', 'teamclaude'), "alias claude='teamclaude run --'");
+  assert.equal(aliasLine('zsh', 'teamclaude'), "alias claude='teamclaude run --'");
+  assert.equal(aliasLine('fish', 'teamclaude'), "alias claude 'teamclaude run --'");
+});
+
+test('aliasLine embeds a quoted absolute path when teamclaude is not on PATH', () => {
+  assert.equal(aliasLine('bash', '"/opt/tc/index.js"'), `alias claude='"/opt/tc/index.js" run --'`);
+  assert.equal(aliasLine('fish', '"/opt/tc/index.js"'), `alias claude '"/opt/tc/index.js" run --'`);
+});
+
+test('teamclaudeRef returns the bare command when it is on PATH', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-path-'));
+  const prev = process.env.PATH;
+  try {
+    const bin = join(dir, 'teamclaude');
+    writeFileSync(bin, '#!/bin/sh\n', { mode: 0o755 });
+    chmodSync(bin, 0o755);
+    process.env.PATH = dir;
+    assert.equal(teamclaudeRef(), 'teamclaude');
+  } finally {
+    process.env.PATH = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('teamclaudeRef falls back to a quoted absolute path when not on PATH', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-path-'));
+  const prev = process.env.PATH;
+  try {
+    process.env.PATH = dir; // empty dir → no teamclaude
+    const ref = teamclaudeRef();
+    assert.match(ref, /^".*"$/);          // quoted
+    assert.ok(ref.includes('/'));          // an absolute-ish path, not the bare command
+    assert.notEqual(ref, 'teamclaude');
+  } finally {
+    process.env.PATH = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('rcPathForShell maps shells to their rc files', () => {
@@ -36,7 +71,8 @@ test('install adds the alias, is idempotent, and uninstall removes it cleanly', 
   try {
     installAlias({ shell: 'bash', rcPath });
     let text = await readFile(rcPath, 'utf8');
-    assert.ok(text.includes("alias claude='teamclaude run --'"));
+    assert.match(text, /alias claude=.*run --/);
+    assert.ok(text.includes('# teamclaude alias'));
     assert.ok(text.includes('# existing user content')); // preserved
 
     // Idempotent: a second install doesn't duplicate the line.
@@ -44,12 +80,29 @@ test('install adds the alias, is idempotent, and uninstall removes it cleanly', 
     text = await readFile(rcPath, 'utf8');
     assert.equal(text.match(/alias claude=/g).length, 1);
 
-    // Uninstall restores the original content (no alias, no marker).
+    // Uninstall removes our block; user content stays intact.
     uninstallAlias({ shell: 'bash', rcPath });
     text = await readFile(rcPath, 'utf8');
     assert.ok(!text.includes('alias claude='));
     assert.ok(!text.includes('# teamclaude alias'));
-    assert.ok(text.includes('export FOO=1')); // user content intact
+    assert.ok(text.includes('export FOO=1'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('uninstall removes our block even if the embedded path differs', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-alias-'));
+  const rcPath = join(dir, '.bashrc');
+  // Simulate a previously-installed alias with an absolute path that no longer
+  // matches what teamclaudeRef() would compute now.
+  await writeFile(rcPath, 'export FOO=1\n# teamclaude alias\nalias claude=\'"/old/path/index.js" run --\'\n');
+  try {
+    uninstallAlias({ shell: 'bash', rcPath });
+    const text = await readFile(rcPath, 'utf8');
+    assert.ok(!text.includes('alias claude='));
+    assert.ok(!text.includes('# teamclaude alias'));
+    assert.ok(text.includes('export FOO=1'));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { aliasLine, rcPathForShell, installAlias, uninstallAlias } from '../src/alias.js';
+
+test('aliasLine uses the right syntax per shell', () => {
+  assert.equal(aliasLine('bash'), "alias claude='teamclaude run --'");
+  assert.equal(aliasLine('zsh'), "alias claude='teamclaude run --'");
+  assert.equal(aliasLine('fish'), "alias claude 'teamclaude run --'");
+});
+
+test('rcPathForShell maps shells to their rc files', () => {
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = '/home/u';
+  delete process.env.XDG_CONFIG_HOME;
+  try {
+    assert.equal(rcPathForShell('bash'), '/home/u/.bashrc');
+    assert.equal(rcPathForShell('zsh'), '/home/u/.zshrc');
+    assert.equal(rcPathForShell('sh'), '/home/u/.profile');
+    assert.equal(rcPathForShell('fish'), '/home/u/.config/fish/conf.d/teamclaude.fish');
+  } finally {
+    process.env.HOME = prevHome;
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdg;
+  }
+});
+
+test('install adds the alias, is idempotent, and uninstall removes it cleanly', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-alias-'));
+  const rcPath = join(dir, '.bashrc');
+  await writeFile(rcPath, '# existing user content\nexport FOO=1\n');
+  try {
+    installAlias({ shell: 'bash', rcPath });
+    let text = await readFile(rcPath, 'utf8');
+    assert.ok(text.includes("alias claude='teamclaude run --'"));
+    assert.ok(text.includes('# existing user content')); // preserved
+
+    // Idempotent: a second install doesn't duplicate the line.
+    installAlias({ shell: 'bash', rcPath });
+    text = await readFile(rcPath, 'utf8');
+    assert.equal(text.match(/alias claude=/g).length, 1);
+
+    // Uninstall restores the original content (no alias, no marker).
+    uninstallAlias({ shell: 'bash', rcPath });
+    text = await readFile(rcPath, 'utf8');
+    assert.ok(!text.includes('alias claude='));
+    assert.ok(!text.includes('# teamclaude alias'));
+    assert.ok(text.includes('export FOO=1')); // user content intact
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('uninstall of a dedicated fish drop-file removes the file when empty', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-alias-'));
+  const rcPath = join(dir, 'teamclaude.fish');
+  try {
+    installAlias({ shell: 'fish', rcPath });
+    assert.ok(existsSync(rcPath));
+    uninstallAlias({ shell: 'fish', rcPath });
+    assert.ok(!existsSync(rcPath)); // emptied → removed
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
A lightweight alternative to the PATH-shim in #10 for making plain `claude` route through the proxy.

## Design
Put the smarts in `teamclaude run`, so the alias can be a dumb passthrough:

- **`teamclaude run` now probes the proxy port.** If it's up → route Claude Code through it (as before). If it's **down** → launch `claude` directly (with a one-line notice) so a stopped proxy never breaks `claude`. Probe is a fast local TCP connect (600ms timeout).
- **`teamclaude alias`** — prints `alias claude='teamclaude run --'` for your shell by default; **`--install`** writes it to your rc (idempotent, marked block), **`--uninstall`** removes it, **`--shell`** overrides detection. bash/zsh/sh get an alias line; fish gets its alias in a `conf.d` file.

## Why an alias instead of the PATH shim (#10)
- **Scope:** an interactive-shell alias covers “when I type `claude`” — the common case — in ~110 lines, no binary shadowing, one reversible line per rc. The PATH shim (#10, ~340 lines, edits multiple rc files, survives claude self-updates) is only needed to also intercept `claude` spawned by editors/scripts. We opted for the lighter tool.
- **Safe / opt-in:** changes nothing for users who don't run it; `--install` is reversible; default is print-only.
- **No recursion:** `run` spawns `claude` via `spawnSync` (PATH lookup, not the shell), so it resolves the real binary — the alias only exists in interactive shells.

## Tests
`test/alias.test.js` — per-shell alias syntax, rc-path mapping, install idempotency, clean uninstall (incl. fish drop-file removal). Full suite 42 passing, lint clean.

Closes #10 in spirit (credit to @teocns for the original shim — see comment there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)