### PR TITLE
Opt-in background quota probe (+ Sonnet 7d bar, closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
+- **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet weekly bucket
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
 
@@ -163,6 +164,7 @@ teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
 teamclaude enable <name>     # Re-enable it (also clears a stuck error state)
 teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
+teamclaude probe 300         # Enable background quota refresh (off by default)
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude api <path>        # Call an API endpoint with account credentials
 teamclaude help              # Show all commands
@@ -226,10 +228,25 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `proxy.apiKey` | API key clients use to authenticate with the proxy |
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts |
+| `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default) |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
+
+### Quota probe (optional, off by default)
+
+By default TeamClaude is **passive** — it learns each account's quota only from the responses that flow through it, so an account that hasn't been used yet shows unknown quota until it's first rotated to.
+
+If you'd rather keep idle accounts' quota fresh, enable the background probe:
+
+```bash
+teamclaude probe 300    # refresh every 300s
+teamclaude probe off    # back to passive (default)
+teamclaude probe        # show current setting
+```
+
+It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** bucket as an extra bar in the TUI / `status` (when your plan exposes it).
 
 ## How It Works
 

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
   },
   "upstream": "https://api.anthropic.com",
   "switchThreshold": 0.98,
+  "quotaProbeSeconds": 0,
   "accounts": [
     {
       "name": "primary-max",

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -5,7 +5,8 @@ import { sameIdentity } from './identity.js';
 // windows, learned passively from upstream responses. Transient/derived state
 // (probing, requalify, rateLimitedUntil) is intentionally excluded.
 const PERSISTED_QUOTA_FIELDS = [
-  'unified5h', 'unified7d', 'unified5hReset', 'unified7dReset', 'unifiedStatus',
+  'unified5h', 'unified7d', 'unified7dSonnet',
+  'unified5hReset', 'unified7dReset', 'unified7dSonnetReset', 'unifiedStatus',
   'tokensLimit', 'tokensRemaining', 'requestsLimit', 'requestsRemaining', 'resetsAt',
 ];
 
@@ -17,11 +18,13 @@ function emptyQuota() {
     requestsLimit: null,
     requestsRemaining: null,
     // Unified rate limits (Claude Max accounts)
-    unified5h: null,       // utilization 0-1
-    unified7d: null,       // utilization 0-1
-    unified5hReset: null,  // ms timestamp
-    unified7dReset: null,  // ms timestamp
-    unifiedStatus: null,   // allowed | allowed_warning | rejected
+    unified5h: null,            // utilization 0-1
+    unified7d: null,            // utilization 0-1
+    unified7dSonnet: null,      // utilization 0-1 (Sonnet-specific weekly bucket)
+    unified5hReset: null,       // ms timestamp
+    unified7dReset: null,       // ms timestamp
+    unified7dSonnetReset: null, // ms timestamp
+    unifiedStatus: null,        // allowed | allowed_warning | rejected
     resetsAt: null,
   };
 }
@@ -132,6 +135,11 @@ export class AccountManager {
       q.unified7d = null;
       q.unified7dReset = null;
       q.unifiedStatus = null;
+      changed = true;
+    }
+    if (q.unified7dSonnet != null && q.unified7dSonnetReset && now >= q.unified7dSonnetReset) {
+      q.unified7dSonnet = null;
+      q.unified7dSonnetReset = null;
       changed = true;
     }
 
@@ -377,6 +385,37 @@ export class AccountManager {
       account.status = 'active';
       account.rateLimitedUntil = null;
       console.log(`[TeamClaude] Account "${account.name}" re-enabled — clearing error state`);
+    }
+  }
+
+  /**
+   * Apply quota learned from the OAuth usage endpoint (the background probe).
+   * Updates utilization/reset for the 5h, 7d, and Sonnet-7d buckets WITHOUT
+   * touching usage counters — a probe is not real client traffic.
+   */
+  applyUsageData(accountIndex, usage) {
+    const account = this.accounts[accountIndex];
+    if (!account || !usage) return;
+    const q = account.quota;
+
+    if (usage.fiveHour) {
+      if (usage.fiveHour.utilization != null) q.unified5h = usage.fiveHour.utilization;
+      if (usage.fiveHour.resetAt != null) q.unified5hReset = usage.fiveHour.resetAt;
+    }
+    if (usage.sevenDay) {
+      if (usage.sevenDay.utilization != null) q.unified7d = usage.sevenDay.utilization;
+      if (usage.sevenDay.resetAt != null) q.unified7dReset = usage.sevenDay.resetAt;
+    }
+    if (usage.sevenDaySonnet) {
+      if (usage.sevenDaySonnet.utilization != null) q.unified7dSonnet = usage.sevenDaySonnet.utilization;
+      if (usage.sevenDaySonnet.resetAt != null) q.unified7dSonnetReset = usage.sevenDaySonnet.resetAt;
+    }
+
+    // If we just learned this account's weekly window while probing, re-evaluate
+    // selection (same path as learning it from a live response).
+    if (account.probing && q.unified7dReset != null) {
+      account.probing = false;
+      account.requalify = true;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
 import * as alias from './alias.js';
+import { Prober } from './prober.js';
 import { TUI } from './tui.js';
 
 const args = process.argv.slice(2);
@@ -63,6 +64,10 @@ switch (command) {
     break;
   case 'alias':
     aliasCommand();
+    process.exit(0);
+    break;
+  case 'probe':
+    await probeCommand();
     process.exit(0);
     break;
   case 'help':
@@ -157,13 +162,25 @@ async function serverCommand() {
   const headless = args.includes('--headless') || args.includes('--no-tui');
   const useTUI = !headless && process.stdout.isTTY && process.stdin.isTTY;
 
+  // Opt-in background quota probe (config.quotaProbeSeconds, default 0 = off).
+  let prober = null;
+
   // Re-sync accounts from disk without a restart. The TUI's 'R' key, the
   // POST /teamclaude/reload endpoint, and the CLI notify after add/change all
-  // funnel through here. Returns the number of newly added accounts.
+  // funnel through here. Returns the number of newly added accounts. Also picks
+  // up a changed probe interval so `teamclaude probe` applies live.
   const reloadAccounts = async () => {
     const diskConfig = await loadConfig();
     if (!diskConfig) return 0;
-    return syncAccountsFromDisk(diskConfig, config, accountManager);
+    const added = await syncAccountsFromDisk(diskConfig, config, accountManager);
+    if (prober) {
+      const ms = (diskConfig.quotaProbeSeconds || 0) * 1000;
+      if (ms !== prober.intervalMs) {
+        config.quotaProbeSeconds = diskConfig.quotaProbeSeconds || 0;
+        prober.reschedule(ms);
+      }
+    }
+    return added;
   };
 
   let tui = null;
@@ -190,6 +207,7 @@ async function serverCommand() {
       }),
       syncAccounts: reloadAccounts,
       onQuit: async () => {
+        prober?.stop();
         if (quotaSaveInterval) clearInterval(quotaSaveInterval);
         await persistQuotaState();
         server.close(() => process.exit(0));
@@ -246,9 +264,14 @@ async function serverCommand() {
   quotaSaveInterval = setInterval(persistQuotaState, 60_000);
   quotaSaveInterval.unref?.();
 
+  // Start the opt-in quota probe (no-op when quotaProbeSeconds is 0).
+  prober = new Prober(accountManager, { intervalMs: (config.quotaProbeSeconds || 0) * 1000 });
+  prober.start();
+
   if (!tui) {
     const shutdown = async () => {
       console.log('\n[TeamClaude] Shutting down...');
+      prober?.stop();
       clearInterval(quotaSaveInterval);
       await persistQuotaState();
       server.close(() => process.exit(0));
@@ -449,10 +472,12 @@ async function statusCommand() {
       console.log(`  ${acct.name} (${acct.type})${current}`);
       console.log(`    Status:   ${acct.status}${acct.disabled ? ' (disabled)' : ''}`);
 
-      if (q.unified5h != null || q.unified7d != null) {
+      if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null) {
         const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' : '-';
         const wk = q.unified7d != null ? (q.unified7d * 100).toFixed(1) + '%' : '-';
-        console.log(`    Session:  ${ses} used    Weekly: ${wk} used`);
+        let line = `    Session:  ${ses} used    Weekly: ${wk} used`;
+        if (q.unified7dSonnet != null) line += `    Sonnet7d: ${(q.unified7dSonnet * 100).toFixed(1)}% used`;
+        console.log(line);
       } else {
         const tok = q.tokensLimit ? ((1 - q.tokensRemaining / q.tokensLimit) * 100).toFixed(1) + '%' : '-';
         const req = q.requestsLimit ? ((1 - q.requestsRemaining / q.requestsLimit) * 100).toFixed(1) + '%' : '-';
@@ -654,6 +679,42 @@ function aliasCommand() {
   }
 }
 
+// ── probe ───────────────────────────────────────────────────
+
+async function probeCommand() {
+  const config = await loadOrCreateConfig();
+  const arg = args[1];
+
+  if (arg === undefined) {
+    const cur = config.quotaProbeSeconds || 0;
+    console.log(cur > 0 ? `Quota probe: every ${cur}s` : 'Quota probe: off (passive only)');
+    console.log('Set with: teamclaude probe <off|seconds>   e.g. teamclaude probe 300');
+    return;
+  }
+
+  let seconds;
+  if (arg === 'off' || arg === '0') {
+    seconds = 0;
+  } else {
+    seconds = parseInt(arg, 10);
+    if (Number.isNaN(seconds) || seconds < 0) {
+      console.error('Usage: teamclaude probe <off|seconds>');
+      process.exit(1);
+    }
+    if (seconds > 0 && seconds < 30) {
+      console.error('Minimum probe interval is 30s (to avoid hammering the usage endpoint).');
+      process.exit(1);
+    }
+  }
+
+  config.quotaProbeSeconds = seconds;
+  await saveConfig(config);
+  console.log(seconds > 0
+    ? `Quota probe set to every ${seconds}s (reads /api/oauth/usage; does not spend quota).`
+    : 'Quota probe disabled (passive only).');
+  await notifyRunningServer(config);
+}
+
 // ── remove ──────────────────────────────────────────────────
 
 /**
@@ -786,6 +847,8 @@ Commands:
   disable <name>      Temporarily exclude an account from rotation
   enable <name>       Re-enable a disabled account (also clears a stuck error)
   priority <name> <n> Set rotation priority (lower = preferred; --first/--last)
+  probe [off|secs]    Opt-in background quota refresh for idle accounts
+                      (off by default; reads usage endpoint, spends no quota)
   api <path>          Call an API endpoint with account credentials
   help                Show this help
 

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -24,6 +24,8 @@ export async function importCredentials(filePath) {
 }
 
 const PROFILE_URL = 'https://api.anthropic.com/api/oauth/profile';
+const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const OAUTH_USAGE_BETA = 'oauth-2025-04-20';
 const DEFAULT_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
 const DEFAULT_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
@@ -137,6 +139,73 @@ export async function fetchProfile(accessToken) {
     };
   } catch (err) {
     return { error: err.message || String(err) };
+  }
+}
+
+// Normalize one usage bucket from the /api/oauth/usage payload into
+// { utilization: 0-1, resetAt: ms-epoch }. Tolerant of field-name and
+// percentage/fraction and seconds/ms variations across payload versions.
+export function normalizeUsageBucket(bucket) {
+  if (!bucket || typeof bucket !== 'object') return null;
+
+  const rawPct = bucket.used_percentage ?? bucket.utilization ?? bucket.usedPercentage;
+  const parsedPct = typeof rawPct === 'number' ? rawPct : parseFloat(rawPct);
+  const utilization = Number.isFinite(parsedPct)
+    ? (parsedPct > 1 ? parsedPct / 100 : parsedPct)
+    : null;
+
+  const rawReset = bucket.resets_at ?? bucket.resetsAt ?? bucket.reset_at ?? bucket.resetAt;
+  let resetAt = null;
+  if (typeof rawReset === 'number') {
+    resetAt = rawReset < 1e12 ? rawReset * 1000 : rawReset;
+  } else if (typeof rawReset === 'string') {
+    const asNum = Number(rawReset);
+    if (Number.isFinite(asNum) && rawReset.trim() !== '') {
+      resetAt = asNum < 1e12 ? asNum * 1000 : asNum;
+    } else {
+      const parsed = Date.parse(rawReset);
+      if (Number.isFinite(parsed)) resetAt = parsed;
+    }
+  }
+
+  return { utilization, resetAt };
+}
+
+/**
+ * Fetch OAuth subscription usage from the usage endpoint. This reports quota
+ * utilization WITHOUT spending message quota, which is what makes it safe to
+ * poll. Returns normalized { fiveHour, sevenDay, sevenDaySonnet } buckets, or
+ * { error, status } on failure.
+ */
+export async function fetchUsage(accessToken) {
+  try {
+    const res = await fetch(USAGE_URL, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'anthropic-beta': OAUTH_USAGE_BETA,
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      let detail = '';
+      try {
+        const body = await res.json();
+        detail = body?.error?.message || JSON.stringify(body).slice(0, 200);
+      } catch {
+        detail = await res.text().catch(() => '');
+      }
+      return { error: `HTTP ${res.status}${detail ? ': ' + detail : ''}`, status: res.status };
+    }
+
+    const data = await res.json();
+    return {
+      fiveHour: normalizeUsageBucket(data?.five_hour),
+      sevenDay: normalizeUsageBucket(data?.seven_day),
+      sevenDaySonnet: normalizeUsageBucket(data?.seven_day_sonnet),
+    };
+  } catch (err) {
+    return { error: err.message || String(err), status: null };
   }
 }
 

--- a/src/prober.js
+++ b/src/prober.js
@@ -1,0 +1,82 @@
+// Opt-in background quota probe.
+//
+// DISABLED BY DEFAULT. When enabled (config.quotaProbeSeconds > 0), periodically
+// reads each OAuth account's quota from the zero-spend /api/oauth/usage endpoint
+// so idle accounts' utilization/reset stay fresh without waiting to be rotated
+// to — and without consuming any message quota. This is the one sanctioned
+// active-upstream feature; the proxy is otherwise passive.
+
+import { fetchUsage } from './oauth.js';
+
+export class Prober {
+  constructor(accountManager, { intervalMs = 0, probeFn = fetchUsage, timeoutMs = 10_000, log = console.log } = {}) {
+    this.am = accountManager;
+    this.intervalMs = intervalMs;
+    this.probeFn = probeFn;
+    this.timeoutMs = timeoutMs;
+    this.log = log;
+    this.timer = null;
+    this._running = false;
+  }
+
+  start() {
+    if (this.intervalMs > 0) this.reschedule(this.intervalMs);
+  }
+
+  /** Change the interval at runtime (0 = off). Probes once immediately when on. */
+  reschedule(intervalMs) {
+    const wasOn = this.intervalMs > 0 && this.timer;
+    this.intervalMs = intervalMs;
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+
+    if (intervalMs > 0) {
+      // Probe right away so quota populates without waiting a full cycle.
+      this.probeAll().catch(() => {});
+      this.timer = setInterval(() => this.probeAll().catch(() => {}), intervalMs);
+      this.timer.unref?.();
+      this.log(`[TeamClaude] Quota probe enabled (every ${Math.round(intervalMs / 1000)}s)`);
+    } else if (wasOn) {
+      this.log('[TeamClaude] Quota probe disabled');
+    }
+  }
+
+  stop() {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /** Probe every OAuth account once. Overlapping cycles are skipped. */
+  async probeAll() {
+    if (this._running) return;
+    this._running = true;
+    try {
+      const accounts = this.am.accounts.filter(a => a.type === 'oauth' && a.credential);
+      await Promise.all(accounts.map(a => this.probeOne(a)));
+    } finally {
+      this._running = false;
+    }
+  }
+
+  async probeOne(account) {
+    try {
+      await this.am.ensureTokenFresh(account.index);
+      let usage = await this._withTimeout(this.probeFn(account.credential));
+      if (usage?.status === 401) {
+        // Token rejected — force a refresh and retry once.
+        await this.am.ensureTokenFresh(account.index, true);
+        usage = await this._withTimeout(this.probeFn(account.credential));
+      }
+      if (!usage || usage.error) return; // transient — try again next cycle
+      this.am.applyUsageData(account.index, usage);
+    } catch { /* best-effort; never let a probe throw */ }
+  }
+
+  _withTimeout(promise) {
+    return Promise.race([
+      promise,
+      new Promise(resolve => {
+        const t = setTimeout(() => resolve(null), this.timeoutMs);
+        t.unref?.();
+      }),
+    ]);
+  }
+}

--- a/src/tui.js
+++ b/src/tui.js
@@ -529,7 +529,7 @@ export class TUI {
     const q = a.quota;
     let r1 = null, r2 = null, l1 = 'Ses', l2 = 'Wk ', t1 = null, t2 = null;
 
-    if (q.unified5h != null || q.unified7d != null) {
+    if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null) {
       r1 = q.unified5h;
       r2 = q.unified7d;
       t1 = q.unified5hReset;
@@ -548,6 +548,10 @@ export class TUI {
     let line = ` ${sel}${cur} ${name} ${type} ${status} ${l1} ${bar(r1, bw, t1)}`;
     if (showBoth) {
       line += `  ${l2} ${bar(r2, bw, t2)}`;
+      // Sonnet weekly bar — only shown when the usage probe has populated it.
+      if (q.unified7dSonnet != null) {
+        line += `  S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset)}`;
+      }
     }
     return line;
   }

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeUsageBucket } from '../src/oauth.js';
+import { AccountManager } from '../src/account-manager.js';
+import { Prober } from '../src/prober.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// ── normalizeUsageBucket ──────────────────────────────────────
+
+test('normalizeUsageBucket converts percentages and fractions to 0-1', () => {
+  assert.equal(normalizeUsageBucket({ used_percentage: 42 }).utilization, 0.42);
+  assert.equal(normalizeUsageBucket({ utilization: 0.5 }).utilization, 0.5);
+  assert.equal(normalizeUsageBucket({ used_percentage: '30' }).utilization, 0.3);
+  assert.equal(normalizeUsageBucket(null), null);
+  assert.equal(normalizeUsageBucket({}).utilization, null);
+});
+
+test('normalizeUsageBucket normalizes resets to ms epoch', () => {
+  assert.equal(normalizeUsageBucket({ resets_at: 1700000000 }).resetAt, 1700000000000);     // seconds → ms
+  assert.equal(normalizeUsageBucket({ resets_at: 1700000000000 }).resetAt, 1700000000000);  // already ms
+  assert.equal(normalizeUsageBucket({ resets_at: '2026-01-01T00:00:00Z' }).resetAt, Date.parse('2026-01-01T00:00:00Z'));
+});
+
+// ── applyUsageData ────────────────────────────────────────────
+
+test('applyUsageData populates 5h/7d/sonnet without counting a request', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.applyUsageData(0, {
+    fiveHour: { utilization: 0.2, resetAt: 111 },
+    sevenDay: { utilization: 0.4, resetAt: 222 },
+    sevenDaySonnet: { utilization: 0.6, resetAt: 333 },
+  });
+  const a = am.accounts[0];
+  assert.equal(a.quota.unified5h, 0.2);
+  assert.equal(a.quota.unified7d, 0.4);
+  assert.equal(a.quota.unified7dSonnet, 0.6);
+  assert.equal(a.quota.unified7dSonnetReset, 333);
+  assert.equal(a.usage.totalRequests, 0);   // a probe is not real traffic
+  assert.equal(a.probing, false);            // learned the weekly window…
+  assert.equal(a.requalify, true);           // …so re-evaluate selection
+});
+
+test('sonnet quota survives the persistence round-trip', () => {
+  const am1 = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
+  am1.applyUsageData(0, { sevenDaySonnet: { utilization: 0.7, resetAt: 999 } });
+  const am2 = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
+  am2.restoreQuotaState(am1.exportQuotaState());
+  assert.equal(am2.accounts[0].quota.unified7dSonnet, 0.7);
+  assert.equal(am2.accounts[0].quota.unified7dSonnetReset, 999);
+});
+
+// ── Prober ────────────────────────────────────────────────────
+
+test('prober probes oauth accounts and applies the usage data', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  let calls = 0;
+  const probeFn = async () => { calls++; return { fiveHour: { utilization: 0.1, resetAt: 1000 }, sevenDay: { utilization: 0.2, resetAt: 2000 } }; };
+  const prober = new Prober(am, { intervalMs: 0, probeFn, log: () => {} });
+  await prober.probeAll();
+  assert.equal(calls, 1);
+  assert.equal(am.accounts[0].quota.unified5h, 0.1);
+  assert.equal(am.accounts[0].quota.unified7d, 0.2);
+});
+
+test('prober skips API-key accounts', async () => {
+  const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
+  let calls = 0;
+  const prober = new Prober(am, { intervalMs: 0, probeFn: async () => { calls++; return {}; }, log: () => {} });
+  await prober.probeAll();
+  assert.equal(calls, 0);
+});
+
+test('prober retries once on a 401', async () => {
+  const am = new AccountManager([oauth('a')], 0.98); // no refreshToken → ensureTokenFresh is a no-op
+  let calls = 0;
+  const probeFn = async () => {
+    calls++;
+    if (calls === 1) return { error: 'HTTP 401', status: 401 };
+    return { sevenDay: { utilization: 0.3, resetAt: 5000 } };
+  };
+  const prober = new Prober(am, { intervalMs: 0, probeFn, log: () => {} });
+  await prober.probeAll();
+  assert.equal(calls, 2);
+  assert.equal(am.accounts[0].quota.unified7d, 0.3);
+});


### PR DESCRIPTION
Adds an **opt-in, off-by-default** background quota refresh, for the users who need idle accounts' quota kept fresh. Passive remains the default and the baseline.

## How it works
- **`teamclaude probe <off|seconds>`** sets `quotaProbeSeconds` (default `0` = off; minimum 30s). Shows current setting with no arg. Writing it notifies a running server, which reschedules the probe **live** (no restart).
- When on, the probe reads each OAuth account's utilization from Anthropic's **usage endpoint** (`/api/oauth/usage`) — which reports quota **without consuming any message quota**. That's the key: it does *not* burn the quota it's measuring (unlike a message-sending prober).
- Per-probe timeout, one 401→refresh→retry, overlap guard; API-key accounts are skipped.

## Why this, given the passive-only stance
The proxy stays passive by default. This is the single sanctioned active-upstream feature, gated behind explicit opt-in, because multiple users had a real need for fresh idle-account quota. The message-sending prober from the original #14 is **not** used — only the zero-spend usage endpoint.

## Sonnet bar — closes #1
The usage payload also exposes the **Sonnet 7-day** bucket, so when probing is on it surfaces a Sonnet weekly bar in the TUI and `teamclaude status`. It's a no-op when the bucket is absent or probing is off — satisfying the "does nothing for people not using that bucket" bar from #1.

## Files
- `src/prober.js` (new), `src/oauth.js` (`fetchUsage`/`normalizeUsageBucket`), `src/account-manager.js` (`applyUsageData` + `unified7dSonnet` fields, persisted), `src/index.js` (lifecycle + `probe` command + reload reschedule), `src/tui.js` + status (Sonnet bar), `config.example.json`, `README.md`.

## Tests
`test/quota-probe.test.js` — bucket normalization (pct/fraction, sec/ms), `applyUsageData` (no request count, sonnet, probing→requalify), persistence round-trip of the sonnet bucket, and prober behavior (applies usage, skips API keys, retries once on 401). Full suite **56 passing**, lint clean.

Closes #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)