### PR TITLE
Select the best account on daemon launch using restored quota

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -232,16 +232,18 @@ export class AccountManager {
     return false;
   }
 
-  _selectNext() {
-    // Selection order among available accounts:
-    //   1. lowest `priority` value (operator-controlled; default 0, lower = preferred)
-    //   2. then the account with no known weekly limit — using it lets us
-    //      discover its quota
-    //   3. then the account whose weekly limit expires soonest: that quota is
-    //      closest to refreshing, so spending it first preserves accounts whose
-    //      weekly window resets further out.
-    // With all priorities at the default 0, this reduces to the original
-    // weekly-reset heuristic.
+  /**
+   * Pick the best available account by selection order, WITHOUT mutating state:
+   *   1. lowest `priority` value (operator-controlled; default 0, lower = preferred)
+   *   2. then the account with no known weekly limit — using it lets us
+   *      discover its quota
+   *   3. then the account whose weekly limit expires soonest: that quota is
+   *      closest to refreshing, so spending it first preserves accounts whose
+   *      weekly window resets further out.
+   * With all priorities at the default 0, this reduces to the weekly-reset
+   * heuristic. Returns the account or null if none are available.
+   */
+  _pickBestAvailable() {
     let best = null;
     let bestPriority = Infinity;
     let bestReset = Infinity;
@@ -263,7 +265,31 @@ export class AccountManager {
         best = account;
       }
     }
+    return best;
+  }
 
+  /**
+   * Select the active account up front (e.g. on daemon launch, once persisted
+   * quota has been restored) so we start on the highest-priority / soonest-
+   * resetting account instead of blindly on index 0. Mirrors rotation order.
+   * Returns the chosen account, or the existing current one if none are
+   * available (the server still starts; requests 429 until a window resets).
+   */
+  selectActiveAccount() {
+    this.refreshExpiredQuotas(); // drop any restored windows that already expired
+    const best = this._pickBestAvailable();
+    if (!best) return this.accounts[this.currentIndex] || null;
+    this.currentIndex = best.index;
+    best.probing = best.quota.unified7dReset == null;
+    const wk = best.quota.unified7d != null
+      ? `${(best.quota.unified7d * 100).toFixed(1)}% weekly used`
+      : 'weekly quota unknown';
+    console.log(`[TeamClaude] Starting on account "${best.name}" (priority ${best.priority || 0}, ${wk})`);
+    return best;
+  }
+
+  _selectNext() {
+    const best = this._pickBestAvailable();
     if (best) {
       const switched = best.index !== this.currentIndex;
       this.currentIndex = best.index;

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,10 @@ async function serverCommand() {
   });
   if (savedState?.quota) accountManager.restoreQuotaState(savedState.quota);
 
+  // With quota restored, pick the best account up front (highest priority /
+  // soonest-resetting weekly window) instead of defaulting to the first one.
+  accountManager.selectActiveAccount();
+
   // Periodically persist quota (and once more on shutdown) to the state file.
   const persistQuotaState = () =>
     saveState({ quota: accountManager.exportQuotaState() })

--- a/test/rotation-priority.test.js
+++ b/test/rotation-priority.test.js
@@ -79,3 +79,65 @@ test('common case: all-equal priority leaves getActiveAccount on the healthy cur
   am.currentIndex = 2;
   assert.equal(am.getActiveAccount().name, 'c'); // unchanged — no preemption when priorities tie
 });
