### PR TITLE
Show MITM forward-proxy traffic in the live TUI activity feed

### DIFF
--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -49,12 +49,22 @@ export function h2Relay(claude, upstream, opts = {}) {
   const tap = opts.tap || null; // optional request-logging tap (per streamId)
   const log = opts.log || (() => {});
 
+  // Streams that have started (request headers seen) but not yet completed, so a
+  // mid-flight connection teardown can close their tap records instead of
+  // leaking them (e.g. a stuck "in-flight" entry in the TUI activity feed).
+  const openStreams = new Set();
+  const closeStream = (id) => { if (bodyPatchers) bodyPatchers.delete(id); tap?.end(id); openStreams.delete(id); };
+
   const reqDec = new HpackDecoder();         // decodes claude's request blocks
   const reqEnc = new HpackEncoder();         // re-encodes to upstream
   reqEnc.dynamicIndexing = false;            // independent of upstream's table size
   const respDec = new HpackDecoder();        // read-only, decodes upstream responses
 
-  const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
+  const destroyBoth = () => {
+    for (const id of openStreams) tap?.end(id);
+    openStreams.clear();
+    claude.destroy(); upstream.destroy();
+  };
 
   // ── request direction: claude → upstream (rewrite HEADERS) ──
   let rbuf = Buffer.alloc(0);
@@ -107,7 +117,7 @@ export function h2Relay(claude, upstream, opts = {}) {
       if (fr.flags & FLAG.END_STREAM && bodyPatchers) bodyPatchers.delete(fr.streamId);
       return;
     }
-    if (fr.type === FRAME.RST_STREAM) { if (bodyPatchers) bodyPatchers.delete(fr.streamId); tap?.end(fr.streamId); }
+    if (fr.type === FRAME.RST_STREAM) { closeStream(fr.streamId); }
     if (fr.type === FRAME.SETTINGS && fr.streamId === 0 && !(fr.flags & 0x1)) {
       applyTableSizeSetting(fr.payload, respDec); // claude's setting governs response encoding
     }
@@ -120,6 +130,7 @@ export function h2Relay(claude, upstream, opts = {}) {
     const fields = reqDec.decode(Buffer.concat(frags)); // keep decoder dynamic table in sync
     const rewritten = rewriteRequest(fields);
     if (tap) tap.req(streamId, rewritten);
+    openStreams.add(streamId);
     const newBlock = reqEnc.encode(rewritten);
     writeBackpressured(upstream, buildHeaderBlock(streamId, newBlock, { endStream, priority }), reqCtl);
   }
@@ -151,11 +162,12 @@ export function h2Relay(claude, upstream, opts = {}) {
       const { block } = stripHeadersPayload(fr.payload, fr.flags);
       rasm = { streamId: fr.streamId, frags: [block] };
       if (fr.flags & FLAG.END_HEADERS) finishRespBlock(fr.streamId);
-      if (fr.flags & FLAG.END_STREAM) tap?.end(fr.streamId);
+      if (fr.flags & FLAG.END_STREAM) closeStream(fr.streamId);
       return;
     }
     if (fr.type === FRAME.DATA) {
-      if (tap) { tap.resData(fr.streamId, Buffer.from(fr.payload)); if (fr.flags & FLAG.END_STREAM) tap.end(fr.streamId); }
+      if (tap) tap.resData(fr.streamId, Buffer.from(fr.payload));
+      if (fr.flags & FLAG.END_STREAM) closeStream(fr.streamId);
     }
   }
 

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -19,7 +19,7 @@ import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { h2Relay, h1Relay, rewriteH1Auth } from './h2/relay.js';
 import { AccountUuidPatcher } from './account-uuid-rewrite.js';
-import { makeMitmTap } from './request-log.js';
+import { makeMitmTap, makeActivityTap, combineTaps } from './request-log.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -109,7 +109,7 @@ export function hostMode(host, config) {
  * at the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, logDir = null, log = () => {} }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, upstreamTlsOptions = {}, logDir = null, hooks = {}, log = () => {} }) {
   return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
     const [host, portStr] = (req.url || '').split(':');
@@ -126,12 +126,12 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, upstr
       return;
     }
 
