### PR TITLE
1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Version bump to **1.0.8**.

Releases the fixes merged in #47:
- Throttled re-probe so a stale/poisoned cached quota can't pin the proxy in a permanent `All N accounts exhausted` 429.
- `error` reserved for genuine auth rejections (400/401/403) — transient refresh failures and upstream transport throws no longer permanently sideline a healthy account.

Tag `v1.0.8` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)