### PR TITLE
Make MITM forward-proxy mode the default for run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet weekly bucket
-- **Optional MITM proxy mode** — `teamclaude run --mitm` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected
+- **MITM proxy mode (default)** — `teamclaude run` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected; pass `--no-mitm` for base-URL routing only
 - **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
 - **Zero dependencies** — uses only Node.js built-in modules
@@ -255,14 +255,18 @@ You can also set the interval live from the TUI settings screen (`g` → `p`), a
 
 It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** bucket as an extra bar in the TUI / `status` (when your plan exposes it).
 
-### MITM proxy mode (optional, off by default)
+### MITM proxy mode (default)
 
-The normal reverse-proxy only intercepts what `ANTHROPIC_BASE_URL` covers. Some Claude Code features (e.g. the **Claude Design MCP**) use a **hardcoded** `https://api.anthropic.com` URL that ignores that variable, so they bypass the proxy. MITM proxy mode captures those too.
-
-Run claude with the `--mitm` flag:
+The plain reverse-proxy only intercepts what `ANTHROPIC_BASE_URL` covers. Some Claude Code features (e.g. the **Claude Design MCP**) use a **hardcoded** `https://api.anthropic.com` URL that ignores that variable, so they bypass the proxy. MITM proxy mode captures those too, which is why it's the default for `teamclaude run` (and the shell alias):
 
 ```bash
-teamclaude run --mitm -- <claude args...>
+teamclaude run -- <claude args...>
+```
+
+To opt out and route via `ANTHROPIC_BASE_URL` only, pass `--no-mitm`:
+
+```bash
+teamclaude run --no-mitm -- <claude args...>
 ```
 
 That launches claude pointed at teamclaude as an **HTTPS forward proxy** (`HTTPS_PROXY`) and trusts a locally-generated CA (`NODE_EXTRA_CA_CERTS`). For an intercepted host, teamclaude **dials the real upstream first, mirrors its negotiated ALPN** (HTTP/2 or HTTP/1.1), then terminates TLS toward claude with the same protocol and relays the traffic **as transparently as possible** — rewriting only what it must:
