### PR TITLE
Bump to 1.1.0 and document MITM-default change

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ teamclaude run
 
 `run` probes the proxy first: if it's up, Claude Code is routed through it; if it's **not** running, `claude` is launched directly so nothing breaks.
 
+Since **1.1.0**, `run` defaults to [MITM forward-proxy mode](#mitm-proxy-mode-default) so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) are intercepted. To keep the previous base-URL-only behavior, pass `--no-mitm`:
+
+```bash
+teamclaude run --no-mitm
+```
+
 Or manually set the environment:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Follow-up to #55, which merged the MITM-default feature but **without** the version bump (my bump commit landed on the already-merged branch and never reached master).

This branch is the missing piece:

- Bumps version **1.0.9 → 1.1.0**.
- Adds the since-1.1.0 note under "Run Claude Code through the proxy" with the `--no-mitm` opt-out example.

Merging this triggers the publish workflow (package.json changed) and ships 1.1.0 to npm with provenance, tag, and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)