### PR TITLE
Transparent h2/h1 MITM forward-proxy (faithful relay, rewrite only auth + account_uuid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,13 @@ Run claude with the `--mitm` flag:
 teamclaude run --mitm -- <claude args...>
 ```
 
-That launches claude pointed at teamclaude as an **HTTPS forward proxy** (`HTTPS_PROXY`) and trusts a locally-generated CA (`NODE_EXTRA_CA_CERTS`). teamclaude terminates TLS for the upstream host, injects the real account token, and forwards to the real Anthropic API. **Everything else is tunneled untouched.** The server accepts *both* base-URL and proxy clients at once, so instances launched with and without `--mitm` can share one server.
+That launches claude pointed at teamclaude as an **HTTPS forward proxy** (`HTTPS_PROXY`) and trusts a locally-generated CA (`NODE_EXTRA_CA_CERTS`). For an intercepted host, teamclaude **dials the real upstream first, mirrors its negotiated ALPN** (HTTP/2 or HTTP/1.1), then terminates TLS toward claude with the same protocol and relays the traffic **as transparently as possible** — rewriting only what it must:
+
+- the **`authorization`** header → the active account's real token (dropping any client `x-api-key`);
+- the **`account_uuid`** inside `metadata.user_id` → the active account's UUID (so the body agrees with the injected token);
+- and it reads `anthropic-ratelimit-*` from responses for quota.
+
+Everything else is copied byte-for-byte (HTTP/2 is handled with a built-in HPACK codec so the only header changed is the auth one). Any host other than the upstream is blind-tunnelled. The server accepts *both* base-URL and proxy clients at once, so instances launched with and without `--mitm` can share one server.
 
 Trust model:
 - The CA is generated locally, stored in the config dir, and trusted **only** by the claude process you launch via `teamclaude run` (through `NODE_EXTRA_CA_CERTS`) — it is **never** added to your system trust store. The leaf private key is `0600`; the CA private key is never written to disk.

--- a/src/account-uuid-rewrite.js
+++ b/src/account-uuid-rewrite.js
@@ -1,0 +1,115 @@
+// Rewrite the request body's account_uuid to match the account whose token we
+// inject. Claude Code puts the logged-in account's UUID inside `metadata.user_id`
+// (a stringified JSON) of /v1/messages; under rotation that would disagree with
+// the injected token.
+//
+// This is a STREAMING, byte-exact JSON state machine — no regex, no whole-body
+// buffering — so it handles arbitrarily large bodies fed in chunks. It tracks
+// JSON structure (container stack, current key, in-string/escape) to find the
+// `metadata.user_id` string value, and only inside that value does it look for
+// the `account_uuid` field and overwrite its 36-char value with the new UUID
+// (same length → no content-length/flow-control changes). A stray `account_uuid`
+// elsewhere in the body (user content, tool results) is never touched.
+
+// Byte sequence of `account_uuid":"` as it appears INSIDE the (escaped) user_id
+// string: account_uuid \ " : \ "
+const PREFIX = Buffer.from('account_uuid\\":\\"', 'latin1');
+
+export class AccountUuidPatcher {
+  constructor(newUuid) {
+    this.newUuid = (typeof newUuid === 'string' && newUuid.length === 36) ? Buffer.from(newUuid, 'latin1') : null;
+    this.frames = [];          // container stack: { container:'obj'|'arr', name, key, awaitingKey }
+    this.inStr = false;
+    this.esc = false;
+    this.readingKey = false;
+    this.keyBuf = [];
+    this.target = false;       // inside the metadata.user_id string value
+    this.matchPos = 0;         // PREFIX match progress (within target)
+    this.uuidRemaining = 0;    // value bytes left to overwrite
+    this.done = false;         // patched the one account_uuid already
+    this.changed = false;
+  }
+
+  /** Feed a chunk; returns a same-length chunk (patched in place). */
+  push(chunk) {
+    if (!this.newUuid || this.done) return chunk;
+    const out = Buffer.from(chunk);
+    for (let i = 0; i < out.length; i++) {
+      out[i] = this.#byte(out[i]);
+      if (this.done) break; // rest passes through unchanged
+    }
+    return out;
+  }
+
+  #top() { return this.frames[this.frames.length - 1]; }
+
+  #byte(b) {
+    if (this.target) return this.#targetByte(b);
+
+    if (this.inStr) {
+      if (this.esc) { this.esc = false; if (this.readingKey) this.keyBuf.push(b); return b; }
+      if (b === 0x5c) { this.esc = true; return b; }             // backslash
+      if (b === 0x22) {                                          // end of string
+        this.inStr = false;
+        if (this.readingKey) { this.#top().key = Buffer.from(this.keyBuf).toString('latin1'); this.keyBuf = []; this.readingKey = false; }
+        return b;
+      }
+      if (this.readingKey) this.keyBuf.push(b);
+      return b;
+    }
+
+    const top = this.#top();
+    switch (b) {
+      case 0x7b: this.frames.push({ container: 'obj', name: top ? top.key : null, key: null, awaitingKey: true }); break; // {
+      case 0x5b: this.frames.push({ container: 'arr', name: top ? top.key : null, key: null, awaitingKey: false }); break; // [
+      case 0x7d: case 0x5d: this.frames.pop(); break;            // } ]
+      case 0x3a: if (top) top.awaitingKey = false; break;        // : (key → value)
+      case 0x2c: if (top && top.container === 'obj') top.awaitingKey = true; break; // ,
+      case 0x22:                                                 // string start
+        if (top && top.container === 'obj' && top.awaitingKey) {
+          this.readingKey = true; this.keyBuf = []; this.inStr = true; this.esc = false;
+        } else {
+          this.inStr = true; this.esc = false; this.readingKey = false;
+          if (top && top.container === 'obj' && top.name === 'metadata' && top.key === 'user_id' && this.frames.length === 2) {
+            this.target = true; this.matchPos = 0; this.uuidRemaining = 0;
+          }
+        }
+        break;
+      default: break; // scalars / whitespace
+    }
+    return b;
+  }
+
+  // Inside the metadata.user_id string value: stream-match the account_uuid key
+  // and overwrite its 36-byte value. Detect the (unescaped) closing quote to exit.
+  #targetByte(b) {
+    if (this.uuidRemaining > 0) {
+      const outByte = this.newUuid[this.newUuid.length - this.uuidRemaining];
+      this.uuidRemaining--;
+      if (outByte !== b) this.changed = true;
+      if (this.uuidRemaining === 0) this.done = true; // only one account_uuid per body
+      return outByte;
+    }
+    if (this.esc) { this.esc = false; this.#match(b); return b; }
+    if (b === 0x5c) { this.esc = true; this.#match(b); return b; }
+    if (b === 0x22) { this.target = false; this.matchPos = 0; return b; } // end of user_id value
+    this.#match(b);
+    return b;
+  }
+
+  #match(b) {
+    if (b === PREFIX[this.matchPos]) {
+      this.matchPos++;
+      if (this.matchPos === PREFIX.length) { this.uuidRemaining = 36; this.matchPos = 0; }
+    } else {
+      this.matchPos = (b === PREFIX[0]) ? 1 : 0; // PREFIX has no internal repeat of its first byte
+    }
+  }
+}
+
+/** One-shot convenience (whole-buffer); returns the same instance if unchanged. */
+export function patchAccountUuid(buf, newUuid) {
+  const p = new AccountUuidPatcher(newUuid);
+  const out = p.push(buf);
+  return p.changed ? out : buf;
+}

--- a/src/h2/frames.js
+++ b/src/h2/frames.js
@@ -1,0 +1,83 @@
+// Minimal HTTP/2 framing (RFC 7540 §4) — just what the MITM relay needs:
+// split a byte stream into frames, re-serialize frames, and (de)construct
+// HEADERS/CONTINUATION header blocks so we can rewrite one header and re-emit.
+// All other frame types are forwarded verbatim by the relay.
+
+export const FRAME = {
+  DATA: 0x0, HEADERS: 0x1, PRIORITY: 0x2, RST_STREAM: 0x3, SETTINGS: 0x4,
+  PUSH_PROMISE: 0x5, PING: 0x6, GOAWAY: 0x7, WINDOW_UPDATE: 0x8, CONTINUATION: 0x9,
+};
+export const FLAG = { END_STREAM: 0x1, END_HEADERS: 0x4, PADDED: 0x8, PRIORITY: 0x20 };
+
+// Client connection preface: "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" (RFC 7540 §3.5).
+export const PREFACE = Buffer.from('505249202a20485454502f322e300d0a0d0a534d0d0a0d0a', 'hex');
+
+/**
+ * Split as many complete frames as possible out of `buf`.
+ * Returns { frames, rest } where rest is the unconsumed tail (incomplete frame).
+ * Each frame: { type, flags, streamId, payload, raw } (payload/raw are subarrays).
+ */
+export function readFrames(buf) {
+  const frames = [];
+  let off = 0;
+  while (buf.length - off >= 9) {
+    const length = buf.readUIntBE(off, 3);
+    if (buf.length - off < 9 + length) break;
+    frames.push({
+      type: buf[off + 3],
+      flags: buf[off + 4],
+      streamId: buf.readUInt32BE(off + 5) & 0x7fffffff,
+      payload: buf.subarray(off + 9, off + 9 + length),
+      raw: buf.subarray(off, off + 9 + length),
+    });
+    off += 9 + length;
+  }
+  return { frames, rest: buf.subarray(off) };
+}
+
+/** Serialize one frame. */
+export function buildFrame({ type, flags = 0, streamId, payload = Buffer.alloc(0) }) {
+  const h = Buffer.alloc(9);
+  h.writeUIntBE(payload.length, 0, 3);
+  h[3] = type;
+  h[4] = flags;
+  h.writeUInt32BE(streamId & 0x7fffffff, 5);
+  return Buffer.concat([h, payload]);
+}
+
+/**
+ * Pull the header-block fragment out of a HEADERS payload, stripping any
+ * PADDED / PRIORITY prefixes. Returns { block, priority } where priority is the
+ * 5-byte priority field (or null). Padding is discarded.
+ */
+export function stripHeadersPayload(payload, flags) {
+  let off = 0;
+  let padLen = 0;
+  if (flags & FLAG.PADDED) { padLen = payload[0]; off = 1; }
+  let priority = null;
+  if (flags & FLAG.PRIORITY) { priority = Buffer.from(payload.subarray(off, off + 5)); off += 5; }
+  const block = Buffer.from(payload.subarray(off, payload.length - padLen));
+  return { block, priority };
+}
+
+/**
+ * Build a HEADERS frame (+ CONTINUATION frames if the block exceeds
+ * maxFrameSize) for a re-encoded header block. Padding is not re-added.
+ */
+export function buildHeaderBlock(streamId, block, { endStream = false, priority = null, maxFrameSize = 16384 } = {}) {
+  const prio = priority || Buffer.alloc(0);
+  const firstCap = Math.max(0, maxFrameSize - prio.length);
+  const firstChunk = block.subarray(0, firstCap);
+  let rest = block.subarray(firstChunk.length);
+
+  let hFlags = (endStream ? FLAG.END_STREAM : 0) | (priority ? FLAG.PRIORITY : 0);
+  if (rest.length === 0) hFlags |= FLAG.END_HEADERS;
+
+  const out = [buildFrame({ type: FRAME.HEADERS, flags: hFlags, streamId, payload: Buffer.concat([prio, firstChunk]) })];
+  while (rest.length) {
+    const chunk = rest.subarray(0, maxFrameSize);
+    rest = rest.subarray(chunk.length);
+    out.push(buildFrame({ type: FRAME.CONTINUATION, flags: rest.length === 0 ? FLAG.END_HEADERS : 0, streamId, payload: chunk }));
+  }
+  return Buffer.concat(out);
+}

--- a/src/h2/hpack.js
+++ b/src/h2/hpack.js
@@ -264,6 +264,11 @@ export class HpackEncoder {
     this.table = new DynamicTable(maxSize);
     this.useHuffman = true;
     this.pendingSizeUpdate = maxSize === DEFAULT_TABLE_SIZE ? null : maxSize;
+    // When false, never insert into / reference the dynamic table — emit every
+    // field as a literal (full static matches still use the static index). This
+    // makes the encoder independent of the peer's SETTINGS_HEADER_TABLE_SIZE,
+    // which the MITM relay relies on (it doesn't track the upstream's table).
+    this.dynamicIndexing = true;
   }
   encode(fields) {
     const out = [];
@@ -281,9 +286,13 @@ export class HpackEncoder {
       return;
     }
     const m = this.table.find(name, value);
-    if (m && m.valueMatched) { encodeInt(out, m.index, 7, 0x80); return; }
-    this.#literal(out, 0x40, 6, m ? m.index : null, name, value);
-    this.table.insert(name, value);
+    if (m && m.valueMatched) { encodeInt(out, m.index, 7, 0x80); return; } // indexed (static when no indexing)
+    if (this.dynamicIndexing) {
+      this.#literal(out, 0x40, 6, m ? m.index : null, name, value); // literal w/ incremental indexing
+      this.table.insert(name, value);
+    } else {
+      this.#literal(out, 0x00, 4, m ? m.index : null, name, value); // literal without indexing; no insert
+    }
   }
   #literal(out, pattern, prefix, nameIdx, name, value) {
     if (nameIdx !== null) encodeInt(out, nameIdx, prefix, pattern);

--- a/src/h2/hpack.js
+++ b/src/h2/hpack.js
@@ -1,0 +1,305 @@
+// HPACK header compression (RFC 7541) — pure JS, no deps.
+//
+// Ported clean-room from the compcol Rust implementation (itself transcribed
+// from RFC 7541's appendices). Used by the MITM proxy to decode/re-encode the
+// HTTP/2 header block so it can rewrite only the `authorization` field while
+// leaving everything else intact. Names/values are Buffers (byte-exact).
+//
+// State note: an HPACK codec is stateful across header blocks (the dynamic
+// table evolves), so one HpackDecoder/HpackEncoder instance is kept per
+// direction per connection.
+
+// ── Huffman code table (RFC 7541 Appendix B): [code, bitLength] by symbol ──
+// Index = symbol value; index 256 = EOS.
+const CODES = [
+  [0x1ff8,13],[0x7fffd8,23],[0xfffffe2,28],[0xfffffe3,28],[0xfffffe4,28],[0xfffffe5,28],[0xfffffe6,28],[0xfffffe7,28],
+  [0xfffffe8,28],[0xffffea,24],[0x3ffffffc,30],[0xfffffe9,28],[0xfffffea,28],[0x3ffffffd,30],[0xfffffeb,28],[0xfffffec,28],
+  [0xfffffed,28],[0xfffffee,28],[0xfffffef,28],[0xffffff0,28],[0xffffff1,28],[0xffffff2,28],[0x3ffffffe,30],[0xffffff3,28],
+  [0xffffff4,28],[0xffffff5,28],[0xffffff6,28],[0xffffff7,28],[0xffffff8,28],[0xffffff9,28],[0xffffffa,28],[0xffffffb,28],
+  [0x14,6],[0x3f8,10],[0x3f9,10],[0xffa,12],[0x1ff9,13],[0x15,6],[0xf8,8],[0x7fa,11],
+  [0x3fa,10],[0x3fb,10],[0xf9,8],[0x7fb,11],[0xfa,8],[0x16,6],[0x17,6],[0x18,6],
+  [0x0,5],[0x1,5],[0x2,5],[0x19,6],[0x1a,6],[0x1b,6],[0x1c,6],[0x1d,6],
+  [0x1e,6],[0x1f,6],[0x5c,7],[0xfb,8],[0x7ffc,15],[0x20,6],[0xffb,12],[0x3fc,10],
+  [0x1ffa,13],[0x21,6],[0x5d,7],[0x5e,7],[0x5f,7],[0x60,7],[0x61,7],[0x62,7],
+  [0x63,7],[0x64,7],[0x65,7],[0x66,7],[0x67,7],[0x68,7],[0x69,7],[0x6a,7],
+  [0x6b,7],[0x6c,7],[0x6d,7],[0x6e,7],[0x6f,7],[0x70,7],[0x71,7],[0x72,7],
+  [0xfc,8],[0x73,7],[0xfd,8],[0x1ffb,13],[0x7fff0,19],[0x1ffc,13],[0x3ffc,14],[0x22,6],
+  [0x7ffd,15],[0x3,5],[0x23,6],[0x4,5],[0x24,6],[0x5,5],[0x25,6],[0x26,6],
+  [0x27,6],[0x6,5],[0x74,7],[0x75,7],[0x28,6],[0x29,6],[0x2a,6],[0x7,5],
+  [0x2b,6],[0x76,7],[0x2c,6],[0x8,5],[0x9,5],[0x2d,6],[0x77,7],[0x78,7],
+  [0x79,7],[0x7a,7],[0x7b,7],[0x7ffe,15],[0x7fc,11],[0x3ffd,14],[0x1ffd,13],[0xffffffc,28],
+  [0xfffe6,20],[0x3fffd2,22],[0xfffe7,20],[0xfffe8,20],[0x3fffd3,22],[0x3fffd4,22],[0x3fffd5,22],[0x7fffd9,23],
+  [0x3fffd6,22],[0x7fffda,23],[0x7fffdb,23],[0x7fffdc,23],[0x7fffdd,23],[0x7fffde,23],[0xffffeb,24],[0x7fffdf,23],
+  [0xffffec,24],[0xffffed,24],[0x3fffd7,22],[0x7fffe0,23],[0xffffee,24],[0x7fffe1,23],[0x7fffe2,23],[0x7fffe3,23],
+  [0x7fffe4,23],[0x1fffdc,21],[0x3fffd8,22],[0x7fffe5,23],[0x3fffd9,22],[0x7fffe6,23],[0x7fffe7,23],[0xffffef,24],
+  [0x3fffda,22],[0x1fffdd,21],[0xfffe9,20],[0x3fffdb,22],[0x3fffdc,22],[0x7fffe8,23],[0x7fffe9,23],[0x1fffde,21],
+  [0x7fffea,23],[0x3fffdd,22],[0x3fffde,22],[0xfffff0,24],[0x1fffdf,21],[0x3fffdf,22],[0x7fffeb,23],[0x7fffec,23],
+  [0x1fffe0,21],[0x1fffe1,21],[0x3fffe0,22],[0x1fffe2,21],[0x7fffed,23],[0x3fffe1,22],[0x7fffee,23],[0x7fffef,23],
+  [0xfffea,20],[0x3fffe2,22],[0x3fffe3,22],[0x3fffe4,22],[0x7ffff0,23],[0x3fffe5,22],[0x3fffe6,22],[0x7ffff1,23],
+  [0x3ffffe0,26],[0x3ffffe1,26],[0xfffeb,20],[0x7fff1,19],[0x3fffe7,22],[0x7ffff2,23],[0x3fffe8,22],[0x1ffffec,25],
+  [0x3ffffe2,26],[0x3ffffe3,26],[0x3ffffe4,26],[0x7ffffde,27],[0x7ffffdf,27],[0x3ffffe5,26],[0xfffff1,24],[0x1ffffed,25],
+  [0x7fff2,19],[0x1fffe3,21],[0x3ffffe6,26],[0x7ffffe0,27],[0x7ffffe1,27],[0x3ffffe7,26],[0x7ffffe2,27],[0xfffff2,24],
+  [0x1fffe4,21],[0x1fffe5,21],[0x3ffffe8,26],[0x3ffffe9,26],[0xffffffd,28],[0x7ffffe3,27],[0x7ffffe4,27],[0x7ffffe5,27],
+  [0xfffec,20],[0xfffff3,24],[0xfffed,20],[0x1fffe6,21],[0x3fffe9,22],[0x1fffe7,21],[0x1fffe8,21],[0x7ffff3,23],
+  [0x3fffea,22],[0x3fffeb,22],[0x1ffffee,25],[0x1ffffef,25],[0xfffff4,24],[0xfffff5,24],[0x3ffffea,26],[0x7ffff4,23],
+  [0x3ffffeb,26],[0x7ffffe6,27],[0x3ffffec,26],[0x3ffffed,26],[0x7ffffe7,27],[0x7ffffe8,27],[0x7ffffe9,27],[0x7ffffea,27],
+  [0x7ffffeb,27],[0xffffffe,28],[0x7ffffec,27],[0x7ffffed,27],[0x7ffffee,27],[0x7ffffef,27],[0x7fffff0,27],[0x3ffffee,26],
+  [0x3fffffff,30],
+];
+const EOS = 256;
+
+class HpackError extends Error {}
+
+// ── Huffman decode trie (built once) ──────────────────────────────────────
+const trie = { c0: [-1], c1: [-1], leaf: [-1] }; // node 0 = root
+(function buildTrie() {
+  for (let sym = 0; sym < CODES.length; sym++) {
+    const [code, len] = CODES[sym];
+    let node = 0;
+    for (let i = len - 1; i >= 0; i--) {
+      const bit = (code >>> i) & 1;
+      const arr = bit ? trie.c1 : trie.c0;
+      let next = arr[node];
+      if (next === -1) {
+        next = trie.leaf.length;
+        trie.c0.push(-1); trie.c1.push(-1); trie.leaf.push(-1);
+        arr[node] = next;
+      }
+      node = next;
+    }
+    trie.leaf[node] = sym;
+  }
+})();
+
+export function huffmanEncodedLen(buf) {
+  let bits = 0;
+  for (const b of buf) bits += CODES[b][1];
+  return Math.ceil(bits / 8);
+}
+
+export function huffmanEncode(buf) {
+  const out = [];
+  let acc = 0n, nbits = 0n;
+  for (const b of buf) {
+    const [code, len] = CODES[b];
+    acc = (acc << BigInt(len)) | BigInt(code);
+    nbits += BigInt(len);
+    while (nbits >= 8n) {
+      nbits -= 8n;
+      out.push(Number((acc >> nbits) & 0xffn));
+    }
+  }
+  if (nbits > 0n) {
+    const pad = 8n - nbits;
+    out.push(Number(((acc << pad) | ((1n << pad) - 1n)) & 0xffn));
+  }
+  return Buffer.from(out);
+}
+
+export function huffmanDecode(buf) {
+  const out = [];
+  let node = 0, depth = 0, allOnes = true;
+  for (const byte of buf) {
+    for (let i = 7; i >= 0; i--) {
+      const bit = (byte >> i) & 1;
+      node = bit ? trie.c1[node] : trie.c0[node];
+      depth++; allOnes = allOnes && bit === 1;
+      const sym = trie.leaf[node];
+      if (sym >= 0) {
+        if (sym === EOS) throw new HpackError('EOS symbol in input');
+        out.push(sym);
+        node = 0; depth = 0; allOnes = true;
+      }
+    }
+  }
+  if (depth >= 8 || !allOnes) throw new HpackError('bad Huffman padding');
+  return Buffer.from(out);
+}
+
+// ── integer codec (RFC 7541 §5.1) ─────────────────────────────────────────
+export function encodeInt(out, value, n, flags) {
+  const maxPrefix = (1 << n) - 1;
+  if (value < maxPrefix) { out.push(flags | value); return; }
+  out.push(flags | maxPrefix);
+  let v = value - maxPrefix;
+  while (v >= 128) { out.push((v & 0x7f) | 0x80); v = Math.floor(v / 128); }
+  out.push(v);
+}
+
+export function decodeInt(buf, pos, n) {
+  const maxPrefix = (1 << n) - 1;
+  if (pos >= buf.length) throw new HpackError('truncated integer');
+  let value = buf[pos] & maxPrefix;
+  let p = pos + 1;
+  if (value < maxPrefix) return [value, p];
+  let shift = 0;
+  for (;;) {
+    if (p >= buf.length) throw new HpackError('truncated integer');
+    const b = buf[p++];
+    if (shift >= 53) throw new HpackError('integer overflow');
+    value += (b & 0x7f) * 2 ** shift;
+    if (!(b & 0x80)) break;
+    shift += 7;
+  }
+  return [value, p];
+}
+
+// ── static table (RFC 7541 Appendix A) ─────────────────────────────────────
+const STATIC_TABLE = [
+  [':authority', ''], [':method', 'GET'], [':method', 'POST'], [':path', '/'],
+  [':path', '/index.html'], [':scheme', 'http'], [':scheme', 'https'], [':status', '200'],
+  [':status', '204'], [':status', '206'], [':status', '304'], [':status', '400'],
+  [':status', '404'], [':status', '500'], ['accept-charset', ''], ['accept-encoding', 'gzip, deflate'],
+  ['accept-language', ''], ['accept-ranges', ''], ['accept', ''], ['access-control-allow-origin', ''],
+  ['age', ''], ['allow', ''], ['authorization', ''], ['cache-control', ''],
+  ['content-disposition', ''], ['content-encoding', ''], ['content-language', ''], ['content-length', ''],
+  ['content-location', ''], ['content-range', ''], ['content-type', ''], ['cookie', ''],
+  ['date', ''], ['etag', ''], ['expect', ''], ['expires', ''],
+  ['from', ''], ['host', ''], ['if-match', ''], ['if-modified-since', ''],
+  ['if-none-match', ''], ['if-range', ''], ['if-unmodified-since', ''], ['last-modified', ''],
+  ['link', ''], ['location', ''], ['max-forwards', ''], ['proxy-authenticate', ''],
+  ['proxy-authorization', ''], ['range', ''], ['referer', ''], ['refresh', ''],
+  ['retry-after', ''], ['server', ''], ['set-cookie', ''], ['strict-transport-security', ''],
+  ['transfer-encoding', ''], ['user-agent', ''], ['vary', ''], ['via', ''],
+  ['www-authenticate', ''],
+].map(([n, v]) => [Buffer.from(n), Buffer.from(v)]);
+const STATIC_LEN = STATIC_TABLE.length;
+const ENTRY_OVERHEAD = 32;
+
+class DynamicTable {
+  constructor(maxSize) { this.entries = []; this.size = 0; this.maxSize = maxSize; }
+  setMaxSize(m) { this.maxSize = m; this.#evict(0); }
+  #entrySize(n, v) { return n.length + v.length + ENTRY_OVERHEAD; }
+  #evict(incoming) {
+    while (this.size + incoming > this.maxSize && this.entries.length) {
+      const [n, v] = this.entries.pop();
+      this.size -= this.#entrySize(n, v);
+    }
+  }
+  insert(name, value) {
+    const need = this.#entrySize(name, value);
+    this.#evict(need);
+    if (need <= this.maxSize) { this.entries.unshift([name, value]); this.size += need; }
+  }
+  get(index) {
+    if (index === 0) return null;
+    if (index <= STATIC_LEN) return STATIC_TABLE[index - 1];
+    const e = this.entries[index - STATIC_LEN - 1];
+    return e || null;
+  }
+  find(name, value) {
+    let nameOnly = null;
+    for (let i = 0; i < STATIC_TABLE.length; i++) {
+      const [n, v] = STATIC_TABLE[i];
+      if (n.equals(name)) {
+        if (v.equals(value)) return { index: i + 1, valueMatched: true };
+        if (nameOnly === null) nameOnly = i + 1;
+      }
+    }
+    for (let pos = 0; pos < this.entries.length; pos++) {
+      const [n, v] = this.entries[pos];
+      if (n.equals(name)) {
+        const index = STATIC_LEN + 1 + pos;
+        if (v.equals(value)) return { index, valueMatched: true };
+        if (nameOnly === null) nameOnly = index;
+      }
+    }
+    return nameOnly === null ? null : { index: nameOnly, valueMatched: false };
+  }
+}
+
+export const DEFAULT_TABLE_SIZE = 4096;
+
+function readString(block, pos) {
+  if (pos >= block.length) throw new HpackError('truncated string');
+  const huff = (block[pos] & 0x80) !== 0;
+  const [len, p] = decodeInt(block, pos, 7);
+  const end = p + len;
+  if (end > block.length) throw new HpackError('truncated string');
+  const raw = block.subarray(p, end);
+  return [huff ? huffmanDecode(raw) : Buffer.from(raw), end];
+}
+
+// A decoded/encodable field. name/value are Buffers; sensitive = never-indexed.
+export class HpackDecoder {
+  constructor(maxSize = DEFAULT_TABLE_SIZE) { this.table = new DynamicTable(maxSize); this.sizeLimit = maxSize; }
+  decode(block) {
+    const fields = [];
+    let pos = 0;
+    while (pos < block.length) {
+      const b = block[pos];
+      if (b & 0x80) { // §6.1 indexed
+        const [idx, np] = decodeInt(block, pos, 7); pos = np;
+        if (idx === 0) throw new HpackError('index 0');
+        const e = this.table.get(idx); if (!e) throw new HpackError('bad index');
+        fields.push({ name: e[0], value: e[1], sensitive: false });
+      } else if (b & 0x40) { // §6.2.1 literal w/ incremental indexing
+        const [name, value, np] = this.#readLiteral(block, pos, 6); pos = np;
+        this.table.insert(name, value);
+        fields.push({ name, value, sensitive: false });
+      } else if (b & 0x20) { // §6.3 dynamic table size update
+        const [newMax, np] = decodeInt(block, pos, 5); pos = np;
+        if (newMax > this.sizeLimit) throw new HpackError('size update over limit');
+        this.table.setMaxSize(newMax);
+      } else { // §6.2.2 / §6.2.3 (4-bit prefix; 0x10 = never indexed)
+        const sensitive = (b & 0x10) !== 0;
+        const [name, value, np] = this.#readLiteral(block, pos, 4); pos = np;
+        fields.push({ name, value, sensitive });
+      }
+    }
+    return fields;
+  }
+  #readLiteral(block, pos, prefix) {
+    const [idx, p0] = decodeInt(block, pos, prefix);
+    let p = p0, name;
+    if (idx === 0) { const [n, np] = readString(block, p); name = n; p = np; }
+    else { const e = this.table.get(idx); if (!e) throw new HpackError('bad name index'); name = e[0]; }
+    const [value, np] = readString(block, p);
+    return [name, value, np];
+  }
+}
+
+export class HpackEncoder {
+  constructor(maxSize = DEFAULT_TABLE_SIZE) {
+    this.table = new DynamicTable(maxSize);
+    this.useHuffman = true;
+    this.pendingSizeUpdate = maxSize === DEFAULT_TABLE_SIZE ? null : maxSize;
+  }
+  encode(fields) {
+    const out = [];
+    if (this.pendingSizeUpdate !== null) { encodeInt(out, this.pendingSizeUpdate, 5, 0x20); this.pendingSizeUpdate = null; }
+    for (const f of fields) this.#field(out, f);
+    return Buffer.from(out);
+  }
+  #field(out, f) {
+    const name = Buffer.isBuffer(f.name) ? f.name : Buffer.from(f.name);
+    const value = Buffer.isBuffer(f.value) ? f.value : Buffer.from(f.value);
+    if (f.sensitive) {
+      const m = this.table.find(name, value);
+      const nameIdx = (m && this.table.get(m.index)[0].equals(name)) ? m.index : null;
+      this.#literal(out, 0x10, 4, nameIdx, name, value);
+      return;
+    }
+    const m = this.table.find(name, value);
+    if (m && m.valueMatched) { encodeInt(out, m.index, 7, 0x80); return; }
+    this.#literal(out, 0x40, 6, m ? m.index : null, name, value);
+    this.table.insert(name, value);
+  }
+  #literal(out, pattern, prefix, nameIdx, name, value) {
+    if (nameIdx !== null) encodeInt(out, nameIdx, prefix, pattern);
+    else { encodeInt(out, 0, prefix, pattern); this.#string(out, name); }
+    this.#string(out, value);
+  }
+  #string(out, s) {
+    if (this.useHuffman && huffmanEncodedLen(s) < s.length) {
+      const coded = huffmanEncode(s);
+      encodeInt(out, coded.length, 7, 0x80);
+      for (const b of coded) out.push(b);
+    } else {
+      encodeInt(out, s.length, 7, 0x00);
+      for (const b of s) out.push(b);
+    }
+  }
+}
+
+export { HpackError };

--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -148,6 +148,70 @@ export function h2Relay(claude, upstream, opts = {}) {
   respCtl = link(upstream, claude, onRespData, destroyBoth);
 }
 
+/**
+ * Faithful HTTP/1.1 relay for the rare h1 case. Reads the first request head,
+ * rewrites only the auth line (via `rewriteHead`), forwards it, then tunnels
+ * both directions raw. (Real Anthropic traffic is h2; on a keep-alive h1
+ * connection only the first request's auth is rewritten — documented tradeoff.)
+ *
+ * @param opts.rewriteHead (headText) => headText
+ */
+export function h1Relay(claude, upstream, opts = {}) {
+  const rewriteHead = opts.rewriteHead || ((h) => h);
+  const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
+  claude.on('error', destroyBoth);
+  upstream.on('error', destroyBoth);
+  claude.on('close', () => upstream.destroy());
+  upstream.on('close', () => claude.destroy());
+
+  let buf = Buffer.alloc(0);
+  let done = false;
+  const onData = (chunk) => {
+    buf = Buffer.concat([buf, chunk]);
+    const idx = buf.indexOf('\r\n\r\n');
+    if (idx < 0) {
+      if (buf.length > 65536) destroyBoth(); // runaway head
+      return;
+    }
+    done = true;
+    claude.removeListener('data', onData);
+    const head = rewriteHead(buf.subarray(0, idx + 4).toString('latin1'));
+    upstream.write(Buffer.from(head, 'latin1'));
+    const remainder = buf.subarray(idx + 4);
+    if (remainder.length) upstream.write(remainder);
+    claude.pipe(upstream);
+    upstream.pipe(claude);
+  };
+  claude.on('data', onData);
+  void done;
+}
+
+/** Rewrite an HTTP/1.1 request head: replace the Authorization line with
+ *  `authValue` (or set x-api-key), and drop the other client-supplied key. */
+export function rewriteH1Auth(headText, { authorization = null, apiKey = null }) {
+  const lines = headText.split('\r\n');
+  const out = [lines[0]]; // request line
+  let setAuth = false;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') { out.push(line); continue; }
+    const lower = line.toLowerCase();
+    if (lower.startsWith('x-api-key:')) continue;
+    if (lower.startsWith('authorization:')) {
+      if (authorization) { out.push(`authorization: ${authorization}`); setAuth = true; }
+      continue;
+    }
+    out.push(line);
+  }
+  // insert our credential just before the terminating blank line if not already set
+  if (!setAuth && (authorization || apiKey)) {
+    const blank = out.lastIndexOf('');
+    const hdr = authorization ? `authorization: ${authorization}` : `x-api-key: ${apiKey}`;
+    out.splice(blank, 0, hdr);
+  }
+  return out.join('\r\n');
+}
+
 // Parse a SETTINGS payload for HEADER_TABLE_SIZE and apply it to a decoder's
 // size limit (so it stays in sync with the announcing peer's encoder).
 function applyTableSizeSetting(payload, decoder) {

--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -46,6 +46,7 @@ export function h2Relay(claude, upstream, opts = {}) {
   const onResponseHeaders = opts.onResponseHeaders || (() => {});
   const makeBodyPatcher = opts.makeBodyPatcher || null; // () => { push(buf)->buf } per stream
   const bodyPatchers = makeBodyPatcher ? new Map() : null; // streamId -> patcher
+  const tap = opts.tap || null; // optional request-logging tap (per streamId)
   const log = opts.log || (() => {});
 
   const reqDec = new HpackDecoder();         // decodes claude's request blocks
@@ -91,18 +92,22 @@ export function h2Relay(claude, upstream, opts = {}) {
       if (fr.flags & FLAG.END_HEADERS) finishReqBlock();
       return;
     }
-    if (fr.type === FRAME.DATA && bodyPatchers) {
+    if (fr.type === FRAME.DATA && (bodyPatchers || tap)) {
       // Same-length in-place body patch (account_uuid) via a per-stream streaming
       // JSON state machine; re-emit the DATA frame unchanged in length/flags so
       // framing & flow control are preserved.
-      let p = bodyPatchers.get(fr.streamId);
-      if (!p) { p = makeBodyPatcher(); bodyPatchers.set(fr.streamId, p); }
-      const payload = p.push(Buffer.from(fr.payload));
+      let payload = Buffer.from(fr.payload);
+      if (bodyPatchers) {
+        let p = bodyPatchers.get(fr.streamId);
+        if (!p) { p = makeBodyPatcher(); bodyPatchers.set(fr.streamId, p); }
+        payload = p.push(payload);
+      }
+      if (tap) tap.reqData(fr.streamId, payload);
       writeBackpressured(upstream, buildFrame({ type: FRAME.DATA, flags: fr.flags, streamId: fr.streamId, payload }), reqCtl);
-      if (fr.flags & FLAG.END_STREAM) bodyPatchers.delete(fr.streamId);
+      if (fr.flags & FLAG.END_STREAM && bodyPatchers) bodyPatchers.delete(fr.streamId);
       return;
     }
-    if (fr.type === FRAME.RST_STREAM && bodyPatchers) bodyPatchers.delete(fr.streamId);
+    if (fr.type === FRAME.RST_STREAM) { if (bodyPatchers) bodyPatchers.delete(fr.streamId); tap?.end(fr.streamId); }
     if (fr.type === FRAME.SETTINGS && fr.streamId === 0 && !(fr.flags & 0x1)) {
       applyTableSizeSetting(fr.payload, respDec); // claude's setting governs response encoding
     }
@@ -114,6 +119,7 @@ export function h2Relay(claude, upstream, opts = {}) {
     asm = null;
     const fields = reqDec.decode(Buffer.concat(frags)); // keep decoder dynamic table in sync
     const rewritten = rewriteRequest(fields);
+    if (tap) tap.req(streamId, rewritten);
     const newBlock = reqEnc.encode(rewritten);
     writeBackpressured(upstream, buildHeaderBlock(streamId, newBlock, { endStream, priority }), reqCtl);
   }
@@ -137,23 +143,29 @@ export function h2Relay(claude, upstream, opts = {}) {
     if (rasm) {
       if (fr.type === FRAME.CONTINUATION && fr.streamId === rasm.streamId) {
         rasm.frags.push(Buffer.from(fr.payload));
-        if (fr.flags & FLAG.END_HEADERS) finishRespBlock();
+        if (fr.flags & FLAG.END_HEADERS) finishRespBlock(rasm.streamId);
       }
       return;
     }
     if (fr.type === FRAME.HEADERS) {
       const { block } = stripHeadersPayload(fr.payload, fr.flags);
       rasm = { streamId: fr.streamId, frags: [block] };
-      if (fr.flags & FLAG.END_HEADERS) finishRespBlock();
+      if (fr.flags & FLAG.END_HEADERS) finishRespBlock(fr.streamId);
+      if (fr.flags & FLAG.END_STREAM) tap?.end(fr.streamId);
+      return;
+    }
+    if (fr.type === FRAME.DATA) {
+      if (tap) { tap.resData(fr.streamId, Buffer.from(fr.payload)); if (fr.flags & FLAG.END_STREAM) tap.end(fr.streamId); }
     }
   }
 
-  function finishRespBlock() {
+  function finishRespBlock(streamId) {
     const { frags } = rasm;
     rasm = null;
     try {
       const fields = respDec.decode(Buffer.concat(frags));
       onResponseHeaders(fields);
+      if (tap) tap.res(streamId, fields);
     } catch (err) {
       log(`[TeamClaude] h2 response header decode failed: ${err.message}`);
     }
@@ -174,12 +186,17 @@ export function h1Relay(claude, upstream, opts = {}) {
   const rewriteHead = opts.rewriteHead || ((h) => h);
   const patcher = opts.makeBodyPatcher ? opts.makeBodyPatcher() : null;
   const rewriteData = patcher ? (b) => patcher.push(b) : (b) => b; // same-length body patch
+  const tap = opts.tap || null;
+  const SID = 1; // single logical request id for h1
   const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
   claude.on('error', destroyBoth);
   upstream.on('error', destroyBoth);
   claude.on('close', () => upstream.destroy());
-  upstream.on('close', () => claude.destroy());
-  upstream.pipe(claude); // responses: verbatim
+  upstream.on('close', () => { tap?.end(SID); claude.destroy(); });
+
+  // responses: verbatim (observed for logging)
+  upstream.on('data', (c) => { if (tap) tap.resData(SID, Buffer.from(c)); claude.write(c); });
+  upstream.on('end', () => { tap?.end(SID); claude.end(); });
 
   let buf = Buffer.alloc(0);
   const onData = (chunk) => {
@@ -190,11 +207,13 @@ export function h1Relay(claude, upstream, opts = {}) {
       return;
     }
     claude.removeListener('data', onData);
-    upstream.write(Buffer.from(rewriteHead(buf.subarray(0, idx + 4).toString('latin1')), 'latin1'));
+    const head = rewriteHead(buf.subarray(0, idx + 4).toString('latin1'));
+    if (tap) tap.reqHead(SID, head);
+    upstream.write(Buffer.from(head, 'latin1'));
     const remainder = buf.subarray(idx + 4);
-    if (remainder.length) upstream.write(rewriteData(Buffer.from(remainder)));
+    if (remainder.length) { const patched = rewriteData(Buffer.from(remainder)); if (tap) tap.reqData(SID, patched); upstream.write(patched); }
     // forward (patched) request body
-    claude.on('data', (c) => upstream.write(rewriteData(Buffer.from(c))));
+    claude.on('data', (c) => { const patched = rewriteData(Buffer.from(c)); if (tap) tap.reqData(SID, patched); upstream.write(patched); });
     claude.on('end', () => upstream.end());
   };
   claude.on('data', onData);

--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -1,0 +1,161 @@
+// Transparent HTTP/2 relay for the MITM proxy.
+//
+// Bridges two already-decrypted h2 byte streams (claude ⇄ upstream). The
+// request direction (claude→upstream) is parsed frame-by-frame: HEADERS/
+// CONTINUATION blocks are HPACK-decoded, handed to `rewriteRequest` (which
+// rewrites only the auth field), re-encoded, and re-framed; every other frame
+// is forwarded verbatim. The response direction (upstream→claude) is passed
+// through byte-for-byte and only *observed* (read-only HPACK decode) so we can
+// surface `:status` + rate-limit headers for quota tracking.
+
+import { readFrames, buildHeaderBlock, stripHeadersPayload, FRAME, FLAG, PREFACE } from './frames.js';
+import { HpackDecoder, HpackEncoder } from './hpack.js';
+
+const SETTINGS_HEADER_TABLE_SIZE = 0x1;
+
+// Wire src→dst with backpressure; `onClose` fires once when either side ends.
+function link(src, dst, onData, onClose) {
+  let closed = false;
+  const close = () => { if (closed) return; closed = true; onClose(); };
+  src.on('data', (chunk) => {
+    try { onData(chunk); } catch (err) { close(); src.destroy(err); }
+  });
+  src.on('end', close);
+  src.on('close', close);
+  src.on('error', close);
+  return { pauseSrc: () => src.pause(), resumeSrc: () => src.resume() };
+}
+
+function writeBackpressured(dst, buf, ctl) {
+  if (buf.length === 0) return;
+  if (!dst.write(buf)) {
+    ctl.pauseSrc();
+    dst.once('drain', () => ctl.resumeSrc());
+  }
+}
+
+/**
+ * @param claude decrypted duplex toward the client
+ * @param upstream decrypted duplex toward Anthropic
+ * @param opts.rewriteRequest (fields[]) => fields[]   // mutate/return the header list
+ * @param opts.onResponseHeaders (fields[]) => void    // observe response headers
+ * @param opts.log
+ */
+export function h2Relay(claude, upstream, opts = {}) {
+  const rewriteRequest = opts.rewriteRequest || ((f) => f);
+  const onResponseHeaders = opts.onResponseHeaders || (() => {});
+  const log = opts.log || (() => {});
+
+  const reqDec = new HpackDecoder();         // decodes claude's request blocks
+  const reqEnc = new HpackEncoder();         // re-encodes to upstream
+  reqEnc.dynamicIndexing = false;            // independent of upstream's table size
+  const respDec = new HpackDecoder();        // read-only, decodes upstream responses
+
+  const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
+
+  // ── request direction: claude → upstream (rewrite HEADERS) ──
+  let rbuf = Buffer.alloc(0);
+  let prefaceSeen = false;
+  let asm = null; // { streamId, frags:[], priority, endStream } while assembling a block
+  let reqCtl;
+
+  const onReqData = (chunk) => {
+    rbuf = Buffer.concat([rbuf, chunk]);
+    if (!prefaceSeen) {
+      if (rbuf.length < PREFACE.length) return;
+      writeBackpressured(upstream, rbuf.subarray(0, PREFACE.length), reqCtl); // forward preface verbatim
+      rbuf = rbuf.subarray(PREFACE.length);
+      prefaceSeen = true;
+    }
+    const { frames, rest } = readFrames(rbuf);
+    rbuf = rest;
+    for (const fr of frames) handleReqFrame(fr);
+  };
+
+  function handleReqFrame(fr) {
+    // Mid-block: only CONTINUATION on the same stream may follow (RFC 7540 §6.10).
+    if (asm) {
+      if (fr.type === FRAME.CONTINUATION && fr.streamId === asm.streamId) {
+        asm.frags.push(Buffer.from(fr.payload));
+        if (fr.flags & FLAG.END_HEADERS) finishReqBlock();
+        return;
+      }
+      // Shouldn't happen; bail safely.
+      throw new Error('interleaved frame during header block');
+    }
+    if (fr.type === FRAME.HEADERS) {
+      const { block, priority } = stripHeadersPayload(fr.payload, fr.flags);
+      asm = { streamId: fr.streamId, frags: [block], priority, endStream: !!(fr.flags & FLAG.END_STREAM) };
+      if (fr.flags & FLAG.END_HEADERS) finishReqBlock();
+      return;
+    }
+    if (fr.type === FRAME.SETTINGS && fr.streamId === 0 && !(fr.flags & 0x1)) {
+      applyTableSizeSetting(fr.payload, respDec); // claude's setting governs response encoding
+    }
+    writeBackpressured(upstream, fr.raw, reqCtl); // everything else: verbatim
+  }
+
+  function finishReqBlock() {
+    const { streamId, frags, priority, endStream } = asm;
+    asm = null;
+    const fields = reqDec.decode(Buffer.concat(frags)); // keep decoder dynamic table in sync
+    const rewritten = rewriteRequest(fields);
+    const newBlock = reqEnc.encode(rewritten);
+    writeBackpressured(upstream, buildHeaderBlock(streamId, newBlock, { endStream, priority }), reqCtl);
+  }
+
+  reqCtl = link(claude, upstream, onReqData, destroyBoth);
+
+  // ── response direction: upstream → claude (passthrough + observe) ──
+  let sbuf = Buffer.alloc(0);
+  let rasm = null;
+  let respCtl;
+
+  const onRespData = (chunk) => {
+    writeBackpressured(claude, chunk, respCtl); // verbatim passthrough first
+    sbuf = Buffer.concat([sbuf, chunk]);
+    const { frames, rest } = readFrames(sbuf);
+    sbuf = rest;
+    for (const fr of frames) observeRespFrame(fr);
+  };
+
+  function observeRespFrame(fr) {
+    if (rasm) {
+      if (fr.type === FRAME.CONTINUATION && fr.streamId === rasm.streamId) {
+        rasm.frags.push(Buffer.from(fr.payload));
+        if (fr.flags & FLAG.END_HEADERS) finishRespBlock();
+      }
+      return;
+    }
+    if (fr.type === FRAME.HEADERS) {
+      const { block } = stripHeadersPayload(fr.payload, fr.flags);
+      rasm = { streamId: fr.streamId, frags: [block] };
+      if (fr.flags & FLAG.END_HEADERS) finishRespBlock();
+    }
+  }
+
+  function finishRespBlock() {
+    const { frags } = rasm;
+    rasm = null;
+    try {
+      const fields = respDec.decode(Buffer.concat(frags));
+      onResponseHeaders(fields);
+    } catch (err) {
+      log(`[TeamClaude] h2 response header decode failed: ${err.message}`);
+    }
+  }
+
+  respCtl = link(upstream, claude, onRespData, destroyBoth);
+}
+
+// Parse a SETTINGS payload for HEADER_TABLE_SIZE and apply it to a decoder's
+// size limit (so it stays in sync with the announcing peer's encoder).
+function applyTableSizeSetting(payload, decoder) {
+  for (let i = 0; i + 6 <= payload.length; i += 6) {
+    if (payload.readUInt16BE(i) === SETTINGS_HEADER_TABLE_SIZE) {
+      const size = payload.readUInt32BE(i + 2);
+      decoder.sizeLimit = size;
+      decoder.table.setMaxSize(Math.min(size, decoder.table.maxSize));
+    }
+  }
+}

--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -8,7 +8,7 @@
 // through byte-for-byte and only *observed* (read-only HPACK decode) so we can
 // surface `:status` + rate-limit headers for quota tracking.
 
-import { readFrames, buildHeaderBlock, stripHeadersPayload, FRAME, FLAG, PREFACE } from './frames.js';
+import { readFrames, buildFrame, buildHeaderBlock, stripHeadersPayload, FRAME, FLAG, PREFACE } from './frames.js';
 import { HpackDecoder, HpackEncoder } from './hpack.js';
 
 const SETTINGS_HEADER_TABLE_SIZE = 0x1;
@@ -44,6 +44,8 @@ function writeBackpressured(dst, buf, ctl) {
 export function h2Relay(claude, upstream, opts = {}) {
   const rewriteRequest = opts.rewriteRequest || ((f) => f);
   const onResponseHeaders = opts.onResponseHeaders || (() => {});
+  const makeBodyPatcher = opts.makeBodyPatcher || null; // () => { push(buf)->buf } per stream
+  const bodyPatchers = makeBodyPatcher ? new Map() : null; // streamId -> patcher
   const log = opts.log || (() => {});
 
   const reqDec = new HpackDecoder();         // decodes claude's request blocks
@@ -89,6 +91,18 @@ export function h2Relay(claude, upstream, opts = {}) {
       if (fr.flags & FLAG.END_HEADERS) finishReqBlock();
       return;
     }
+    if (fr.type === FRAME.DATA && bodyPatchers) {
+      // Same-length in-place body patch (account_uuid) via a per-stream streaming
+      // JSON state machine; re-emit the DATA frame unchanged in length/flags so
+      // framing & flow control are preserved.
+      let p = bodyPatchers.get(fr.streamId);
+      if (!p) { p = makeBodyPatcher(); bodyPatchers.set(fr.streamId, p); }
+      const payload = p.push(Buffer.from(fr.payload));
+      writeBackpressured(upstream, buildFrame({ type: FRAME.DATA, flags: fr.flags, streamId: fr.streamId, payload }), reqCtl);
+      if (fr.flags & FLAG.END_STREAM) bodyPatchers.delete(fr.streamId);
+      return;
+    }
+    if (fr.type === FRAME.RST_STREAM && bodyPatchers) bodyPatchers.delete(fr.streamId);
     if (fr.type === FRAME.SETTINGS && fr.streamId === 0 && !(fr.flags & 0x1)) {
       applyTableSizeSetting(fr.payload, respDec); // claude's setting governs response encoding
     }
@@ -158,14 +172,16 @@ export function h2Relay(claude, upstream, opts = {}) {
  */
 export function h1Relay(claude, upstream, opts = {}) {
   const rewriteHead = opts.rewriteHead || ((h) => h);
+  const patcher = opts.makeBodyPatcher ? opts.makeBodyPatcher() : null;
+  const rewriteData = patcher ? (b) => patcher.push(b) : (b) => b; // same-length body patch
   const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
   claude.on('error', destroyBoth);
   upstream.on('error', destroyBoth);
   claude.on('close', () => upstream.destroy());
   upstream.on('close', () => claude.destroy());
+  upstream.pipe(claude); // responses: verbatim
 
   let buf = Buffer.alloc(0);
-  let done = false;
   const onData = (chunk) => {
     buf = Buffer.concat([buf, chunk]);
     const idx = buf.indexOf('\r\n\r\n');
@@ -173,17 +189,15 @@ export function h1Relay(claude, upstream, opts = {}) {
       if (buf.length > 65536) destroyBoth(); // runaway head
       return;
     }
-    done = true;
     claude.removeListener('data', onData);
-    const head = rewriteHead(buf.subarray(0, idx + 4).toString('latin1'));
-    upstream.write(Buffer.from(head, 'latin1'));
+    upstream.write(Buffer.from(rewriteHead(buf.subarray(0, idx + 4).toString('latin1')), 'latin1'));
     const remainder = buf.subarray(idx + 4);
-    if (remainder.length) upstream.write(remainder);
-    claude.pipe(upstream);
-    upstream.pipe(claude);
+    if (remainder.length) upstream.write(rewriteData(Buffer.from(remainder)));
+    // forward (patched) request body
+    claude.on('data', (c) => upstream.write(rewriteData(Buffer.from(c))));
+    claude.on('end', () => upstream.end());
   };
   claude.on('data', onData);
-  void done;
 }
 
 /** Rewrite an HTTP/1.1 request head: replace the Authorization line with

--- a/src/json-format-stream.js
+++ b/src/json-format-stream.js
@@ -1,0 +1,65 @@
+// Streaming JSON pretty-printer (no regex, no buffering of the whole body).
+//
+// Built on the same idea as the account_uuid patcher: walk the bytes once,
+// tracking only enough state (nesting depth, in-string, escape) to know where
+// we are, and re-emit with indentation as we go. This lets the request logger
+// flush a readable body to disk *as it streams* — so when a request blocks
+// mid-flight, the partial (pretty) body is already on disk and you can see how
+// far it got. Bodies can be ~1M tokens, so we never hold more than the current
+// chunk.
+//
+// Whitespace outside strings is dropped and re-inserted; strings (including any
+// whitespace/escapes inside them) are copied verbatim. Operates on latin1 so a
+// multi-byte UTF-8 sequence split across chunks is preserved byte-for-byte.
+export class JsonStreamFormatter {
+  constructor(indent = 2) {
+    this.pad = ' '.repeat(indent);
+    this.depth = 0;
+    this.inStr = false;
+    this.esc = false;
+    this.freshContainer = false; // just opened { or [ — first element needs a newline+indent
+    this.started = false;
+  }
+
+  nl(depth) { return '\n' + this.pad.repeat(depth); }
+
+  // Feed a chunk; returns the formatted text for that chunk.
+  push(buf) {
+    const text = Buffer.isBuffer(buf) ? buf.toString('latin1') : String(buf);
+    let out = '';
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i];
+
+      if (this.inStr) {
+        out += ch;
+        if (this.esc) this.esc = false;
+        else if (ch === '\\') this.esc = true;
+        else if (ch === '"') this.inStr = false;
+        continue;
+      }
+
+      // Outside a string: collapse existing whitespace; we re-insert our own.
+      if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') continue;
+
+      if (ch === '}' || ch === ']') {
+        this.depth--;
+        // Empty container: emit "{}" / "[]" with no inner newline.
+        if (this.freshContainer) { this.freshContainer = false; out += ch; }
+        else out += this.nl(this.depth) + ch;
+        continue;
+      }
+
+      // Any other token. If it's the first token inside a just-opened
+      // container, break the line and indent first.
+      if (this.freshContainer) { out += this.nl(this.depth); this.freshContainer = false; }
+
+      if (ch === '{' || ch === '[') { out += ch; this.depth++; this.freshContainer = true; continue; }
+      if (ch === ',') { out += ',' + this.nl(this.depth); continue; }
+      if (ch === ':') { out += ': '; continue; }
+      if (ch === '"') { this.inStr = true; out += ch; continue; }
+      out += ch; // number / true / false / null character
+    }
+    this.started = this.started || out.length > 0;
+    return out;
+  }
+}

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -146,7 +146,10 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   if (!account) { clientSocket.destroy(); return; }
   await accountManager.ensureTokenFresh(account.index);
 
-  const upstreamSock = tls.connect({ host, port, servername: host, ALPNProtocols: ['h2', 'http/1.1'], ...upstreamTlsOptions });
+  // autoSelectFamily (happy-eyeballs) is the default on Node 20+ but not 18; set
+  // it explicitly so a dual-stack upstream whose IPv6 path is unreachable falls
+  // back to IPv4 instead of hanging the connect (option ignored pre-18.13).
+  const upstreamSock = tls.connect({ host, port, servername: host, autoSelectFamily: true, ALPNProtocols: ['h2', 'http/1.1'], ...upstreamTlsOptions });
   await new Promise((resolve, reject) => {
     upstreamSock.once('secureConnect', resolve);
     upstreamSock.once('error', reject);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -19,6 +19,7 @@ import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { h2Relay, h1Relay, rewriteH1Auth } from './h2/relay.js';
 import { AccountUuidPatcher } from './account-uuid-rewrite.js';
+import { makeMitmTap } from './request-log.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -108,7 +109,7 @@ export function hostMode(host, config) {
  * at the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, log = () => {} }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, logDir = null, log = () => {} }) {
   return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
     const [host, portStr] = (req.url || '').split(':');
@@ -125,12 +126,12 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, upstr
       return;
     }
 
-    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, log })
+    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log })
       .catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
   };
 }
 
-async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, log }) {
+async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log }) {
   const { key, cert } = await ensureLeaf();
 
   if (mode === 'test') {
@@ -163,19 +164,21 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   const makeBodyPatcher = account.accountUuid
     ? () => new AccountUuidPatcher(account.accountUuid)
     : null;
+  const tap = makeMitmTap(logDir, account.name);
 
   if (alpn === 'h2') {
     h2Relay(claudeTls, upstreamSock, {
       rewriteRequest: makeRewriteRequest(account),
       makeBodyPatcher,
       onResponseHeaders: makeQuotaObserver(accountManager, account),
+      tap,
       log,
     });
   } else {
     const auth = account.type === 'oauth'
       ? { authorization: `Bearer ${account.credential}` }
       : { apiKey: account.credential };
-    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth), makeBodyPatcher });
+    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth), makeBodyPatcher, tap });
   }
 }
 

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -18,6 +18,7 @@ import tls from 'node:tls';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { h2Relay, h1Relay, rewriteH1Auth } from './h2/relay.js';
+import { AccountUuidPatcher } from './account-uuid-rewrite.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -157,9 +158,16 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
 
   await new Promise((resolve) => claudeTls.once('secure', resolve));
 
+  // Per-stream streaming body patcher: align metadata.user_id.account_uuid with
+  // the injected account (same length; no-op if the account has no UUID).
+  const makeBodyPatcher = account.accountUuid
+    ? () => new AccountUuidPatcher(account.accountUuid)
+    : null;
+
   if (alpn === 'h2') {
     h2Relay(claudeTls, upstreamSock, {
       rewriteRequest: makeRewriteRequest(account),
+      makeBodyPatcher,
       onResponseHeaders: makeQuotaObserver(accountManager, account),
       log,
     });
@@ -167,7 +175,7 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     const auth = account.type === 'oauth'
       ? { authorization: `Bearer ${account.credential}` }
       : { apiKey: account.credential };
-    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth) });
+    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth), makeBodyPatcher });
   }
 }
 

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -1,10 +1,14 @@
-// MITM forward-proxy support: local cert lifecycle + CONNECT handling.
+// MITM forward-proxy support: local cert lifecycle + transparent CONNECT relay.
 //
-// When a claude instance is launched with HTTPS_PROXY pointed at teamclaude, it
-// sends `CONNECT api.anthropic.com:443`. We terminate TLS with a locally-minted
-// leaf cert (trusted by that process via NODE_EXTRA_CA_CERTS), hand the
-// decrypted stream to the normal request handler (which injects the real token),
-// and forward to the real upstream. Any other CONNECT target is blind-tunneled.
+// When a claude instance is launched with HTTPS_PROXY pointed at teamclaude it
+// sends `CONNECT api.anthropic.com:443`. We act as a transparent MITM: dial the
+// real upstream first (mirroring SNI + adopting its negotiated ALPN), present
+// claude our locally-minted leaf advertising that same protocol, then relay the
+// decrypted stream — rewriting ONLY the auth header (h2 via our HPACK codec, h1
+// via a plaintext head edit) and reading quota from responses. Everything else
+// is copied as-is. A host routing table decides per-CONNECT behavior:
+//   api.anthropic.com → rewrite,  www.example.org → local test server,
+//   anything else      → blind tunnel.
 
 import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { X509Certificate } from 'node:crypto';
@@ -13,6 +17,7 @@ import net from 'node:net';
 import tls from 'node:tls';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
+import { h2Relay, h1Relay, rewriteH1Auth } from './h2/relay.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -85,43 +90,152 @@ export async function ensureCerts(host) {
   };
 }
 
+function upstreamHostOf(config) {
+  try { return new URL(config?.upstream || 'https://api.anthropic.com').hostname; }
+  catch { return 'api.anthropic.com'; }
+}
+
+/** Per-CONNECT behavior: 'rewrite' (intercept + token inject), 'test', or 'tunnel'. */
+export function hostMode(host, config) {
+  if (host === TEST_HOST) return 'test';
+  if (host === upstreamHostOf(config)) return 'rewrite';
+  return 'tunnel';
+}
+
 /**
- * Build a `connect` event handler. CONNECT to `mitmHost` is TLS-terminated and
- * fed to `mitmServer` (an http.Server using the normal request handler); any
- * other target is blind-tunneled.
+ * Build a `connect` event handler implementing the transparent MITM described
+ * at the top of this file.
+ * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ interceptHosts, ensureLeaf, mitmServer, log = () => {} }) {
-  const intercepted = new Set(interceptHosts);
-  return async (req, clientSocket, head) => {
+export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, log = () => {} }) {
+  return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
     const [host, portStr] = (req.url || '').split(':');
     const port = parseInt(portStr, 10) || 443;
+    const mode = hostMode(host, config);
 
-    if (intercepted.has(host)) {
-      try {
-        const { key, cert } = await ensureLeaf();
-        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
-        if (head && head.length) clientSocket.unshift(head);
-        const tlsSocket = new tls.TLSSocket(clientSocket, {
-          isServer: true, key, cert, ALPNProtocols: ['http/1.1'],
-        });
-        tlsSocket.__tcLocal = true; // mark as trusted local MITM stream for the auth gate
-        tlsSocket.on('error', () => tlsSocket.destroy());
-        mitmServer.emit('connection', tlsSocket);
-      } catch (err) {
-        log(`[TeamClaude] MITM setup failed for ${host}: ${err.message}`);
-        clientSocket.destroy();
-      }
+    if (mode === 'tunnel') {
+      const up = net.connect(port, host, () => {
+        reply200Raw(clientSocket);
+        if (head && head.length) up.write(head);
+        up.pipe(clientSocket); clientSocket.pipe(up);
+      });
+      up.on('error', () => clientSocket.destroy());
       return;
     }
 
-    // Transparent passthrough for everything that isn't the intercepted host.
-    const upstream = net.connect(port, host, () => {
-      clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
-      if (head && head.length) upstream.write(head);
-      upstream.pipe(clientSocket);
-      clientSocket.pipe(upstream);
-    });
-    upstream.on('error', () => clientSocket.destroy());
+    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, log })
+      .catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
   };
+}
+
+async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, log }) {
+  const { key, cert } = await ensureLeaf();
+
+  if (mode === 'test') {
+    reply200Raw(clientSocket);
+    const tlsSock = termClaude(clientSocket, head, key, cert, ['http/1.1']);
+    serveTest(tlsSock);
+    return;
+  }
+
+  // rewrite: dial upstream first, mirror its ALPN, then terminate claude.
+  const account = accountManager.getActiveAccount();
+  if (!account) { clientSocket.destroy(); return; }
+  await accountManager.ensureTokenFresh(account.index);
+
+  const upstreamSock = tls.connect({ host, port, servername: host, ALPNProtocols: ['h2', 'http/1.1'], ...upstreamTlsOptions });
+  await new Promise((resolve, reject) => {
+    upstreamSock.once('secureConnect', resolve);
+    upstreamSock.once('error', reject);
+  });
+  const alpn = upstreamSock.alpnProtocol || 'http/1.1';
+
+  reply200Raw(clientSocket);
+  const claudeTls = termClaude(clientSocket, head, key, cert, [alpn]);
+  upstreamSock.on('error', () => claudeTls.destroy());
+
+  await new Promise((resolve) => claudeTls.once('secure', resolve));
+
+  if (alpn === 'h2') {
+    h2Relay(claudeTls, upstreamSock, {
+      rewriteRequest: makeRewriteRequest(account),
+      onResponseHeaders: makeQuotaObserver(accountManager, account),
+      log,
+    });
+  } else {
+    const auth = account.type === 'oauth'
+      ? { authorization: `Bearer ${account.credential}` }
+      : { apiKey: account.credential };
+    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth) });
+  }
+}
+
+function reply200Raw(sock) { sock.write('HTTP/1.1 200 Connection Established\r\n\r\n'); }
+
+function termClaude(clientSocket, head, key, cert, alpn) {
+  if (head && head.length) clientSocket.unshift(head);
+  const t = new tls.TLSSocket(clientSocket, { isServer: true, key, cert, ALPNProtocols: alpn });
+  t.on('error', () => t.destroy());
+  return t;
+}
+
+// Rewrite only the auth field on an h2 request header list (account token in,
+// client's x-api-key out). Preserves order; marks auth never-indexed.
+function makeRewriteRequest(account) {
+  const isOAuth = account.type === 'oauth';
+  return (fields) => {
+    let replaced = false;
+    const out = [];
+    for (const f of fields) {
+      const n = f.name.toString().toLowerCase();
+      if (n === 'x-api-key') continue;
+      if (n === 'authorization') {
+        if (isOAuth) { out.push({ name: f.name, value: Buffer.from(`Bearer ${account.credential}`), sensitive: true }); replaced = true; }
+        continue;
+      }
+      out.push(f);
+    }
+    if (!replaced) {
+      out.push(isOAuth
+        ? { name: Buffer.from('authorization'), value: Buffer.from(`Bearer ${account.credential}`), sensitive: true }
+        : { name: Buffer.from('x-api-key'), value: Buffer.from(account.credential), sensitive: true });
+    }
+    return out;
+  };
+}
+
+function makeQuotaObserver(accountManager, account) {
+  return (fields) => {
+    const m = {};
+    for (const f of fields) m[f.name.toString().toLowerCase()] = f.value.toString();
+    if (!m[':status']) return;
+    const rl = {};
+    for (const k in m) if (k.startsWith('anthropic-ratelimit-')) rl[k] = m[k];
+    if (Object.keys(rl).length) accountManager.updateQuota(account.index, rl);
+    if (m[':status'] === '429') {
+      let ra = parseInt(m['retry-after'], 10);
+      if (Number.isNaN(ra)) ra = 60;
+      accountManager.markRateLimited(account.index, Math.min(Math.max(ra, 1), 300));
+    }
+  };
+}
+
+// Answer the built-in test host locally over h1 with a canned JSON response.
+function serveTest(tlsSock) {
+  let buf = Buffer.alloc(0);
+  const onData = (chunk) => {
+    buf = Buffer.concat([buf, chunk]);
+    const idx = buf.indexOf('\r\n\r\n');
+    if (idx < 0) { if (buf.length > 65536) tlsSock.destroy(); return; }
+    tlsSock.removeListener('data', onData);
+    const reqLine = buf.subarray(0, buf.indexOf('\r\n')).toString('latin1');
+    const path = reqLine.split(' ')[1] || '/';
+    const body = JSON.stringify({ teamclaude: 'mitm-proxy-ok', host: TEST_HOST, path });
+    tlsSock.end(
+      `HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: ${Buffer.byteLength(body)}\r\nconnection: close\r\n\r\n${body}`,
+    );
+  };
+  tlsSock.on('data', onData);
+  tlsSock.on('error', () => tlsSock.destroy());
 }

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -1,10 +1,19 @@
 // Per-request logging for the MITM relay (parity with the reverse-proxy path's
 // --log-to). One tap per CONNECT/connection (h2 stream ids restart per
-// connection, so taps must not be shared); it accumulates request/response
-// headers + (capped) bodies per stream and writes one file when the stream ends.
+// connection, so taps must not be shared).
+//
+// Logs STREAM to disk as the request/response flow: the file is opened and the
+// request head written the moment headers arrive, and every body chunk is
+// appended as it is relayed. JSON bodies are pretty-printed on the fly via a
+// streaming state machine (src/json-format-stream.js) — never buffered whole,
+// so even ~1M-token bodies cost only the current chunk, and a request that
+// blocks mid-stream leaves its partial (readable) body on disk so you can see
+// exactly how far it got. Auth/x-api-key are masked. No size caps.
 
-import { writeFile, mkdir } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { JsonStreamFormatter } from './json-format-stream.js';
 
 let seq = 0; // module-global so filenames are unique across connections
 
@@ -36,12 +45,14 @@ function maskHeadText(text) {
   }).join('\r\n');
 }
 
-// Log the WHOLE body — AI requests can carry the full conversation (up to ~1M
-// tokens), so never truncate. JSON is pretty-printed; anything else is verbatim.
-function bodySection(label, buf) {
-  if (!buf.length) return `=== ${label} ===\n(empty)`;
-  try { return `=== ${label} ===\n${JSON.stringify(JSON.parse(buf.toString()), null, 2)}`; } catch { /* not json */ }
-  return `=== ${label} (${buf.length} bytes) ===\n${buf.toString('utf-8')}`;
+// content-type from an h2 field list / an h1 head text (lowercased, or '').
+function ctOfFields(fields) {
+  const f = fields.find((x) => x.name.toString().toLowerCase() === 'content-type');
+  return f ? f.value.toString().toLowerCase() : '';
+}
+function ctOfHead(text) {
+  const line = text.split('\r\n').find((l) => l.toLowerCase().startsWith('content-type:'));
+  return line ? line.slice(line.indexOf(':') + 1).trim().toLowerCase() : '';
 }
 
 function stamp() {
@@ -50,39 +61,75 @@ function stamp() {
   return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
 }
 
+// Tracks how one direction's body is written: decide formatter-vs-raw on the
+// first chunk (event-stream → raw; otherwise pretty-print if it looks like JSON,
+// i.e. the first non-whitespace byte is { or [). Writes the section header once.
+class BodyWriter {
+  constructor(write, label, contentType) {
+    this.write = write;
+    this.label = label;
+    this.isStream = /event-stream/.test(contentType);
+    this.decided = false;
+    this.fmt = null;
+    this.headerWritten = false;
+  }
+  chunk(buf) {
+    if (!buf.length) return;
+    if (!this.headerWritten) { this.write(`\n\n=== ${this.label} ===\n`); this.headerWritten = true; }
+    if (!this.decided) {
+      const first = buf.toString('latin1').trimStart()[0];
+      if (!this.isStream && (first === '{' || first === '[')) this.fmt = new JsonStreamFormatter();
+      this.decided = true;
+    }
+    this.write(this.fmt ? this.fmt.push(buf) : buf.toString('latin1'));
+  }
+}
+
 export function makeMitmTap(logDir, accountName = '') {
   if (!logDir) return null;
   mkdir(logDir, { recursive: true }).catch(() => {});
   const recs = new Map();
-  const rec = (id) => {
-    let r = recs.get(id);
-    if (!r) { r = { reqFields: null, reqHead: null, reqBody: [], resFields: null, resBody: [], written: false }; recs.set(id, r); }
-    return r;
-  };
 
-  function write(r) {
-    if (r.written) return;
-    r.written = true;
-    const s = [];
-    if (r.reqFields) {
-      s.push(`=== REQUEST (h2${accountName ? `, account: ${accountName}` : ''}) ===\n${get(r.reqFields, ':method')} ${get(r.reqFields, ':path')}\n${fmtFields(r.reqFields, { pseudo: false })}`);
-    } else if (r.reqHead) {
-      s.push(`=== REQUEST (h1${accountName ? `, account: ${accountName}` : ''}) ===\n${maskHeadText(r.reqHead).trimEnd()}`);
-    }
-    if (r.reqBody.length) s.push(bodySection('REQUEST BODY', Buffer.concat(r.reqBody)));
-    if (r.resFields) s.push(`=== RESPONSE ${get(r.resFields, ':status')} ===\n${fmtFields(r.resFields, { pseudo: false })}`);
-    if (r.resBody.length) s.push(bodySection('RESPONSE BODY', Buffer.concat(r.resBody)));
-    if (!s.length) return;
+  function open() {
     const file = join(logDir, `${stamp()}_mitm_${String(++seq).padStart(5, '0')}.log`);
-    writeFile(file, s.join('\n\n'), 'utf-8').catch(() => {});
+    const ws = createWriteStream(file, { flags: 'a' });
+    ws.on('error', () => {});
+    return ws;
+  }
+
+  function rec(id) {
+    let r = recs.get(id);
+    if (!r) {
+      r = { ws: open(), reqBody: null, resBody: null, ended: false };
+      r.write = (s) => { if (!r.ended && s) r.ws.write(s); };
+      recs.set(id, r);
+    }
+    return r;
   }
 
   return {
-    req(id, fields) { rec(id).reqFields = fields; },
-    reqHead(id, text) { rec(id).reqHead = text; },
-    reqData(id, buf) { rec(id).reqBody.push(buf); },
-    res(id, fields) { rec(id).resFields = fields; },
-    resData(id, buf) { rec(id).resBody.push(buf); },
-    end(id) { const r = recs.get(id); if (r) { recs.delete(id); write(r); } },
+    req(id, fields) {
+      const r = rec(id);
+      r.write(`=== REQUEST (h2${accountName ? `, account: ${accountName}` : ''}) ===\n${get(fields, ':method')} ${get(fields, ':path')}\n${fmtFields(fields, { pseudo: false })}`);
+      r.reqBody = new BodyWriter(r.write, 'REQUEST BODY', ctOfFields(fields));
+    },
+    reqHead(id, text) {
+      const r = rec(id);
+      r.write(`=== REQUEST (h1${accountName ? `, account: ${accountName}` : ''}) ===\n${maskHeadText(text).trimEnd()}`);
+      r.reqBody = new BodyWriter(r.write, 'REQUEST BODY', ctOfHead(text));
+    },
+    reqData(id, buf) { rec(id).reqBody?.chunk(buf); },
+    res(id, fields) {
+      const r = rec(id);
+      r.write(`\n\n=== RESPONSE ${get(fields, ':status')} ===\n${fmtFields(fields, { pseudo: false })}`);
+      r.resBody = new BodyWriter(r.write, 'RESPONSE BODY', ctOfFields(fields));
+    },
+    resData(id, buf) { rec(id).resBody?.chunk(buf); },
+    end(id) {
+      const r = recs.get(id);
+      if (!r) return;
+      recs.delete(id);
+      if (!r.ended) { r.ended = true; r.ws.end('\n'); }
+    },
   };
 }

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -1,0 +1,91 @@
+// Per-request logging for the MITM relay (parity with the reverse-proxy path's
+// --log-to). One tap per CONNECT/connection (h2 stream ids restart per
+// connection, so taps must not be shared); it accumulates request/response
+// headers + (capped) bodies per stream and writes one file when the stream ends.
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const REQ_CAP = 64 * 1024;
+const RES_CAP = 16 * 1024;
+let seq = 0; // module-global so filenames are unique across connections
+
+function maskValue(name, val) {
+  const n = name.toLowerCase();
+  if (n === 'authorization') return val.slice(0, 20) + '...';
+  if (n === 'x-api-key') return val.slice(0, 15) + '...';
+  return val;
+}
+
+function fmtFields(fields, { pseudo = true } = {}) {
+  return fields
+    .filter((f) => pseudo || !f.name.toString().startsWith(':'))
+    .map((f) => { const n = f.name.toString(); return `  ${n}: ${maskValue(n, f.value.toString())}`; })
+    .join('\n');
+}
+
+function get(fields, name) {
+  const f = fields.find((x) => x.name.toString() === name);
+  return f ? f.value.toString() : '';
+}
+
+function maskHeadText(text) {
+  return text.split('\r\n').map((line) => {
+    const lower = line.toLowerCase();
+    if (lower.startsWith('authorization:')) return 'authorization: ' + line.slice(14).trim().slice(0, 20) + '...';
+    if (lower.startsWith('x-api-key:')) return 'x-api-key: ...';
+    return line;
+  }).join('\r\n');
+}
+
+function bodySection(label, buf, total, cap) {
+  if (!buf.length) return `=== ${label} ===\n(empty)`;
+  if (total <= cap) {
+    try { return `=== ${label} ===\n${JSON.stringify(JSON.parse(buf.toString()), null, 2)}`; } catch { /* not json */ }
+  }
+  const note = total > cap ? ` (${total} bytes, truncated)` : ` (${total} bytes)`;
+  return `=== ${label}${note} ===\n${buf.toString('utf-8').slice(0, cap)}`;
+}
+
+function stamp() {
+  const d = new Date();
+  const p = (n, w = 2) => String(n).padStart(w, '0');
+  return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
+}
+
+export function makeMitmTap(logDir, accountName = '') {
+  if (!logDir) return null;
+  mkdir(logDir, { recursive: true }).catch(() => {});
+  const recs = new Map();
+  const rec = (id) => {
+    let r = recs.get(id);
+    if (!r) { r = { reqFields: null, reqHead: null, reqBody: [], reqLen: 0, resFields: null, resBody: [], resLen: 0, written: false }; recs.set(id, r); }
+    return r;
+  };
+
+  function write(r) {
+    if (r.written) return;
+    r.written = true;
+    const s = [];
+    if (r.reqFields) {
+      s.push(`=== REQUEST (h2${accountName ? `, account: ${accountName}` : ''}) ===\n${get(r.reqFields, ':method')} ${get(r.reqFields, ':path')}\n${fmtFields(r.reqFields, { pseudo: false })}`);
+    } else if (r.reqHead) {
+      s.push(`=== REQUEST (h1${accountName ? `, account: ${accountName}` : ''}) ===\n${maskHeadText(r.reqHead).trimEnd()}`);
+    }
+    if (r.reqLen) s.push(bodySection('REQUEST BODY', Buffer.concat(r.reqBody), r.reqLen, REQ_CAP));
+    if (r.resFields) s.push(`=== RESPONSE ${get(r.resFields, ':status')} ===\n${fmtFields(r.resFields, { pseudo: false })}`);
+    if (r.resLen) s.push(bodySection('RESPONSE BODY', Buffer.concat(r.resBody), r.resLen, RES_CAP));
+    if (!s.length) return;
+    const file = join(logDir, `${stamp()}_mitm_${String(++seq).padStart(5, '0')}.log`);
+    writeFile(file, s.join('\n\n'), 'utf-8').catch(() => {});
+  }
+
+  return {
+    req(id, fields) { rec(id).reqFields = fields; },
+    reqHead(id, text) { rec(id).reqHead = text; },
+    reqData(id, buf) { const r = rec(id); if (r.reqLen < REQ_CAP) { r.reqBody.push(buf); r.reqLen += buf.length; } },
+    res(id, fields) { rec(id).resFields = fields; },
+    resData(id, buf) { const r = rec(id); if (r.resLen < RES_CAP) { r.resBody.push(buf); r.resLen += buf.length; } },
+    end(id) { const r = recs.get(id); if (r) { recs.delete(id); write(r); } },
+  };
+}

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -6,8 +6,6 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-const REQ_CAP = 64 * 1024;
-const RES_CAP = 16 * 1024;
 let seq = 0; // module-global so filenames are unique across connections
 
 function maskValue(name, val) {
@@ -38,13 +36,12 @@ function maskHeadText(text) {
   }).join('\r\n');
 }
 
-function bodySection(label, buf, total, cap) {
+// Log the WHOLE body — AI requests can carry the full conversation (up to ~1M
+// tokens), so never truncate. JSON is pretty-printed; anything else is verbatim.
+function bodySection(label, buf) {
   if (!buf.length) return `=== ${label} ===\n(empty)`;
-  if (total <= cap) {
-    try { return `=== ${label} ===\n${JSON.stringify(JSON.parse(buf.toString()), null, 2)}`; } catch { /* not json */ }
-  }
-  const note = total > cap ? ` (${total} bytes, truncated)` : ` (${total} bytes)`;
-  return `=== ${label}${note} ===\n${buf.toString('utf-8').slice(0, cap)}`;
+  try { return `=== ${label} ===\n${JSON.stringify(JSON.parse(buf.toString()), null, 2)}`; } catch { /* not json */ }
+  return `=== ${label} (${buf.length} bytes) ===\n${buf.toString('utf-8')}`;
 }
 
 function stamp() {
@@ -59,7 +56,7 @@ export function makeMitmTap(logDir, accountName = '') {
   const recs = new Map();
   const rec = (id) => {
     let r = recs.get(id);
-    if (!r) { r = { reqFields: null, reqHead: null, reqBody: [], reqLen: 0, resFields: null, resBody: [], resLen: 0, written: false }; recs.set(id, r); }
+    if (!r) { r = { reqFields: null, reqHead: null, reqBody: [], resFields: null, resBody: [], written: false }; recs.set(id, r); }
     return r;
   };
 
@@ -72,9 +69,9 @@ export function makeMitmTap(logDir, accountName = '') {
     } else if (r.reqHead) {
       s.push(`=== REQUEST (h1${accountName ? `, account: ${accountName}` : ''}) ===\n${maskHeadText(r.reqHead).trimEnd()}`);
     }
-    if (r.reqLen) s.push(bodySection('REQUEST BODY', Buffer.concat(r.reqBody), r.reqLen, REQ_CAP));
+    if (r.reqBody.length) s.push(bodySection('REQUEST BODY', Buffer.concat(r.reqBody)));
     if (r.resFields) s.push(`=== RESPONSE ${get(r.resFields, ':status')} ===\n${fmtFields(r.resFields, { pseudo: false })}`);
-    if (r.resLen) s.push(bodySection('RESPONSE BODY', Buffer.concat(r.resBody), r.resLen, RES_CAP));
+    if (r.resBody.length) s.push(bodySection('RESPONSE BODY', Buffer.concat(r.resBody)));
     if (!s.length) return;
     const file = join(logDir, `${stamp()}_mitm_${String(++seq).padStart(5, '0')}.log`);
     writeFile(file, s.join('\n\n'), 'utf-8').catch(() => {});
@@ -83,9 +80,9 @@ export function makeMitmTap(logDir, accountName = '') {
   return {
     req(id, fields) { rec(id).reqFields = fields; },
     reqHead(id, text) { rec(id).reqHead = text; },
-    reqData(id, buf) { const r = rec(id); if (r.reqLen < REQ_CAP) { r.reqBody.push(buf); r.reqLen += buf.length; } },
+    reqData(id, buf) { rec(id).reqBody.push(buf); },
     res(id, fields) { rec(id).resFields = fields; },
-    resData(id, buf) { const r = rec(id); if (r.resLen < RES_CAP) { r.resBody.push(buf); r.resLen += buf.length; } },
+    resData(id, buf) { rec(id).resBody.push(buf); },
     end(id) { const r = recs.get(id); if (r) { recs.delete(id); write(r); } },
   };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -263,7 +263,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       try {
         logSections.push(`=== REQUEST BODY ===\n${JSON.stringify(JSON.parse(body.toString()), null, 2)}`);
       } catch {
-        logSections.push(`=== REQUEST BODY (${body.length} bytes) ===\n${body.toString().slice(0, 4096)}`);
+        logSections.push(`=== REQUEST BODY (${body.length} bytes) ===\n${body.toString()}`);
       }
     }
   }
@@ -365,7 +365,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
         try {
           logSections.push(`=== RESPONSE BODY ===\n${JSON.stringify(JSON.parse(buf.toString()), null, 2)}`);
         } catch {
-          logSections.push(`=== RESPONSE BODY (${buf.length} bytes) ===\n${buf.toString().slice(0, 8192)}`);
+          logSections.push(`=== RESPONSE BODY (${buf.length} bytes) ===\n${buf.toString()}`);
         }
         writeRequestLog(logDir, reqId, logSections);
       }

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import http from 'node:http';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
+import { patchAccountUuid } from './account-uuid-rewrite.js';
 
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -240,6 +241,10 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   const upstreamUrl = `${upstream}${req.url}`;
   const method = req.method;
 
+  // Align the body's account_uuid (in metadata.user_id) with the account whose
+  // token we're injecting (same-length patch; no-op if absent).
+  const sendBody = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
+
   // Build log sections
   const logSections = [];
   if (logDir) {
@@ -267,7 +272,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
     const upstreamRes = await fetch(upstreamUrl, {
       method,
       headers,
-      body: ['GET', 'HEAD'].includes(method) ? undefined : body,
+      body: ['GET', 'HEAD'].includes(method) ? undefined : sendBody,
       redirect: 'manual',
     });
 

--- a/src/server.js
+++ b/src/server.js
@@ -119,7 +119,7 @@ export function createProxyServer(accountManager, config, hooks = {}) {
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, log: console.error }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, log: console.error }));
 
   return server;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { ensureCerts, createConnectHandler, TEST_HOST } from './mitm.js';
+import { ensureCerts, createConnectHandler } from './mitm.js';
 
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -21,26 +21,10 @@ export function createProxyServer(accountManager, config, hooks = {}) {
 
   const requestHandler = async (req, res) => {
     try {
-      // Built-in MITM test endpoint: answer www.example.org ourselves (never
-      // forwarded) so the proxy + CA can be verified without credentials.
-      const hostHeader = (req.headers.host || '').split(':')[0];
-      if (hostHeader === TEST_HOST) {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          teamclaude: 'mitm-proxy-ok',
-          host: TEST_HOST,
-          method: req.method,
-          path: req.url,
-        }));
-        return;
-      }
-
-      // Auth check — skip for localhost connections (and decrypted MITM streams,
-      // which originate from a localhost CONNECT and are marked trusted).
+      // Auth check — skip for localhost connections.
       const clientKey = req.headers['x-api-key'];
       const remoteAddr = req.socket.remoteAddress;
-      const isLocal = req.socket.__tcLocal === true ||
-        remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1';
+      const isLocal = remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1';
       if (proxyApiKey && clientKey !== proxyApiKey && !isLocal) {
         res.writeHead(401, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
@@ -124,20 +108,17 @@ export function createProxyServer(accountManager, config, hooks = {}) {
 
   // Forward-proxy support (always on, so multiple claude instances can use
   // either ANTHROPIC_BASE_URL or HTTPS_PROXY against the same server). A CONNECT
-  // to the upstream host is TLS-terminated and handled like a normal request
-  // (token injection happens in forwardRequest); anything else is tunneled.
-  // Certs are minted lazily on the first intercepted CONNECT.
+  // to the upstream host is a transparent MITM relay (rewrite only auth); the
+  // test host is answered locally; anything else is blind-tunneled. Certs are
+  // minted lazily on the first intercepted CONNECT.
   const mitmHost = (() => { try { return new URL(upstream).hostname; } catch { return 'api.anthropic.com'; } })();
-  const mitmServer = http.createServer(requestHandler);
   let certsPromise = null;
   const ensureLeaf = async () => {
     certsPromise ||= ensureCerts(mitmHost);
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({
-    interceptHosts: [mitmHost, TEST_HOST], ensureLeaf, mitmServer, log: console.error,
-  }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, log: console.error }));
 
   return server;
 }

--- a/test/account-uuid-rewrite.test.js
+++ b/test/account-uuid-rewrite.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { patchAccountUuid, AccountUuidPatcher } from '../src/account-uuid-rewrite.js';
+
+const OLD = '4c39e915-eb47-450d-9bf4-4cbbcd049a08';
+const NEW = '11111111-2222-3333-4444-555555555555';
+
+test('patches account_uuid inside metadata.user_id (escaped) same-length', () => {
+  const body = Buffer.from(JSON.stringify({
+    model: 'claude',
+    metadata: { user_id: JSON.stringify({ device_id: 'abc', account_uuid: OLD, x: 1 }) },
+  }));
+  const out = patchAccountUuid(body, NEW);
+  assert.equal(out.length, body.length);          // same length
+  assert.ok(out.toString().includes(NEW));
+  assert.ok(!out.toString().includes(OLD));
+  // the inner stringified JSON is still valid and keeps device_id
+  const parsed = JSON.parse(out.toString());
+  const inner = JSON.parse(parsed.metadata.user_id);
+  assert.equal(inner.account_uuid, NEW);
+  assert.equal(inner.device_id, 'abc');
+});
+
+test('does NOT touch account_uuid outside metadata.user_id (no false positives)', () => {
+  // A stray account_uuid in user content must be left intact.
+  const body = Buffer.from(JSON.stringify({
+    messages: [{ role: 'user', content: `here is some json: {"account_uuid":"${OLD}"}` }],
+    metadata: { user_id: JSON.stringify({ account_uuid: OLD }) },
+  }));
+  const out = patchAccountUuid(body, NEW).toString();
+  const parsed = JSON.parse(out);
+  assert.equal(JSON.parse(parsed.metadata.user_id).account_uuid, NEW); // the metadata one IS rewritten
+  assert.ok(parsed.messages[0].content.includes(OLD));                 // the content one is NOT
+  assert.ok(!parsed.messages[0].content.includes(NEW));
+});
+
+test('streaming: byte-by-byte chunks produce the same result as one-shot (large body, uuid split across chunks)', () => {
+  const filler = 'q'.repeat(50_000);
+  const body = Buffer.from(JSON.stringify({
+    model: 'claude', big: filler,
+    metadata: { user_id: JSON.stringify({ device_id: 'd', account_uuid: OLD }) },
+    messages: [{ role: 'user', content: `not me: account_uuid":"${OLD}"` }],
+  }));
+  // Feed one byte at a time to force chunk boundaries inside the UUID/keys.
+  const p = new AccountUuidPatcher(NEW);
+  const parts = [];
+  for (const byte of body) parts.push(p.push(Buffer.from([byte])));
+  const streamed = Buffer.concat(parts);
+  assert.equal(streamed.length, body.length);
+  assert.deepEqual(streamed, patchAccountUuid(body, NEW)); // same as one-shot
+  const parsed = JSON.parse(streamed.toString());
+  assert.equal(JSON.parse(parsed.metadata.user_id).account_uuid, NEW); // metadata patched
+  assert.ok(parsed.messages[0].content.includes(OLD));                 // content untouched
+});
+
+test('no-op when already the target / no user_id / bad uuid length', () => {
+  const inner = (u) => JSON.stringify({ metadata: { user_id: JSON.stringify({ account_uuid: u }) } });
+  const same = Buffer.from(inner(NEW));
+  assert.equal(patchAccountUuid(same, NEW), same);             // unchanged instance
+  const none = Buffer.from('{"hello":"world"}');
+  assert.equal(patchAccountUuid(none, NEW), none);
+  const body = Buffer.from(inner(OLD));
+  assert.equal(patchAccountUuid(body, 'not-a-uuid'), body);    // wrong length → no-op
+});

