### PR TITLE
Publish to npm automatically on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish
+
+# Publish to npm whenever a version bump lands on master. The job compares the
+# package.json version against what is already on npm, so it only publishes when
+# the version is new — merging any other PR is a no-op. Publishing is idempotent:
+# re-running on the same version simply skips.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the git tag + GitHub release
+      id-token: write   # npm provenance attestation
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Read package version
+        id: pkg
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version is already on npm
+        id: check
+        run: |
+          name='${{ steps.pkg.outputs.name }}'
+          version='${{ steps.pkg.outputs.version }}'
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published — skipping."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$name@$version is new — will publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.publish == 'true'
+        run: npm install
+
+      - name: Run tests
+        if: steps.check.outputs.publish == 'true'
+        run: npm test
+
+      - name: Publish to npm
+        if: steps.check.outputs.publish == 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag the release and create a GitHub release
+        if: steps.check.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ steps.pkg.outputs.version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists — skipping release."
+          else
+            gh release create "$tag" \
+              --target "${{ github.sha }}" \
+              --title "$tag" \
+              --generate-notes
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ name: Publish
 # package.json version against what is already on npm, so it only publishes when
 # the version is new — merging any other PR is a no-op. Publishing is idempotent:
 # re-running on the same version simply skips.
+#
+# Authentication uses npm Trusted Publishing (OIDC) — no long-lived NPM_TOKEN.
+# npm mints a short-lived credential from the GitHub OIDC token at publish time,
+# and provenance is attached automatically. This requires a one-time setup on
+# npmjs.com: on the package's Settings → Trusted Publisher, add a GitHub Actions
+# publisher for owner KarpelesLab, repo teamclaude, workflow "publish.yml".
 on:
   push:
     branches: [master]
@@ -16,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # create the git tag + GitHub release
-      id-token: write   # npm provenance attestation
+      id-token: write   # OIDC token for npm Trusted Publishing + provenance
     steps:
       - uses: actions/checkout@v6
 
@@ -53,11 +59,17 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         run: npm test
 
-      - name: Publish to npm
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1. Upgrade so this works
+      # regardless of which npm the runner image happens to ship.
+      - name: Upgrade npm for Trusted Publishing
         if: steps.check.outputs.publish == 'true'
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (Trusted Publishing via OIDC)
+        if: steps.check.outputs.publish == 'true'
+        # No NODE_AUTH_TOKEN: npm exchanges the OIDC token (id-token: write) for a
+        # short-lived publish credential, and attaches provenance automatically.
+        run: npm publish --access public
 
       - name: Tag the release and create a GitHub release
         if: steps.check.outputs.publish == 'true'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` so that **merging a version bump to `master` publishes the package to npm** — no manual `npm publish` or tag step.

Authentication uses **npm Trusted Publishing (OIDC)** — no long-lived `NPM_TOKEN` secret. The workflow exchanges the GitHub OIDC token for a short-lived publish credential at publish time, and provenance is attached automatically.

## How it works

On every push to `master` that touches `package.json`, the job:

1. Reads `name` + `version` from `package.json`.
2. Checks `npm view <name>@<version>` — if that version is **already on npm**, it stops (no-op).
3. If the version is **new**: `npm install` → `npm test` → upgrade npm (Trusted Publishing needs npm ≥ 11.5.1) → `npm publish --access public` (OIDC, auto-provenance) → create the `v<version>` git tag + a GitHub release with generated notes.

This is **idempotent and self-gating**: merging a PR that doesn't change the version, or re-running on an already-published version, does nothing. Matches the existing flow (bump the version in a PR, merge it) without needing a separate release trigger.

## ⚠️ Required one-time setup (no secrets)

Configure this repo as a **trusted publisher** on npm:

1. npmjs.com → the `@karpeleslab/teamclaude` package → **Settings → Trusted Publisher**.
2. Add a **GitHub Actions** publisher:
   - Organization/owner: `KarpelesLab`
   - Repository: `teamclaude`
   - Workflow filename: `publish.yml`
   - (Environment: leave blank — the workflow doesn't use one.)

That's it — no token to generate, store, or rotate. The workflow already grants `id-token: write` so npm can verify the OIDC token.

## Notes

- Tests run inside the publish job as a release gate, independent of the CI matrix.
- The `paths: package.json` filter is only an optimization; the npm-view check is the real gate.
- Provenance is generated automatically under Trusted Publishing, so no `--provenance` flag is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)