### PR TITLE
Fix MITM ConnectionRefused: faithfully mirror the client's ALPN

### DIFF
--- a/src/mitm.js
+++ b/src/mitm.js
@@ -141,26 +141,47 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     return;
   }
 
-  // rewrite: dial upstream first, mirror its ALPN, then terminate claude.
+  // rewrite: be a faithful ALPN mirror. We don't terminate TLS at the byte
+  // level (that's node:tls), so to avoid imposing our own protocol preference we
+  // peek the client's ClientHello, read the exact ALPN list it offers, present
+  // THAT list to the upstream, let the upstream pick, then terminate the client
+  // with whatever the upstream selected. The upstream decides — constrained to
+  // what the client can speak — so an http/1.1-only client (undici/claude) and
+  // an h2 client both negotiate end-to-end exactly as they would directly.
   const account = accountManager.getActiveAccount();
   if (!account) { clientSocket.destroy(); return; }
   await accountManager.ensureTokenFresh(account.index);
 
+  reply200Raw(clientSocket);
+  const offered = await peekClientAlpn(clientSocket, head); // client's ALPN list, or null
+
   // autoSelectFamily (happy-eyeballs) is the default on Node 20+ but not 18; set
   // it explicitly so a dual-stack upstream whose IPv6 path is unreachable falls
   // back to IPv4 instead of hanging the connect (option ignored pre-18.13).
-  const upstreamSock = tls.connect({ host, port, servername: host, autoSelectFamily: true, ALPNProtocols: ['h2', 'http/1.1'], ...upstreamTlsOptions });
+  const upstreamSock = tls.connect({
+    host, port, servername: host, autoSelectFamily: true,
+    ...(offered ? { ALPNProtocols: offered } : {}),
+    ...upstreamTlsOptions,
+  });
   await new Promise((resolve, reject) => {
     upstreamSock.once('secureConnect', resolve);
     upstreamSock.once('error', reject);
   });
-  const alpn = upstreamSock.alpnProtocol || 'http/1.1';
+  const upstreamAlpn = upstreamSock.alpnProtocol; // false if none negotiated
+  const alpn = upstreamAlpn || 'http/1.1';        // relay protocol selector
 
-  reply200Raw(clientSocket);
-  const claudeTls = termClaude(clientSocket, head, key, cert, [alpn]);
+  // Terminate the client advertising exactly what the upstream chose (a subset
+  // of what the client offered, so it always overlaps).
+  const claudeTls = new tls.TLSSocket(clientSocket, {
+    isServer: true, key, cert,
+    ...(upstreamAlpn ? { ALPNProtocols: [upstreamAlpn] } : {}),
+  });
+  claudeTls.on('error', () => { claudeTls.destroy(); upstreamSock.destroy(); });
   upstreamSock.on('error', () => claudeTls.destroy());
-
-  await new Promise((resolve) => claudeTls.once('secure', resolve));
+  await new Promise((resolve, reject) => {
+    claudeTls.once('secure', resolve);
+    claudeTls.once('error', reject);
+  });
 
   // Per-stream streaming body patcher: align metadata.user_id.account_uuid with
   // the injected account (same length; no-op if the account has no UUID).