+
+// ── selectActiveAccount (daemon-launch up-front selection) ───────────────────
+
+test('selectActiveAccount picks the soonest-resetting weekly window, not index 0', () => {
+  const now = Date.now();
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  // All same priority and available; b's weekly resets soonest → spend it first.
+  am.accounts[0].quota.unified7d = 0.5; am.accounts[0].quota.unified7dReset = now + 5 * 86400_000;
+  am.accounts[1].quota.unified7d = 0.5; am.accounts[1].quota.unified7dReset = now + 1 * 86400_000;
+  am.accounts[2].quota.unified7d = 0.5; am.accounts[2].quota.unified7dReset = now + 3 * 86400_000;
+  const chosen = am.selectActiveAccount();
+  assert.equal(chosen.name, 'b');
+  assert.equal(am.currentIndex, 1); // currentIndex actually moved off 0
+});
+
+test('selectActiveAccount honors priority over the weekly heuristic', () => {
+  const now = Date.now();
+  const am = new AccountManager([
+    oauth('a', { priority: 0 }),
+    oauth('b', { priority: 1 }), // higher-priority value = less preferred
+  ], 0.98);
+  // b resets sooner, but a has the better (lower) priority value → a wins.
+  am.accounts[0].quota.unified7d = 0.5; am.accounts[0].quota.unified7dReset = now + 5 * 86400_000;
+  am.accounts[1].quota.unified7d = 0.5; am.accounts[1].quota.unified7dReset = now + 1 * 86400_000;
+  assert.equal(am.selectActiveAccount().name, 'a');
+});
+
+test('selectActiveAccount skips an account already over the weekly threshold', () => {
+  const now = Date.now();
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.accounts[0].quota.unified7d = 0.99; am.accounts[0].quota.unified7dReset = now + 86400_000; // near-exhausted
+  am.accounts[1].quota.unified7d = 0.10; am.accounts[1].quota.unified7dReset = now + 5 * 86400_000;
+  assert.equal(am.selectActiveAccount().name, 'b');
+});
+
+test('selectActiveAccount restores onto the best account after an export → restore cycle', () => {
+  const now = Date.now();
+  const am1 = new AccountManager([
+    oauth('a', { accountUuid: 'p1' }),
+    oauth('b', { accountUuid: 'p2' }),
+  ], 0.98);
+  am1.accounts[0].quota.unified7d = 0.8; am1.accounts[0].quota.unified7dReset = now + 6 * 86400_000;
+  am1.accounts[1].quota.unified7d = 0.2; am1.accounts[1].quota.unified7dReset = now + 2 * 86400_000;
+
+  const am2 = new AccountManager([
+    oauth('a', { accountUuid: 'p1' }),
+    oauth('b', { accountUuid: 'p2' }),
+  ], 0.98);
+  am2.restoreQuotaState(am1.exportQuotaState());
+  // b's weekly resets sooner → start there, mirroring a real daemon launch.
+  assert.equal(am2.selectActiveAccount().name, 'b');
+});
+
+test('selectActiveAccount leaves current account when none are available', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.accounts[0].status = 'exhausted';
+  am.accounts[1].disabled = true;
+  am.currentIndex = 1;
+  const chosen = am.selectActiveAccount();
+  assert.equal(chosen.name, 'b');   // falls back to the existing current account
+  assert.equal(am.currentIndex, 1); // unchanged
+});


### PR DESCRIPTION
Now that quota survives a restart (state file), the daemon should **start on the account the rotation logic would prefer**, not blindly on index 0.

## Why it was needed
`getActiveAccount()` is intentionally sticky — it keeps the current account unless a *strictly higher-priority* one is available, so the common all-equal-priority case never thrashes. The flip side: at launch `currentIndex` is `0`, and if account 0 is available the daemon stays on it — ignoring the restored quotas, even when a same-priority account has a sooner-resetting weekly window that should be spent first.

## Change
- `AccountManager.selectActiveAccount()` (new): clears any restored windows that already expired, then picks the best available account by the **same order rotation uses** — priority → unknown-weekly-first (to discover) → soonest weekly reset — and sets `currentIndex` up front. Logs e.g. `Starting on account "x" (priority 0, 18.3% weekly used)`.
- The daemon calls it right after `restoreQuotaState()`.
- Factored the selection scan out of `_selectNext()` into a pure `_pickBestAvailable()` shared by both (no behavior change to rotation).

With no persisted quota, every account is still "probing" and the pick collapses to the first priority-0 account (index 0) — identical to today.

## Tests
`test/rotation-priority.test.js` gains coverage: picks soonest-resetting weekly over index 0; honors priority over the weekly heuristic; skips an account over the switch threshold; lands on the best account after an export→restore cycle (simulated launch); and falls back to the current account when none are available. 102 tests pass on Node 18/20/22/24; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)