### PR TITLE
Bump to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch version bump 1.1.1 → 1.1.2.

Ships the changes merged since 1.1.1:
- Per-request account selection in MITM mode (no more per-tunnel pinning; a rate-limited account is replaced on the next request without a restart) — #60
- Block-refresh of an already-expired token before injection — #60
- npm-global self-update (`teamclaude update` / `version`, auto-update for global installs) — #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)