### PR TITLE
docs: add Star History chart to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,16 @@ npm package. TeamClaude is **never** distributed as a downloadable binary
 archive — be wary of soft-forks that bundle a `.zip` and tell you to extract and
 run it. See [SECURITY.md](SECURITY.md) for details and how to report issues.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=KarpelesLab%2Fteamclaude&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=KarpelesLab/teamclaude&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=KarpelesLab/teamclaude&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=KarpelesLab/teamclaude&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Adds a Star History chart section (light/dark aware) just before the License section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)