### PR TITLE
Bump to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch release cutting **1.1.1**.

Merging this to `master` triggers the publish workflow: npm publish (Trusted Publishing/OIDC), git tag `v1.1.1`, and a generated GitHub release.

## What's in 1.1.1

- **fix: Remote Control control channel (`/v1/code/*`) passes through untouched (#58, fixes #57)** — the MITM auth rewrite no longer injects the rotated account token onto Claude Code's Remote Control control channel, so it no longer drops with a `403` across account rotation. Inference (`/v1/messages`) keeps rotating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)