### PR TITLE
TUI settings screen: rotation threshold + quota-probe interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
 - **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; switches to the next on persistent errors
-- **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls
+- **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
@@ -230,8 +230,8 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `proxy.port` | Local port the proxy listens on |
 | `proxy.apiKey` | API key clients use to authenticate with the proxy |
 | `upstream` | Upstream API base URL |
-| `switchThreshold` | Quota utilization (0–1) at which to switch accounts |
-| `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default) |
+| `switchThreshold` | Quota utilization (0–1) at which to switch accounts (TUI: `g` → `t`) |
+| `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
@@ -250,6 +250,8 @@ teamclaude probe 300    # refresh every 300s
 teamclaude probe off    # back to passive (default)
 teamclaude probe        # show current setting
 ```
+
+You can also set the interval live from the TUI settings screen (`g` → `p`), alongside the rotation threshold (`t`).
 
 It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** bucket as an extra bar in the TUI / `status` (when your plan exposes it).
 

--- a/src/index.js
+++ b/src/index.js
@@ -230,6 +230,9 @@ async function serverCommand() {
         });
         // Persist sx.org settings (set/cleared from the TUI settings screen).
         if (config.sx) diskConfig.sx = config.sx; else delete diskConfig.sx;
+        // Persist other runtime-tunable settings edited from the TUI.
+        if (config.switchThreshold != null) diskConfig.switchThreshold = config.switchThreshold;
+        if (config.quotaProbeSeconds != null) diskConfig.quotaProbeSeconds = config.quotaProbeSeconds;
       }),
       syncAccounts: reloadAccounts,
       onQuit: async () => {

--- a/src/tui.js
+++ b/src/tui.js
@@ -245,7 +245,19 @@ export class TUI {
   }
 
   _keySettings(k) {
-    if (k === 'k') {
+    if (k === 't') {
+      this.mode = 'input';
+      this.inputPrompt = 'Switch threshold % (1-100)';
+      this.inputBuf = '';
+      this.inputCb = v => { if (v) this._doSetThreshold(v.trim()); };
+    }
+    else if (k === 'p') {
+      this.mode = 'input';
+      this.inputPrompt = 'Quota probe seconds (0=off, min 30)';
+      this.inputBuf = '';
+      this.inputCb = v => { if (v) this._doSetProbe(v.trim()); };
+    }
+    else if (k === 'k') {
       this.mode = 'input';
       this.inputPrompt = 'sx.org API key';
       this.inputBuf = '';
@@ -254,6 +266,38 @@ export class TUI {
     else if (k === 'm') { this._doCycleSxMode(); }
     else if (k === 'x') { this._doClearSxKey(); }
     else if (k === 'esc' || k === 'q') { this.mode = 'normal'; }
+  }
+
+  async _doSetThreshold(input) {
+    const pct = Number(input);
+    if (!Number.isFinite(pct) || pct < 1 || pct > 100) {
+      this._addLog('Invalid threshold — enter 1–100'); this.mode = 'settings'; if (this.running) this.render(); return;
+    }
+    const v = Math.round(pct) / 100;
+    this.config.switchThreshold = v;
+    this.am.switchThreshold = v; // apply to the running rotation immediately
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save: ${e.message}`); }
+    this._addLog(`Switch threshold set to ${Math.round(v * 100)}%`);
+    this.mode = 'settings';
+    if (this.running) this.render();
+  }
+
+  async _doSetProbe(input) {
+    let secs = parseInt(input, 10);
+    if (Number.isNaN(secs) || secs < 0) {
+      this._addLog('Invalid interval — enter 0 (off) or seconds'); this.mode = 'settings'; if (this.running) this.render(); return;
+    }
+    if (secs > 0 && secs < 30) secs = 30; // match the CLI minimum (don't hammer the usage endpoint)
+    this.config.quotaProbeSeconds = secs;
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save: ${e.message}`); }
+    // syncAccounts re-reads disk config and reschedules the running prober live.
+    try { await this.syncAccounts(); }
+    catch (e) { this._addLog(`Reload failed: ${e.message}`); }
+    this._addLog(secs > 0 ? `Quota probe every ${secs}s` : 'Quota probe disabled');
+    this.mode = 'settings';
+    if (this.running) this.render();
   }
 
   _keySelect(k) {
@@ -629,6 +673,17 @@ export class TUI {
 
   _renderSettings(lines) {
     lines.push('');
+    // ── Rotation
+    const thr = this.am.switchThreshold ?? this.config.switchThreshold ?? 0.98;
+    lines.push(bold('  Rotation') + dim('  — switch accounts when quota crosses the threshold'));
+    lines.push(`  Switch at:  ${green(`${Math.round(thr * 100)}%`)}  ${dim('utilization')}`);
+    lines.push('');
+    // ── Quota probe
+    const probe = this.config.quotaProbeSeconds || 0;
+    lines.push(bold('  Quota probe') + dim('  — refresh idle accounts from the usage endpoint'));
+    lines.push(`  Interval:   ${probe > 0 ? green(`${probe}s`) : gray('off (passive)')}`);
+    lines.push('');
+    // ── sx.org
     lines.push(bold('  sx.org proxy') + dim('  — route upstream via a residential IP (429 workaround)'));
     lines.push('');
     if (!this.sx) { lines.push(yellow('  Unavailable in this build.')); return; }
@@ -661,7 +716,7 @@ export class TUI {
       case 'normal':
         return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
       case 'settings':
-        return ` ${bold('m')} mode  ${bold('k')} set API key  ${bold('x')} clear key  ${bold('Esc')} back`;
+        return ` ${bold('t')} threshold  ${bold('p')} probe  ${bold('m')} sx-mode  ${bold('k')} sx-key  ${bold('x')} clear-key  ${bold('Esc')} back`;
       case 'select': {
         const act = this.selAction === 'switch' ? 'switch'
           : this.selAction === 'toggle' ? 'enable/disable'


### PR DESCRIPTION
## Why

The settings screen (`g`) only had the sx.org proxy controls. The other runtime-tunable settings weren't reachable from the TUI:
- **`switchThreshold`** (rotation threshold) had **no UI at all** — config-file edit only.
- **`quotaProbeSeconds`** had the `teamclaude probe` CLI but nothing in the TUI.

## What

The settings screen now has **Rotation / Quota probe / sx.org** sections and two new keys:

| Key | Setting | Behavior |
|-----|---------|----------|
| `t` | Switch threshold | Enter 1–100%; stored as `switchThreshold` (0–1) and applied to the running `AccountManager` **immediately**. |
| `p` | Quota probe interval | Seconds (`0`=off, min `30` to match the CLI). Persisted and applied live by reusing the existing reload path, which reschedules the running prober. |

Existing keys (`m` sx-mode, `k` sx-key, `x` clear-key) are unchanged.

## How

- Both values persist through the TUI's `saveConfig` updater, extended to write `switchThreshold` / `quotaProbeSeconds` (it previously only wrote `accounts` + `sx`).
- Threshold applies live via `accountManager.switchThreshold = …` (a plain instance field read on every rotation check).
- Probe applies live via `syncAccounts()` → the existing reload path that reschedules the prober.

## Tests

Full suite green (**114**), eslint clean. The TUI has no test harness, so the two handlers were smoke-tested directly with stubs: threshold `90`→`0.9` (applied to AccountManager + saved), invalid `250` rejected, probe `300`→synced, `5`→clamped to `30`, `0`→off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)