### PR TITLE
Add repository metadata to package.json (unblocks npm provenance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,14 @@
     "multi-account"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KarpelesLab/teamclaude.git"
+  },
+  "bugs": {
+    "url": "https://github.com/KarpelesLab/teamclaude/issues"
+  },
+  "homepage": "https://github.com/KarpelesLab/teamclaude#readme",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Why

The first publish run authenticated fine via Trusted Publishing and signed provenance, but npm rejected it:

```
422 Unprocessable Entity — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match
"https://github.com/KarpelesLab/teamclaude" from provenance
```

npm provenance (generated automatically under Trusted Publishing) requires `package.json` to declare a `repository.url` matching the repo the build ran in. The file had no `repository` field.

## Change

Adds `repository`, `bugs`, and `homepage` fields pointing at this repo.

Merging this changes `package.json`, so the publish workflow's `push` trigger fires automatically and publishes **1.0.9** (still at version 1.0.9 — it was never published). This also exercises the automatic path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)