### PR TITLE
1.0.7 — README badges + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TeamClaude
 
+[![CI](https://github.com/KarpelesLab/teamclaude/actions/workflows/ci.yml/badge.svg)](https://github.com/KarpelesLab/teamclaude/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@karpeleslab/teamclaude.svg)](https://www.npmjs.com/package/@karpeleslab/teamclaude)
+[![node](https://img.shields.io/node/v/@karpeleslab/teamclaude.svg)](https://nodejs.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Multi-account Claude proxy with automatic quota-based rotation for [Claude Code](https://claude.ai/claude-code).
 
 Sits transparently between Claude Code and the Anthropic API, managing multiple Claude Max (or API key) accounts and automatically switching when one approaches its session or weekly quota limit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
- Bump version 1.0.6 → **1.0.7** (patch).
- Add badges to the README header: **CI** status (GitHub Actions), **npm version**, **Node** (from published `engines`), and **License: MIT** (links to `LICENSE`).

No code changes; full suite still 46 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)