@@ -192,6 +213,93 @@ function termClaude(clientSocket, head, key, cert, alpn) {
   const t = new tls.TLSSocket(clientSocket, { isServer: true, key, cert, ALPNProtocols: alpn });
   t.on('error', () => t.destroy());
   return t;
+}
+
+// Read the client's first TLS record (the ClientHello) to learn the ALPN
+// protocol list it offers, WITHOUT consuming it: bytes are unshifted back so the
+// real TLS handshake still sees the full ClientHello. Returns the protocol
+// string array, or null if there is no ALPN extension / it can't be parsed (in
+// which case we offer the upstream no ALPN and mirror its no-ALPN result).
+function peekClientAlpn(sock, head) {
+  return new Promise((resolve) => {
+    let buf = head && head.length ? Buffer.from(head) : Buffer.alloc(0);
+    let done = false;
+    const finish = (result) => {
+      if (done) return; done = true;
+      sock.removeListener('readable', onReadable);
+      sock.removeListener('end', onEnd);
+      sock.removeListener('error', onEnd);
+      if (buf.length) sock.unshift(buf); // put the ClientHello back for node:tls
+      resolve(result);
+    };
+    const tryParse = () => {
+      const r = parseClientHelloAlpn(buf);
+      if (r === undefined && buf.length < 16384) return false; // need more bytes
+      finish(Array.isArray(r) ? r : null);
+      return true;
+    };
+    // Read in PAUSED mode (readable/read) — never switch the socket to flowing,
+    // or the TLSSocket we hand it to afterwards won't receive the unshifted bytes.
+    const onReadable = () => {
+      let chunk;
+      while ((chunk = sock.read()) !== null) {
+        buf = Buffer.concat([buf, chunk]);
+        if (tryParse()) return;
+      }
+    };
+    const onEnd = () => finish(null);
+    sock.on('readable', onReadable);
+    sock.once('end', onEnd);
+    sock.once('error', onEnd);
+    if (tryParse()) return; // head may already contain the whole ClientHello
+    onReadable();           // drain anything already buffered
+  });
+}
+
+// Parse the ALPN protocol list out of a TLS ClientHello.
+//   returns string[]  — ALPN extension present
+//   returns null       — parsed far enough to know there is no usable ALPN
+//   returns undefined  — need more bytes to decide
+export function parseClientHelloAlpn(buf) {
+  if (buf.length < 5) return undefined;
+  if (buf[0] !== 0x16) return null;                 // not a handshake record
+  const recEnd = 5 + buf.readUInt16BE(3);
+  if (buf.length < recEnd) return undefined;        // wait for the full record
+  let p = 5;
+  if (buf[p] !== 0x01) return null;                 // not a ClientHello
+  const hsEnd = p + 4 + ((buf[p + 1] << 16) | (buf[p + 2] << 8) | buf[p + 3]);
+  const end = Math.min(hsEnd, recEnd);
+  p += 4;
+  p += 2 + 32;                                      // client_version + random
+  if (p >= end) return null;
+  p += 1 + buf[p];                                  // session_id
+  if (p + 2 > end) return null;
+  p += 2 + buf.readUInt16BE(p);                     // cipher_suites
+  if (p + 1 > end) return null;
+  p += 1 + buf[p];                                  // compression_methods
+  if (p + 2 > end) return null;
+  let extEnd = p + 2 + buf.readUInt16BE(p);
+  p += 2;
+  extEnd = Math.min(extEnd, end);
+  while (p + 4 <= extEnd) {
+    const type = buf.readUInt16BE(p);
+    const len = buf.readUInt16BE(p + 2);
+    p += 4;
+    if (type === 0x0010) {                          // application_layer_protocol_negotiation
+      let q = p + 2;                                // skip ALPN list length
+      const listEnd = Math.min(p + len, extEnd);
+      const protos = [];
+      while (q < listEnd) {
+        const l = buf[q]; q += 1;
+        if (q + l > listEnd) break;
+        protos.push(buf.toString('latin1', q, q + l));
+        q += l;
+      }
+      return protos.length ? protos : null;
+    }
+    p += len;
+  }
+  return null;                                      // no ALPN extension
 }
 
 // Rewrite only the auth field on an h2 request header list (account token in,

--- a/test/clienthello-alpn.test.js
+++ b/test/clienthello-alpn.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import tls from 'node:tls';
+import { parseClientHelloAlpn } from '../src/mitm.js';
+
+// Capture the real ClientHello bytes a node TLS client sends for a given ALPN
+// offer, by pointing it at a plain TCP server that just records the first bytes.
+function captureClientHello(alpn) {
+  return new Promise((resolve) => {
+    const srv = net.createServer((sock) => {
+      sock.once('data', (d) => { resolve(d); sock.destroy(); srv.close(); });
+    });
+    srv.listen(0, '127.0.0.1', () => {
+      const c = tls.connect({ host: '127.0.0.1', port: srv.address().port, ALPNProtocols: alpn, rejectUnauthorized: false });
+      c.on('error', () => {}); // handshake won't complete; we only want the ClientHello
+    });
+  });
+}
+
+test('parses the ALPN list from a real ClientHello (h2 + http/1.1)', async () => {
+  const hello = await captureClientHello(['h2', 'http/1.1']);
+  assert.deepEqual(parseClientHelloAlpn(hello), ['h2', 'http/1.1']);
+});
+
+test('parses the ALPN list from a real ClientHello (http/1.1 only)', async () => {
+  const hello = await captureClientHello(['http/1.1']);
+  assert.deepEqual(parseClientHelloAlpn(hello), ['http/1.1']);
+});
+
+test('returns undefined for a partial record (need more bytes)', async () => {
+  const hello = await captureClientHello(['h2', 'http/1.1']);
+  assert.equal(parseClientHelloAlpn(hello.subarray(0, 4)), undefined); // shorter than a record header
+  assert.equal(parseClientHelloAlpn(hello.subarray(0, hello.length - 10)), undefined); // truncated record
+});
+
+test('returns null when there is no ALPN extension', async () => {
+  const hello = await captureClientHello(undefined); // no ALPN offered
+  assert.equal(parseClientHelloAlpn(hello), null);
+});
+
+test('returns null for non-handshake bytes', () => {
+  assert.equal(parseClientHelloAlpn(Buffer.from('GET / HTTP/1.1\r\n\r\n')), null);
+});

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -216,3 +216,44 @@ test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewr
     tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }
 });
