### PR TITLE
Add manual trigger to publish workflow (backfill 1.0.9)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ on:
     branches: [master]
     paths:
       - 'package.json'
+  # Manual trigger: publish the version currently on master on demand. Useful to
+  # backfill a version that was bumped before this workflow existed, or to re-run
+  # after fixing the npm Trusted Publisher setup. The npm-view check below still
+  # gates it, so a manual run on an already-published version is a safe no-op.
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Why

The publish workflow only triggers on a push to `master` that changes `package.json`. Version **1.0.9** was bumped (PR #50) **before** the workflow existed, so there's no qualifying push to fire it — and npm is still at 1.0.8. There was no way to trigger a publish by hand.

## Change

Adds a `workflow_dispatch` trigger so the workflow can be run manually from the Actions tab (or `gh workflow run publish.yml`). The job's existing `npm view` gate is unchanged, so a manual run on an already-published version is a safe no-op.

After this merges, running it once will publish the current master version (1.0.9). From then on, future version bumps publish automatically via the push trigger.

## ⚠️ Reminder

A manual run still requires the one-time **npm Trusted Publisher** setup (package Settings → Trusted Publisher → GitHub Actions: owner `KarpelesLab`, repo `teamclaude`, workflow `publish.yml`). Without it the publish step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)