### PR TITLE
feat: npm-global self-update (auto-update like Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,22 @@ teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
 teamclaude probe 300         # Enable background quota refresh (off by default)
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude api <path>        # Call an API endpoint with account credentials
+teamclaude update            # Check npm for a newer teamclaude and install it
+teamclaude version           # Print the installed version
 teamclaude help              # Show all commands
 ```
+
+### Auto-update
+
+When teamclaude is installed globally via npm, it self-updates in the
+background: it checks the npm registry at most once a day, and when a newer
+version is published it runs `npm install -g @karpeleslab/teamclaude@latest` and
+applies it on the next launch. The check runs after a `teamclaude run` session
+ends and when a headless server starts; a git checkout is never touched (update
+it with `git pull`). Run `teamclaude update` to update on demand.
+
+Disable auto-update with `TEAMCLAUDE_DISABLE_AUTOUPDATE=1` or `"autoUpdate": false`
+in the config.
 
 When the same email belongs to multiple organizations, accounts are named
 `email (Org)` to keep them distinct. Pass `--org <name|uuid>` to disambiguate a

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,7 @@
   "upstream": "https://api.anthropic.com",
   "switchThreshold": 0.98,
   "quotaProbeSeconds": 0,
+  "autoUpdate": true,
   "accounts": [
     {
       "name": "primary-max",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
         Buffer: 'readonly',
         TextDecoder: 'readonly',
         fetch: 'readonly',
+        AbortController: 'readonly',
       },
     },
     rules: {

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
 import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
+import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -70,6 +71,16 @@ switch (command) {
     break;
   case 'probe':
     await probeCommand();
+    process.exit(0);
+    break;
+  case 'update':
+    await updateCommand();
+    process.exit(0);
+    break;
+  case 'version':
+  case '--version':
+  case '-V':
+    console.log(currentVersion() || 'unknown');
     process.exit(0);
     break;
   case 'help':
@@ -297,6 +308,11 @@ async function serverCommand() {
   prober = new Prober(accountManager, { intervalMs: (config.quotaProbeSeconds || 0) * 1000 });
   prober.start();
 
+  // Background self-update for a backgrounded (headless) server. Skipped under
+  // the TUI, where npm's install output would corrupt the display — interactive
+  // users update via `teamclaude run` (post-session) or `teamclaude update`.
+  if (!tui) autoUpdate({ config }).catch(() => {});
+
   if (!tui) {
     const shutdown = async () => {
       console.log('\n[TeamClaude] Shutting down...');
@@ -499,6 +515,11 @@ async function runCommand() {
     }
     process.exit(1);
   }
+
+  // Session over — check for a newer teamclaude and (for a global npm install)
+  // self-update. Throttled to once/day, so this is a no-op on almost every run;
+  // it applies to the NEXT launch, never the session that just ran.
+  await autoUpdate({ config }).catch(() => {});
 
   process.exit(result.status ?? 1);
 }
@@ -766,6 +787,39 @@ async function probeCommand() {
   await notifyRunningServer(config);
 }
 
+// ── update ──────────────────────────────────────────────────
+
+async function updateCommand() {
+  const cur = currentVersion();
+  console.log(`Current version: ${cur || 'unknown'}`);
+
+  const kind = installKind();
+  if (kind === 'git') {
+    console.log('This is a git checkout — update it with `git pull`, not npm.');
+    return;
+  }
+
+  const info = await checkForUpdate({ force: true });
+  if (!info) {
+    console.error('Could not reach the npm registry to check for updates.');
+    process.exitCode = 1;
+    return;
+  }
+  if (!info.updateAvailable) {
+    console.log(`Already up to date (latest is ${info.latest}).`);
+    return;
+  }
+
+  console.log(`Updating ${info.current} → ${info.latest} …`);
+  const ok = runUpdate(info.latest);
+  if (ok) {
+    console.log(`Updated to ${info.latest}. Restart teamclaude to use the new version.`);
+  } else {
+    console.error(`Update failed. Try manually: npm install -g ${PKG_NAME}@latest`);
+    process.exitCode = 1;
+  }
+}
+
 // ── remove ──────────────────────────────────────────────────
 
 /**
@@ -905,6 +959,8 @@ Commands:
   probe [off|secs]    Opt-in background quota refresh for idle accounts
                       (off by default; reads usage endpoint, spends no quota)
   api <path>          Call an API endpoint with account credentials
+  update              Check npm for a newer teamclaude and install it
+  version             Print the installed version
   help                Show this help
 
 Options:
@@ -922,6 +978,10 @@ launched with and without --no-mitm can share one server.
 
 A running server re-syncs accounts from config on POST /teamclaude/reload
 (local only). add/login/enable/disable/priority trigger it automatically.
+
+A global npm install self-updates in the background (checked once/day, applied
+on the next launch). Disable with TEAMCLAUDE_DISABLE_AUTOUPDATE=1 or
+"autoUpdate": false in the config.
 
 Config: ${getConfigPath()}
 `);

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,0 +1,160 @@
+// Opt-out-able self-update, in the spirit of Claude Code's auto-updater.
+//
+// We ONLY ever touch a global npm install (`npm install -g @karpeleslab/teamclaude`):
+//   - a git checkout (a `.git` at the package root) is a dev tree — never touched;
+//   - a local dependency / npx copy is left alone (we only notify).
+// Checks hit the npm registry at most once a day (cached in a small file next to
+// the config), so the overwhelmingly common invocation does zero network I/O.
+// Disable entirely with TEAMCLAUDE_DISABLE_AUTOUPDATE=1 or config.autoUpdate=false.
+//
+// Every side-effecting dependency (fetch, spawn, the clock, the cache path) is
+// injectable so the logic is unit-testable without network or npm.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { getConfigPath } from './config.js';
+
+export const PKG_NAME = '@karpeleslab/teamclaude';
+const REGISTRY = 'https://registry.npmjs.org';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Package root = one directory above this file's src/ directory. */
+function packageRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+/** Installed version, read from the shipped package.json (null if unreadable). */
+export function currentVersion(root = packageRoot()) {
+  try {
+    return JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric compare of x.y.z (prerelease/build suffix ignored). >0 if a is newer. */
+export function compareVersions(a, b) {
+  const nums = (v) => String(v).split('+')[0].split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const pa = nums(a), pb = nums(b);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d) return d;
+  }
+  return 0;
+}
+
+/** `npm root -g` (the global modules dir), or null if npm is unavailable. */
+function npmGlobalRoot() {
+  try {
+    const r = spawnSync('npm', ['root', '-g'], { encoding: 'utf8', timeout: 5000 });
+    if (r.status === 0 && r.stdout) return r.stdout.trim();
+  } catch { /* npm missing */ }
+  return null;
+}
+
+/** How this copy was installed: 'git', 'global', 'local', or 'unknown'. */
+export function installKind({ root = packageRoot(), globalRoot = npmGlobalRoot } = {}) {
+  if (existsSync(join(root, '.git'))) return 'git';
+  const norm = root.split('\\').join('/');
+  if (!norm.includes('/node_modules/')) return 'unknown';
+  const g = typeof globalRoot === 'function' ? globalRoot() : globalRoot;
+  if (g && norm.startsWith(g.split('\\').join('/'))) return 'global';
+  return 'local';
+}
+
+/** Fetch the registry's current "latest" version (null on any failure/timeout). */
+export async function fetchLatestVersion({ fetchImpl = fetch, timeoutMs = 5000 } = {}) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`${REGISTRY}/${PKG_NAME}`, {
+      signal: ctrl.signal,
+      headers: { accept: 'application/vnd.npm.install-v1+json' }, // abbreviated packument (small, has dist-tags)
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json['dist-tags']?.latest || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function defaultCacheFile() {
+  return join(dirname(getConfigPath()), 'update-check.json');
+}
+async function readCache(path) {
+  try { return JSON.parse(await readFile(path, 'utf8')); } catch { return {}; }
+}
+async function writeCache(path, obj) {
+  try { await writeFile(path, JSON.stringify(obj)); } catch { /* best effort */ }
+}
+
+/**
+ * Throttled version check. Returns { current, latest, updateAvailable } or null
+ * if the version is unknown / the registry couldn't be reached and nothing is
+ * cached. Only fetches when the cached check is older than `intervalMs` (or
+ * `force`), so back-to-back invocations do no network I/O.
+ */
+export async function checkForUpdate({
+  current = currentVersion(),
+  cachePath = defaultCacheFile(),
+  fetchImpl = fetch,
+  now = Date.now(),
+  intervalMs = DAY_MS,
+  force = false,
+} = {}) {
+  if (!current) return null;
+  const cache = await readCache(cachePath);
+  let latest = cache.latest || null;
+  const fresh = cache.checkedAt && (now - cache.checkedAt) < intervalMs;
+  if (force || !fresh) {
+    const fetched = await fetchLatestVersion({ fetchImpl });
+    if (fetched) latest = fetched;
+    await writeCache(cachePath, { checkedAt: now, latest });
+  }
+  if (!latest) return null;
+  return { current, latest, updateAvailable: compareVersions(latest, current) > 0 };
+}
+
+/** Install a specific version globally. Returns true on success. */
+export function runUpdate(version = 'latest', { spawnImpl = spawnSync } = {}) {
+  const r = spawnImpl('npm', ['install', '-g', `${PKG_NAME}@${version}`], {
+    stdio: 'inherit',
+    timeout: 180000,
+  });
+  return !!r && !r.error && r.status === 0;
+}
+
+/**
+ * The automatic path used at startup / session-end. Skips dev checkouts and
+ * respects the opt-out; when an update exists it silently installs it for a
+ * global install, or just prints a one-line notice otherwise. Cheap in the
+ * common case: the expensive `npm root -g` probe only runs when an update is
+ * actually available.
+ */
+export async function autoUpdate({ config = {}, force = false, log = console.error } = {}) {
+  const root = packageRoot();
+  if (existsSync(join(root, '.git'))) return { skipped: 'git' }; // dev checkout — never touch
+  if (process.env.TEAMCLAUDE_DISABLE_AUTOUPDATE || config.autoUpdate === false) {
+    return { skipped: 'disabled' };
+  }
+  const info = await checkForUpdate({ force });
+  if (!info) return { skipped: 'check-failed' };
+  if (!info.updateAvailable) return { ...info, upToDate: true };
+
+  if (installKind({ root }) !== 'global') {
+    log(`[TeamClaude] Update available: ${info.current} → ${info.latest}. Run: teamclaude update`);
+    return { ...info, notified: true };
+  }
+  log(`[TeamClaude] Updating ${info.current} → ${info.latest}…`);
+  const ok = runUpdate(info.latest);
+  log(ok
+    ? `[TeamClaude] Updated to ${info.latest}. Restart teamclaude to use the new version.`
+    : `[TeamClaude] Auto-update failed. Run manually: npm install -g ${PKG_NAME}@latest`);
+  return { ...info, updated: ok };
+}

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  compareVersions, installKind, fetchLatestVersion, checkForUpdate, runUpdate, PKG_NAME,
+} from '../src/updater.js';
+
+// ── compareVersions ─────────────────────────────────────────
+
+test('compareVersions orders x.y.z numerically and ignores pre-release', () => {
+  assert.ok(compareVersions('1.2.0', '1.1.9') > 0);
+  assert.ok(compareVersions('1.10.0', '1.9.0') > 0);   // numeric, not lexical
+  assert.ok(compareVersions('2.0.0', '1.9.9') > 0);
+  assert.equal(compareVersions('1.1.1', '1.1.1'), 0);
+  assert.equal(compareVersions('1.1.1', '1.1.1-beta.2'), 0); // suffix ignored
+  assert.ok(compareVersions('1.0.0', '1.0.1') < 0);
+});
+
+// ── installKind ──────────────────────────────────────────────
+
+test('installKind detects a git checkout by a .git dir', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-git-'));
+  mkdirSync(join(dir, '.git'));
+  try {
+    assert.equal(installKind({ root: dir, globalRoot: () => '/usr/lib/node_modules' }), 'git');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('installKind flags a global npm install and distinguishes a local one', () => {
+  const gRoot = '/usr/lib/node_modules';
+  const global = `${gRoot}/@karpeleslab/teamclaude`;
+  const local = '/home/x/project/node_modules/@karpeleslab/teamclaude';
+  assert.equal(installKind({ root: global, globalRoot: () => gRoot }), 'global');
+  assert.equal(installKind({ root: local, globalRoot: () => gRoot }), 'local');
+});
+
+test('installKind is unknown outside node_modules (e.g. running from source path)', () => {
+  assert.equal(installKind({ root: '/opt/teamclaude-src', globalRoot: () => null }), 'unknown');
+});
+
+// ── fetchLatestVersion ───────────────────────────────────────
+
+test('fetchLatestVersion reads dist-tags.latest from the registry', async () => {
+  const fetchImpl = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '1.2.3' } }) });
+  assert.equal(await fetchLatestVersion({ fetchImpl }), '1.2.3');
+});
+
+test('fetchLatestVersion returns null on a non-ok response or a throw', async () => {
+  assert.equal(await fetchLatestVersion({ fetchImpl: async () => ({ ok: false }) }), null);
+  assert.equal(await fetchLatestVersion({ fetchImpl: async () => { throw new Error('offline'); } }), null);
+});
+
+// ── checkForUpdate (throttle + compare) ──────────────────────
+
+function tmpCache() {
+  return join(mkdtempSync(join(tmpdir(), 'tc-upd-')), 'update-check.json');
+}
+
+test('checkForUpdate fetches when uncached and reports an available update', async () => {
+  const cachePath = tmpCache();
+  let calls = 0;
+  const fetchImpl = async () => { calls++; return { ok: true, json: async () => ({ 'dist-tags': { latest: '2.0.0' } }) }; };
+  const info = await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 1_000 });
+  assert.deepEqual(info, { current: '1.0.0', latest: '2.0.0', updateAvailable: true });
+  assert.equal(calls, 1);
+});
+
+test('checkForUpdate does NOT hit the network while the cache is fresh', async () => {
+  const cachePath = tmpCache();
+  let calls = 0;
+  const fetchImpl = async () => { calls++; return { ok: true, json: async () => ({ 'dist-tags': { latest: '2.0.0' } }) }; };
+  // First call populates the cache at t=1000.
+  await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 1_000 });
+  // Second call an hour later: cache still fresh → no fetch, still reports update.
+  const info = await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 1_000 + 3_600_000 });
+  assert.equal(calls, 1, 'no second network call within the interval');
+  assert.equal(info.updateAvailable, true);
+});
+
+test('checkForUpdate refetches once the interval elapses, and force overrides', async () => {
+  const cachePath = tmpCache();
+  let calls = 0;
+  const fetchImpl = async () => { calls++; return { ok: true, json: async () => ({ 'dist-tags': { latest: '1.0.0' } }) }; };
+  await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 0 });
+  await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 25 * 3600_000 }); // > 1 day later
+  assert.equal(calls, 2, 'refetched after the interval');
+  await checkForUpdate({ current: '1.0.0', cachePath, fetchImpl, now: 25 * 3600_000, force: true });
+  assert.equal(calls, 3, 'force bypasses the throttle');
+});
+
+test('checkForUpdate reports no update when already on the latest', async () => {
+  const cachePath = tmpCache();
+  const fetchImpl = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '1.1.1' } }) });
+  const info = await checkForUpdate({ current: '1.1.1', cachePath, fetchImpl, now: 1 });
+  assert.equal(info.updateAvailable, false);
+});
+
+// ── runUpdate ────────────────────────────────────────────────
+
+test('runUpdate invokes the global npm install for the requested version', () => {
+  const calls = [];
+  const spawnImpl = (cmd, argv) => { calls.push([cmd, argv]); return { status: 0 }; };
+  const ok = runUpdate('2.3.4', { spawnImpl });
+  assert.equal(ok, true);
+  assert.deepEqual(calls[0], ['npm', ['install', '-g', `${PKG_NAME}@2.3.4`]]);
+});
+
+test('runUpdate returns false when npm fails', () => {
+  assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ status: 1 }) }), false);
+  assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ error: new Error('ENOENT') }) }), false);
+});