+
+// Regression (the run --mitm "ConnectionRefused"): an http/1.1-only client — what
+// undici/claude offers when it tunnels through a proxy — against an upstream that
+// ALSO speaks h2. We must adopt the CLIENT's protocol (http/1.1) and mirror it
+// upstream, not force the upstream's preferred h2 onto the client (which would
+// fail the TLS handshake with no_application_protocol).
+test('MITM: http/1.1-only client against a dual h2+h1 upstream negotiates http/1.1', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+
+  // Dual-protocol upstream: allowHTTP1 means it serves BOTH h2 (stream) and
+  // http/1.1 (request). It prefers h2 when offered both.
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem, allowHTTP1: true });
+  upstream.on('stream', (s, h) => { // h2 path (should NOT be taken here)
+    s.respond({ ':status': 200, 'x-proto': 'h2', 'x-saw-auth': h.authorization || 'none' });
+    s.end('h2');
+  });
+  upstream.on('request', (req, res) => { // http/1.1 path
+    res.writeHead(200, { 'connection': 'close', 'x-proto': 'h1', 'x-saw-auth': req.headers.authorization || 'none', 'x-saw-xkey': req.headers['x-api-key'] || 'none' });
+    res.end('h1-ok');
+  });
+  const upPort = await listen(upstream);
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {});
+  const proxyPort = await listen(proxy);
+
+  // Client offers ONLY http/1.1 — like undici tunnelling through the proxy.
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['http/1.1']);
+  try {
+    assert.equal(tlsSock.alpnProtocol, 'http/1.1'); // client's choice honored, not forced to h2
+    tlsSock.write('GET /v1/messages HTTP/1.1\r\nhost: localhost\r\nauthorization: Bearer FAKE\r\nx-api-key: sk-fake\r\n\r\n');
+    let buf = '';
+    tlsSock.setEncoding('utf8');
+    tlsSock.on('data', (d) => { buf += d; });
+    await once(tlsSock, 'end');
+    assert.match(buf, /x-proto: h1/i);              // served over http/1.1 end-to-end
+    assert.match(buf, /x-saw-auth: Bearer REAL-TOKEN/i); // token injected
+    assert.match(buf, /x-saw-xkey: none/i);         // x-api-key dropped
+    assert.match(buf, /h1-ok/);
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});


### PR DESCRIPTION
## The bug
`teamclaude run --mitm` failed for real claude clients with repeated **`Unable to connect to API (ConnectionRefused)`**, even though the proxy, CA, and CONNECT path all worked via curl.

Root cause is in #38: the MITM dialed the **upstream first** and mirrored the *upstream's* negotiated ALPN onto the client-facing leaf. api.anthropic.com (offered both) picks **h2**, so our leaf advertised only `h2`. But claude's client (undici, tunnelling through an HTTP proxy) offers only **http/1.1** — no ALPN overlap → the TLS handshake aborts with `no_application_protocol`, surfaced by the client as ConnectionRefused. curl negotiated h2, so my tests and manual checks never reproduced it.

Confirmed directly:
```
client offers [h2,http/1.1]: OK, negotiated h2
client offers [http/1.1]   : TLS ERROR ...tlsv1 alert no application protocol
```

## The fix — be a faithful ALPN mirror
Peek the client's ClientHello to read the **exact ALPN list it offers**, present *that same list* to the upstream, let the **upstream** choose, then terminate the client with whatever the upstream selected (always a subset of the client's offer, so it overlaps). The upstream decides the protocol, constrained to what the client can speak — identical to a direct connection.

We don't own TLS at the byte level (that's `node:tls`), so the client's offer is obtained by parsing just the ALPN extension out of the ClientHello and then unshifting the bytes back so the real handshake is unaffected. The peek runs in **paused** mode (`readable`/`read()`) — flowing mode would swallow the bytes and the subsequent `TLSSocket` would hang.

## Verification
- Live against real `api.anthropic.com` through a fresh proxy: an **http/1.1-only** client now negotiates `http/1.1` and reaches the API; an **h2** client negotiates `h2`. Previously the h1 client failed the handshake.
- `test/clienthello-alpn.test.js` (new): parses real captured ClientHellos — `[h2,http/1.1]`, `[http/1.1]`, truncated (need-more-bytes), no-ALPN, and non-handshake bytes.
- `test/mitm-integration.test.js`: new case — http/1.1-only client against a **dual h2+h1** upstream must negotiate http/1.1 end-to-end (auth injected, x-api-key dropped).
- 97 tests pass on Node 18/20/22/24; lint clean (1 pre-existing warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)