### PR TITLE
sx.org residential-proxy mode (IP-based 429 workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet weekly bucket
 - **Optional MITM proxy mode** — `teamclaude run --mitm` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected
+- **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
 
@@ -207,6 +208,7 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
   },
   "upstream": "https://api.anthropic.com",
   "switchThreshold": 0.98,
+  "sx": { "apiKey": "your-sx-org-api-key", "mode": "always" },
   "accounts": [
     {
       "name": "user@example.com (Acme)",
@@ -230,6 +232,8 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts |
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default) |
+| `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
+| `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
@@ -278,6 +282,24 @@ Verify the proxy + CA without any credentials — the proxy always answers a bui
 curl --proxy http://localhost:3456 --cacert ~/.config/teamclaude-ca.pem https://www.example.org/
 # → {"teamclaude":"mitm-proxy-ok","host":"www.example.org",...}
 ```
+
+### sx.org proxy mode (optional, off by default)
+
+Some transient `429`s key on the proxy's **outbound IP**, not the account — so rotating accounts doesn't help. To work around them, TeamClaude can route upstream requests through a residential proxy from [sx.org](https://sx.org), giving a different egress IP.
+
+Open the TUI and press **`g`** for the settings screen, then **`k`** to paste your sx.org API key (stored in `config.sx.apiKey`). TeamClaude reuses an existing active proxy port on your sx.org account, or auto-creates a residential US one, and dials the upstream through it via HTTP `CONNECT` on **both** the reverse-proxy and `--mitm` paths.
+
+Press **`m`** to cycle the **mode**:
+
+| Mode | Behavior |
+|------|----------|
+| **always** | Tunnel **every** upstream request through sx.org. |
+| **on 429 only** | Connect directly; on a `429` (which is IP-based), immediately retry that request through sx.org's fresh egress IP — no wait. On the `--mitm` path, a recent `429` routes new tunnels through sx.org for a short window. |
+| **off** | Never use sx.org, but **keep the API key** so you can re-enable it instantly. |
+
+TLS is established **end-to-end with `api.anthropic.com` over the tunnel**, so the sx.org proxy only ever relays ciphertext and the real Anthropic certificate is still verified. Mode and key changes apply live (no restart). Press **`x`** to forget the key entirely.
+
+> **Cost:** in **always** mode *all* Claude traffic flows through the residential proxy, which sx.org meters by bandwidth — expect real per-GB cost. **on 429 only** uses the proxy just when you're actually being throttled, so it's the cheaper way to ride out rate limits.
 
 ## How It Works
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
 import { TUI } from './tui.js';
+import { SxManager } from './sx.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -170,6 +171,16 @@ async function serverCommand() {
   // Opt-in background quota probe (config.quotaProbeSeconds, default 0 = off).
   let prober = null;
 
+  // sx.org proxy (IP-based-429 workaround). Dormant unless an API key is set in
+  // config.sx.apiKey; when set we provision a proxy and route upstream through it.
+  const sx = new SxManager({ log: console.error });
+  if (config.sx?.apiKey) {
+    const r = await sx.configure(config.sx.apiKey, config.sx.mode);
+    if (!r.ok) console.error(`[TeamClaude] sx.org disabled: ${r.error}`);
+  } else if (config.sx?.mode) {
+    await sx.setMode(config.sx.mode);
+  }
+
   // Re-sync accounts from disk without a restart. The TUI's 'R' key, the
   // POST /teamclaude/reload endpoint, and the CLI notify after add/change all
   // funnel through here. Returns the number of newly added accounts. Also picks
@@ -178,6 +189,14 @@ async function serverCommand() {
     const diskConfig = await loadConfig();
     if (!diskConfig) return 0;
     const added = await syncAccountsFromDisk(diskConfig, config, accountManager);
+    // Apply an sx.org key/mode change made on disk (e.g. via POST /teamclaude/reload).
+    const diskSxKey = diskConfig.sx?.apiKey || null;
+    const diskSxMode = diskConfig.sx?.mode || 'always';
+    if (diskSxKey !== sx.apiKey || diskSxMode !== sx.mode) {
+      config.sx = diskConfig.sx;
+      if (diskSxKey) await sx.configure(diskSxKey, diskSxMode);
+      else { sx.disable(); await sx.setMode(diskSxMode); }
+    }
     if (prober) {
       const ms = (diskConfig.quotaProbeSeconds || 0) * 1000;
       if (ms !== prober.intervalMs) {
@@ -193,7 +212,7 @@ async function serverCommand() {
 
   if (useTUI) {
     tui = new TUI({
-      accountManager, config,
+      accountManager, config, sx,
       saveConfig: () => atomicConfigUpdate(async diskConfig => {
         // Write in-memory accounts as the authoritative state, preserving
         // extra disk-only fields (e.g. importFrom) where the account still exists.
@@ -209,6 +228,8 @@ async function serverCommand() {
           const diskAcct = diskConfig.accounts.find(d => sameIdentity(d, a));
           return diskAcct ? { ...diskAcct, ...live } : live;
         });
+        // Persist sx.org settings (set/cleared from the TUI settings screen).
+        if (config.sx) diskConfig.sx = config.sx; else delete diskConfig.sx;
       }),
       syncAccounts: reloadAccounts,
       onQuit: async () => {
@@ -228,7 +249,7 @@ async function serverCommand() {
   // Expose reload to the proxy's control endpoint (works with or without TUI).
   hooks.reload = reloadAccounts;
 
-  const server = createProxyServer(accountManager, config, hooks);
+  const server = createProxyServer(accountManager, config, hooks, sx);
   // Catch bind-time errors (e.g. EADDRINUSE) only. Once the socket is bound we
   // remove this handler so a later runtime 'error' isn't misreported as a
   // listen failure and exit the whole proxy.

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -20,6 +20,7 @@ import { generateCertChain } from './x509.js';
 import { h2Relay, h1Relay, rewriteH1Auth } from './h2/relay.js';
 import { AccountUuidPatcher } from './account-uuid-rewrite.js';
 import { makeMitmTap } from './request-log.js';
+import { tunnelTls } from './sx.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -109,7 +110,7 @@ export function hostMode(host, config) {
  * at the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, logDir = null, log = () => {} }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, logDir = null, log = () => {}, sx = null }) {
   return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
     const [host, portStr] = (req.url || '').split(':');
@@ -126,12 +127,12 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, upstr
       return;
     }
 
-    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log })
+    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log, sx })
       .catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
   };
 }
 
-async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log }) {
+async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log, sx }) {
   const { key, cert } = await ensureLeaf();
 
   if (mode === 'test') {
@@ -155,18 +156,29 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   reply200Raw(clientSocket);
   const offered = await peekClientAlpn(clientSocket, head); // client's ALPN list, or null
 
+  // When sx.org is enabled, dial the upstream THROUGH its proxy (different egress
+  // IP — the IP-based-429 workaround); TLS still terminates end-to-end at the
+  // upstream, so the proxy sees only ciphertext. Otherwise connect directly.
   // autoSelectFamily (happy-eyeballs) is the default on Node 20+ but not 18; set
   // it explicitly so a dual-stack upstream whose IPv6 path is unreachable falls
   // back to IPv4 instead of hanging the connect (option ignored pre-18.13).
-  const upstreamSock = tls.connect({
-    host, port, servername: host, autoSelectFamily: true,
-    ...(offered ? { ALPNProtocols: offered } : {}),
-    ...upstreamTlsOptions,
-  });
-  await new Promise((resolve, reject) => {
-    upstreamSock.once('secureConnect', resolve);
-    upstreamSock.once('error', reject);
-  });
+  let upstreamSock;
+  if (sx?.useForConnect()) {
+    upstreamSock = await tunnelTls({
+      proxy: sx.getProxy(), targetHost: host, targetPort: port,
+      tlsOptions: { ...(offered ? { ALPNProtocols: offered } : {}), ...upstreamTlsOptions },
+    });
+  } else {
+    upstreamSock = tls.connect({
+      host, port, servername: host, autoSelectFamily: true,
+      ...(offered ? { ALPNProtocols: offered } : {}),
+      ...upstreamTlsOptions,
+    });
+    await new Promise((resolve, reject) => {
+      upstreamSock.once('secureConnect', resolve);
+      upstreamSock.once('error', reject);
+    });
+  }
   const upstreamAlpn = upstreamSock.alpnProtocol; // false if none negotiated
   const alpn = upstreamAlpn || 'http/1.1';        // relay protocol selector
 
@@ -194,7 +206,7 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     h2Relay(claudeTls, upstreamSock, {
       rewriteRequest: makeRewriteRequest(account),
       makeBodyPatcher,
-      onResponseHeaders: makeQuotaObserver(accountManager, account),
+      onResponseHeaders: makeQuotaObserver(accountManager, account, sx),
       tap,
       log,
     });
@@ -205,7 +217,7 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     h1Relay(claudeTls, upstreamSock, {
       rewriteHead: (h) => rewriteH1Auth(h, auth),
       makeBodyPatcher,
-      onResponseHeaders: makeQuotaObserver(accountManager, account),
+      onResponseHeaders: makeQuotaObserver(accountManager, account, sx),
       tap,
     });
   }
@@ -332,7 +344,7 @@ function makeRewriteRequest(account) {
   };
 }
 
-function makeQuotaObserver(accountManager, account) {
+function makeQuotaObserver(accountManager, account, sx = null) {
   return (fields) => {
     const m = {};
     for (const f of fields) m[f.name.toString().toLowerCase()] = f.value.toString();
@@ -343,7 +355,11 @@ function makeQuotaObserver(accountManager, account) {
     if (m[':status'] === '429') {
       let ra = parseInt(m['retry-after'], 10);
       if (Number.isNaN(ra)) ra = 60;
-      accountManager.markRateLimited(account.index, Math.min(Math.max(ra, 1), 300));
+      ra = Math.min(Math.max(ra, 1), 300);
+      accountManager.markRateLimited(account.index, ra);
+      // Arm sx.org sticky routing so the next MITM tunnel uses the proxy (in
+      // '429' mode); no-op in 'off'/'always'.
+      sx?.noteRateLimited(ra);
     }
   };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
 import { BodyWriter } from './request-log.js';
+import { upstreamFetch } from './upstream-fetch.js';
 
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -12,7 +13,7 @@ const HOP_BY_HOP_HEADERS = new Set([
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
 
-export function createProxyServer(accountManager, config, hooks = {}) {
+export function createProxyServer(accountManager, config, hooks = {}, sx = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
@@ -68,7 +69,7 @@ export function createProxyServer(accountManager, config, hooks = {}) {
       // The proxy manages its own tokens via ensureTokenFresh(); intercepting
       // or rewriting client refreshes would cause token rotation conflicts.
       if (req.method === 'POST' && req.url === '/v1/oauth/token') {
-        await relayRaw(req, res, upstream);
+        await relayRaw(req, res, upstream, sx);
         return;
       }
 
@@ -85,7 +86,7 @@ export function createProxyServer(accountManager, config, hooks = {}) {
 
       const ctx = { account: null, status: null };
       try {
-        await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir);
+        await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
         ctx.status = ctx.status || 502;
         console.error('[TeamClaude] Unhandled error:', err);
@@ -121,7 +122,7 @@ export function createProxyServer(accountManager, config, hooks = {}) {
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, log: console.error }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, log: console.error, sx }));
 
   return server;
 }
@@ -129,13 +130,13 @@ export function createProxyServer(accountManager, config, hooks = {}) {
 /**
  * Relay a request to upstream with no header rewriting — pure passthrough.
  */
-async function relayRaw(req, res, upstream) {
+async function relayRaw(req, res, upstream, sx) {
   const bodyChunks = [];
   for await (const chunk of req) bodyChunks.push(chunk);
   const body = Buffer.concat(bodyChunks);
 
   try {
-    const upstreamRes = await fetch(`${upstream}${req.url}`, {
+    const upstreamRes = await upstreamFetch(`${upstream}${req.url}`, {
       method: req.method,
       headers: {
         'content-type': req.headers['content-type'] || 'application/json',
@@ -143,7 +144,7 @@ async function relayRaw(req, res, upstream) {
         'user-agent': req.headers['user-agent'] || 'node',
       },
       body: body.length > 0 ? body : undefined,
-    });
+    }, sx, sx?.useByDefault());
 
     const responseBody = await upstreamRes.text();
     const responseHeaders = {};
@@ -200,8 +201,11 @@ function formatHeaders(headers) {
   return Object.entries(headers).map(([k, v]) => `  ${k}: ${v}`).join('\n');
 }
 
-async function forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir) {
+async function forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, useSx) {
   const maxRetries = accountManager.accounts.length;
+  // Whether THIS attempt dials via sx.org. Undefined on the first call → derive
+  // from the default policy ('always' routes; 'off'/'429' start direct).
+  const route = useSx === undefined ? !!(sx?.useByDefault()) : useSx;
 
   // Select account
   const account = accountManager.getActiveAccount();
@@ -231,7 +235,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   // Refresh OAuth token if needed
   await accountManager.ensureTokenFresh(account.index);
   if (account.status === 'error' && retryCount < maxRetries) {
-    return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
+    return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
   }
 
   // Build upstream request headers
@@ -278,12 +282,12 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   };
 
   try {
-    const upstreamRes = await fetch(upstreamUrl, {
+    const upstreamRes = await upstreamFetch(upstreamUrl, {
       method,
       headers,
       body: ['GET', 'HEAD'].includes(method) ? undefined : sendBody,
       redirect: 'manual',
-    });
+    }, sx, route);
 
     // Extract rate limit headers
     const rateLimitHeaders = {};
@@ -307,6 +311,13 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       // Discard the 429 response body
       await upstreamRes.body?.cancel();
 
+      // sx.org failover: 429s are IP-based, so retry via the proxy's egress IP.
+      // 'always' is already on sx; '429' switches direct→sx now and skips the
+      // wait (a fresh IP isn't throttled). Also arm the sticky window for MITM.
+      const nextUseSx = !!(sx?.useOn429());
+      const switchingToSx = nextUseSx && !route;
+      sx?.noteRateLimited(retryAfter);
+
       // Bound the retries: a persistently-throttled upstream must not loop
       // forever (that would tie up the client connection indefinitely).
       // Once retries are exhausted, throttle this account and re-dispatch —
@@ -315,14 +326,18 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       if (retryCount >= maxRetries) {
         console.log(`[TeamClaude] Persistent 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching`);
         accountManager.markRateLimited(account.index, retryAfter);
-        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
 
-      console.log(`[TeamClaude] 429 on "${account.name}" — waiting ${retryAfter}s before retry`);
-      await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+      if (switchingToSx) {
+        console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
+      } else {
+        console.log(`[TeamClaude] 429 on "${account.name}" — waiting ${retryAfter}s before retry`);
+        await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+      }
       // Client may have disconnected during the wait
       if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
     }
 
     // Log the request head (once) followed by the response headers, streaming
@@ -387,7 +402,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
 
     if (retryCount < maxRetries && !res.headersSent) {
       account.status = 'error';
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir);
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
     }
     ctx.status = 502;
 

--- a/src/sx.js
+++ b/src/sx.js
@@ -1,0 +1,215 @@
+// sx.org proxy integration — an IP-based-429 workaround.
+//
+// teamclaude's transient 429s key on the proxy's OUTBOUND IP, not the account,
+// so account failover doesn't help. sx.org is a residential proxy-port provider:
+// with an API key we provision a port and tunnel upstream Anthropic traffic
+// through it, giving a different egress IP. Crucially, TLS terminates END-TO-END
+// at the upstream (we `tls.connect` over the tunnel with the upstream's
+// servername and the default secure cert check) — the sx.org proxy only ever
+// relays ciphertext and cannot see request content.
+//
+// When no API key is configured (or mode is 'off') this module is dormant and the
+// dial paths behave exactly as before — routing is decided per-attempt by
+// useByDefault() / useOn429() / useForConnect(), all false until provisioned.
+
+import net from 'node:net';
+import tls from 'node:tls';
+
+const CONNECT_TIMEOUT_MS = 30000; // residential exits can be slow to establish
+
+// Resolved per call (not at import) so tests can point it at a local mock.
+const sxBase = () => process.env.SX_API_BASE || 'https://api.sx.org';
+
+// ── sx.org REST (apiKey is a query param; these hit api.sx.org directly, never
+// the proxy, and are unrelated to Anthropic traffic) ──
+async function sxGet(path, apiKey, params = {}) {
+  const url = new URL(sxBase() + path);
+  url.searchParams.set('apiKey', apiKey);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, String(v));
+  const res = await fetch(url, { headers: { accept: 'application/json' } });
+  return res.json();
+}
+
+async function sxPost(path, apiKey, body) {
+  const url = new URL(sxBase() + path);
+  url.searchParams.set('apiKey', apiKey);
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+export const SX_MODES = ['off', '429', 'always'];
+const normalizeMode = (m) => (SX_MODES.includes(m) ? m : 'always');
+
+// Normalize either API shape into { host, port, username, password, portId }.
+//   ports-list:  { proxy: "host:port", login, password, id }
+//   create-port: { server, port, login, password, id }
+function parsePort(p) {
+  let host, port;
+  if (typeof p.proxy === 'string' && p.proxy.includes(':')) {
+    const i = p.proxy.lastIndexOf(':');
+    host = p.proxy.slice(0, i); port = p.proxy.slice(i + 1);
+  } else {
+    host = p.server; port = p.port;
+  }
+  return { host, port: parseInt(port, 10), username: p.login, password: p.password, portId: p.id };
+}
+
+/**
+ * Open a CONNECT tunnel through an HTTP proxy to targetHost:targetPort and
+ * resolve with the raw (still-plaintext) socket once the proxy answers 200.
+ */
+export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, targetPort, timeout = CONNECT_TIMEOUT_MS }) {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(proxyPort, proxyHost);
+    let buf = '';
+    const timer = setTimeout(() => fail(new Error(`sx.org proxy CONNECT timed out after ${timeout}ms`)), timeout);
+    const cleanup = () => {
+      clearTimeout(timer);
+      sock.removeListener('data', onData);
+      sock.removeListener('error', fail);
+    };
+    const fail = (err) => { cleanup(); sock.destroy(); reject(err); };
+    const onData = (chunk) => {
+      buf += chunk.toString('latin1');
+      const idx = buf.indexOf('\r\n\r\n');
+      if (idx < 0) { if (buf.length > 65536) fail(new Error('sx.org proxy CONNECT response too large')); return; }
+      const statusLine = buf.slice(0, buf.indexOf('\r\n'));
+      const m = statusLine.match(/^HTTP\/\d\.\d\s+(\d{3})/);
+      if (!m || m[1] !== '200') { fail(new Error(`sx.org proxy refused CONNECT: ${statusLine}`)); return; }
+      cleanup();
+      sock.pause(); // stop flowing so the TLS layer we hand it to sees every byte
+      const rest = Buffer.from(buf.slice(idx + 4), 'latin1'); // bytes already past the header
+      if (rest.length) sock.unshift(rest);
+      resolve(sock);
+    };
+    sock.once('connect', () => {
+      const lines = [`CONNECT ${targetHost}:${targetPort} HTTP/1.1`, `Host: ${targetHost}:${targetPort}`];
+      if (auth) lines.push(`Proxy-Authorization: Basic ${Buffer.from(auth).toString('base64')}`);
+      lines.push('Proxy-Connection: keep-alive', '', '');
+      sock.write(lines.join('\r\n'));
+    });
+    sock.on('data', onData);
+    sock.once('error', fail);
+  });
+}
+
+/**
+ * CONNECT through `proxy`, then complete a TLS handshake to targetHost so TLS is
+ * end-to-end (the proxy sees ciphertext only). Resolves with the TLSSocket after
+ * secureConnect. Cert verification stays at its secure default; tests inject a CA
+ * via tlsOptions.ca.
+ */
+export async function tunnelTls({ proxy, targetHost, targetPort = 443, tlsOptions = {} }) {
+  const sock = await connectThroughProxy({
+    proxyHost: proxy.host,
+    proxyPort: proxy.port,
+    auth: proxy.username ? `${proxy.username}:${proxy.password}` : null,
+    targetHost,
+    targetPort,
+  });
+  return new Promise((resolve, reject) => {
+    const tlsSock = tls.connect({ socket: sock, servername: targetHost, ...tlsOptions });
+    const onErr = (err) => { tlsSock.removeListener('secureConnect', onOk); sock.destroy(); reject(err); };
+    const onOk = () => { tlsSock.removeListener('error', onErr); resolve(tlsSock); };
+    tlsSock.once('secureConnect', onOk);
+    tlsSock.once('error', onErr);
+  });
+}
+
+/**
+ * Holds the sx.org credential + the provisioned proxy. Shared in-process by the
+ * reverse proxy, the MITM handler, and the TUI so a key change applies live.
+ */
+export class SxManager {
+  constructor({ log = () => {} } = {}) {
+    this.log = log;
+    this.apiKey = null;
+    this.proxy = null;   // { host, port, username, password, portId }
+    this.mode = 'always'; // off | 429 | always — how routing decisions are made
+    this._rlUntil = 0;    // sticky-routing window end (ms) for '429' mode
+  }
+
+  isProvisioned() { return !!(this.apiKey && this.proxy); }
+  getProxy() { return this.proxy; }
+  getMode() { return this.mode; }
+
+  // ── routing decisions ──
+  // Reverse-proxy first attempt: only 'always' routes pre-emptively.
+  useByDefault() { return this.isProvisioned() && this.mode === 'always'; }
+  // Reverse-proxy retry after a 429: 'always' and '429' both route (the 429 is
+  // IP-based, so a fresh egress IP can clear it).
+  useOn429() { return this.isProvisioned() && this.mode !== 'off'; }
+  // MITM connect-time (one tunnel carries many requests, so no per-request
+  // failover): 'always' routes; '429' routes only inside the sticky window set
+  // when a 429 was recently observed.
+  useForConnect() {
+    if (!this.isProvisioned() || this.mode === 'off') return false;
+    return this.mode === 'always' || this.isRecentlyRateLimited();
+  }
+
+  noteRateLimited(seconds = 60) { this._rlUntil = Date.now() + Math.min(Math.max(seconds, 1), 300) * 1000; }
+  isRecentlyRateLimited() { return Date.now() < this._rlUntil; }
+
+  /** Set the API key (+ optional mode) and provision unless mode is 'off'. */
+  async configure(apiKey, mode = this.mode) {
+    this.mode = normalizeMode(mode);
+    if (!apiKey) { this.disable(); return { ok: false, error: 'no API key' }; }
+    this.apiKey = apiKey;
+    if (this.mode === 'off') { this.proxy = null; return { ok: true, mode: this.mode, proxy: null }; }
+    return this._ensureProxy();
+  }
+
+  /** Switch mode WITHOUT clearing the key; provision lazily when turning on. */
+  async setMode(mode) {
+    this.mode = normalizeMode(mode);
+    if (this.mode === 'off') { this.proxy = null; return { ok: true, mode: this.mode }; }
+    if (this.apiKey && !this.proxy) return this._ensureProxy();
+    return { ok: true, mode: this.mode, proxy: this.proxy };
+  }
+
+  /** Full deconfigure — forget the key entirely. */
+  disable() { this.apiKey = null; this.proxy = null; }
+
+  async _ensureProxy() {
+    try {
+      this.proxy = await this.provision();
+      this.log(`[TeamClaude] sx.org proxy ready: ${this.proxy.host}:${this.proxy.port}`);
+      return { ok: true, mode: this.mode, proxy: this.proxy };
+    } catch (err) {
+      this.proxy = null;
+      this.log(`[TeamClaude] sx.org provisioning failed: ${err.message}`);
+      return { ok: false, error: err.message };
+    }
+  }
+
+  /** Account balance/traffic, or null on error. */
+  async getBalance() {
+    if (!this.apiKey) return null;
+    try {
+      const r = await sxGet('/v2/user/balance', this.apiKey);
+      return r?.success ? r : null;
+    } catch { return null; }
+  }
+
+  /** Reuse an active port if one exists, else create a residential US one. */
+  async provision() {
+    if (!this.apiKey) throw new Error('sx.org API key not set');
+    const list = await sxGet('/v2/proxy/ports', this.apiKey, { per_page: 50 });
+    const proxies = list?.message?.proxies || [];
+    const active = proxies.find((p) => p.status === 1 && p.login && p.password && p.proxy);
+    if (active) return parsePort(active);
+
+    const created = await sxPost('/v2/proxy/create-port', this.apiKey, {
+      country_code: 'US', proxy_type_id: 1, type_id: 1, // type_id 1 = residential
+    });
+    if (!created?.success || !created.data) {
+      const detail = created?.errors ? JSON.stringify(created.errors) : (created?.message || JSON.stringify(created));
+      throw new Error(`sx.org create-port failed: ${detail}`);
+    }
+    return parsePort(created.data);
+  }
+}

--- a/src/sx.js
+++ b/src/sx.js
@@ -64,7 +64,10 @@ function parsePort(p) {
  */
 export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, targetPort, timeout = CONNECT_TIMEOUT_MS }) {
   return new Promise((resolve, reject) => {
-    const sock = net.connect(proxyPort, proxyHost);
+    // autoSelectFamily (happy-eyeballs) — default on Node 20+ but not 18; set it
+    // so a dual-stack proxy host whose IPv6 path is unreachable falls back to IPv4
+    // instead of hanging the connect (sx.org returns an IP, but be robust).
+    const sock = net.connect({ port: proxyPort, host: proxyHost, autoSelectFamily: true });
     let buf = '';
     const timer = setTimeout(() => fail(new Error(`sx.org proxy CONNECT timed out after ${timeout}ms`)), timeout);
     const cleanup = () => {

--- a/src/tui.js
+++ b/src/tui.js
@@ -115,16 +115,18 @@ function timestamp() {
 // ── TUI class ────────────────────────────────────────────────
 
 export class TUI {
-  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit }) {
+  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null }) {
     this.am = accountManager;
     this.config = config;
     this.saveConfig = saveConfig;
     this.syncAccounts = syncAccounts;
     this.onQuit = onQuit;
+    this.sx = sx;            // sx.org proxy manager (may be null)
+    this.sxBalance = null;   // last fetched sx.org balance, for the settings screen
 
     this.log = [];           // completed activity entries
     this.active = new Map(); // in-flight requests
-    this.mode = 'normal';    // normal | select | add | input
+    this.mode = 'normal';    // normal | select | add | input | settings
     this.selAction = null;   // switch | remove
     this.selIdx = 0;
     this.inputPrompt = '';
@@ -221,6 +223,7 @@ export class TUI {
       case 'select': this._keySelect(k); break;
       case 'add':    this._keyAdd(k); break;
       case 'input':  this._keyInput(k); break;
+      case 'settings': this._keySettings(k); break;
     }
     this.render();
   }
@@ -238,6 +241,19 @@ export class TUI {
     }
     else if (k === 'a') { this.mode = 'add'; }
     else if (k === 'R') { this._doSync(); }
+    else if (k === 'g' && this.sx) { this.mode = 'settings'; this._loadSxBalance(); }
+  }
+
+  _keySettings(k) {
+    if (k === 'k') {
+      this.mode = 'input';
+      this.inputPrompt = 'sx.org API key';
+      this.inputBuf = '';
+      this.inputCb = v => { if (v) this._doSetSxKey(v.trim()); };
+    }
+    else if (k === 'm') { this._doCycleSxMode(); }
+    else if (k === 'x') { this._doClearSxKey(); }
+    else if (k === 'esc' || k === 'q') { this.mode = 'normal'; }
   }
 
   _keySelect(k) {
@@ -294,6 +310,57 @@ export class TUI {
     } catch (e) {
       this._addLog(`Sync failed: ${e.message}`);
     }
+  }
+
+  // ── sx.org settings ────────────────────────────────
+
+  _loadSxBalance() {
+    this.sxBalance = null;
+    if (!this.sx?.apiKey) return;
+    this.sx.getBalance()
+      .then(b => { this.sxBalance = b; if (this.running) this.render(); })
+      .catch(() => {});
+  }
+
+  _sxModeLabel(m) { return m === 'always' ? 'always' : m === '429' ? 'on 429 only' : 'off'; }
+
+  async _doSetSxKey(key) {
+    const mode = this.config.sx?.mode || 'always';
+    this.config.sx = { apiKey: key, mode };
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save sx.org key: ${e.message}`); }
+    this._addLog('sx.org: configuring...');
+    const r = await this.sx.configure(key, mode);
+    if (r.ok && r.proxy) this._addLog(`sx.org key saved — proxy ${r.proxy.host}:${r.proxy.port} (mode: ${this._sxModeLabel(mode)})`);
+    else if (r.ok) this._addLog(`sx.org key saved (mode: ${this._sxModeLabel(mode)})`);
+    else this._addLog(`sx.org error: ${r.error}`);
+    this._loadSxBalance();
+    this.mode = 'settings';
+    if (this.running) this.render();
+  }
+
+  // Cycle off → on-429 → always. Keeps the API key, so the user can disable
+  // sx.org without deconfiguring it.
+  async _doCycleSxMode() {
+    const order = ['off', '429', 'always'];
+    const next = order[(order.indexOf(this.sx.getMode()) + 1) % order.length];
+    this.config.sx = { ...(this.config.sx || {}), mode: next };
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save: ${e.message}`); }
+    const r = await this.sx.setMode(next);
+    this._addLog(`sx.org mode: ${this._sxModeLabel(next)}${r.ok ? '' : ` — ${r.error}`}`);
+    if (next !== 'off') this._loadSxBalance();
+    if (this.running) this.render();
+  }
+
+  async _doClearSxKey() {
+    this.config.sx = null;
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save: ${e.message}`); }
+    this.sx.disable();
+    this.sxBalance = null;
+    this._addLog('sx.org key cleared');
+    if (this.running) this.render();
   }
 
   async _doImport() {
@@ -439,6 +506,10 @@ export class TUI {
     lines.push(left + ' '.repeat(Math.max(1, W - vw(left) - vw(right))) + right);
     lines.push(' ' + dim('─'.repeat(W - 2)));
 
+    const footerH = 2;
+    if (this.mode === 'settings') {
+      this._renderSettings(lines);
+    } else {
     // ── Accounts
     if (this.am.accounts.length === 0) {
       lines.push('');
@@ -472,11 +543,11 @@ export class TUI {
     }
 
     // Completed log
-    const footerH = 2;
     const space = Math.max(0, H - lines.length - footerH);
     for (let i = 0; i < space && i < this.log.length; i++) {
       lines.push(`   ${gray(this.log[i].t)}  ${this.log[i].msg}`);
     }
+    } // end non-settings body
 
     // Pad to fill
     while (lines.length < H - footerH) lines.push('');
@@ -556,10 +627,41 @@ export class TUI {
     return line;
   }
 
+  _renderSettings(lines) {
+    lines.push('');
+    lines.push(bold('  sx.org proxy') + dim('  — route upstream via a residential IP (429 workaround)'));
+    lines.push('');
+    if (!this.sx) { lines.push(yellow('  Unavailable in this build.')); return; }
+    const key = this.config.sx?.apiKey;
+    const masked = key ? key.slice(0, 4) + '…' + key.slice(-4) : dim('(not set)');
+    const mode = this.sx.getMode();
+    const modeStr = mode === 'always' ? green('always')
+      : mode === '429' ? cyan('on 429 only')
+      : gray('off');
+    const p = this.sx.getProxy?.();
+    const proxyStr = mode === 'off' ? gray('—')
+      : this.sx.isProvisioned() ? green(`${p.host}:${p.port}`)
+      : key ? yellow('not provisioned')
+      : gray('no key');
+    const b = this.sxBalance;
+    lines.push(`  Mode:     ${modeStr}`);
+    lines.push(`  API key:  ${masked}`);
+    lines.push(`  Proxy:    ${proxyStr}`);
+    lines.push(`  Balance:  ${b ? green('$' + Number(b.balance).toFixed(4)) : dim('…')}`);
+    lines.push('');
+    lines.push(dim('  always    tunnel ALL upstream traffic through sx.org'));
+    lines.push(dim('  on 429    only retry through sx.org after a 429 (fresh IP)'));
+    lines.push(dim('  off       never use sx.org (API key is kept)'));
+    lines.push('');
+    lines.push(dim('  TLS stays end-to-end; residential traffic is metered by sx.org.'));
+  }
+
   _renderFooter() {
     switch (this.mode) {
       case 'normal':
-        return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('q')}uit`;
+        return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
+      case 'settings':
+        return ` ${bold('m')} mode  ${bold('k')} set API key  ${bold('x')} clear key  ${bold('Esc')} back`;
       case 'select': {
         const act = this.selAction === 'switch' ? 'switch'
           : this.selAction === 'toggle' ? 'enable/disable'

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -1,0 +1,85 @@
+// Zero-dependency `fetch` shim that routes upstream requests through the sx.org
+// proxy when it is enabled. With sx disabled it IS global fetch (byte-for-byte
+// the same behavior), so the default path is unchanged.
+//
+// Node's global fetch can't use a CONNECT proxy without `undici` (a dependency —
+// and "zero dependencies" is a project feature), so when sx is enabled we issue
+// the request with `https.request` over a tunneled TLS socket and return a small
+// object exposing exactly the fetch-Response surface src/server.js relies on:
+// `status`, `headers.get()/.entries()`, `text()`, `arrayBuffer()`, and `body`
+// (a web ReadableStream, so streamResponse()'s getReader()/cancel() is untouched).
+
+import https from 'node:https';
+import { Readable } from 'node:stream';
+import { tunnelTls } from './sx.js';
+
+// `useProxy` is decided by the caller (it varies per attempt — e.g. direct first,
+// then via sx after a 429). With it false, or sx unprovisioned, this is plain fetch.
+export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
+  if (!sx || !useProxy || !sx.isProvisioned()) return fetch(url, opts);
+  return proxiedFetch(url, opts, sx);
+}
+
+function proxiedFetch(url, opts, sx) {
+  const u = new URL(url);
+  const proxy = sx.getProxy();
+
+  // Custom agent: every socket is a TLS connection tunneled through sx.org.
+  const agent = new https.Agent({ keepAlive: true });
+  agent.createConnection = (_options, cb) => {
+    // sx.tlsOptions is undefined in production (system CAs verify api.anthropic.com);
+    // tests inject a CA here to reach a self-signed upstream.
+    tunnelTls({ proxy, targetHost: u.hostname, targetPort: Number(u.port) || 443, tlsOptions: sx.tlsOptions || {} })
+      .then((sock) => cb(null, sock))
+      .catch((err) => cb(err));
+    return undefined; // socket delivered asynchronously via cb
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      u,
+      { method: opts.method || 'GET', headers: opts.headers || {}, agent },
+      (res) => resolve(makeResponse(res)),
+    );
+    req.once('error', reject);
+
+    const body = opts.body;
+    const method = (opts.method || 'GET').toUpperCase();
+    if (body == null || method === 'GET' || method === 'HEAD') req.end();
+    else if (typeof body === 'string' || Buffer.isBuffer(body) || body instanceof Uint8Array) req.end(Buffer.from(body));
+    else req.end(String(body));
+  });
+}
+
+// Wrap a Node IncomingMessage as the subset of a fetch Response that server.js uses.
+function makeResponse(res) {
+  const web = Readable.toWeb(res); // single web stream — one consumer either way
+  const collect = async () => {
+    const chunks = [];
+    const reader = web.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks);
+  };
+  return {
+    status: res.statusCode,
+    headers: makeHeaders(res.headers),
+    body: web,
+    async text() { return (await collect()).toString('utf8'); },
+    async arrayBuffer() { const b = await collect(); return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength); },
+  };
+}
+
+// res.headers already has lowercased keys; values are string | string[] (set-cookie).
+function makeHeaders(h) {
+  const flat = (v) => (Array.isArray(v) ? v.join(', ') : v);
+  const entries = function* () { for (const [k, v] of Object.entries(h)) yield [k, flat(v)]; };
+  return {
+    get: (name) => { const v = h[name.toLowerCase()]; return v == null ? null : flat(v); },
+    entries,
+    [Symbol.iterator]: entries,
+  };
+}

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -51,7 +51,7 @@ function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
 
 const ACCOUNT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
-function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir = null) {
+function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir = null, sx = null) {
   const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN', accountUuid: ACCOUNT_UUID, name: 'acct@x' };
   const accountManager = {
     getActiveAccount: () => account,
@@ -71,8 +71,29 @@ function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir =
     upstreamTlsOptions: { ca: [caCertPem], servername: 'localhost' },
     logDir,
     log: () => {},
+    sx,
   }));
   return proxy;
+}
+
+// A minimal HTTP CONNECT proxy that blind-tunnels to the requested target and
+// records the CONNECT line (so a test can prove the MITM dialed THROUGH it).
+function makeConnectProxy() {
+  const seen = { target: null };
+  const srv = net.createServer((client) => {
+    client.once('data', (buf) => {
+      const target = buf.toString('latin1').split('\r\n')[0].match(/^CONNECT (\S+)/)?.[1];
+      seen.target = target;
+      const [host, port] = (target || '').split(':');
+      const up = net.connect(parseInt(port, 10), host, () => {
+        client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        up.pipe(client); client.pipe(up);
+      });
+      up.on('error', () => client.destroy());
+    });
+    client.on('error', () => {});
+  });
+  return { srv, seen };
 }
 
 test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', T, async () => {
@@ -116,6 +137,43 @@ test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', T, 
     client.close();
   } finally {
     tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});
+
+// When sx.org is enabled the MITM must dial the upstream THROUGH the sx proxy
+// (different egress IP — the 429 workaround), while auth rewriting and end-to-end
+// TLS still work exactly as in the direct case.
+test('MITM with sx.org enabled tunnels the upstream dial through the proxy', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
+  upstream.on('stream', (s, h) => {
+    s.respond({ ':status': 200, 'x-saw-auth': h.authorization || 'none' });
+    s.end('via-sx');
+  });
+  const upPort = await listen(upstream);
+
+  const { srv: sxProxy, seen } = makeConnectProxy();
+  const sxPort = await listen(sxProxy);
+  const sx = { useForConnect: () => true, getProxy: () => ({ host: '127.0.0.1', port: sxPort, username: null, password: null }) };
+
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {}, null, sx);
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  try {
+    const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer FAKE' });
+    let resp, body = '';
+    req.on('response', (h) => { resp = h; });
+    req.setEncoding('utf8'); req.on('data', (d) => { body += d; }); req.end('{}');
+    await once(req, 'close');
+
+    assert.equal(seen.target, `127.0.0.1:${upPort}`, 'MITM dialed upstream through the sx proxy');
+    assert.equal(resp['x-saw-auth'], 'Bearer REAL-TOKEN', 'auth still rewritten over the tunnel');
+    assert.equal(body, 'via-sx', 'end-to-end TLS through the tunnel works');
+    client.close();
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream); closeHard(sxProxy);
   }
 });
 

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -85,7 +85,7 @@ function makeConnectProxy() {
       const target = buf.toString('latin1').split('\r\n')[0].match(/^CONNECT (\S+)/)?.[1];
       seen.target = target;
       const [host, port] = (target || '').split(':');
-      const up = net.connect(parseInt(port, 10), host, () => {
+      const up = net.connect({ port: parseInt(port, 10), host, autoSelectFamily: true }, () => {
         client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
         up.pipe(client); client.pipe(up);
       });

--- a/test/sx.test.js
+++ b/test/sx.test.js
@@ -1,0 +1,273 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import tls from 'node:tls';
+import http from 'node:http';
+import { once } from 'node:events';
+import { generateCertChain } from '../src/x509.js';
+import { connectThroughProxy, tunnelTls, SxManager } from '../src/sx.js';
+import { upstreamFetch } from '../src/upstream-fetch.js';
+
+const T = { timeout: 30000 };
+const listen = (s) => new Promise((r) => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+function closeHard(s) { if (!s) return; s.closeAllConnections?.(); try { s.close(); } catch { /* closing */ } }
+
+// A minimal HTTP CONNECT proxy: requires Basic auth, then blind-tunnels to the
+// requested host:port. Records whether auth was seen and the CONNECT target.
+function makeConnectProxy({ requireAuth = 'user:pass' } = {}) {
+  const seen = { auth: null, target: null, plaintextBytesAfterConnect: 0 };
+  const srv = net.createServer((client) => {
+    client.once('data', (buf) => {
+      const head = buf.toString('latin1');
+      const line = head.split('\r\n')[0];
+      const m = line.match(/^CONNECT (\S+) HTTP\/1\.1/);
+      if (!m) { client.end('HTTP/1.1 400 Bad Request\r\n\r\n'); return; }
+      seen.target = m[1];
+      const authLine = head.split('\r\n').find((l) => l.toLowerCase().startsWith('proxy-authorization:'));
+      seen.auth = authLine ? Buffer.from(authLine.split(/\s+/)[2], 'base64').toString() : null;
+      if (requireAuth && seen.auth !== requireAuth) { client.end('HTTP/1.1 407 Proxy Authentication Required\r\n\r\n'); return; }
+      const [host, port] = m[1].split(':');
+      const up = net.connect(parseInt(port, 10), host, () => {
+        client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        // Everything after this point is TLS ciphertext (proxy can't read it).
+        client.on('data', (d) => { seen.plaintextBytesAfterConnect += isPrintableTls(d) ? 0 : 0; });
+        up.pipe(client); client.pipe(up);
+      });
+      up.on('error', () => client.destroy());
+    });
+    client.on('error', () => {});
+  });
+  return { srv, seen };
+}
+function isPrintableTls() { return false; }
+
+test('connectThroughProxy + tunnelTls establish END-TO-END TLS through the proxy', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  // TLS upstream that echoes a JSON body over HTTP/1.1.
+  const upstream = tls.createServer({ key: leafKeyPem, cert: leafCertPem }, (s) => {
+    s.on('data', () => {
+      const body = JSON.stringify({ ok: true, sni: s.servername || null });
+      s.end(`HTTP/1.1 200 OK\r\ncontent-length: ${Buffer.byteLength(body)}\r\nconnection: close\r\n\r\n${body}`);
+    });
+  });
+  const upPort = await listen(upstream);
+  const { srv: proxy, seen } = makeConnectProxy();
+  const proxyPort = await listen(proxy);
+
+  try {
+    const tlsSock = await tunnelTls({
+      proxy: { host: '127.0.0.1', port: proxyPort, username: 'user', password: 'pass' },
+      targetHost: 'localhost', targetPort: upPort,
+      tlsOptions: { ca: caCertPem },
+    });
+    tlsSock.write('GET / HTTP/1.1\r\nhost: localhost\r\n\r\n');
+    let buf = '';
+    tlsSock.setEncoding('utf8');
+    tlsSock.on('data', (d) => { buf += d; });
+    await once(tlsSock, 'end');
+
+    assert.equal(seen.target, `localhost:${upPort}`, 'proxy saw the CONNECT target');
+    assert.equal(seen.auth, 'user:pass', 'proxy received Basic auth');
+    const body = JSON.parse(buf.slice(buf.indexOf('{')));
+    assert.equal(body.ok, true, 'TLS terminated at the upstream (decrypted its response)');
+    assert.equal(body.sni, 'localhost', 'upstream saw correct SNI through the tunnel');
+  } finally {
+    closeHard(proxy); closeHard(upstream);
+  }
+});
+
+test('connectThroughProxy rejects on a non-200 CONNECT (bad auth)', T, async () => {
+  const { srv: proxy } = makeConnectProxy({ requireAuth: 'user:pass' });
+  const proxyPort = await listen(proxy);
+  try {
+    await assert.rejects(
+      connectThroughProxy({ proxyHost: '127.0.0.1', proxyPort, auth: 'user:WRONG', targetHost: 'localhost', targetPort: 9, timeout: 5000 }),
+      /refused CONNECT/,
+    );
+  } finally { closeHard(proxy); }
+});
+
+test('upstreamFetch routes through the proxy and exposes the fetch-Response surface', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  // Upstream replies JSON for /json and an SSE stream for /sse.
+  const upstream = tls.createServer({ key: leafKeyPem, cert: leafCertPem }, (s) => {
+    s.once('data', (d) => {
+      const path = d.toString('latin1').split(' ')[1] || '/';
+      if (path === '/sse') {
+        s.write('HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n');
+        s.write('data: one\n\n');
+        s.write('data: two\n\n');
+        s.end();
+      } else {
+        const body = JSON.stringify({ hello: 'world' });
+        s.end(`HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-test: yes\r\ncontent-length: ${Buffer.byteLength(body)}\r\nconnection: close\r\n\r\n${body}`);
+      }
+    });
+  });
+  const upPort = await listen(upstream);
+  const { srv: proxy, seen } = makeConnectProxy({ requireAuth: null });
+  const proxyPort = await listen(proxy);
+
+  // sx stub: provisioned, with a test CA so the self-signed upstream verifies.
+  const sx = {
+    isProvisioned: () => true,
+    getProxy: () => ({ host: '127.0.0.1', port: proxyPort, username: null, password: null }),
+    tlsOptions: { ca: caCertPem },
+  };
+
+  try {
+    // Non-streaming: status, headers.get/.entries, text/arrayBuffer.
+    const res = await upstreamFetch(`https://localhost:${upPort}/json`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }, sx, true);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('x-test'), 'yes');
+    assert.equal(res.headers.get('X-Test'), 'yes', 'header lookup is case-insensitive');
+    const keys = [...res.headers.entries()].map(([k]) => k);
+    assert.ok(keys.includes('content-type'));
+    const txt = await res.text();
+    assert.deepEqual(JSON.parse(txt), { hello: 'world' });
+    assert.equal(seen.target, `localhost:${upPort}`);
+
+    // Streaming: body is a web ReadableStream with a working reader.
+    const sse = await upstreamFetch(`https://localhost:${upPort}/sse`, {}, sx, true);
+    assert.equal(sse.headers.get('content-type'), 'text/event-stream');
+    const reader = sse.body.getReader();
+    let streamed = '';
+    for (;;) { const { done, value } = await reader.read(); if (done) break; streamed += Buffer.from(value).toString('utf8'); }
+    assert.match(streamed, /data: one/);
+    assert.match(streamed, /data: two/);
+  } finally {
+    closeHard(proxy); closeHard(upstream);
+  }
+});
+
+test('upstreamFetch is plain global fetch when useProxy is false', T, async () => {
+  const server = http.createServer((req, res) => { res.writeHead(200, { 'content-type': 'application/json' }); res.end('{"direct":true}'); });
+  const port = await listen(server);
+  try {
+    // no sx
+    const res = await upstreamFetch(`http://127.0.0.1:${port}/`, {}, null, true);
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(await res.text()), { direct: true });
+    // provisioned but useProxy=false → still direct (would otherwise fail: no real proxy)
+    const sx = { isProvisioned: () => true, getProxy: () => ({ host: '127.0.0.1', port: 1 }) };
+    const res2 = await upstreamFetch(`http://127.0.0.1:${port}/`, {}, sx, false);
+    assert.equal(res2.status, 200);
+  } finally { closeHard(server); }
+});
+
+test('SxManager routing decisions follow the mode', T, () => {
+  const sx = new SxManager();
+  sx.apiKey = 'k'; sx.proxy = { host: 'h', port: 1 }; // simulate provisioned
+
+  sx.mode = 'always';
+  assert.deepEqual([sx.useByDefault(), sx.useOn429(), sx.useForConnect()], [true, true, true]);
+
+  sx.mode = '429';
+  assert.equal(sx.useByDefault(), false, 'first attempt is direct in 429 mode');
+  assert.equal(sx.useOn429(), true, 'retry routes via sx after a 429');
+  assert.equal(sx.useForConnect(), false, 'MITM stays direct until a 429 is seen');
+  sx.noteRateLimited(10);
+  assert.equal(sx.useForConnect(), true, 'MITM routes via sx inside the sticky window');
+
+  sx.mode = 'off';
+  assert.deepEqual([sx.useByDefault(), sx.useOn429(), sx.useForConnect()], [false, false, false]);
+
+  sx.mode = 'always'; sx.proxy = null; // unprovisioned: nothing routes
+  assert.deepEqual([sx.useByDefault(), sx.useOn429(), sx.useForConnect()], [false, false, false]);
+});
+
+test('SxManager mode off keeps the key and skips provisioning; turning on provisions', T, async () => {
+  const api = makeSxApi((path) => {
+    if (path === '/v2/proxy/ports') return { success: true, message: { proxies: [{ id: 7, status: 1, proxy: '9.9.9.9:1080', login: 'u', password: 'p' }] } };
+    return { success: false };
+  });
+  const port = await listen(api);
+  process.env.SX_API_BASE = `http://127.0.0.1:${port}`;
+  try {
+    const sx = new SxManager();
+    const r = await sx.configure('KEY', 'off');
+    assert.equal(r.ok, true);
+    assert.equal(sx.getMode(), 'off');
+    assert.equal(sx.apiKey, 'KEY', 'key retained');
+    assert.equal(sx.isProvisioned(), false, 'not provisioned while off');
+
+    const r2 = await sx.setMode('always');
+    assert.equal(r2.ok, true);
+    assert.equal(sx.isProvisioned(), true, 'provisioned when turned on');
+    assert.deepEqual(sx.getProxy(), { host: '9.9.9.9', port: 1080, username: 'u', password: 'p', portId: 7 });
+  } finally { delete process.env.SX_API_BASE; closeHard(api); }
+});
+
+// Mock the sx.org REST API so provision() can be exercised without network/spend.
+function makeSxApi(handler) {
+  const srv = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      const out = handler(req.url.split('?')[0], req.method, body);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(out));
+    });
+  });
+  return srv;
+}
+
+test('SxManager.provision reuses an existing active port', T, async () => {
+  const api = makeSxApi((path) => {
+    if (path === '/v2/proxy/ports') {
+      return { success: true, message: { proxies: [
+        { id: 1, status: 2, proxy: 'dead:1', login: 'x', password: 'y' }, // inactive
+        { id: 2, status: 1, proxy: '1.2.3.4:9999', login: 'alice', password: 'secret' },
+      ] } };
+    }
+    return { success: false };
+  });
+  const port = await listen(api);
+  process.env.SX_API_BASE = `http://127.0.0.1:${port}`;
+  try {
+    const sx = new SxManager();
+    const r = await sx.configure('KEY');
+    assert.equal(r.ok, true);
+    assert.deepEqual(sx.getProxy(), { host: '1.2.3.4', port: 9999, username: 'alice', password: 'secret', portId: 2 });
+    assert.equal(sx.isProvisioned(), true);
+  } finally { delete process.env.SX_API_BASE; closeHard(api); }
+});
+
+test('SxManager.provision creates a port when none exist', T, async () => {
+  let created = false;
+  const api = makeSxApi((path, method, body) => {
+    if (path === '/v2/proxy/ports') return { success: true, message: { proxies: [] } };
+    if (path === '/v2/proxy/create-port' && method === 'POST') {
+      const b = JSON.parse(body);
+      assert.equal(b.country_code, 'US'); assert.equal(b.type_id, 1); assert.equal(b.proxy_type_id, 1);
+      created = true;
+      return { success: true, data: { id: 42, server: '5.6.7.8', port: 8080, login: 'bob', password: 'pw' } };
+    }
+    return { success: false };
+  });
+  const port = await listen(api);
+  process.env.SX_API_BASE = `http://127.0.0.1:${port}`;
+  try {
+    const sx = new SxManager();
+    const r = await sx.configure('KEY');
+    assert.equal(created, true, 'create-port was called');
+    assert.equal(r.ok, true);
+    assert.deepEqual(sx.getProxy(), { host: '5.6.7.8', port: 8080, username: 'bob', password: 'pw', portId: 42 });
+  } finally { delete process.env.SX_API_BASE; closeHard(api); }
+});
+
+test('SxManager.configure reports an error when provisioning fails', T, async () => {
+  const api = makeSxApi((path) => {
+    if (path === '/v2/proxy/ports') return { success: true, message: { proxies: [] } };
+    return { success: false, errors: { country_code: ['required'] } };
+  });
+  const port = await listen(api);
+  process.env.SX_API_BASE = `http://127.0.0.1:${port}`;
+  try {
+    const sx = new SxManager();
+    const r = await sx.configure('KEY');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /create-port failed/);
+    assert.equal(sx.isProvisioned(), false, 'not enabled when provisioning fails');
+  } finally { delete process.env.SX_API_BASE; closeHard(api); }
+});

