### PR TITLE
1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Version bump to **1.0.9**.

Releases #49: `/api/oauth/usage` reports `utilization` as a 0–100 percentage (verified against the live endpoint — `2.0` = 2%, corroborated by `limits[].percent`). The previous `>1` heuristic inflated any value ≤ 1% up to 100%, wrongly marking low-usage accounts as near-quota. Now always divided by 100.

Tag `v1.0.9` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)