-    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log })
+    intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, hooks, log })
       .catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
   };
 }
 
-async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, log }) {
+async function intercept({ host, port, mode, clientSocket, head, accountManager, ensureLeaf, upstreamTlsOptions, logDir, hooks = {}, log }) {
   const { key, cert } = await ensureLeaf();
 
   if (mode === 'test') {
@@ -188,7 +188,10 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   const makeBodyPatcher = account.accountUuid
     ? () => new AccountUuidPatcher(account.accountUuid)
     : null;
-  const tap = makeMitmTap(logDir, account.name);
+  // Fan request lifecycle out to the on-disk log (when configured) AND the live
+  // TUI activity feed, so MITM traffic is visible in the TUI like reverse-proxy
+  // traffic — not just on disk.
+  const tap = combineTaps(makeMitmTap(logDir, account.name), makeActivityTap(hooks, account.name));
 
   if (alpn === 'h2') {
     h2Relay(claudeTls, upstreamSock, {

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -142,3 +142,53 @@ export function makeMitmTap(logDir, accountName = '') {
     },
   };
 }
+
+let activitySeq = 0; // module-global so TUI ids are unique across MITM connections
+
+// A tap (same interface as makeMitmTap) that, instead of writing to disk,
+// translates each relayed request's lifecycle into the server's TUI hooks —
+// so MITM traffic shows up in the live activity feed like reverse-proxy traffic.
+// Relay-local ids (h2 stream ids / h1 request ids restart per connection) are
+// mapped to globally-unique string ids ("m<n>") so they never collide with the
+// reverse-proxy's numeric ids or with each other across connections.
+export function makeActivityTap(hooks, accountName = '') {
+  if (!hooks || (!hooks.onRequestStart && !hooks.onRequestEnd)) return null;
+  const ids = new Map(); // relay-local id -> { gid, method, path, status }
+
+  function start(localId, method, path) {
+    const gid = `m${++activitySeq}`;
+    ids.set(localId, { gid, method, path, status: null });
+    hooks.onRequestStart?.(gid, { method, path });
+    if (accountName) hooks.onRequestRouted?.(gid, { account: accountName });
+  }
+
+  return {
+    req(id, fields) { start(id, get(fields, ':method'), get(fields, ':path')); },
+    reqHead(id, text) {
+      const parts = text.split('\r\n')[0].split(' ');
+      start(id, (parts[0] || '').toUpperCase(), parts[1] || '');
+    },
+    reqData() {},
+    res(id, fields) { const r = ids.get(id); if (r) r.status = get(fields, ':status'); },
+    resHead(id, text) { const r = ids.get(id); if (r) r.status = text.split('\r\n')[0].split(' ')[1] || ''; },
+    resData() {},
+    end(id) {
+      const r = ids.get(id);
+      if (!r) return;
+      ids.delete(id);
+      hooks.onRequestEnd?.(r.gid, { method: r.method, path: r.path, account: accountName, status: r.status });
+    },
+  };
+}
+
+// Fan one relay's tap callbacks out to several taps (disk + TUI activity).
+// Returns null if none are live, the single tap if only one is, else a proxy.
+export function combineTaps(...taps) {
+  const live = taps.filter(Boolean);
+  if (live.length <= 1) return live[0] || null;
+  const fan = (m) => (...a) => { for (const t of live) t[m]?.(...a); };
+  return {
+    req: fan('req'), reqHead: fan('reqHead'), reqData: fan('reqData'),
+    res: fan('res'), resHead: fan('resHead'), resData: fan('resData'), end: fan('end'),
+  };
+}

--- a/src/server.js
+++ b/src/server.js
@@ -121,7 +121,7 @@ export function createProxyServer(accountManager, config, hooks = {}) {
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, log: console.error }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error }));
 
   return server;
 }

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -51,7 +51,7 @@ function connectThroughProxy(proxyPort, target, caCertPem, alpn) {
 
 const ACCOUNT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
-function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir = null) {
+function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir = null, hooks = {}) {
   const account = { index: 0, type: 'oauth', credential: 'REAL-TOKEN', accountUuid: ACCOUNT_UUID, name: 'acct@x' };
   const accountManager = {
     getActiveAccount: () => account,
@@ -70,6 +70,7 @@ function makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, onQuota, logDir =
     ensureLeaf: async () => ({ key: leafKeyPem, cert: leafCertPem }),
     upstreamTlsOptions: { ca: [caCertPem], servername: 'localhost' },
     logDir,
+    hooks,
     log: () => {},
   }));
   return proxy;