--- a/test/sx.test.js
+++ b/test/sx.test.js
@@ -15,7 +15,7 @@ function closeHard(s) { if (!s) return; s.closeAllConnections?.(); try { s.close
 // A minimal HTTP CONNECT proxy: requires Basic auth, then blind-tunnels to the
 // requested host:port. Records whether auth was seen and the CONNECT target.
 function makeConnectProxy({ requireAuth = 'user:pass' } = {}) {
-  const seen = { auth: null, target: null, plaintextBytesAfterConnect: 0 };
+  const seen = { auth: null, target: null };
   const srv = net.createServer((client) => {
     client.once('data', (buf) => {
       const head = buf.toString('latin1');
@@ -27,10 +27,11 @@ function makeConnectProxy({ requireAuth = 'user:pass' } = {}) {
       seen.auth = authLine ? Buffer.from(authLine.split(/\s+/)[2], 'base64').toString() : null;
       if (requireAuth && seen.auth !== requireAuth) { client.end('HTTP/1.1 407 Proxy Authentication Required\r\n\r\n'); return; }
       const [host, port] = m[1].split(':');
-      const up = net.connect(parseInt(port, 10), host, () => {
+      // autoSelectFamily so 'localhost' falls back to IPv4 on Node 18 (no
+      // happy-eyeballs by default) instead of hanging on an unreachable ::1.
+      // After the 200, everything is TLS ciphertext — the proxy just relays it.
+      const up = net.connect({ port: parseInt(port, 10), host, autoSelectFamily: true }, () => {
         client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
-        // Everything after this point is TLS ciphertext (proxy can't read it).
-        client.on('data', (d) => { seen.plaintextBytesAfterConnect += isPrintableTls(d) ? 0 : 0; });
         up.pipe(client); client.pipe(up);
       });
       up.on('error', () => client.destroy());
@@ -39,7 +40,6 @@ function makeConnectProxy({ requireAuth = 'user:pass' } = {}) {
   });
   return { srv, seen };
 }
-function isPrintableTls() { return false; }
 
 test('connectThroughProxy + tunnelTls establish END-TO-END TLS through the proxy', T, async () => {
   const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');


### PR DESCRIPTION
## Why

teamclaude's transient `429`s key on the proxy's **outbound IP**, not the account, so account failover can't clear them — a different egress IP can. This adds optional routing of upstream traffic through an [sx.org](https://sx.org) residential proxy, with the egress IP swapped out.

## What

A new **TUI settings screen** (press `g`) holds an sx.org API key (`config.sx.apiKey`). TeamClaude reuses an existing active sx.org port or auto-creates a residential US one, then dials the upstream through it via HTTP `CONNECT` on **both** the reverse-proxy and `--mitm` paths.

**Three modes** (cycle with `m`, persisted to `config.sx.mode`):

| Mode | Behavior |
|------|----------|
| **always** | Tunnel **all** upstream traffic through sx.org. |
| **on 429 only** | Connect directly; on a `429`, retry that request through the proxy's fresh egress IP **with no wait** (reverse proxy). On `--mitm`, a recent `429` routes new tunnels via the proxy for a short sticky window. |
| **off** | Never use sx.org, but **keep the key** for instant re-enable. |

`x` forgets the key entirely. Mode/key changes apply live (no restart). Default mode is `always` when a key is set.

## How

- **`src/sx.js`** — `SxManager` (configure/setMode/provision/getBalance) + `connectThroughProxy` (CONNECT tunnel) + `tunnelTls` (end-to-end TLS over it). Routing is decided **per-attempt** via `useByDefault()` / `useOn429()` / `useForConnect()`.
- **`src/upstream-fetch.js`** — zero-dep `fetch` shim (`https.request` over the tunnel, returning a fetch-`Response`-shaped object). Global `fetch` can't use a CONNECT proxy without `undici`, and "zero dependencies" is a project feature. With the proxy off it **is** global `fetch`, so the default path is byte-for-byte unchanged.
- `server.js` threads the per-attempt routing decision incl. 429 failover; `mitm.js` dials through the tunnel when `useForConnect()` is true.

**TLS terminates end-to-end at `api.anthropic.com` over the tunnel** — the sx.org proxy only relays ciphertext and the real Anthropic certificate is still verified.

## Tests

New `test/sx.test.js` (CONNECT tunnel end-to-end TLS, the fetch-Response adapter, the mode-decision matrix, provision reuse/create against a mock API) + a MITM-through-proxy integration case. **113 tests pass**, eslint clean. The no-key path is covered by the unchanged existing reverse-proxy / MITM / 429 / log tests.

Validated live against the real sx.org API (provision/reuse, balance, all three mode decisions) and end-to-end through the real tunnel to `api.anthropic.com` (401 in ~1.4s, verified TLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)