### PR DESCRIPTION
## What

Answers "detect if we're npm-installed and auto-update like Claude does." teamclaude now detects how it was installed and self-updates when it's a **global npm install**.

- **Detection** (`installKind`): `git` (a `.git` at the package root — dev tree), `global` (under `npm root -g`), `local` (a dependency/npx copy), or `unknown`.
- **Throttled check**: hits the npm registry at most **once a day**, cached in `update-check.json` next to the config, so the common invocation does **zero** network I/O.
- **Apply**: when a newer version is published, runs `npm install -g @karpeleslab/teamclaude@latest` and it takes effect on the **next** launch (never the session that just ran).
- **Safety**: a git checkout is never touched (told to `git pull`); a local/npx copy is only *notified*, not modified.

## Triggers

- After a `teamclaude run` session ends (blocking `spawnSync` means we can't check during the session, so we check at the end).
- When a **headless** server starts (async, non-blocking). Skipped under the TUI, where npm's install output would corrupt the display.

## Opt-out

`TEAMCLAUDE_DISABLE_AUTOUPDATE=1` or `"autoUpdate": false` in the config.

## New commands

- `teamclaude update` — force a check and install on demand.
- `teamclaude version` / `--version` / `-V` — print the installed version.

## ⚠️ Defaulted decisions (please confirm)

You were away when I asked, so I defaulted to the Claude-like options — easy to change:

1. **Auto-install silently** (vs. notify-only or prompt). If you'd rather it only *notify* ("run: teamclaude update") and never auto-run npm, that's a one-line change in `autoUpdate()`.
2. **Triggers = run + headless-server**. Could narrow to `run` only, or make it manual-only.

## Files

- `src/updater.js` — all logic; every side effect (fetch/spawn/clock/cache path) is injectable.
- `src/index.js` — command wiring + run/server hooks + help note.
- `test/updater.test.js` — 12 unit tests (version compare, install detection, throttle behavior, npm invocation), no network/npm needed.
- `eslint.config.js` — allow the `AbortController` global.
- `README.md` / `config.example.json` — docs.

## Testing

145 tests pass (12 new), eslint clean. Verified `version`/`--version` print, and `update` correctly refuses to touch this git checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)