@@ -114,6 +115,45 @@ test('MITM h2: ALPN mirrored, only authorization rewritten, quota observed', T, 
     assert.equal(body, 'upstream-ok');
     assert.ok(quota && quota['anthropic-ratelimit-unified-5h-utilization'] === '0.7');
     client.close();
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});
+
+test('MITM h2: relayed requests fire the TUI activity hooks', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+
+  const upstream = http2.createSecureServer({ key: leafKeyPem, cert: leafCertPem });
+  upstream.on('stream', (s) => { s.respond({ ':status': 201 }); s.end('ok'); });
+  const upPort = await listen(upstream);
+
+  const events = [];
+  const hooks = {
+    onRequestStart: (id, info) => events.push({ ev: 'start', id, ...info }),
+    onRequestRouted: (id, info) => events.push({ ev: 'routed', id, ...info }),
+    onRequestEnd: (id, info) => events.push({ ev: 'end', id, ...info }),
+  };
+  const proxy = makeProxy(upPort, caCertPem, leafCertPem, leafKeyPem, () => {}, null, hooks);
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2', 'http/1.1']);
+  try {
+    const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer FAKE' });
+    req.resume(); req.end('{}');
+    await once(req, 'close');
+    client.close();
+
+    const start = events.find((e) => e.ev === 'start');
+    const routed = events.find((e) => e.ev === 'routed');
+    const end = events.find((e) => e.ev === 'end');
+    assert.ok(start, 'onRequestStart fired');
+    assert.equal(start.method, 'POST');
+    assert.equal(start.path, '/v1/messages');
+    assert.equal(routed?.account, 'acct@x');   // routed to the injected account
+    assert.ok(end, 'onRequestEnd fired');
+    assert.equal(end.id, start.id);            // same (globally-unique) id
+    assert.equal(end.status, '201');           // upstream status surfaced
   } finally {
     tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }


### PR DESCRIPTION
## Problem

Running `teamclaude run --mitm` showed **nothing** in the TUI activity log, even though requests were flowing.

The TUI activity list is fed only by the **reverse-proxy** request path (`hooks.onRequestStart`/`onRequestEnd` in `server.js`). The `--mitm` CONNECT path relays via `h2Relay`/`h1Relay` and only:
- wrote per-request detail to **disk** (and only when `config.logDir` is set), and
- called `log` (`console.error`) on **errors only**.

So a successful MITM request produced zero TUI entries. (Account quota bars still updated, which was the only live signal.)

## Change

- **`makeActivityTap` (`request-log.js`)** — a tap with the same interface as the disk tap that translates each relayed request's lifecycle into the TUI hooks (`onRequestStart` / `onRequestRouted` / `onRequestEnd`). Relay-local ids (h2 stream ids / h1 request ids restart per connection) are mapped to globally-unique `m<n>` ids so they never collide with the reverse-proxy's numeric ids or across connections.
- **`combineTaps`** — fans the relay's tap callbacks out to both the disk tap and the activity tap.
- Threaded `hooks` through `createConnectHandler` → `intercept`, building the composite tap there; wired `hooks` in at `server.js`.
- **h2 teardown fix** — close open h2 streams on `destroyBoth`. The h1 path already had `endOpen`, but h2 left mid-flight streams unclosed, which (with this change) would leave a stuck "in-flight" entry in the TUI and an unclosed disk log. Now consistent.

## Tests

Added an integration test asserting a relayed h2 request fires `onRequestStart`/`onRequestRouted`/`onRequestEnd` with matching id, method, path, account, and upstream status. Full suite: **104 passing**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)