### PR TITLE
Recover from stale state & stop wrongly sidelining healthy accounts (#46)

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -58,6 +58,12 @@ export class AccountManager {
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
+    // When every account reads as over-quota we would otherwise refuse locally
+    // forever (a stale cached utilization is never re-validated because no
+    // request is ever sent). Instead, allow one real upstream probe at most this
+    // often to refresh the cached quota. See _selectProbe.
+    this.probeIntervalMs = 60_000;
+    this._nextProbeAt = 0;
   }
 
   /**
@@ -86,7 +92,76 @@ export class AccountManager {
         this._isAvailable(a) && (a.priority || 0) < (current.priority || 0));
       return betterExists ? this._selectNext() : current;
     }
-    return this._selectNext();
+    const next = this._selectNext();
+    if (next) return next;
+    // No account is under the switch threshold. Before refusing locally, allow a
+    // throttled probe so a stale/poisoned cached quota can't pin us in a
+    // permanent "all exhausted" state — the probe's real response refreshes the
+    // quota (or upstream's own 429 converts soft exhaustion into a hard
+    // rate-limit hold). null here means the caller emits the synthetic 429.
+    return this._selectProbe();
+  }
+
+  _isProbeable(account) {
+    if (!account) return false;
+    // Never probe an account the operator has taken out of rotation, one whose
+    // token is broken, or one upstream has explicitly rate-limited — those are
+    // hard states, not stale soft-quota guesses.
+    if (account.disabled) return false;
+    if (account.status === 'error' || account.status === 'exhausted') return false;
+    if (account.status === 'throttled' && account.rateLimitedUntil
+        && Date.now() < account.rateLimitedUntil) return false;
+    return true;
+  }
+
+  /** Highest utilization across all known quota dimensions (0-1), used to pick
+   * the least-exhausted probe target. Mirrors the ratios in _isNearQuota. */
+  _maxUtilization(account) {
+    const q = account.quota;
+    let max = 0;
+    if (q.unified5h != null) max = Math.max(max, q.unified5h);
+    if (q.unified7d != null) max = Math.max(max, q.unified7d);
+    if (q.tokensLimit != null && q.tokensRemaining != null) {
+      max = Math.max(max, 1 - q.tokensRemaining / q.tokensLimit);
+    }
+    if (q.requestsLimit != null && q.requestsRemaining != null) {
+      max = Math.max(max, 1 - q.requestsRemaining / q.requestsLimit);
+    }
+    return max;
+  }
+
+  /**
+   * Pick an account to send a single revalidation probe upstream when every
+   * account reads as over the switch threshold. Throttled to one probe per
+   * probeIntervalMs so a genuinely-exhausted fleet isn't hammered — between
+   * probes this returns null and the caller falls back to the synthetic 429.
+   * The chosen account is the least-utilized probeable one (most likely to have
+   * stale headroom), so the refreshed quota corrects the cache fastest.
+   */
+  _selectProbe() {
+    const now = Date.now();
+    if (now < this._nextProbeAt) return null;
+
+    let best = null;
+    let bestPriority = Infinity;
+    let bestUsage = Infinity;
+    for (const account of this.accounts) {
+      if (!this._isProbeable(account)) continue;
+      const priority = account.priority || 0;
+      const usage = this._maxUtilization(account);
+      if (priority < bestPriority ||
+          (priority === bestPriority && usage < bestUsage)) {
+        bestPriority = priority;
+        bestUsage = usage;
+        best = account;
+      }
+    }
+    if (!best) return null;
+
+    this._nextProbeAt = now + this.probeIntervalMs;
+    this.currentIndex = best.index;
+    console.log(`[TeamClaude] All accounts over threshold — probing "${best.name}" to refresh quota`);
+    return best;
   }
 
   _isAvailable(account) {

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -30,7 +30,10 @@ function emptyQuota() {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken } = {}) {
+    // Injectable for tests (mirrors Prober's probeFn); defaults to the real
+    // OAuth token refresh.
+    this._refreshFn = refreshFn;
     this.accounts = accounts.map((acct, index) => ({
       index,
       name: acct.name,
@@ -70,36 +73,39 @@ export class AccountManager {
    * Get the best available account, rotating if the current one is near quota.
    * Returns null if all accounts are exhausted.
    */
-  getActiveAccount() {
+  getActiveAccount(exclude = null) {
     // Clear expired quotas across all accounts and switch proactively if a
     // session reset made a sooner-expiring account the better choice. This runs
     // on every request so the behaviour holds without the TUI render loop.
     this.refreshExpiredQuotas();
     const current = this.accounts[this.currentIndex];
+    // `exclude` is a per-request set of indices already tried this request (e.g.
+    // an account that just threw a transport error). It is never a persistent
+    // status change — the account stays healthy for the next request.
     // We just learned a probed account's weekly quota — re-evaluate which
     // account is best now that its limit is known.
     if (current && current.requalify) {
       current.requalify = false;
-      const next = this._selectNext();
+      const next = this._selectNext(exclude);
       if (next) return next;
     }
-    if (this._isAvailable(current)) {
+    if (this._isAvailable(current) && !exclude?.has(current.index)) {
       // A strictly higher-priority (lower value) available account preempts a
       // healthy current one. Within the same priority tier we stay put, so the
       // common case (all accounts at the default priority 0) is unchanged and
       // never thrashes — preemption only triggers when priorities differ.
       const betterExists = this.accounts.some(a =>
-        this._isAvailable(a) && (a.priority || 0) < (current.priority || 0));
-      return betterExists ? this._selectNext() : current;
+        this._isAvailable(a) && !exclude?.has(a.index) && (a.priority || 0) < (current.priority || 0));
+      return betterExists ? this._selectNext(exclude) : current;
     }
-    const next = this._selectNext();
+    const next = this._selectNext(exclude);
     if (next) return next;
     // No account is under the switch threshold. Before refusing locally, allow a
     // throttled probe so a stale/poisoned cached quota can't pin us in a
     // permanent "all exhausted" state — the probe's real response refreshes the
     // quota (or upstream's own 429 converts soft exhaustion into a hard
     // rate-limit hold). null here means the caller emits the synthetic 429.
-    return this._selectProbe();
+    return this._selectProbe(exclude);
   }
 
   _isProbeable(account) {
@@ -138,7 +144,7 @@ export class AccountManager {
    * The chosen account is the least-utilized probeable one (most likely to have
    * stale headroom), so the refreshed quota corrects the cache fastest.
    */
-  _selectProbe() {
+  _selectProbe(exclude = null) {
     const now = Date.now();
     if (now < this._nextProbeAt) return null;
 
@@ -146,6 +152,7 @@ export class AccountManager {
     let bestPriority = Infinity;
     let bestUsage = Infinity;
     for (const account of this.accounts) {
+      if (exclude?.has(account.index)) continue;
       if (!this._isProbeable(account)) continue;
       const priority = account.priority || 0;
       const usage = this._maxUtilization(account);
@@ -318,13 +325,14 @@ export class AccountManager {
    * With all priorities at the default 0, this reduces to the weekly-reset
    * heuristic. Returns the account or null if none are available.
    */
-  _pickBestAvailable() {
+  _pickBestAvailable(exclude = null) {
     let best = null;
     let bestPriority = Infinity;
     let bestReset = Infinity;
 
     for (let i = 0; i < this.accounts.length; i++) {
       const account = this.accounts[i];
+      if (exclude?.has(account.index)) continue;
       // _isAvailable filters out accounts at/above the switch threshold, so the
       // soonest-expiring pick only ever lands on an account whose 5-hour quota
       // is still below 98%.
@@ -363,8 +371,8 @@ export class AccountManager {
     return best;
   }
 
-  _selectNext() {
-    const best = this._pickBestAvailable();
+  _selectNext(exclude = null) {
+    const best = this._pickBestAvailable(exclude);
     if (best) {
       const switched = best.index !== this.currentIndex;
       this.currentIndex = best.index;
@@ -382,6 +390,7 @@ export class AccountManager {
     let soonestTime = Infinity;
 
     for (const account of this.accounts) {
+      if (exclude?.has(account.index)) continue;
       const resetTime = account.rateLimitedUntil
         || account.quota.unified5hReset
         || account.quota.unified7dReset
@@ -548,7 +557,7 @@ export class AccountManager {
     account._refreshPromise = (async () => {
       console.log(`[TeamClaude] Refreshing token for account "${account.name}"...`);
       try {
-        const newTokens = await refreshAccessToken(account.refreshToken);
+        const newTokens = await this._refreshFn(account.refreshToken);
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
@@ -556,10 +565,16 @@ export class AccountManager {
         this._onTokenRefresh?.(accountIndex, newTokens);
       } catch (err) {
         console.error(`[TeamClaude] Token refresh failed for "${account.name}": ${err.message}`);
-        // Only mark as error if the access token is actually expired;
-        // a failed proactive refresh shouldn't kill a still-valid token
-        if (!account.expiresAt || Date.now() >= account.expiresAt) {
+        // Reserve 'error' (which drops the account from rotation until re-login)
+        // for a GENUINE auth rejection: the refresh token itself is no longer
+        // valid — revoked, or invalidated by an account/plan migration. A
+        // transient failure (network, 5xx, timeout) must NOT sideline a healthy
+        // account: keep its current token and retry on the next request. This is
+        // what kept accounts wrongly "errored" after a momentary refresh blip.
+        const isAuthRejection = err.status === 400 || err.status === 401 || err.status === 403;
+        if (isAuthRejection) {
           account.status = 'error';
+          console.error(`[TeamClaude] Account "${account.name}" needs re-login (refresh token rejected) — run: teamclaude login`);
         }
       } finally {
         account._refreshPromise = null;

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -64,7 +64,13 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
           continue;
         }
         const text = await res.text();
-        throw new Error(`Token refresh failed (${res.status}): ${text}`);
+        const err = new Error(`Token refresh failed (${res.status}): ${text}`);
+        // Surface the HTTP status so callers can distinguish a genuine auth
+        // rejection (the refresh token is dead — re-login needed) from a
+        // transient server error. 5xx is retried above; reaching here with a 5xx
+        // means retries were exhausted, which is still transient, not auth.
+        err.status = res.status;
+        throw err;
       }
 
       const data = await res.json();

--- a/src/server.js
+++ b/src/server.js
@@ -84,7 +84,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       }
       const body = Buffer.concat(bodyChunks);
 
-      const ctx = { account: null, status: null };
+      const ctx = { account: null, status: null, tried: new Set() };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -207,8 +207,8 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   // from the default policy ('always' routes; 'off'/'429' start direct).
   const route = useSx === undefined ? !!(sx?.useByDefault()) : useSx;
 
-  // Select account
-  const account = accountManager.getActiveAccount();
+  // Select account, skipping any already tried (and failed) this request.
+  const account = accountManager.getActiveAccount(ctx.tried);
   if (!account) {
     ctx.status = 429;
     ctx.account = '(none available)';
@@ -235,6 +235,7 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   // Refresh OAuth token if needed
   await accountManager.ensureTokenFresh(account.index);
   if (account.status === 'error' && retryCount < maxRetries) {
+    ctx.tried.add(account.index);
     return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
   }
 
@@ -400,8 +401,13 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       return;
     }
 
+    // Any other thrown error is a transport/stream failure, NOT proof the
+    // account's credentials are bad — a bad credential comes back as a 401
+    // *response*, never a throw. So don't sideline the account (that would drop
+    // a healthy account from rotation until a credential change). Instead skip
+    // it for the rest of THIS request only and fail over to another account.
     if (retryCount < maxRetries && !res.headersSent) {
-      account.status = 'error';
+      ctx.tried.add(account.index);
       return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
     }
     ctx.status = 502;

--- a/test/account-error-recovery.test.js
+++ b/test/account-error-recovery.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { refreshAccessToken } from '../src/oauth.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+// expiresAt within the 5-minute "expiring soon" window so ensureTokenFresh refreshes.
+function expiring(name) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 1000 };
+}
+
+// ── per-request failover (getActiveAccount exclude) ─────────────────────────
+
+test('getActiveAccount(exclude) fails over to another account', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const first = am.getActiveAccount();
+  const second = am.getActiveAccount(new Set([first.index]));
+  assert.ok(second);
+  assert.notEqual(second.index, first.index);
+});
+
+test('getActiveAccount returns null when every account is excluded', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  assert.equal(am.getActiveAccount(new Set([0, 1])), null);
+});
+
+test('excluding an account for one request never changes its persistent status', () => {
+  // A transport failover must not sideline the account it skipped.
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.getActiveAccount(new Set([0]));
+  assert.equal(am.accounts[0].status, 'active');
+});
+
+// ── refresh-failure classification (the wrongly-errored bug) ────────────────
+
+test('ensureTokenFresh marks error only on a genuine auth rejection', async () => {
+  for (const status of [400, 401, 403]) {
+    const am = new AccountManager([expiring('a')], 0.98, {
+      refreshFn: async () => { throw Object.assign(new Error(`refresh ${status}`), { status }); },
+    });
+    await am.ensureTokenFresh(0);
+    assert.equal(am.accounts[0].status, 'error', `status ${status} should sideline`);
+  }
+});
+
+test('ensureTokenFresh does NOT sideline on a transient refresh failure', async () => {
+  // Network error (no .status) and an exhausted-retries 5xx must both be treated
+  // as transient — the account stays healthy and is retried next request.
+  for (const err of [
+    Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' }),
+    Object.assign(new Error('refresh 503'), { status: 503 }),
+  ]) {
+    const am = new AccountManager([expiring('a')], 0.98, { refreshFn: async () => { throw err; } });
+    await am.ensureTokenFresh(0);
+    assert.equal(am.accounts[0].status, 'active');
+  }
+});
+
+test('ensureTokenFresh applies refreshed tokens on success', async () => {
+  const am = new AccountManager([expiring('a')], 0.98, {
+    refreshFn: async () => ({ accessToken: 'NEW', refreshToken: 'NEWR', expiresAt: Date.now() + 3600_000 }),
+  });
+  await am.ensureTokenFresh(0);
+  assert.equal(am.accounts[0].credential, 'NEW');
+  assert.equal(am.accounts[0].status, 'active');
+});
+
+// ── refreshAccessToken surfaces the HTTP status ─────────────────────────────
+
+test('refreshAccessToken attaches the HTTP status to a rejection error', async () => {
+  const srv = http.createServer((_req, res) => {
+    res.writeHead(400, { 'content-type': 'application/json' });
+    res.end('{"error":"invalid_grant"}');
+  });
+  await new Promise(r => srv.listen(0, '127.0.0.1', r));
+  const endpoint = `http://127.0.0.1:${srv.address().port}/token`;
+  try {
+    await assert.rejects(refreshAccessToken('r', endpoint), (e) => {
+      assert.equal(e.status, 400);
+      return true;
+    });
+  } finally {
+    srv.close();
+  }
+});

--- a/test/probe-on-exhaustion.test.js
+++ b/test/probe-on-exhaustion.test.js
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// Drive an account to a "soft" exhausted state: utilization at/above the switch
+// threshold with a reset still in the future (so it isn't cleared as stale).
+function exhaust(account, utilization) {
+  account.quota.unified7d = utilization;
+  account.quota.unified7dReset = Date.now() + 3600_000;
+}
+
+test('when every account is over threshold, getActiveAccount probes instead of refusing', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  exhaust(am.accounts[0], 0.99);
+  exhaust(am.accounts[1], 0.985);
+
+  const picked = am.getActiveAccount();
+  assert.ok(picked, 'expected a probe account, not null');
+  // Least-utilized is the better probe target (most likely to still have headroom).
+  assert.equal(picked.name, 'b');
+});
+
+test('probing is throttled to one account per probe interval', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  exhaust(am.accounts[0], 0.99);
+  exhaust(am.accounts[1], 0.99);
+
+  assert.ok(am.getActiveAccount(), 'first call probes');
+  // A second request inside the interval must refuse (synthetic 429), not probe again.
+  assert.equal(am.getActiveAccount(), null);
+
+  // Once the interval elapses, a probe is allowed again.
+  am._nextProbeAt = Date.now() - 1;
+  assert.ok(am.getActiveAccount(), 'probe allowed after the interval');
+});
+
+test('a hard upstream rate-limit is respected — no probe, synthetic 429 stands', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.markRateLimited(0, 300);
+  am.markRateLimited(1, 300);
+  assert.equal(am.getActiveAccount(), null);
+});
+
+test('disabled accounts are never used as a probe target', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  exhaust(am.accounts[0], 0.99);
+  exhaust(am.accounts[1], 0.99);
+  am.accounts[0].disabled = true;
+  am.accounts[1].disabled = true;
+  assert.equal(am.getActiveAccount(), null);
+});
+
+test('a probe refreshing healthy quota restores normal (non-throttled) selection', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  exhaust(am.accounts[0], 0.99);
+
+  const probe = am.getActiveAccount();
+  assert.ok(probe, 'probe issued');
+  // Simulate the upstream response showing real headroom.
+  am.updateQuota(0, { 'anthropic-ratelimit-unified-7d-utilization': '0.10' });
+
+  // Now the account is available the normal way, with no throttle gating.
+  assert.equal(am.getActiveAccount().name, 'a');
+});

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -61,3 +61,51 @@ test('negative Retry-After is clamped and still terminates', async () => {
   assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
   assert.equal(accountStatus, 'throttled');
 });
+
+// Regression for #46: a stale/poisoned cached quota (e.g. 0.98 from before a
+// plan upgrade, with a reset still in the future) must NOT pin the proxy in a
+// permanent synthetic 429. The next request should probe upstream, succeed, and
+// refresh the cached quota — rather than refusing locally without any call.
+test('stale over-threshold quota is re-probed, not refused forever', async () => {
+  let upstreamHits = 0;
+  const upstream = http.createServer((_req, res) => {
+    upstreamHits++;
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      // Real headroom: the upgraded account is nowhere near its limit.
+      'anthropic-ratelimit-unified-7d-utilization': '0.10',
+    });
+    res.end(JSON.stringify({ type: 'message', role: 'assistant', content: [] }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }],
+    0.98,
+  );
+  // Simulate restoring a poisoned snapshot from teamclaude.state.json.
+  am.restoreQuotaState([
+    { name: 'a', quota: { unified7d: 0.98, unified7dReset: Date.now() + 7 * 24 * 3600_000 } },
+  ]);
+
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 200, 'request should be proxied, not refused with a synthetic 429');
+    assert.equal(upstreamHits, 1, 'a real upstream probe should have been made');
+    assert.equal(am.accounts[0].quota.unified7d, 0.10, 'cached quota should be refreshed from the probe');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});


### PR DESCRIPTION
Fixes #46.

Two independent ways the proxy got stuck refusing requests on accounts that were actually fine.

## 1. Stale/poisoned quota → permanent synthetic 429

After a plan upgrade + re-auth, a cached `unified7d: 0.98` (reset still in the future) made `getActiveAccount()` mark every account over threshold and return `null`. The proxy then emitted `All N accounts exhausted` **without any upstream call**, so the stale quota was never refreshed — permanent.

**Fix — throttled re-probe:** when no account is under the switch threshold, send one real upstream request at most once per `probeIntervalMs` (60s) on the least-utilized probeable account. Its genuine response refreshes the quota (or upstream's own 429 converts soft exhaustion into a hard rate-limit hold). Between probes the synthetic 429 still stands, so a genuinely-exhausted fleet isn't hammered.

## 2. Healthy accounts wrongly marked `error`

`error` removes an account from rotation until a credential change / re-login. Two paths set it wrongly:

- **`ensureTokenFresh`** marked `error` on *any* refresh failure when the token had expired — so a momentary network blip or upstream 5xx during a refresh stuck the account forever, never retried. Likely the cause of "accounts errored when they aren't" and the re-login churn after the claude-design migration. Now `error` is reserved for a **genuine auth rejection** (refresh token rejected 400/401/403); transient failures keep the token and retry next request. `refreshAccessToken` now attaches the HTTP status so this is distinguishable.
- **Server catch-all** marked `error` on any non-transient thrown upstream error. But a thrown fetch/stream error is a transport problem, never proof of bad credentials (those come back as a 401 *response*, not a throw). Replaced with a per-request `tried` set: skip the failed account for this request only and fail over to another, leaving its status untouched. `getActiveAccount`/`_selectNext`/`_selectProbe` accept that exclude set.

### Note on OAuth scopes (asked in review)
Verified against the installed `claude` binary (v2.1.187): our `OAUTH_SCOPES` is a character-for-character match of the claude-code OAuth scope set (`org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload`). `user:design:*` is a *separate* scope array used only by claude.ai's design feature — correctly not part of the CLI inference token. So the migration token expiry is server-side (refresh-token invalidation), which #2 now handles gracefully instead of permanently erroring.

## Tests
- `test/probe-on-exhaustion.test.js` — probe on soft exhaustion, throttle, respect hard rate-limits, never probe disabled.
- `test/server-429.test.js` — regression: poisoned `0.98`/future-reset snapshot → next request is proxied (200), hits upstream, refreshes quota.
- `test/account-error-recovery.test.js` — `getActiveAccount(exclude)` failover; `ensureTokenFresh` errors only on 400/401/403 and not on network/5xx; `refreshAccessToken` surfaces HTTP status.

`npm test` → 127/127 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)