--- a/test/h2-frames.test.js
+++ b/test/h2-frames.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { FRAME, FLAG, PREFACE, readFrames, buildFrame, stripHeadersPayload, buildHeaderBlock } from '../src/h2/frames.js';
+
+test('buildFrame / readFrames round-trip multiple frames', () => {
+  const a = buildFrame({ type: FRAME.SETTINGS, flags: 0, streamId: 0, payload: Buffer.alloc(0) });
+  const b = buildFrame({ type: FRAME.DATA, flags: FLAG.END_STREAM, streamId: 5, payload: Buffer.from('hello') });
+  const { frames, rest } = readFrames(Buffer.concat([a, b]));
+  assert.equal(rest.length, 0);
+  assert.equal(frames.length, 2);
+  assert.equal(frames[0].type, FRAME.SETTINGS);
+  assert.equal(frames[1].type, FRAME.DATA);
+  assert.equal(frames[1].streamId, 5);
+  assert.equal(frames[1].flags & FLAG.END_STREAM, FLAG.END_STREAM);
+  assert.equal(frames[1].payload.toString(), 'hello');
+});
+
+test('readFrames leaves an incomplete trailing frame in rest', () => {
+  const f = buildFrame({ type: FRAME.PING, streamId: 0, payload: Buffer.alloc(8) });
+  // feed all but the last 3 bytes
+  const partial = f.subarray(0, f.length - 3);
+  const { frames, rest } = readFrames(partial);
+  assert.equal(frames.length, 0);
+  assert.equal(rest.length, partial.length);
+  // now complete it
+  const { frames: f2, rest: r2 } = readFrames(Buffer.concat([rest, f.subarray(f.length - 3)]));
+  assert.equal(f2.length, 1);
+  assert.equal(r2.length, 0);
+});
+
+test('stripHeadersPayload removes PADDED + PRIORITY and yields the block', () => {
+  const block = Buffer.from('deadbeef', 'hex');
+  const prio = Buffer.from('0000000105', 'hex'); // 5-byte priority
+  const pad = Buffer.from('aabbcc', 'hex');       // 3 bytes padding
+  const payload = Buffer.concat([Buffer.from([pad.length]), prio, block, pad]);
+  const got = stripHeadersPayload(payload, FLAG.PADDED | FLAG.PRIORITY);
+  assert.equal(got.block.toString('hex'), 'deadbeef');
+  assert.equal(got.priority.toString('hex'), '0000000105');
+});
+
+test('buildHeaderBlock single frame and split into CONTINUATION', () => {
+  const block = Buffer.from('1122334455', 'hex');
+  // single frame (END_HEADERS set, END_STREAM honored)
+  let out = buildHeaderBlock(7, block, { endStream: true });
+  let { frames } = readFrames(out);
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].type, FRAME.HEADERS);
+  assert.ok(frames[0].flags & FLAG.END_HEADERS);
+  assert.ok(frames[0].flags & FLAG.END_STREAM);
+  assert.equal(frames[0].payload.toString('hex'), '1122334455');
+
+  // force a split with tiny maxFrameSize=2
+  out = buildHeaderBlock(7, block, { maxFrameSize: 2 });
+  ({ frames } = readFrames(out));
+  assert.equal(frames[0].type, FRAME.HEADERS);
+  assert.equal(frames[0].flags & FLAG.END_HEADERS, 0); // not last
+  assert.equal(frames[frames.length - 1].type, FRAME.CONTINUATION);
+  assert.ok(frames[frames.length - 1].flags & FLAG.END_HEADERS);
+  // reassembled fragments equal the original block
+  const reassembled = Buffer.concat(frames.map(f => f.payload));
+  assert.equal(reassembled.toString('hex'), '1122334455');
+});
+
+test('PREFACE is the 24-byte client connection preface', () => {
+  assert.equal(PREFACE.length, 24);
+  assert.equal(PREFACE.toString('latin1'), 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n');
+});

--- a/test/h2-relay.test.js
+++ b/test/h2-relay.test.js
@@ -7,9 +7,27 @@ import { h2Relay } from '../src/h2/relay.js';
 
 function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
 
-test('h2 relay rewrites only authorization, drops x-api-key, observes response', async () => {
+// Per-test timeout: turn any future deadlock into a fast, located failure
+// instead of a 30-minute CI stall (option form works on Node 18).
+const T = { timeout: 30000 };
+
+// Tear everything down hard. node:test runs each file in its own child process
+// and, on Node 18 (unlike Node 20+), does not force-exit that child — so any
+// socket/session left open after the assertions keeps the event loop alive and
+// the whole run hangs. Graceful client.close() is exactly such a leak on the CI
+// runner; destroy() + destroying tracked connections/sessions drains the loop.
+function teardown({ client, conns = [], sessions = [], servers = [] }) {
+  try { client?.destroy(); } catch { /* already gone */ }
+  for (const s of sessions) { try { s.destroy(); } catch { /* */ } }
+  for (const c of conns) { try { c.destroy(); } catch { /* */ } }
+  for (const srv of servers) { try { srv.closeAllConnections?.(); srv.close(); } catch { /* */ } }
+}
+
+test('h2 relay rewrites only authorization, drops x-api-key, observes response', T, async () => {
   // Upstream (cleartext h2) echoes what it received + a rate-limit header.
   const upstream = http2.createServer();
+  const sessions = [];
+  upstream.on('session', (s) => sessions.push(s));
   upstream.on('stream', (s, h) => {
     s.respond({
       ':status': 200,
@@ -24,8 +42,10 @@ test('h2 relay rewrites only authorization, drops x-api-key, observes response',
   const upPort = await listen(upstream);
 
   // Relay front door: each TCP conn → dial upstream, bridge with h2Relay.
+  const conns = [];
   let observed = null;
   const front = net.createServer((clientSock) => {
+    conns.push(clientSock);
     const upSock = net.connect(upPort, '127.0.0.1', () => {
       h2Relay(clientSock, upSock, {
         rewriteRequest: (fields) => fields
@@ -40,6 +60,7 @@ test('h2 relay rewrites only authorization, drops x-api-key, observes response',
         },
       });
     });
+    conns.push(upSock);
   });
   const frontPort = await listen(front);
 
@@ -66,19 +87,22 @@ test('h2 relay rewrites only authorization, drops x-api-key, observes response',
     assert.equal(observed[':status'], '200');
     assert.equal(observed['anthropic-ratelimit-unified-5h-utilization'], '0.5');
   } finally {
-    client.close();
-    front.close();
-    upstream.close();
+    teardown({ client, conns, sessions, servers: [front, upstream] });
   }
 });
 
-test('h2 relay streams a larger body intact (backpressure path)', async () => {
+test('h2 relay streams a larger body intact (backpressure path)', T, async () => {
   const upstream = http2.createServer();
+  const sessions = [];
+  upstream.on('session', (s) => sessions.push(s));
   const big = 'x'.repeat(200_000);
   upstream.on('stream', (s) => { s.respond({ ':status': 200 }); s.end(big); });
   const upPort = await listen(upstream);
+  const conns = [];
   const front = net.createServer((c) => {
+    conns.push(c);
     const u = net.connect(upPort, '127.0.0.1', () => h2Relay(c, u, {}));
+    conns.push(u);
   });
   const frontPort = await listen(front);
   const client = http2.connect(`http://127.0.0.1:${frontPort}`);
@@ -91,6 +115,6 @@ test('h2 relay streams a larger body intact (backpressure path)', async () => {
     await once(req, 'close');
     assert.equal(body.length, big.length);
   } finally {
-    client.close(); front.close(); upstream.close();
+    teardown({ client, conns, sessions, servers: [front, upstream] });
   }
 });

--- a/test/h2-relay.test.js
+++ b/test/h2-relay.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http2 from 'node:http2';
+import net from 'node:net';
+import { once } from 'node:events';
+import { h2Relay } from '../src/h2/relay.js';
+
+function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
+
+test('h2 relay rewrites only authorization, drops x-api-key, observes response', async () => {
+  // Upstream (cleartext h2) echoes what it received + a rate-limit header.
+  const upstream = http2.createServer();
+  upstream.on('stream', (s, h) => {
+    s.respond({
+      ':status': 200,
+      'x-saw-auth': h.authorization || 'none',
+      'x-saw-xkey': h['x-api-key'] || 'none',
+      'x-saw-path': h[':path'],
+      'x-saw-ct': h['content-type'] || 'none',
+      'anthropic-ratelimit-unified-5h-utilization': '0.5',
+    });
+    s.end('upstream-body');
+  });
+  const upPort = await listen(upstream);
+
+  // Relay front door: each TCP conn → dial upstream, bridge with h2Relay.
+  let observed = null;
+  const front = net.createServer((clientSock) => {
+    const upSock = net.connect(upPort, '127.0.0.1', () => {
+      h2Relay(clientSock, upSock, {
+        rewriteRequest: (fields) => fields
+          .filter(f => f.name.toString().toLowerCase() !== 'x-api-key')
+          .map(f => f.name.toString().toLowerCase() === 'authorization'
+            ? { name: Buffer.from('authorization'), value: Buffer.from('Bearer REAL'), sensitive: true }
+            : f),
+        onResponseHeaders: (fields) => {
+          const m = {};
+          for (const f of fields) m[f.name.toString()] = f.value.toString();
+          if (m[':status']) observed = m;
+        },
+      });
+    });
+  });
+  const frontPort = await listen(front);
+
+  const client = http2.connect(`http://127.0.0.1:${frontPort}`);
+  try {
+    const req = client.request({
+      ':method': 'POST', ':path': '/v1/messages',
+      authorization: 'Bearer FAKE', 'x-api-key': 'sk-fake', 'content-type': 'application/json',
+    });
+    let respHeaders;
+    let body = '';
+    req.on('response', (h) => { respHeaders = h; });
+    req.setEncoding('utf8');
+    req.on('data', (d) => { body += d; });
+    req.end('{}');
+    await once(req, 'close');
+
+    assert.equal(respHeaders['x-saw-auth'], 'Bearer REAL');  // rewritten
+    assert.equal(respHeaders['x-saw-xkey'], 'none');         // x-api-key dropped
+    assert.equal(respHeaders['x-saw-path'], '/v1/messages'); // path preserved
+    assert.equal(respHeaders['x-saw-ct'], 'application/json'); // other headers preserved
+    assert.equal(body, 'upstream-body');                     // response body relayed
+    // response observed for quota
+    assert.equal(observed[':status'], '200');
+    assert.equal(observed['anthropic-ratelimit-unified-5h-utilization'], '0.5');
+  } finally {
+    client.close();
+    front.close();
+    upstream.close();
+  }
+});
+
+test('h2 relay streams a larger body intact (backpressure path)', async () => {
+  const upstream = http2.createServer();
+  const big = 'x'.repeat(200_000);
+  upstream.on('stream', (s) => { s.respond({ ':status': 200 }); s.end(big); });
+  const upPort = await listen(upstream);
+  const front = net.createServer((c) => {
+    const u = net.connect(upPort, '127.0.0.1', () => h2Relay(c, u, {}));
+  });
+  const frontPort = await listen(front);
+  const client = http2.connect(`http://127.0.0.1:${frontPort}`);
+  try {
+    const req = client.request({ ':path': '/' });
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (d) => { body += d; });
+    req.end();
+    await once(req, 'close');
+    assert.equal(body.length, big.length);
+  } finally {
+    client.close(); front.close(); upstream.close();
+  }
+});

--- a/test/hpack.test.js
+++ b/test/hpack.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  huffmanEncode, huffmanDecode, encodeInt, decodeInt,
+  HpackEncoder, HpackDecoder,
+} from '../src/h2/hpack.js';
+
+const hex = (b) => Buffer.from(b).toString('hex');
+
+// ── RFC 7541 §C.1 integer ──
+test('integer C.1 vectors', () => {
+  let out = []; encodeInt(out, 10, 5, 0); assert.equal(hex(out), '0a');
+  assert.deepEqual(decodeInt(Buffer.from(out), 0, 5), [10, 1]);
+  out = []; encodeInt(out, 1337, 5, 0); assert.equal(hex(out), '1f9a0a');
+  assert.deepEqual(decodeInt(Buffer.from(out), 0, 5), [1337, 3]);
+  out = []; encodeInt(out, 42, 8, 0); assert.equal(hex(out), '2a');
+  assert.deepEqual(decodeInt(Buffer.from(out), 0, 8), [42, 1]);
+});
+
+// ── RFC 7541 §C.4 Huffman strings ──
+test('huffman C.4 vectors', () => {
+  assert.equal(hex(huffmanEncode(Buffer.from('www.example.com'))), 'f1e3c2e5f23a6ba0ab90f4ff');
+  assert.deepEqual(huffmanDecode(Buffer.from('f1e3c2e5f23a6ba0ab90f4ff', 'hex')), Buffer.from('www.example.com'));
+  assert.equal(hex(huffmanEncode(Buffer.from('no-cache'))), 'a8eb10649cbf');
+  assert.equal(hex(huffmanEncode(Buffer.from('custom-key'))), '25a849e95ba97d7f');
+  assert.equal(hex(huffmanEncode(Buffer.from('custom-value'))), '25a849e95bb8e8b4bf');
+});
+
+test('huffman round-trips all byte values', () => {
+  const all = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+  assert.deepEqual(huffmanDecode(huffmanEncode(all)), all);
+  assert.deepEqual(huffmanDecode(Buffer.alloc(0)), Buffer.alloc(0));
+});
+
+test('huffman rejects EOS symbol and bad padding', () => {
+  assert.throws(() => huffmanDecode(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xc0]))); // 30 ones = EOS
+  assert.throws(() => huffmanDecode(Buffer.from([0b00000000]))); // "0" then 0-padding
+});
+
+// ── RFC 7541 §C.3 request sequence WITHOUT Huffman (shared dynamic table) ──
+test('C.3 request sequence (literal, dynamic table evolves)', () => {
+  const dec = new HpackDecoder();
+  const f = (blockHex, expect) => {
+    const got = dec.decode(Buffer.from(blockHex.replace(/\s/g, ''), 'hex'))
+      .map(h => [h.name.toString(), h.value.toString()]);
+    assert.deepEqual(got, expect);
+  };
+  // C.3.1
+  f('828684410f7777772e6578616d706c652e636f6d', [[':method','GET'],[':scheme','http'],[':path','/'],[':authority','www.example.com']]);
+  // C.3.2 — :authority comes from the dynamic table (index 62)
+  f('828684be58086e6f2d6361636865', [[':method','GET'],[':scheme','http'],[':path','/'],[':authority','www.example.com'],['cache-control','no-cache']]);
+  // C.3.3
+  f('828785bf400a637573746f6d2d6b65790c637573746f6d2d76616c7565',
+    [[':method','GET'],[':scheme','https'],[':path','/index.html'],[':authority','www.example.com'],['custom-key','custom-value']]);
+});
+
+// ── RFC 7541 §C.6 response sequence WITH Huffman + eviction ──
+test('C.6 response sequence (Huffman + dynamic eviction) decodes', () => {
+  const dec = new HpackDecoder(256); // C.6 uses a 256-byte table
+  const b1 = '4882 6402 5885 aec3 771a 4b61 96d0 7abe 9410 54d4 44a8 2005 9504 0b81 66e0 82a6 2d1b ff6e 919d 29ad 1718 63c7 8f0b 97c8 e9ae 82ae 43d3';
+  const out1 = dec.decode(Buffer.from(b1.replace(/\s/g, ''), 'hex')).map(h => [h.name.toString(), h.value.toString()]);
+  assert.deepEqual(out1, [[':status','302'],['cache-control','private'],['date','Mon, 21 Oct 2013 20:13:21 GMT'],['location','https://www.example.com']]);
+});
+
+// ── encoder ↔ decoder interop (our encoder is simple; must decode back) ──
+test('encoder/decoder round-trip incl. sensitive auth + dynamic indexing', () => {
+  const enc = new HpackEncoder();
+  const dec = new HpackDecoder();
+  const fields = [
+    { name: ':method', value: 'POST' },
+    { name: ':path', value: '/v1/messages' },
+    { name: 'authorization', value: 'Bearer sk-ant-oat01-secret', sensitive: true },
+    { name: 'content-type', value: 'application/json' },
+  ];
+  // two blocks to exercise dynamic table state
+  for (let i = 0; i < 2; i++) {
+    const block = enc.encode(fields);
+    const got = dec.decode(block).map(h => ({ name: h.name.toString(), value: h.value.toString(), sensitive: h.sensitive }));
+    assert.equal(got[2].name, 'authorization');
+    assert.equal(got[2].value, 'Bearer sk-ant-oat01-secret');
+    assert.equal(got[2].sensitive, true); // round-trips as never-indexed
+    assert.deepEqual(got.map(h => [h.name, h.value]), fields.map(f => [f.name, f.value]));
+  }
+});

--- a/test/json-format-stream.test.js
+++ b/test/json-format-stream.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JsonStreamFormatter } from '../src/json-format-stream.js';
+
+// Format a value by feeding it as one chunk.
+function fmt(value) {
+  const f = new JsonStreamFormatter();
+  return f.push(Buffer.from(JSON.stringify(value)));
+}
+
+test('streaming format matches JSON.stringify(value, null, 2)', () => {
+  const cases = [
+    { a: 1, b: 'two', c: [1, 2, 3], d: { e: true, f: null } },
+    [],
+    {},
+    { empty: {}, arr: [], nested: { x: [{ y: 1 }] } },
+    { 'with spaces': 'and : colons, commas {}[] inside', n: -3.14e10 },
+    'a bare string',
+    42,
+    [{ a: 1 }, { b: 2 }],
+  ];
+  for (const v of cases) {
+    assert.equal(fmt(v), JSON.stringify(v, null, 2), `mismatch for ${JSON.stringify(v)}`);
+  }
+});
+
+test('result is identical regardless of how the input is chunked', () => {
+  const value = { metadata: { user_id: 'x', items: [1, 2, { deep: 'value, with comma' }] }, list: [true, false, null] };
+  const full = JSON.stringify(value);
+  const expected = JSON.stringify(value, null, 2);
+
+  // Feed byte-by-byte — the hardest chunking (splits strings, escapes, tokens).
+  const f = new JsonStreamFormatter();
+  let out = '';
+  for (const byte of Buffer.from(full)) out += f.push(Buffer.from([byte]));
+  assert.equal(out, expected);
+});
+
+test('strings with braces/quotes/escapes are copied verbatim', () => {
+  const value = { s: 'he said "{ , : }" and \\ backslash', t: 'tab\tnewline\n' };
+  assert.equal(fmt(value), JSON.stringify(value, null, 2));
+});
+
+test('pre-existing whitespace in the input is normalized away', () => {
+  const messy = '{  "a" :\n\t1 ,   "b":[ 2,3 ]  }';
+  const f = new JsonStreamFormatter();
+  assert.equal(f.push(Buffer.from(messy)), JSON.stringify({ a: 1, b: [2, 3] }, null, 2));
+});

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -13,6 +13,20 @@ import { createConnectHandler } from '../src/mitm.js';
 
 function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
 
+// Tear a server down hard: destroy any lingering connections (CONNECT-hijacked
+// sockets are NOT closed by server.close(), which only stops accepting), then
+// close. Without this, Node 18's test runner — which, unlike Node 20+, does not
+// force-exit — keeps the event loop alive on a leaked handle and the run hangs.
+function closeHard(server) {
+  if (!server) return;
+  server.closeAllConnections?.();
+  try { server.close(); } catch { /* already closing */ }
+}
+
+// node:test per-test timeout: turn any future deadlock into a fast, located
+// failure instead of a 30-minute CI stall (option form works on Node 18).
+const T = { timeout: 30000 };
+
 // Drive a CONNECT through the proxy, then TLS over the tunnel; resolve the TLS socket.
 function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
   return new Promise((resolve, reject) => {
@@ -57,7 +71,7 @@ function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir =
   return proxy;
 }
 
-test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', async () => {
+test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', T, async () => {
   const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
 
   const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
@@ -97,11 +111,11 @@ test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', asy
     assert.ok(quota && quota['anthropic-ratelimit-unified-5h-utilization'] === '0.7');
     client.close();
   } finally {
-    proxy.close(); upstream.close();
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }
 });
 
-test('MITM h2 rewrites body account_uuid to the injected account', async () => {
+test('MITM h2 rewrites body account_uuid to the injected account', T, async () => {
   const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
   const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
   upstream.on('stream', (s) => {
@@ -130,11 +144,11 @@ test('MITM h2 rewrites body account_uuid to the injected account', async () => {
     assert.equal(resp['x-seen-uuid'], ACCOUNT_UUID); // body uuid rewritten to the injected account's
     client.close();
   } finally {
-    proxy.close(); upstream.close();
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }
 });
 
-test('MITM logs proxied requests when --log-to is set', async () => {
+test('MITM logs proxied requests when --log-to is set', T, async () => {
   const dir = mkdtempSync(join(tmpdir(), 'tc-mitmlog-'));
   const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
   const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
@@ -159,11 +173,11 @@ test('MITM logs proxied requests when --log-to is set', async () => {
     assert.ok(!content.includes('SECRET-FAKE'));  // client token never logged (replaced + masked)
     client.close();
   } finally {
-    proxy.close(); upstream.close(); rmSync(dir, { recursive: true, force: true });
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream); rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewritten', async () => {
+test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewritten', T, async () => {
   const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
 
   // http/1.1-only TLS upstream that echoes the authorization it received.
@@ -195,6 +209,6 @@ test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewr
     assert.equal(body.auth, 'Bearer REAL-TOKEN'); // rewritten
     assert.equal(body.xkey, 'none');              // dropped
   } finally {
-    proxy.close(); upstream.close();
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }
 });

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -1,0 +1,132 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http2 from 'node:http2';
+import net from 'node:net';
+import tls from 'node:tls';
+import http from 'node:http';
+import { once } from 'node:events';
+import { generateCertChain } from '../src/x509.js';
+import { createConnectHandler } from '../src/mitm.js';
+
+function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
+
+// Drive a CONNECT through the proxy, then TLS over the tunnel; resolve the TLS socket.
+function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
+  return new Promise((resolve, reject) => {
+    const raw = net.connect(proxyPort, '127.0.0.1');
+    raw.once('error', reject);
+    raw.once('connect', () => raw.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`));
+    let buf = Buffer.alloc(0);
+    const onData = (d) => {
+      buf = Buffer.concat([buf, d]);
+      if (buf.includes('\r\n\r\n')) {
+        raw.removeListener('data', onData);
+        const sock = tls.connect(
+          { socket: raw, servername: 'localhost', ca: [caCertPem], ALPNProtocols: alpn },
+          () => resolve(sock),
+        );
+        sock.once('error', reject);
+      }
+    };
+    raw.on('data', onData);
+  });
+}
+
+function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota) {
+  const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN' };
+  const accountManager = {
+    getActiveAccount: () => account,
+    ensureTokenFresh: async () => {},
+    updateQuota: (i, h) => onQuota(h),
+    markRateLimited: () => {},
+  };
+  const proxy = http.createServer();
+  proxy.on('connect', createConnectHandler({
+    config: { upstream: `https://localhost:${upPort}` },
+    accountManager,
+    ensureLeaf: async () => ({ key: leafKeyPem, cert: leafCertPem }),
+    upstreamTlsOptions: { ca: [caCertPem] },
+    log: () => {},
+  }));
+  return proxy;
+}
+
+test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
+  upstream.on('stream', (s, h) => {
+    s.respond({
+      ':status': 200,
+      'x-saw-auth': h.authorization || 'none',
+      'x-saw-xkey': h['x-api-key'] || 'none',
+      'x-saw-ct': h['content-type'] || 'none',
+      'anthropic-ratelimit-unified-5h-utilization': '0.7',
+    });
+    s.end('upstream-ok');
+  });
+  const upPort = await listen(upstream);
+
+  let quota = null;
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, (h) => { quota = h; });
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  try {
+    assert.equal(tlsSock.alpnProtocol, 'h2'); // mirrored from the (h2) upstream
+    const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+    const req = client.request({
+      ':method': 'POST', ':path': '/v1/design/mcp',
+      authorization: 'Bearer FAKE', 'x-api-key': 'sk-fake', 'content-type': 'application/json',
+    });
+    let resp, body = '';
+    req.on('response', (h) => { resp = h; });
+    req.setEncoding('utf8'); req.on('data', (d) => { body += d; }); req.end('{}');
+    await once(req, 'close');
+
+    assert.equal(resp['x-saw-auth'], 'Bearer REAL-TOKEN'); // injected
+    assert.equal(resp['x-saw-xkey'], 'none');              // dropped
+    assert.equal(resp['x-saw-ct'], 'application/json');    // preserved
+    assert.equal(body, 'upstream-ok');
+    assert.ok(quota && quota['anthropic-ratelimit-unified-5h-utilization'] === '0.7');
+    client.close();
+  } finally {
+    proxy.close(); upstream.close();
+  }
+});
+
+test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewritten', async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+
+  // http/1.1-only TLS upstream that echoes the authorization it received.
+  const upstream = tls.createServer({ key: leafKeyPem, cert: leafCertPem, ALPNProtocols: ['http/1.1'] }, (s) => {
+    let buf = '';
+    s.on('data', (d) => {
+      buf += d;
+      if (buf.includes('\r\n\r\n')) {
+        const auth = (buf.match(/authorization: (.*)\r\n/i) || [])[1] || 'none';
+        const xkey = /x-api-key:/i.test(buf) ? 'present' : 'none';
+        const body = JSON.stringify({ auth, xkey });
+        s.end(`HTTP/1.1 200 OK\r\ncontent-length: ${Buffer.byteLength(body)}\r\nconnection: close\r\n\r\n${body}`);
+      }
+    });
+  });
+  const upPort = await listen(upstream);
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {});
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['http/1.1']);
+  try {
+    assert.equal(tlsSock.alpnProtocol, 'http/1.1'); // mirrored
+    tlsSock.write('GET /v1/messages HTTP/1.1\r\nhost: localhost\r\nauthorization: Bearer FAKE\r\nx-api-key: sk-fake\r\n\r\n');
+    let buf = '';
+    tlsSock.setEncoding('utf8');
+    tlsSock.on('data', (d) => { buf += d; });
+    await once(tlsSock, 'end');
+    const body = JSON.parse(buf.slice(buf.indexOf('{')));
+    assert.equal(body.auth, 'Bearer REAL-TOKEN'); // rewritten
+    assert.equal(body.xkey, 'none');              // dropped
+  } finally {
+    proxy.close(); upstream.close();
+  }
+});

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -61,10 +61,14 @@ function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir =
   };
   const proxy = http.createServer();
   proxy.on('connect', createConnectHandler({
-    config: { upstream: `https://localhost:${upPort}` },
+    // Address the upstream by IP (servers bind 127.0.0.1) so the test never
+    // depends on how the host resolves `localhost` — on a dual-stack box that
+    // prefers ::1, Node 18 (no happy-eyeballs) would otherwise hang the dial.
+    // SNI is pinned to the cert's name via upstreamTlsOptions.servername.
+    config: { upstream: `https://127.0.0.1:${upPort}` },
     accountManager,
     ensureLeaf: async () => ({ key: leafKeyPem, cert: leafCertPem }),
-    upstreamTlsOptions: { ca: [caCertPem] },
+    upstreamTlsOptions: { ca: [caCertPem], servername: 'localhost' },
     logDir,
     log: () => {},
   }));
@@ -91,7 +95,7 @@ test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', T, 
   const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, (h) => { quota = h; });
   const proxyPort = await listen(proxy);
 
-  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2', 'http/1.1']);
   try {
     assert.equal(tlsSock.alpnProtocol, 'h2'); // mirrored from the (h2) upstream
     const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
@@ -132,7 +136,7 @@ test('MITM h2 rewrites body account_uuid to the injected account', T, async () =
   const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {});
   const proxyPort = await listen(proxy);
 
-  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2', 'http/1.1']);
   try {
     const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
     const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer FAKE' });
@@ -157,7 +161,7 @@ test('MITM logs proxied requests when --log-to is set', T, async () => {
   const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {}, dir);
   const proxyPort = await listen(proxy);
 
-  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2', 'http/1.1']);
   try {
     const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
     const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer SECRET-FAKE' });
@@ -197,7 +201,7 @@ test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewr
   const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {});
   const proxyPort = await listen(proxy);
 
-  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['http/1.1']);
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['http/1.1']);
   try {
     assert.equal(tlsSock.alpnProtocol, 'http/1.1'); // mirrored
     tlsSock.write('GET /v1/messages HTTP/1.1\r\nhost: localhost\r\nauthorization: Bearer FAKE\r\nx-api-key: sk-fake\r\n\r\n');

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -32,8 +32,10 @@ function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
   });
 }
 
