### PR TITLE
Pass Remote Control control channel (/v1/code/*) through untouched (fixes 403)

### DIFF
--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -382,6 +382,13 @@ function headFields(headText) {
  *  `authValue` (or set x-api-key), and drop the other client-supplied key. */
 export function rewriteH1Auth(headText, { authorization = null, apiKey = null }) {
   const lines = headText.split('\r\n');
+  // Claude Code's Remote Control control channel (/v1/code/*) is bound to the
+  // claude.ai identity the session is paired with. Injecting a rotated account's
+  // token makes the upstream reject the worker event stream with 403, which kills
+  // Remote Control. Pass these requests through untouched so Claude's own paired
+  // credential reaches the server (same spirit as the /v1/oauth/token passthrough).
+  const reqPath = (lines[0] || '').split(' ')[1] || '';
+  if (reqPath.startsWith('/v1/code/')) return headText;
   const out = [lines[0]]; // request line
   let setAuth = false;
   for (let i = 1; i < lines.length; i++) {

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -327,6 +327,12 @@ export function parseClientHelloAlpn(buf) {
 function makeRewriteRequest(account) {
   const isOAuth = account.type === 'oauth';
   return (fields) => {
+    // Remote Control control channel (/v1/code/*) is bound to the session's
+    // paired claude.ai identity; injecting a rotated account's token makes the
+    // worker event stream 403 and breaks Remote Control. Pass it through so
+    // Claude's own credential reaches the server (mirror of rewriteH1Auth).
+    const pathField = fields.find((f) => f.name.toString().toLowerCase() === ':path');
+    if (pathField && pathField.value.toString().startsWith('/v1/code/')) return fields;
     let replaced = false;
     const out = [];
     for (const f of fields) {

--- a/test/remote-control-passthrough.test.js
+++ b/test/remote-control-passthrough.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rewriteH1Auth } from '../src/h2/relay.js';
+
+const CRLF = '\r\n';
+const head = (requestLine, headers) => [requestLine, ...headers, '', ''].join(CRLF);
+
+const ROTATED = 'Bearer sk-ant-oat01-ROTATED';
+
+test('rewriteH1Auth injects the account token on a normal request', () => {
+  const input = head('POST /v1/messages?beta=true HTTP/1.1', [
+    'host: api.anthropic.com',
+    'authorization: Bearer sk-ant-oat01-CLIENT',
+  ]);
+  const out = rewriteH1Auth(input, { authorization: ROTATED });
+  assert.match(out, /authorization: Bearer sk-ant-oat01-ROTATED/);
+  assert.doesNotMatch(out, /sk-ant-oat01-CLIENT/);
+});
+
+// Remote Control's control channel (/v1/code/*) is bound to the session's paired
+// claude.ai identity. If the rotated account's token is injected, the upstream
+// rejects the worker event stream with 403 and Remote Control drops. The proxy
+// must leave these requests untouched so Claude's own credential reaches the server.
+test('rewriteH1Auth passes Remote Control (/v1/code/*) through untouched', () => {
+  const input = head('GET /v1/code/sessions/cse_abc/worker/events/stream HTTP/1.1', [
+    'host: api.anthropic.com',
+    'authorization: Bearer sk-ant-oat01-CLIENT',
+  ]);
+  const out = rewriteH1Auth(input, { authorization: ROTATED });
+  assert.equal(out, input);
+  assert.match(out, /sk-ant-oat01-CLIENT/);
+  assert.doesNotMatch(out, /ROTATED/);
+});


### PR DESCRIPTION
Fixes #57.

## Problem

Running Claude Code through TeamClaude breaks Remote Control: it connects, then drops with `Transport closed: server rejected connection (code 403)`. Inference is unaffected.

The control channel lives under `/v1/code/*` and is bound to the claude.ai identity the session is paired with. The MITM auth rewrite injects the active (rotated) account's token onto those requests too; the upstream tolerates it on `triggers`/`presence` but rejects `GET /v1/code/sessions/<id>/worker/events/stream` with **403**, which tears Remote Control down. It is the same class of credential as `/v1/oauth/token`, which is already passed through.

## Change

Pass `/v1/code/*` through untouched on both rewrite paths:
- `rewriteH1Auth` (h1) — `src/h2/relay.js`
- `makeRewriteRequest` (h2) — `src/mitm.js`

Remote Control then uses Claude's own paired credential, while inference (`/v1/messages`) keeps rotating.

## Tests

Added `test/remote-control-passthrough.test.js` (normal request → token injected; `/v1/code/*` → untouched). Full suite: **129/129 pass**.

## Verification

Live against Claude Code v2.1.196 with 3 Max accounts:
- `worker/events/stream`: 403 → 200
- Remote Control stays connected across a forced account rotation (`teamclaude disable` on the active account); 14 `/v1/code/*` requests, 0 × 403.

The h1 path is the one exercised by Remote Control in practice (its control channel negotiates HTTP/1.1); the h2 change is the symmetric guard on the other rewrite path.
