### PR TITLE
Headless mode + local reload endpoint (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; switches to the next on persistent errors
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
-- **Hot-reload accounts** — add accounts via `import` or `login` while the server is running, press **R** to pick them up
+- **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
+- **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
@@ -103,7 +104,15 @@ When running from a TTY, shows an interactive TUI with:
 - Real-time activity log with request tracking
 - Keyboard shortcuts (see below)
 
-Falls back to plain log output when not a TTY (e.g. running as a service).
+Falls back to plain log output when not a TTY (e.g. running as a service). Pass `--headless` (or `--no-tui`) to force the plain-log mode even from a terminal — useful for backgrounding the proxy.
+
+When running headless, you can re-sync accounts from the config without a restart by POSTing to the local control endpoint (the equivalent of pressing **R** in the TUI):
+
+```bash
+curl -X POST http://localhost:3456/teamclaude/reload
+```
+
+You usually don't need to call it directly: `teamclaude login`, `import`, `enable`, `disable`, and `priority` automatically notify a running server to reload. (New accounts and credential/priority/enable-disable changes are picked up live; account *removals* still require a restart.)
 
 #### TUI Keyboard Shortcuts
 

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,17 @@ async function serverCommand() {
     }).catch(err => console.error(`[TeamClaude] Failed to save refreshed token: ${err.message}`));
   });
   const port = config.proxy.port;
-  const useTUI = process.stdout.isTTY && process.stdin.isTTY;
+  const headless = args.includes('--headless') || args.includes('--no-tui');
+  const useTUI = !headless && process.stdout.isTTY && process.stdin.isTTY;
+
+  // Re-sync accounts from disk without a restart. The TUI's 'R' key, the
+  // POST /teamclaude/reload endpoint, and the CLI notify after add/change all
+  // funnel through here. Returns the number of newly added accounts.
+  const reloadAccounts = async () => {
+    const diskConfig = await loadConfig();
+    if (!diskConfig) return 0;
+    return syncAccountsFromDisk(diskConfig, config, accountManager);
+  };
 
   let tui = null;
   let hooks = {};
@@ -178,11 +188,7 @@ async function serverCommand() {
           return diskAcct ? { ...diskAcct, ...live } : live;
         });
       }),
-      syncAccounts: async () => {
-        const diskConfig = await loadConfig();
-        if (!diskConfig) return 0;
-        return syncAccountsFromDisk(diskConfig, config, accountManager);
-      },
+      syncAccounts: reloadAccounts,
       onQuit: async () => {
         if (quotaSaveInterval) clearInterval(quotaSaveInterval);
         await persistQuotaState();
@@ -195,6 +201,9 @@ async function serverCommand() {
       onRequestEnd: (id, info) => tui.onRequestEnd(id, info),
     };
   }
+
+  // Expose reload to the proxy's control endpoint (works with or without TUI).
+  hooks.reload = reloadAccounts;
 
   const server = createProxyServer(accountManager, config, hooks);
   // Catch bind-time errors (e.g. EADDRINUSE) only. Once the socket is bound we
@@ -724,6 +733,7 @@ async function priorityCommand() {
   account.priority = priority;
   await saveConfig(config);
   console.log(`Set priority of "${account.name}" to ${priority} (lower = preferred)`);
+  await notifyRunningServer(config);
 }
 
 // ── enable / disable ────────────────────────────────────────
@@ -751,9 +761,7 @@ async function setDisabledCommand(disabled) {
   }
   await saveConfig(config);
   console.log(`${disabled ? 'Disabled' : 'Enabled'} account "${account.name}"`);
-  if (!disabled) {
-    console.log('(restart or reload the running server to retry it if it was in an error state)');
-  }
+  await notifyRunningServer(config);
 }
 
 // ── help ────────────────────────────────────────────────────