+const ACCOUNT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
 function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota) {
-  const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN' };
+  const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN', accountUuid: ACCOUNT_UUID };
   const accountManager = {
     getActiveAccount: () => account,
     ensureTokenFresh: async () => {},
@@ -89,6 +91,39 @@ test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', asy
     assert.equal(resp['x-saw-ct'], 'application/json');    // preserved
     assert.equal(body, 'upstream-ok');
     assert.ok(quota && quota['anthropic-ratelimit-unified-5h-utilization'] === '0.7');
+    client.close();
+  } finally {
+    proxy.close(); upstream.close();
+  }
+});
+
+test('MITM h2 rewrites body account_uuid to the injected account', async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
+  upstream.on('stream', (s) => {
+    let body = '';
+    s.on('data', (d) => { body += d; });
+    s.on('end', () => {
+      let seen = 'none';
+      try { seen = JSON.parse(JSON.parse(body).metadata.user_id).account_uuid; } catch { /* ignore */ }
+      s.respond({ ':status': 200, 'x-seen-uuid': seen });
+      s.end('ok');
+    });
+  });
+  const upPort = await listen(upstream);
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {});
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  try {
+    const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer FAKE' });
+    const reqBody = JSON.stringify({ metadata: { user_id: JSON.stringify({ device_id: 'd', account_uuid: '4c39e915-eb47-450d-9bf4-4cbbcd049a08' }) } });
+    let resp;
+    req.on('response', (h) => { resp = h; });
+    req.resume(); req.end(reqBody);
+    await once(req, 'close');
+    assert.equal(resp['x-seen-uuid'], ACCOUNT_UUID); // body uuid rewritten to the injected account's
     client.close();
   } finally {
     proxy.close(); upstream.close();

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -5,6 +5,9 @@ import net from 'node:net';
 import tls from 'node:tls';
 import http from 'node:http';
 import { once } from 'node:events';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { generateCertChain } from '../src/x509.js';
 import { createConnectHandler } from '../src/mitm.js';
 
@@ -34,8 +37,8 @@ function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
 
 const ACCOUNT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
-function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota) {
-  const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN', accountUuid: ACCOUNT_UUID };
+function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir = null) {
+  const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN', accountUuid: ACCOUNT_UUID, name: 'acct@x' };
   const accountManager = {
     getActiveAccount: () => account,
     ensureTokenFresh: async () => {},
@@ -48,6 +51,7 @@ function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota) {
     accountManager,
     ensureLeaf: async () => ({ key: leafKeyPem, cert: leafCertPem }),
     upstreamTlsOptions: { ca: [caCertPem] },
+    logDir,
     log: () => {},
   }));
   return proxy;
