### PR TITLE
Fix h1 keep-alive relay: per-request framing, auth rewrite, masked logging

### DIFF
--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -174,49 +174,196 @@ export function h2Relay(claude, upstream, opts = {}) {
   respCtl = link(upstream, claude, onRespData, destroyBoth);
 }
 
+const MAX_HEAD = 65536; // runaway-head guard for a single request/response head
+
+// Parse an HTTP/1.1 message head: its start line + the body framing it declares.
+// `chunked` wins over content-length per RFC 7230 §3.3.3.
+function parseH1Head(headText) {
+  const lines = headText.split('\r\n');
+  let contentLength = null;
+  let chunked = false;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') break;
+    const c = line.indexOf(':');
+    if (c < 0) continue;
+    const name = line.slice(0, c).trim().toLowerCase();
+    const value = line.slice(c + 1).trim().toLowerCase();
+    if (name === 'transfer-encoding') { if (/(^|,)\s*chunked\s*$/.test(value)) chunked = true; }
+    else if (name === 'content-length') { const n = parseInt(value, 10); if (!Number.isNaN(n)) contentLength = n; }
+  }
+  return { startLine: lines[0] || '', contentLength, chunked };
+}
+
+// A streaming body-length tracker. process(buf) returns how many leading bytes of
+// `buf` belong to the current message body and whether the body is complete; it
+// keeps internal state across calls so a body split over many chunks is tracked
+// exactly. `kind`: 'none' | 'length' | 'chunked' | 'until-close'.
+function makeBodyTracker(kind, length = 0) {
+  if (kind === 'none') return () => ({ consumed: 0, done: true });
+  if (kind === 'until-close') return (buf) => ({ consumed: buf.length, done: false });
+  if (kind === 'length') {
+    let need = length;
+    return (buf) => { const take = Math.min(need, buf.length); need -= take; return { consumed: take, done: need === 0 }; };
+  }
+  // chunked: count framing bytes (size lines, data, trailing CRLFs, trailers)
+  let phase = 'size'; // size | data | dataCRLF | trailers
+  let need = 0;       // bytes left in current chunk's data
+  let line = '';      // accumulates a CRLF-terminated control line across chunks
+  return (buf) => {
+    let i = 0;
+    while (i < buf.length) {
+      if (phase === 'size') {
+        const nl = buf.indexOf(0x0a, i);
+        if (nl < 0) { line += buf.toString('latin1', i); return { consumed: buf.length, done: false }; }
+        line += buf.toString('latin1', i, nl + 1); i = nl + 1;
+        const size = parseInt(line.trim().split(';')[0], 16); line = '';
+        if (Number.isNaN(size)) return { consumed: i, done: true };  // malformed: stop here
+        if (size === 0) phase = 'trailers'; else { need = size; phase = 'data'; }
+      } else if (phase === 'data') {
+        const take = Math.min(need, buf.length - i); i += take; need -= take;
+        if (need === 0) phase = 'dataCRLF';
+      } else if (phase === 'dataCRLF') {
+        const nl = buf.indexOf(0x0a, i);
+        if (nl < 0) return { consumed: buf.length, done: false };
+        i = nl + 1; phase = 'size';
+      } else { // trailers: read until a blank line ends the message
+        const nl = buf.indexOf(0x0a, i);
+        if (nl < 0) { line += buf.toString('latin1', i); return { consumed: buf.length, done: false }; }
+        const seg = line + buf.toString('latin1', i, nl + 1); line = ''; i = nl + 1;
+        if (seg === '\r\n' || seg === '\n') return { consumed: i, done: true };
+      }
+    }
+    return { consumed: i, done: false };
+  };
+}
+
+const methodOf = (startLine) => startLine.split(' ')[0].toUpperCase();
+const statusOf = (startLine) => parseInt(startLine.split(' ')[1], 10) || 0;
+
 /**
- * Faithful HTTP/1.1 relay for the rare h1 case. Reads the first request head,
- * rewrites only the auth line (via `rewriteHead`), forwards it, then tunnels
- * both directions raw. (Real Anthropic traffic is h2; on a keep-alive h1
- * connection only the first request's auth is rewritten — documented tradeoff.)
+ * Faithful HTTP/1.1 relay. Frames every request/response on a keep-alive
+ * connection (parsing content-length / chunked bodies), so each request's auth
+ * line is rewritten via `rewriteHead`, each request body is patched, and each
+ * exchange is logged to its own tap record. Responses are written to claude
+ * verbatim first — parsing is observation-only, so a framing miss can never
+ * corrupt the relayed stream — and matched to requests in FIFO order (HTTP/1.1
+ * guarantees in-order responses).
  *
- * @param opts.rewriteHead (headText) => headText
+ * @param opts.rewriteHead (headText) => headText      // rewrite each request head
+ * @param opts.onResponseHeaders (fields[]) => void    // observe each response's headers
  */
 export function h1Relay(claude, upstream, opts = {}) {
   const rewriteHead = opts.rewriteHead || ((h) => h);
-  const patcher = opts.makeBodyPatcher ? opts.makeBodyPatcher() : null;
-  const rewriteData = patcher ? (b) => patcher.push(b) : (b) => b; // same-length body patch
+  const makeBodyPatcher = opts.makeBodyPatcher || null;
+  const onResponseHeaders = opts.onResponseHeaders || (() => {});
   const tap = opts.tap || null;
-  const SID = 1; // single logical request id for h1
   const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
   claude.on('error', destroyBoth);
   upstream.on('error', destroyBoth);
-  claude.on('close', () => upstream.destroy());
-  upstream.on('close', () => { tap?.end(SID); claude.destroy(); });
 
-  // responses: verbatim (observed for logging)
-  upstream.on('data', (c) => { if (tap) tap.resData(SID, Buffer.from(c)); claude.write(c); });
-  upstream.on('end', () => { tap?.end(SID); claude.end(); });
+  let nextId = 0;
+  const pending = []; // request ids awaiting a response head, in send order
 
-  let buf = Buffer.alloc(0);
-  const onData = (chunk) => {
-    buf = Buffer.concat([buf, chunk]);
-    const idx = buf.indexOf('\r\n\r\n');
-    if (idx < 0) {
-      if (buf.length > 65536) destroyBoth(); // runaway head
-      return;
+  // Close any tap records still open when the connection tears down.
+  const endOpen = () => { if (!tap) return; if (resId !== null) tap.end(resId); for (const p of pending) tap.end(p.id); pending.length = 0; };
+
+  // ── request direction: claude → upstream (rewrite head, patch + forward body) ──
+  let reqBuf = Buffer.alloc(0);
+  let reqPhase = 'head';
+  let reqTrack = null, reqPatcher = null, reqId = null;
+
+  const pumpReq = () => {
+    while (reqBuf.length) {
+      if (reqPhase === 'head') {
+        const idx = reqBuf.indexOf('\r\n\r\n');
+        if (idx < 0) { if (reqBuf.length > MAX_HEAD) destroyBoth(); return; }
+        const head = rewriteHead(reqBuf.subarray(0, idx + 4).toString('latin1'));
+        reqBuf = reqBuf.subarray(idx + 4);
+        const info = parseH1Head(head);
+        reqId = ++nextId;
+        pending.push({ id: reqId, method: methodOf(info.startLine) });
+        if (tap) tap.reqHead(reqId, head);
+        upstream.write(Buffer.from(head, 'latin1'));
+        const kind = info.chunked ? 'chunked' : (info.contentLength > 0 ? 'length' : 'none');
+        reqPatcher = makeBodyPatcher ? makeBodyPatcher() : null;
+        reqTrack = makeBodyTracker(kind, info.contentLength || 0);
+        reqPhase = 'body';
+      } else {
+        const { consumed, done } = reqTrack(reqBuf);
+        if (consumed > 0) {
+          let slice = Buffer.from(reqBuf.subarray(0, consumed));
+          reqBuf = reqBuf.subarray(consumed);
+          if (reqPatcher) slice = reqPatcher.push(slice); // same-length account_uuid patch
+          if (tap) tap.reqData(reqId, slice);
+          upstream.write(slice);
+        }
+        if (done) { reqPhase = 'head'; reqTrack = null; reqPatcher = null; }
+        else if (consumed === 0) return; // need more body bytes
+      }
     }
-    claude.removeListener('data', onData);
-    const head = rewriteHead(buf.subarray(0, idx + 4).toString('latin1'));
-    if (tap) tap.reqHead(SID, head);
-    upstream.write(Buffer.from(head, 'latin1'));
-    const remainder = buf.subarray(idx + 4);
-    if (remainder.length) { const patched = rewriteData(Buffer.from(remainder)); if (tap) tap.reqData(SID, patched); upstream.write(patched); }
-    // forward (patched) request body
-    claude.on('data', (c) => { const patched = rewriteData(Buffer.from(c)); if (tap) tap.reqData(SID, patched); upstream.write(patched); });
-    claude.on('end', () => upstream.end());
   };
-  claude.on('data', onData);
+  claude.on('data', (c) => { reqBuf = Buffer.concat([reqBuf, c]); pumpReq(); });
+  claude.on('end', () => upstream.end());
+  claude.on('close', () => upstream.destroy());
+
+  // ── response direction: upstream → claude (verbatim passthrough + observe) ──
+  let resBuf = Buffer.alloc(0);
+  let resPhase = 'head';
+  let resTrack = null, resId = null;
+
+  const pumpRes = () => {
+    while (resBuf.length) {
+      if (resPhase === 'head') {
+        const idx = resBuf.indexOf('\r\n\r\n');
+        if (idx < 0) { if (resBuf.length > MAX_HEAD) resBuf = resBuf.subarray(resBuf.length - MAX_HEAD); return; }
+        const head = resBuf.subarray(0, idx + 4).toString('latin1');
+        resBuf = resBuf.subarray(idx + 4);
+        const info = parseH1Head(head);
+        const status = statusOf(info.startLine);
+        if (status >= 100 && status < 200) continue; // interim (e.g. 100-continue): no body, no request consumed
+        onResponseHeaders(headFields(head));
+        const req = pending.shift();
+        resId = req ? req.id : ++nextId;
+        if (tap) tap.resHead(resId, head);
+        const bodyless = req?.method === 'HEAD' || status === 204 || status === 304;
+        const kind = bodyless ? 'none'
+          : info.chunked ? 'chunked'
+          : info.contentLength !== null ? 'length'
+          : 'until-close';
+        resTrack = makeBodyTracker(kind, info.contentLength || 0);
+        resPhase = 'body';
+      } else {
+        const { consumed, done } = resTrack(resBuf);
+        if (consumed > 0) { if (tap) tap.resData(resId, Buffer.from(resBuf.subarray(0, consumed))); resBuf = resBuf.subarray(consumed); }
+        if (done) { if (tap) tap.end(resId); resId = null; resPhase = 'head'; resTrack = null; }
+        else if (consumed === 0) return;
+      }
+    }
+  };
+  upstream.on('data', (c) => {
+    claude.write(c);                 // faithful passthrough first
+    resBuf = Buffer.concat([resBuf, c]);
+    try { pumpRes(); } catch { resBuf = Buffer.alloc(0); } // never let a parse bug break the relay
+  });
+  upstream.on('end', () => { endOpen(); claude.end(); });
+  upstream.on('close', () => { endOpen(); claude.destroy(); });
+}
+
+// Parse an HTTP/1.1 head into an h2-style [{name,value}] list (lowercased names),
+// so a response can feed the same quota observer the h2 path uses.
+function headFields(headText) {
+  const out = [];
+  const lines = headText.split('\r\n');
+  out.push({ name: ':status', value: String(statusOf(lines[0] || '')) });
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') break;
+    const c = line.indexOf(':');
+    if (c < 0) continue;
+    out.push({ name: line.slice(0, c).trim().toLowerCase(), value: line.slice(c + 1).trim() });
+  }
+  return out;
 }
 
 /** Rewrite an HTTP/1.1 request head: replace the Authorization line with

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -202,7 +202,12 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     const auth = account.type === 'oauth'
       ? { authorization: `Bearer ${account.credential}` }
       : { apiKey: account.credential };
-    h1Relay(claudeTls, upstreamSock, { rewriteHead: (h) => rewriteH1Auth(h, auth), makeBodyPatcher, tap });
+    h1Relay(claudeTls, upstreamSock, {
+      rewriteHead: (h) => rewriteH1Auth(h, auth),
+      makeBodyPatcher,
+      onResponseHeaders: makeQuotaObserver(accountManager, account),
+      tap,
+    });
   }
 }
 

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -127,6 +127,12 @@ export function makeMitmTap(logDir, accountName = '') {
       r.write(`\n\n=== RESPONSE ${get(fields, ':status')} ===\n${fmtFields(fields, { pseudo: false })}`);
       r.resBody = new BodyWriter(r.write, 'RESPONSE BODY', ctOfFields(fields));
     },
+    resHead(id, text) {
+      const r = rec(id);
+      const status = (text.split('\r\n')[0].split(' ')[1]) || '';
+      r.write(`\n\n=== RESPONSE ${status} (h1) ===\n${maskHeadText(text).trimEnd()}`);
+      r.resBody = new BodyWriter(r.write, 'RESPONSE BODY', ctOfHead(text));
+    },
     resData(id, buf) { rec(id).resBody?.chunk(buf); },
     end(id) {
       const r = recs.get(id);

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -217,6 +217,84 @@ test('MITM h1: when upstream is http/1.1, ALPN mirrors and the head auth is rewr
   }
 });
 
+// Regression (token leak / mangled logs seen in a real MITM capture): claude-cli
+// reuses ONE keep-alive h1 connection for many requests. The relay must frame
+// each request — rewrite EVERY request's auth (not just the first), log each
+// exchange to its own masked record, and observe each response's quota — instead
+// of treating everything after the first head as one giant body.
+test('MITM h1 keep-alive: every request is reframed, rewritten, masked, and quota-observed', T, async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-h1ka-'));
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+
+  // Raw http/1.1 upstream that stays keep-alive and echoes, per request, the auth
+  // it saw + the request path, plus a rate-limit header for quota observation.
+  const upstream = tls.createServer({ key: leafKeyPem, cert: leafCertPem, ALPNProtocols: ['http/1.1'] }, (s) => {
+    let buf = '';
+    s.on('data', (d) => {
+      buf += d;
+      let idx;
+      while ((idx = buf.indexOf('\r\n\r\n')) >= 0) {
+        const head = buf.slice(0, idx);
+        const clMatch = head.match(/content-length: (\d+)/i);
+        const need = clMatch ? parseInt(clMatch[1], 10) : 0;
+        if (buf.length < idx + 4 + need) break;          // wait for the full body
+        buf = buf.slice(idx + 4 + need);
+        const auth = (head.match(/authorization: (.*)/i) || [])[1]?.trim() || 'none';
+        const path = head.split('\r\n')[0].split(' ')[1];
+        const body = JSON.stringify({ auth, path });
+        s.write(`HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: ${Buffer.byteLength(body)}\r\nanthropic-ratelimit-unified-5h-utilization: 0.5\r\nconnection: keep-alive\r\n\r\n${body}`);
+      }
+    });
+  });
+  const upPort = await listen(upstream);
+  let quotaHits = 0;
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => { quotaHits++; }, dir);
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['http/1.1']);
+  const readJson = () => new Promise((resolve) => {
+    let buf = '';
+    const onData = (d) => {
+      buf += d;
+      const i = buf.indexOf('\r\n\r\n');
+      if (i < 0) return;
+      const need = parseInt((buf.match(/content-length: (\d+)/i) || [])[1], 10);
+      if (buf.length < i + 4 + need) return;
+      tlsSock.removeListener('data', onData);
+      resolve(JSON.parse(buf.slice(i + 4, i + 4 + need)));
+    };
+    tlsSock.on('data', onData);
+  });
+  try {
+    tlsSock.setEncoding('utf8');
+    // First request: a small JSON body (mirrors the quota probe in the capture).
+    const p1 = readJson();
+    tlsSock.write('POST /v1/messages HTTP/1.1\r\nhost: localhost\r\nauthorization: Bearer FAKE-1\r\ncontent-type: application/json\r\ncontent-length: 9\r\n\r\n{"q":"x"}');
+    const r1 = await p1;
+    // Second request on the SAME connection — the one that used to leak + mangle.
+    const p2 = readJson();
+    tlsSock.write('POST /v1/messages HTTP/1.1\r\nhost: localhost\r\nauthorization: Bearer FAKE-2-LEAK\r\nx-api-key: sk-leak\r\ncontent-type: application/json\r\ncontent-length: 11\r\n\r\n{"hello":1}');
+    const r2 = await p2;
+
+    assert.equal(r1.auth, 'Bearer REAL-TOKEN', 'first request auth rewritten');
+    assert.equal(r2.auth, 'Bearer REAL-TOKEN', 'second request auth ALSO rewritten (was the bug)');
+    assert.equal(quotaHits, 2, 'quota observed on both h1 responses');
+
+    await new Promise((r) => setTimeout(r, 150)); // let async log writes land
+    const files = readdirSync(dir).filter((f) => f.endsWith('.log'));
+    assert.equal(files.length, 2, 'each request gets its OWN log file (was concatenated into one)');
+    const all = files.map((f) => readFileSync(join(dir, f), 'utf8'));
+    const blob = all.join('\n');
+    assert.ok(!blob.includes('FAKE-1') && !blob.includes('FAKE-2-LEAK'), 'client tokens never logged unmasked');
+    assert.ok(!blob.includes('sk-leak'), 'client x-api-key never logged');
+    assert.ok(all.every((c) => /=== REQUEST \(h1/.test(c)), 'both files have a proper request head section');
+    assert.ok(all.every((c) => /=== RESPONSE 200 \(h1\)/.test(c)), 'both files log the response head');
+    assert.ok(all.every((c) => /"auth"/.test(c)), 'response JSON body is logged (pretty)');
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream); rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // Regression (the run --mitm "ConnectionRefused"): an http/1.1-only client — what
 // undici/claude offers when it tunnels through a proxy — against an upstream that
 // ALSO speaks h2. We must adopt the CLIENT's protocol (http/1.1) and mirror it


### PR DESCRIPTION
## Problem

A live MITM capture (`/tmp/http_log2`) showed the h1 relay misbehaving badly on keep-alive connections. claude-cli reuses **one** keep-alive h1 connection for many requests, but `h1Relay` parsed only the *first* request head and then treated everything after it as that request's body. On every request after the first this caused three real bugs:

1. **Token leak** — the 2nd+ request's head, including its full `Authorization: Bearer sk-ant-oat01-…`, was logged via the body path (which does **not** mask) instead of the masked head path.
2. **Mangled logs** — that head was fed to the JSON pretty-printer (the first request was `application/json`), stripping/reflowing whitespace (`POST/v1/messages?beta=trueHTTP/1.1…`).
3. **Wrong auth upstream + concatenated logs** — only the first request's auth was rewritten to the injected account (the client's real token was forwarded for the rest, defeating the proxy), and every request shared one log record (fixed `SID=1`), so they piled into a single file with no response section ever written.

## Fix

Rewrite `h1Relay` to frame each message on the connection:

- Parse **every** request head (content-length / chunked body framing), rewrite each one's auth line, patch each body with a fresh per-request `account_uuid` patcher, and log each exchange to its **own** tap record.
- Match responses to requests in FIFO order (HTTP/1.1 guarantees in-order responses); log each response head via a new masked `tap.resHead`, and feed rate-limit headers to the **same** quota observer the h2 path uses (h1 quota was previously never observed).
- Response bytes are still written to the client **verbatim before parsing**, so a framing miss can never corrupt the relayed stream — parsing is observation-only.

## Test

New regression test `MITM h1 keep-alive: every request is reframed, rewritten, masked, and quota-observed` reproduces the capture: two requests on one keep-alive connection, asserting both auths are rewritten, two separate masked log files are written (no client token / x-api-key leaks), responses are logged, and quota is observed twice. Full suite: 103 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)