@@ -764,7 +772,7 @@ function showHelp() {
 Usage: teamclaude [command] [options]
 
 Commands:
-  server              Start the proxy server (default)
+  server              Start the proxy server (default; --headless to skip the TUI)
   import              Import credentials from Claude Code
   login               OAuth login via browser
   login --api         Add an API key account
@@ -788,6 +796,10 @@ Options:
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)
+  --headless          Run the server without the interactive TUI (for backgrounding)
+
+A running server re-syncs accounts from config on POST /teamclaude/reload
+(local only). add/login/enable/disable/priority trigger it automatically.
 
 Config: ${getConfigPath()}
 `);
@@ -862,6 +874,7 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
 
   await saveConfig(config);
   console.log(`Saved to ${getConfigPath()}`);
+  await notifyRunningServer(config);
 }
 
 // ── config sync helpers ─────────────────────────────────────
@@ -986,6 +999,26 @@ async function resolveAccounts(config) {
 function argValue(flag) {
   const i = args.indexOf(flag);
   return (i >= 0 && args[i + 1]) ? args[i + 1] : null;
+}
+
+// Best-effort: tell a running server (if any) to re-sync accounts from config so
+// CLI changes take effect without a restart. A closed local port refuses the
+// connection immediately, so this is a no-op (and near-instant) when nothing is
+// running. Reload picks up new accounts, credential, priority, and enable/disable
+// changes; account removals still need a restart.
+async function notifyRunningServer(config) {
+  const port = config?.proxy?.port;
+  if (!port) return;
+  try {
+    const res = await fetch(`http://localhost:${port}/teamclaude/reload`, {
+      method: 'POST',
+      headers: { 'x-api-key': config.proxy?.apiKey || '' },
+    });
+    if (res.ok) {
+      const data = await res.json().catch(() => ({}));
+      console.log(`Reloaded running server${data.added ? ` (+${data.added} new account)` : ''}.`);
+    }
+  } catch { /* no server running — nothing to notify */ }
 }
 
 // Quick liveness probe: is something listening on the local proxy port?

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,26 @@ export function createProxyServer(accountManager, config, hooks = {}) {
         return;
       }
 
+      // Reload endpoint — re-sync accounts from config without a restart. This
+      // is the headless equivalent of pressing 'R' in the TUI. Local control
+      // only (no upstream calls); the auth gate above already applies.
+      if (req.method === 'POST' && req.url === '/teamclaude/reload') {
+        if (!hooks.reload) {
+          res.writeHead(501, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'reload not supported' }));
+          return;
+        }
+        try {
+          const added = await hooks.reload();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, added: added || 0 }));
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: err.message }));
+        }
+        return;
+      }
+
       // Let client token refresh requests pass through to upstream untouched.
       // The proxy manages its own tokens via ensureTokenFresh(); intercepting
       // or rewriting client refreshes would cause token rotation conflicts.

--- a/test/server-reload.test.js
+++ b/test/server-reload.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const CONFIG = { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com' };
+const ACCT = [{ name: 'a', type: 'apikey', apiKey: 'k' }];
+
+test('POST /teamclaude/reload invokes hooks.reload and returns the added count', async () => {
+  const am = new AccountManager(ACCT, 0.98);
+  let called = 0;
+  const proxy = createProxyServer(am, CONFIG, { reload: async () => { called++; return 2; } });
+  const port = await listen(proxy);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/reload`, { method: 'POST' });
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.added, 2);
+    assert.equal(called, 1);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('reload returns 501 when no reload handler is wired', async () => {
+  const am = new AccountManager(ACCT, 0.98);
+  const proxy = createProxyServer(am, CONFIG, {});
+  const port = await listen(proxy);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/reload`, { method: 'POST' });
+    const body = await res.json();
+    assert.equal(res.status, 501);
+    assert.equal(body.ok, false);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('reload reports handler errors as 500', async () => {
+  const am = new AccountManager(ACCT, 0.98);
+  const proxy = createProxyServer(am, CONFIG, { reload: async () => { throw new Error('boom'); } });
+  const port = await listen(proxy);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/reload`, { method: 'POST' });
+    const body = await res.json();
+    assert.equal(res.status, 500);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /boom/);
+  } finally {
+    proxy.close();
+  }
+});


### PR DESCRIPTION
Completes the **passive-compatible** parts of the #18 upstreaming stack (from #14), without the active background prober.

## Added
- **`teamclaude server --headless`** (alias `--no-tui`) — run the proxy without the interactive TUI, for backgrounding / running as a service.
- **`POST /teamclaude/reload`** — re-sync accounts from config without a restart; the headless equivalent of pressing `R` in the TUI. Local-only control endpoint (no upstream calls — same trust model as the existing `/teamclaude/status`). Returns `{ok, added}`; 501 if no handler is wired, 500 on error.
- **Auto-notify**: `login` / `import` / `enable` / `disable` / `priority` best-effort POST to `/teamclaude/reload`, so CLI changes apply to a running server live. A closed local port refuses instantly, so it's a near-instant no-op when nothing is running.
- `reloadAccounts` is shared by the TUI `R` key, the endpoint, and the CLI notify.

## Deliberately excluded (passive-only)
The background quota **prober**, **usage-endpoint quota**, and **probe-on-add** from #14/#16 all actively call the Anthropic API on a timer — that violates TeamClaude's passive-only design, so they're not included.

## Notes
- Reload covers new accounts + credential/priority/enable-disable changes (which `syncAccountsFromDisk` already applies). Account **removals** still require a restart — documented in help and README.
- Auth: localhost is already trusted by the proxy, so the reload endpoint is reachable locally without the API key, exactly like `/teamclaude/status`.

## Tests
`test/server-reload.test.js` — endpoint success/501/500. Verified end-to-end: a `--headless` server serves `/teamclaude/status` and `/teamclaude/reload`. Full suite 49 passing, lint clean.

Part of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)