@@ -127,6 +131,35 @@ test('MITM h2 rewrites body account_uuid to the injected account', async () => {
     client.close();
   } finally {
     proxy.close(); upstream.close();
+  }
+});
+
+test('MITM logs proxied requests when --log-to is set', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-mitmlog-'));
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
+  upstream.on('stream', (s) => { s.respond({ ':status': 200 }); s.end('{"ok":true}'); });
+  const upPort = await listen(upstream);
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {}, dir);
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `localhost:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  try {
+    const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer SECRET-FAKE' });
+    req.resume(); req.end('{"hi":1}');
+    await once(req, 'close');
+    await new Promise((r) => setTimeout(r, 150)); // let the async file write land
+    const files = readdirSync(dir).filter((f) => f.endsWith('.log'));
+    assert.ok(files.length >= 1, 'a log file was written');
+    const content = readFileSync(join(dir, files[0]), 'utf8');
+    assert.match(content, /\/v1\/messages/);     // request line
+    assert.match(content, /RESPONSE 200/);        // response status
+    assert.match(content, /REQUEST BODY/);        // request body section
+    assert.ok(!content.includes('SECRET-FAKE'));  // client token never logged (replaced + masked)
+    client.close();
+  } finally {
+    proxy.close(); upstream.close(); rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Replaces the `--mitm` internals from #37 (which forced http/1.1 and re-issued via `fetch`) with a **transparent, protocol-faithful** forward proxy that copies traffic as-is and rewrites only what it must. Reverse-proxy path (`ANTHROPIC_BASE_URL` / `fetch`) is unchanged except it now also aligns the body `account_uuid` and logs full bodies.

## How it works
On `CONNECT` to the upstream host, teamclaude **dials the real upstream first, mirrors its SNI + negotiated ALPN** (HTTP/2 or HTTP/1.1), then terminates TLS toward claude with the same protocol and relays:
- **HTTP/2** via a built-in HPACK codec + frame relay: decode each HEADERS block, rewrite **only `authorization`** (drop `x-api-key`), re-encode; all other frames forwarded verbatim; responses passed through byte-for-byte and only observed for `:status` + rate-limit (quota).
- **HTTP/1.1** via a plaintext head rewrite + raw body relay.
- **Body `account_uuid`**: a streaming JSON state machine (no regex, any size) rewrites `metadata.user_id.account_uuid` to the injected account — same length, in place — on **both** paths. Scoped to `metadata.user_id` so stray UUIDs in user content are untouched.
- **Host routing**: `api.anthropic.com` → rewrite, `www.example.org` → built-in local test responder (credential-free CA/proxy check), everything else → blind tunnel.
- The server serves **both** base-URL and CONNECT clients at once (multiple claude instances, different settings).

## No new dependencies
Pure-JS HPACK (`src/h2/hpack.js`, ported from a clean-room Rust impl, validated against RFC 7541 Appendix C), HTTP/2 framing (`src/h2/frames.js`), relay (`src/h2/relay.js`), TLS/routing (`src/mitm.js`), streaming body patcher (`src/account-uuid-rewrite.js`), and request logging (`src/request-log.js`). `node:http2`/`fetch` are deliberately **not** used on the proxy path.

## Logging
`--log-to` now captures MITM-proxied requests too (was a regression) — one file per request, auth/x-api-key masked, **full bodies** (no truncation — AI requests can be ~1M tokens).

## Trust model
Local CA trusted only by the launched claude via `NODE_EXTRA_CA_CERTS` (never the system store); CA private key never written to disk; upstream TLS verification stays on; off by default (`run --mitm`).

## Tests
85 passing, lint clean: RFC HPACK vectors; h2 framing; end-to-end h2 **and** h1 over real TLS through the CONNECT proxy (ALPN mirrored, auth rewritten, x-api-key dropped, body account_uuid rewritten, quota observed, request logged); byte-by-byte streaming of the body patcher with a UUID split across chunks and stray account_uuid left intact. Plus a live `curl --http2 --cacert` against the test host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)