### PR TITLE
fix 1% usage being parsed into 100%

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -149,15 +149,15 @@ export async function fetchProfile(accessToken) {
 }
 
 // Normalize one usage bucket from the /api/oauth/usage payload into
-// { utilization: 0-1, resetAt: ms-epoch }. Tolerant of field-name and
-// percentage/fraction and seconds/ms variations across payload versions.
+// { utilization: 0-1, resetAt: ms-epoch }. The endpoint reports utilization
+// as a percentage in the 0-100 range, so 1 means 1%, not 100%.
 export function normalizeUsageBucket(bucket) {
   if (!bucket || typeof bucket !== 'object') return null;
 
   const rawPct = bucket.used_percentage ?? bucket.utilization ?? bucket.usedPercentage;
   const parsedPct = typeof rawPct === 'number' ? rawPct : parseFloat(rawPct);
   const utilization = Number.isFinite(parsedPct)
-    ? (parsedPct > 1 ? parsedPct / 100 : parsedPct)
+    ? parsedPct / 100
     : null;
 
   const rawReset = bucket.resets_at ?? bucket.resetsAt ?? bucket.reset_at ?? bucket.resetAt;

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -10,10 +10,16 @@ function oauth(name, extra = {}) {
 
 // ── normalizeUsageBucket ──────────────────────────────────────
 
-test('normalizeUsageBucket converts percentages and fractions to 0-1', () => {
+test('normalizeUsageBucket converts OAuth usage percentages to 0-1', () => {
   assert.equal(normalizeUsageBucket({ used_percentage: 42 }).utilization, 0.42);
-  assert.equal(normalizeUsageBucket({ utilization: 0.5 }).utilization, 0.5);
+  assert.equal(normalizeUsageBucket({ utilization: 1 }).utilization, 0.01);
+  assert.equal(normalizeUsageBucket({ utilization: 2 }).utilization, 0.02);
+  assert.equal(normalizeUsageBucket({ utilization: 100 }).utilization, 1);
   assert.equal(normalizeUsageBucket({ used_percentage: '30' }).utilization, 0.3);
+  assert.equal(normalizeUsageBucket({ used_percentage: 1 }).utilization, 0.01);
+  assert.equal(normalizeUsageBucket({ used_percentage: '1' }).utilization, 0.01);
+  assert.equal(normalizeUsageBucket({ usedPercentage: '1' }).utilization, 0.01);
+  assert.equal(normalizeUsageBucket({ utilization: '1' }).utilization, 0.01);
   assert.equal(normalizeUsageBucket(null), null);
   assert.equal(normalizeUsageBucket({}).utilization, null);
 });


### PR DESCRIPTION
`https://api.anthropic.com/api/oauth/usage` should always return values between 0-100, not 0-1. I think it might have been claude overengineering the solution