@@ -271,7 +275,7 @@ That launches claude pointed at teamclaude as an **HTTPS forward proxy** (`HTTPS
 - the **`account_uuid`** inside `metadata.user_id` → the active account's UUID (so the body agrees with the injected token);
 - and it reads `anthropic-ratelimit-*` from responses for quota.
 
-Everything else is copied byte-for-byte (HTTP/2 is handled with a built-in HPACK codec so the only header changed is the auth one). Any host other than the upstream is blind-tunnelled. The server accepts *both* base-URL and proxy clients at once, so instances launched with and without `--mitm` can share one server.
+Everything else is copied byte-for-byte (HTTP/2 is handled with a built-in HPACK codec so the only header changed is the auth one). Any host other than the upstream is blind-tunnelled. The server accepts *both* base-URL and proxy clients at once, so instances launched with and without `--no-mitm` can share one server.
 
 Trust model:
 - The CA is generated locally, stored in the config dir, and trusted **only** by the claude process you launch via `teamclaude run` (through `NODE_EXTRA_CA_CERTS`) — it is **never** added to your system trust store. The leaf private key is `0600`; the CA private key is never written to disk.

--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,7 @@ async function accountsCommand() {
       a.refreshToken = newTokens.refreshToken;
       a.expiresAt = newTokens.expiresAt;
       configDirty = true;
-    } catch (err) {
+    } catch {
       // refresh failed — fetchProfile will report the specific error
     }
   }));

--- a/src/index.js
+++ b/src/index.js
@@ -444,13 +444,18 @@ async function envCommand() {
 async function runCommand() {
   const config = await loadOrCreateConfig();
 
-  // Args after 'run'. teamclaude flags (e.g. --mitm) are recognized only before
-  // an optional `--` separator; everything after `--` goes verbatim to claude.
+  // Args after 'run'. teamclaude flags (e.g. --no-mitm) are recognized only
+  // before an optional `--` separator; everything after `--` goes verbatim to
+  // claude. MITM forward-proxy mode is the default so hardcoded api.anthropic.com
+  // endpoints are intercepted too; --no-mitm opts back into base-URL-only routing.
+  // --mitm is still accepted (now a no-op) for backward compatibility.
   const rest = args.slice(1);
   const sep = rest.indexOf('--');
   const tcFlags = sep >= 0 ? rest.slice(0, sep) : rest;
-  const useMitm = tcFlags.includes('--mitm');
-  const claudeArgs = sep >= 0 ? rest.slice(sep + 1) : rest.filter(a => a !== '--mitm');
+  const useMitm = !tcFlags.includes('--no-mitm');
+  const claudeArgs = sep >= 0
+    ? rest.slice(sep + 1)
+    : rest.filter(a => a !== '--mitm' && a !== '--no-mitm');
 
   // Route through the proxy only when it's actually up; otherwise launch claude
   // directly so a stopped proxy doesn't break `claude`. This is what lets the
@@ -884,10 +889,11 @@ Commands:
   login               OAuth login via browser
   login --api         Add an API key account
   env                 Print env vars to use with Claude
-  run [--mitm] [-- args...]
-                      Run Claude Code through the proxy (direct if it's down);
-                      --mitm routes via an HTTPS forward proxy + local CA so even
-                      hardcoded api.anthropic.com endpoints are intercepted
+  run [--no-mitm] [-- args...]
+                      Run Claude Code through the proxy (direct if it's down).
+                      Routes via an HTTPS forward proxy + local CA by default, so
+                      even hardcoded api.anthropic.com endpoints are intercepted;
+                      --no-mitm uses base-URL routing only
   alias               Print a shell alias so plain 'claude' routes via the proxy
                       (--install to write it to your shell rc; --uninstall to remove)
   status              Show proxy & account status (live)
@@ -909,10 +915,10 @@ Options:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)
   --headless          Run the server without the interactive TUI (for backgrounding)
-  --mitm              (run) route claude via the HTTPS forward proxy + local CA
+  --no-mitm           (run) skip the forward proxy; route via ANTHROPIC_BASE_URL only
 
 The server always accepts both base-URL and proxy/CONNECT clients, so instances
-launched with and without --mitm can share one server.
+launched with and without --no-mitm can share one server.
 
 A running server re-syncs accounts from config on POST /teamclaude/reload
 (local only). add/login/enable/disable/priority trigger it automatically.
@@ -1117,7 +1123,7 @@ function argValue(flag) {
   return (i >= 0 && args[i + 1]) ? args[i + 1] : null;
 }
 
-// Hostname of the configured upstream (the host MITM-intercepts under `run --mitm`).
+// Hostname of the configured upstream (the host MITM-intercepts under `run`).
 function upstreamHost(config) {
   try { return new URL(config.upstream || 'https://api.anthropic.com').hostname; }
   catch { return 'api.anthropic.com'; }


### PR DESCRIPTION
## Summary

Makes MITM forward-proxy mode the **default** for `teamclaude run` (and the auto-routing alias), so hardcoded `api.anthropic.com` endpoints — e.g. the Claude Design MCP — are intercepted too, not just `ANTHROPIC_BASE_URL`-aware traffic.

- `teamclaude run` now enables the forward proxy by default.
- New `--no-mitm` flag restores the previous base-URL-only routing.
- `--mitm` is still accepted (now a no-op) for backward compatibility.
- teamclaude flags are parsed only before an optional `--` separator; everything after `--` passes verbatim to claude.

## Version & docs

- Bumps version **1.0.9 → 1.1.0** (minor: default behavior change, backward-compatible opt-out).
- Documents the change in the README under "Run Claude Code through the proxy" with a since-1.1.0 note and the `--no-mitm` example; MITM section retitled "MITM proxy mode (default)".

## Housekeeping

- Fixes an unrelated lint warning (unused `catch` binding); `eslint .` is now clean repo-wide.

Merging this publishes 1.1.0 to npm automatically (package.json change triggers the publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)