### PR TITLE
feat: Fable weekly-quota tracking + model-aware routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 ## Features
 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
-- **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; switches to the next on persistent errors
+- **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, including through the MITM relay)
+- **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; a quota rejection (a spent weekly bucket) switches accounts immediately instead of waiting, and switches to the next on persistent errors
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
@@ -23,7 +24,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
-- **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet weekly bucket
+- **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
 - **MITM proxy mode (default)** — `teamclaude run` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected; pass `--no-mitm` for base-URL routing only
 - **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
@@ -273,7 +274,7 @@ teamclaude probe        # show current setting
 
 You can also set the interval live from the TUI settings screen (`g` → `p`), alongside the rotation threshold (`t`).
 
-It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** bucket as an extra bar in the TUI / `status` (when your plan exposes it).
+It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** and **Fable 7-day** buckets as extra bars in the TUI / `status` (when your plan exposes them).
 
 ### MITM proxy mode (default)
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,12 +1,16 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { sameIdentity } from './identity.js';
+import { isFableModel } from './model.js';
+
+// Re-exported for callers that already import model helpers from here.
+export { isFableModel, parseRequestModel } from './model.js';
 
 // Quota fields that survive a restart: utilization levels and their reset
 // windows, learned passively from upstream responses. Transient/derived state
 // (probing, requalify, rateLimitedUntil) is intentionally excluded.
 const PERSISTED_QUOTA_FIELDS = [
-  'unified5h', 'unified7d', 'unified7dSonnet',
-  'unified5hReset', 'unified7dReset', 'unified7dSonnetReset', 'unifiedStatus',
+  'unified5h', 'unified7d', 'unified7dSonnet', 'unified7dFable',
+  'unified5hReset', 'unified7dReset', 'unified7dSonnetReset', 'unified7dFableReset', 'unifiedStatus',
   'tokensLimit', 'tokensRemaining', 'requestsLimit', 'requestsRemaining', 'resetsAt',
 ];
 
@@ -21,9 +25,11 @@ function emptyQuota() {
     unified5h: null,            // utilization 0-1
     unified7d: null,            // utilization 0-1
     unified7dSonnet: null,      // utilization 0-1 (Sonnet-specific weekly bucket)
+    unified7dFable: null,       // utilization 0-1 (Fable-specific weekly bucket)
     unified5hReset: null,       // ms timestamp
     unified7dReset: null,       // ms timestamp
     unified7dSonnetReset: null, // ms timestamp
+    unified7dFableReset: null,  // ms timestamp
     unifiedStatus: null,        // allowed | allowed_warning | rejected
     resetsAt: null,
   };
@@ -73,12 +79,15 @@ export class AccountManager {
    * Get the best available account, rotating if the current one is near quota.
    * Returns null if all accounts are exhausted.
    */
-  getActiveAccount(exclude = null) {
+  getActiveAccount(exclude = null, model = null) {
     // Clear expired quotas across all accounts and switch proactively if a
     // session reset made a sooner-expiring account the better choice. This runs
     // on every request so the behaviour holds without the TUI render loop.
     this.refreshExpiredQuotas();
     const current = this.accounts[this.currentIndex];
+    // `model` scopes availability: an account whose Fable weekly bucket is spent
+    // is still fully usable for other models, so it is only excluded when THIS
+    // request targets Fable (see _isAvailable).
     // `exclude` is a per-request set of indices already tried this request (e.g.
     // an account that just threw a transport error). It is never a persistent
     // status change — the account stays healthy for the next request.
@@ -86,26 +95,26 @@ export class AccountManager {
     // account is best now that its limit is known.
     if (current && current.requalify) {
       current.requalify = false;
-      const next = this._selectNext(exclude);
+      const next = this._selectNext(exclude, model);
       if (next) return next;
     }
-    if (this._isAvailable(current) && !exclude?.has(current.index)) {
+    if (this._isAvailable(current, model) && !exclude?.has(current.index)) {
       // A strictly higher-priority (lower value) available account preempts a
       // healthy current one. Within the same priority tier we stay put, so the
       // common case (all accounts at the default priority 0) is unchanged and
       // never thrashes — preemption only triggers when priorities differ.
       const betterExists = this.accounts.some(a =>
-        this._isAvailable(a) && !exclude?.has(a.index) && (a.priority || 0) < (current.priority || 0));
-      return betterExists ? this._selectNext(exclude) : current;
+        this._isAvailable(a, model) && !exclude?.has(a.index) && (a.priority || 0) < (current.priority || 0));
+      return betterExists ? this._selectNext(exclude, model) : current;
     }
-    const next = this._selectNext(exclude);
+    const next = this._selectNext(exclude, model);
     if (next) return next;
     // No account is under the switch threshold. Before refusing locally, allow a
     // throttled probe so a stale/poisoned cached quota can't pin us in a
     // permanent "all exhausted" state — the probe's real response refreshes the
     // quota (or upstream's own 429 converts soft exhaustion into a hard
     // rate-limit hold). null here means the caller emits the synthetic 429.
-    return this._selectProbe(exclude);
+    return this._selectProbe(exclude, model);
   }
 
   /**
@@ -115,8 +124,8 @@ export class AccountManager {
    * 401. A token that is merely expiring soon (still valid) is left to the
    * caller's opportunistic background refresh; only a hard-expired one blocks.
    */
-  async getActiveAccountFresh(exclude = null) {
-    const account = this.getActiveAccount(exclude);
+  async getActiveAccountFresh(exclude = null, model = null) {
+    const account = this.getActiveAccount(exclude, model);
     if (account && account.type === 'oauth' && account.refreshToken
         && isTokenExpired(account.expiresAt)) {
       await this.ensureTokenFresh(account.index); // coalesces with any in-flight refresh
@@ -160,7 +169,7 @@ export class AccountManager {
    * The chosen account is the least-utilized probeable one (most likely to have
    * stale headroom), so the refreshed quota corrects the cache fastest.
    */
-  _selectProbe(exclude = null) {
+  _selectProbe(exclude = null, model = null) {
     const now = Date.now();
     if (now < this._nextProbeAt) return null;
 
@@ -170,6 +179,10 @@ export class AccountManager {
     for (const account of this.accounts) {
       if (exclude?.has(account.index)) continue;
       if (!this._isProbeable(account)) continue;
+      // A Fable-exhausted account can't serve a Fable request even as a probe —
+      // it would just 429 again — so skip it for Fable and let the caller emit
+      // the synthetic 429 when no other account is available.
+      if (isFableModel(model) && this._fableExhausted(account)) continue;
       const priority = account.priority || 0;
       const usage = this._maxUtilization(account);
       if (priority < bestPriority ||
@@ -187,7 +200,7 @@ export class AccountManager {
     return best;
   }
 
-  _isAvailable(account) {
+  _isAvailable(account, model = null) {
     if (!account) return false;
 
     // Manually disabled accounts are skipped entirely until re-enabled.
@@ -204,7 +217,19 @@ export class AccountManager {
     if (account.status === 'exhausted' || account.status === 'error') return false;
     if (this._isNearQuota(account)) return false;
 
+    // Model-scoped exhaustion: a spent Fable weekly bucket only bars Fable
+    // requests. Non-Fable requests still route here normally.
+    if (isFableModel(model) && this._fableExhausted(account)) return false;
+
     return true;
+  }
+
+  /** True when this account's Fable weekly bucket is at/over the switch
+   * threshold. The reset is cleared by refreshExpiredQuotas before selection, so
+   * a non-null value here is still live. Model-scoped: only gates Fable requests. */
+  _fableExhausted(account) {
+    const q = account.quota;
+    return q.unified7dFable != null && q.unified7dFable >= this.switchThreshold;
   }
 
   /**
@@ -238,6 +263,11 @@ export class AccountManager {
     if (q.unified7dSonnet != null && q.unified7dSonnetReset && now >= q.unified7dSonnetReset) {
       q.unified7dSonnet = null;
       q.unified7dSonnetReset = null;
+      changed = true;
+    }
+    if (q.unified7dFable != null && q.unified7dFableReset && now >= q.unified7dFableReset) {
+      q.unified7dFable = null;
+      q.unified7dFableReset = null;
       changed = true;
     }
 
@@ -341,7 +371,7 @@ export class AccountManager {
    * With all priorities at the default 0, this reduces to the weekly-reset
    * heuristic. Returns the account or null if none are available.
    */
-  _pickBestAvailable(exclude = null) {
+  _pickBestAvailable(exclude = null, model = null) {
     let best = null;
     let bestPriority = Infinity;
     let bestReset = Infinity;
@@ -352,7 +382,7 @@ export class AccountManager {
       // _isAvailable filters out accounts at/above the switch threshold, so the
       // soonest-expiring pick only ever lands on an account whose 5-hour quota
       // is still below 98%.
-      if (!this._isAvailable(account)) continue;
+      if (!this._isAvailable(account, model)) continue;
 
       const priority = account.priority || 0;
       // Unknown weekly reset sorts first so we fill it in.
@@ -387,8 +417,8 @@ export class AccountManager {
     return best;
   }
 
-  _selectNext(exclude = null) {
-    const best = this._pickBestAvailable(exclude);
+  _selectNext(exclude = null, model = null) {
+    const best = this._pickBestAvailable(exclude, model);
     if (best) {
       const switched = best.index !== this.currentIndex;
       this.currentIndex = best.index;
@@ -446,6 +476,15 @@ export class AccountManager {
     const r7d = headers['anthropic-ratelimit-unified-7d-reset'];
     if (r5h) account.quota.unified5hReset = parseInt(r5h, 10) * 1000;
     if (r7d) account.quota.unified7dReset = parseInt(r7d, 10) * 1000;
+
+    // Model-scoped weekly bucket — surfaced in headers as `7d_oi` ("7-day,
+    // overage included"). On current subscription plans this is the Fable weekly
+    // limit (it correlates with the usage endpoint's Fable-scoped weekly bucket).
+    // Utilization here is already a 0-1 fraction (can exceed 1 when in overage).
+    const u7dOi = parseFloat(headers['anthropic-ratelimit-unified-7d_oi-utilization']);
+    if (!isNaN(u7dOi)) account.quota.unified7dFable = u7dOi;
+    const r7dOi = headers['anthropic-ratelimit-unified-7d_oi-reset'];
+    if (r7dOi) account.quota.unified7dFableReset = parseInt(r7dOi, 10) * 1000;
 
     // We switched to this account to discover its weekly quota; now that we
     // know it, flag for re-evaluation so selection can pick the best account.
@@ -516,7 +555,7 @@ export class AccountManager {
 
   /**
    * Apply quota learned from the OAuth usage endpoint (the background probe).
-   * Updates utilization/reset for the 5h, 7d, and Sonnet-7d buckets WITHOUT
+   * Updates utilization/reset for the 5h, 7d, Sonnet-7d, and Fable-7d buckets WITHOUT
    * touching usage counters — a probe is not real client traffic.
    */
   applyUsageData(accountIndex, usage) {
@@ -535,6 +574,10 @@ export class AccountManager {
     if (usage.sevenDaySonnet) {
       if (usage.sevenDaySonnet.utilization != null) q.unified7dSonnet = usage.sevenDaySonnet.utilization;
       if (usage.sevenDaySonnet.resetAt != null) q.unified7dSonnetReset = usage.sevenDaySonnet.resetAt;
+    }
+    if (usage.sevenDayFable) {
+      if (usage.sevenDayFable.utilization != null) q.unified7dFable = usage.sevenDayFable.utilization;
+      if (usage.sevenDayFable.resetAt != null) q.unified7dFableReset = usage.sevenDayFable.resetAt;
     }
 
     // If we just learned this account's weekly window while probing, re-evaluate

--- a/src/h2/relay.js
+++ b/src/h2/relay.js
@@ -10,8 +10,13 @@
 
 import { readFrames, buildFrame, buildHeaderBlock, stripHeadersPayload, FRAME, FLAG, PREFACE } from './frames.js';
 import { HpackDecoder, HpackEncoder } from './hpack.js';
+import { TopLevelFieldFinder } from '../model.js';
 
 const SETTINGS_HEADER_TABLE_SIZE = 0x1;
+// How much request body to feed the model finder before binding an account. The
+// model sits near the top of the Messages JSON, so this is only ever a small
+// prefix; if it hasn't resolved within the cap we bind model-blind.
+const MODEL_PEEK_CAP = 65536;
 
 // Wire src→dst with backpressure; `onClose` fires once when either side ends.
 function link(src, dst, onData, onClose) {
@@ -51,6 +56,11 @@ export function h2Relay(claude, upstream, opts = {}) {
   const onStreamClose = opts.onStreamClose || (() => {});
   const makeBodyPatcher = opts.makeBodyPatcher || null; // () => { push(buf)->buf } per stream
   const bodyPatchers = makeBodyPatcher ? new Map() : null; // streamId -> patcher
+  // Model-aware binding: when enabled, a request with a body is held after its
+  // HEADERS until the body's top-level `model` is peeked, so rewriteRequest can
+  // pick the account from it. Off by default → HEADERS forward immediately.
+  const peekModel = !!opts.peekModel;
+  const deferred = peekModel ? new Map() : null; // streamId -> { fields, priority, chunks, finder, bodyLen }
   const tap = opts.tap || null; // optional request-logging tap (per streamId)
   const log = opts.log || (() => {});
 
@@ -132,6 +142,25 @@ export function h2Relay(claude, upstream, opts = {}) {
       if (fr.flags & FLAG.END_HEADERS) return finishReqBlock(); // may be a promise (token refresh)
       return;
     }
+    if (fr.type === FRAME.DATA && deferred) {
+      // While a stream is held for model peeking, buffer its body frames instead
+      // of forwarding them (upstream hasn't seen the HEADERS yet). Feed the finder
+      // until the top-level `model` resolves, END_STREAM arrives, or the peek cap
+      // is hit — then bind the account and flush everything in order.
+      const d = deferred.get(fr.streamId);
+      if (d) {
+        const payload = Buffer.from(fr.payload);
+        d.chunks.push({ flags: fr.flags, payload });
+        const model = d.bodyLen < MODEL_PEEK_CAP ? d.finder.push(payload) : d.finder.value;
+        d.bodyLen += payload.length;
+        const end = !!(fr.flags & FLAG.END_STREAM);
+        if (d.finder.done || end || d.bodyLen >= MODEL_PEEK_CAP) {
+          deferred.delete(fr.streamId);
+          return forwardReq(fr.streamId, d.fields, d.priority, false, d.chunks, model);
+        }
+        return; // keep buffering
+      }
+    }
     if (fr.type === FRAME.DATA && (bodyPatchers || tap)) {
       // Same-length in-place body patch (account_uuid) via a per-stream streaming
       // JSON state machine; re-emit the DATA frame unchanged in length/flags so
@@ -147,7 +176,12 @@ export function h2Relay(claude, upstream, opts = {}) {
       if (fr.flags & FLAG.END_STREAM && bodyPatchers) bodyPatchers.delete(fr.streamId);
       return;
     }
-    if (fr.type === FRAME.RST_STREAM) { closeStream(fr.streamId); }
+    if (fr.type === FRAME.RST_STREAM) {
+      // A held (not-yet-forwarded) stream: drop it without relaying the RST —
+      // upstream never saw its HEADERS, so a RST would reference an unknown stream.
+      if (deferred?.delete(fr.streamId)) { closeStream(fr.streamId); return; }
+      closeStream(fr.streamId);
+    }
     if (fr.type === FRAME.SETTINGS && fr.streamId === 0 && !(fr.flags & 0x1)) {
       applyTableSizeSetting(fr.payload, respDec); // claude's setting governs response encoding
     }
@@ -158,18 +192,39 @@ export function h2Relay(claude, upstream, opts = {}) {
     const { streamId, frags, priority, endStream } = asm;
     asm = null;
     const fields = reqDec.decode(Buffer.concat(frags)); // keep decoder dynamic table in sync
-    // Encode/forward once we have the (possibly async-rewritten) header list. The
-    // pump awaits this before the next frame, so decode & encode stay in wire
-    // order and the HPACK tables never desync even when a refresh suspends us.
-    const proceed = (rewritten) => {
-      if (tap) tap.req(streamId, rewritten);
-      openStreams.add(streamId);
-      const newBlock = reqEnc.encode(rewritten);
-      writeBackpressured(upstream, buildHeaderBlock(streamId, newBlock, { endStream, priority }), reqCtl);
-    };
-    const rewritten = rewriteRequest(fields, streamId);
-    if (rewritten && typeof rewritten.then === 'function') return rewritten.then(proceed);
-    proceed(rewritten);
+    // Model-aware binding: hold a request that has a body until its `model` is
+    // peeked (see the DATA handler). A bodyless request has no model to read, so
+    // it forwards straight away. The decode above already ran, so the HPACK
+    // decoder table stays in sync even while we defer the encode/forward.
+    if (deferred && !endStream) {
+      deferred.set(streamId, { fields, priority, chunks: [], finder: new TopLevelFieldFinder('model'), bodyLen: 0 });
+      return;
+    }
+    return forwardReq(streamId, fields, priority, endStream, null, null);
+  }
+
+  // Encode + forward a request's HEADERS (choosing the account via rewriteRequest,
+  // now that `model` is known), then flush any buffered body frames through the
+  // account-bound patcher. The pump awaits this so decode & encode stay in wire
+  // order and the HPACK tables never desync even when a token refresh suspends us.
+  async function forwardReq(streamId, fields, priority, endStream, dataChunks, model) {
+    let rewritten = rewriteRequest(fields, streamId, model);
+    if (rewritten && typeof rewritten.then === 'function') rewritten = await rewritten;
+    if (tap) tap.req(streamId, rewritten);
+    openStreams.add(streamId);
+    const newBlock = reqEnc.encode(rewritten);
+    writeBackpressured(upstream, buildHeaderBlock(streamId, newBlock, { endStream, priority }), reqCtl);
+    if (!dataChunks || !dataChunks.length) return;
+    // Bind the body patcher to the chosen account, then replay the buffered body
+    // frames (and, via bodyPatchers, any later DATA frames for this stream).
+    let patcher = NO_PATCH;
+    if (bodyPatchers) { patcher = makeBodyPatcher(streamId) || NO_PATCH; bodyPatchers.set(streamId, patcher); }
+    for (const ch of dataChunks) {
+      const payload = bodyPatchers ? patcher.push(ch.payload) : ch.payload;
+      if (tap) tap.reqData(streamId, payload);
+      writeBackpressured(upstream, buildFrame({ type: FRAME.DATA, flags: ch.flags, streamId, payload }), reqCtl);
+      if ((ch.flags & FLAG.END_STREAM) && bodyPatchers) bodyPatchers.delete(streamId);
+    }
   }
 
   reqCtl = link(claude, upstream, onReqData, destroyBoth);
@@ -311,6 +366,10 @@ export function h1Relay(claude, upstream, opts = {}) {
   const onResponseHeaders = opts.onResponseHeaders || (() => {});
   const onRequestClose = opts.onStreamClose || (() => {});
   const tap = opts.tap || null;
+  // Model-aware binding: hold a content-length request body to peek its top-level
+  // `model` before rewriteHead picks the account. Off by default; chunked and
+  // bodyless requests always bind immediately.
+  const peekModel = !!opts.peekModel;
   const destroyBoth = () => { claude.destroy(); upstream.destroy(); };
   claude.on('error', destroyBoth);
   upstream.on('error', destroyBoth);
@@ -325,6 +384,7 @@ export function h1Relay(claude, upstream, opts = {}) {
   let reqBuf = Buffer.alloc(0);
   let reqPhase = 'head';
   let reqTrack = null, reqPatcher = null, reqId = null;
+  let pend = null; // while peeking a body for `model`: { head, info, track, finder, raw[], len }
 
   // Async ONLY so a request head whose account token expired can await a refresh
   // before it is forwarded (rewriteHead returns a promise in that rare case).
@@ -343,17 +403,51 @@ export function h1Relay(claude, upstream, opts = {}) {
           // Assign the id BEFORE rewriting so the caller can bind this request's
           // account (used again to attribute the response and patch the body).
           reqId = ++nextId;
-          const rew = rewriteHead(reqBuf.subarray(0, idx + 4).toString('latin1'), reqId);
-          const head = (rew && typeof rew.then === 'function') ? await rew : rew;
+          const rawHead = reqBuf.subarray(0, idx + 4).toString('latin1');
           reqBuf = reqBuf.subarray(idx + 4);
-          const info = parseH1Head(head);
+          const info = parseH1Head(rawHead); // framing is unchanged by the auth rewrite
+          const kind = info.chunked ? 'chunked' : (info.contentLength > 0 ? 'length' : 'none');
+          // Defer a content-length body to peek `model` first; bind other requests now.
+          if (peekModel && kind === 'length') {
+            pend = { head: rawHead, info, track: makeBodyTracker('length', info.contentLength), finder: new TopLevelFieldFinder('model'), raw: [], len: 0 };
+            reqPhase = 'peek';
+            continue;
+          }
+          const rew = rewriteHead(rawHead, reqId, null);
+          const head = (rew && typeof rew.then === 'function') ? await rew : rew;
           pending.push({ id: reqId, method: methodOf(info.startLine) });
           if (tap) tap.reqHead(reqId, head);
           upstream.write(Buffer.from(head, 'latin1'));
-          const kind = info.chunked ? 'chunked' : (info.contentLength > 0 ? 'length' : 'none');
           reqPatcher = makeBodyPatcher ? makeBodyPatcher(reqId) : null;
           reqTrack = makeBodyTracker(kind, info.contentLength || 0);
           reqPhase = 'body';
+        } else if (reqPhase === 'peek') {
+          // Accumulate the body (raw, for faithful replay) and feed the finder
+          // until the top-level `model` resolves, the body ends, or the cap is hit.
+          const { consumed, done } = pend.track(reqBuf);
+          if (consumed > 0) {
+            const slice = Buffer.from(reqBuf.subarray(0, consumed));
+            reqBuf = reqBuf.subarray(consumed);
+            pend.raw.push(slice);
+            if (pend.len < MODEL_PEEK_CAP) pend.finder.push(slice);
+            pend.len += slice.length;
+          }
+          if (done || pend.finder.done || pend.len >= MODEL_PEEK_CAP) {
+            const model = pend.finder.value;
+            const rew = rewriteHead(pend.head, reqId, model);
+            const head = (rew && typeof rew.then === 'function') ? await rew : rew;
+            pending.push({ id: reqId, method: methodOf(pend.info.startLine) });
+            if (tap) tap.reqHead(reqId, head);
+            upstream.write(Buffer.from(head, 'latin1'));
+            reqPatcher = makeBodyPatcher ? makeBodyPatcher(reqId) : null;
+            let body = Buffer.concat(pend.raw);
+            if (reqPatcher) body = reqPatcher.push(body);
+            if (body.length) { if (tap) tap.reqData(reqId, body); upstream.write(body); }
+            const remaining = pend.info.contentLength - pend.len;
+            if (done) { reqPhase = 'head'; reqTrack = null; reqPatcher = null; }
+            else { reqTrack = makeBodyTracker('length', remaining); reqPhase = 'body'; }
+            pend = null;
+          } else if (consumed === 0) break; // need more body bytes
         } else {
           const { consumed, done } = reqTrack(reqBuf);
           if (consumed > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -544,11 +544,12 @@ async function statusCommand() {
       console.log(`  ${acct.name} (${acct.type})${current}`);
       console.log(`    Status:   ${acct.status}${acct.disabled ? ' (disabled)' : ''}`);
 
-      if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null) {
+      if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null || q.unified7dFable != null) {
         const ses = q.unified5h != null ? (q.unified5h * 100).toFixed(1) + '%' : '-';
         const wk = q.unified7d != null ? (q.unified7d * 100).toFixed(1) + '%' : '-';
         let line = `    Session:  ${ses} used    Weekly: ${wk} used`;
         if (q.unified7dSonnet != null) line += `    Sonnet7d: ${(q.unified7dSonnet * 100).toFixed(1)}% used`;
+        if (q.unified7dFable != null) line += `    Fable7d: ${(q.unified7dFable * 100).toFixed(1)}% used`;
         console.log(line);
       } else {
         const tok = q.tokensLimit ? ((1 - q.tokensRemaining / q.tokensLimit) * 100).toFixed(1) + '%' : '-';

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -209,14 +209,15 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   // agree on one account even while different requests on this tunnel use
   // different accounts.
   const reqAccounts = new Map(); // id -> account
-  const pickFor = async (id) => {
+  const pickFor = async (id, model = null) => {
     // getActiveAccountFresh blocks to refresh only if the chosen account's token
     // has ALREADY expired (e.g. we just rotated onto an account that sat idle
-    // past its token lifetime) — so we never inject a dead token. Never leave a
-    // mid-tunnel request unauthenticated: if every account is over quota right
-    // now, fall back to the tunnel's initial account (its response 429 will then
-    // throttle it and the next request rolls on).
-    const account = (await accountManager.getActiveAccountFresh()) || initial;
+    // past its token lifetime) — so we never inject a dead token. `model` scopes
+    // the pick: a Fable-exhausted account is skipped for Fable but still serves
+    // other models. Never leave a mid-tunnel request unauthenticated: if every
+    // account is over quota right now, fall back to the tunnel's initial account
+    // (its response 429 will then throttle it and the next request rolls on).
+    const account = (await accountManager.getActiveAccountFresh(null, model)) || initial;
     reqAccounts.set(id, account);
     // Opportunistic (non-blocking) refresh for the expiring-soon case: the
     // current credential is still valid, so this request goes out immediately and
@@ -243,8 +244,10 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
   if (alpn === 'h2') {
     h2Relay(claudeTls, upstreamSock, {
       // Async: pickFor may block to refresh an expired token before we inject it.
-      // The relay awaits the returned promise before forwarding the request.
-      rewriteRequest: async (fields, id) => makeRewriteRequest(await pickFor(id))(fields),
+      // The relay peeks the body's `model`, passes it here, and awaits the pick
+      // before forwarding — so a Fable-exhausted account is skipped for Fable.
+      rewriteRequest: async (fields, id, model) => makeRewriteRequest(await pickFor(id, model))(fields),
+      peekModel: true,
       makeBodyPatcher,
       onResponseHeaders: observer,
       onStreamClose: forget,
@@ -253,13 +256,14 @@ async function intercept({ host, port, mode, clientSocket, head, accountManager,
     });
   } else {
     h1Relay(claudeTls, upstreamSock, {
-      rewriteHead: async (h, id) => {
-        const account = await pickFor(id);
+      rewriteHead: async (h, id, model) => {
+        const account = await pickFor(id, model);
         const auth = account.type === 'oauth'
           ? { authorization: `Bearer ${account.credential}` }
           : { apiKey: account.credential };
         return rewriteH1Auth(h, auth);
       },
+      peekModel: true,
       makeBodyPatcher,
       onResponseHeaders: observer,
       onStreamClose: forget,
@@ -410,13 +414,24 @@ function makeQuotaObserver(accountManager, accountFor, sx = null) {
     if (m[':status'] === '429') {
       let ra = parseInt(m['retry-after'], 10);
       if (Number.isNaN(ra)) ra = 60;
-      ra = Math.min(Math.max(ra, 1), 300);
-      accountManager.markRateLimited(account.index, ra);
-      // The very next request on this same tunnel will now pick a different
-      // account (this one is throttled) — no teardown needed.
-      // Arm sx.org sticky routing so the next MITM tunnel uses the proxy (in
-      // '429' mode); no-op in 'off'/'always'.
-      sx?.noteRateLimited(ra);
+      // A Fable-only rejection (the `7d_oi` weekly bucket is spent while 5h/7d are
+      // fine) must NOT throttle the whole account — it still serves other models.
+      // updateQuota above recorded the spent Fable bucket, so model-aware selection
+      // skips it for Fable requests only. A general rejection spends a shared
+      // bucket, so hold the account for its real reset window (clamped) instead of
+      // the short transient clamp, otherwise it gets re-picked and 429s again.
+      const generalRejected = m['anthropic-ratelimit-unified-5h-status'] === 'rejected'
+        || m['anthropic-ratelimit-unified-7d-status'] === 'rejected';
+      const fableOnly = m['anthropic-ratelimit-unified-7d_oi-status'] === 'rejected' && !generalRejected;
+      if (!fableOnly) {
+        ra = generalRejected ? Math.min(Math.max(ra, 1), 3600) : Math.min(Math.max(ra, 1), 300);
+        accountManager.markRateLimited(account.index, ra);
+        // The very next request on this same tunnel will now pick a different
+        // account (this one is throttled) — no teardown needed. Arm sx.org sticky
+        // routing so the next MITM tunnel uses the proxy (in '429' mode); no-op in
+        // 'off'/'always'. A Fable-only rejection is quota, not IP-based, so skip it.
+        sx?.noteRateLimited(ra);
+      }
     }
   };
 }

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,92 @@
+// Model-id helpers shared by the request path (server + MITM relay) and account
+// selection. Kept dependency-free so the low-level h2/h1 relay can peek a
+// request's model without pulling in the account-manager graph.
+
+// A request targets the Fable model family when its `model` id names Fable
+// (e.g. "claude-fable-5"). Account selection uses this to gate the Fable-only
+// weekly bucket: a Fable-exhausted account still serves every other model.
+export function isFableModel(model) {
+  return typeof model === 'string' && /fable/i.test(model);
+}
+
+// Streaming, byte-exact locator for a TOP-LEVEL string field of a JSON object,
+// fed incrementally. It tracks JSON structure (container stack, key/value,
+// string/escape) so it ONLY matches the field at depth 1 of the root object —
+// a `"model": "..."` sitting inside conversation text (a message, a tool result)
+// is nested deeper and is never mistaken for the real field. No regex, no
+// whole-body buffering, so the relay can peek just the first frames.
+export class TopLevelFieldFinder {
+  constructor(field) {
+    this.field = field;               // target key at the root, e.g. 'model'
+    this.isObj = [];                  // container stack: true=object, false=array
+    this.awaitingKey = false;         // at an object, the next string is a key
+    this.inStr = false;
+    this.esc = false;
+    this.readingKey = false;
+    this.readingValue = false;        // accumulating the target field's value
+    this.curKey = null;               // last key seen in the current object
+    this.buf = [];                    // key/value byte accumulation
+    this.value = null;                // the found value, or null
+    this.done = false;                // found it, or the root object closed without it
+  }
+
+  /** Feed a chunk (Buffer). Returns the found value so far (string) or null. */
+  push(chunk) {
+    if (this.done) return this.value;
+    for (let i = 0; i < chunk.length && !this.done; i++) this.#byte(chunk[i]);
+    return this.value;
+  }
+
+  #atRoot() { return this.isObj.length === 1 && this.isObj[0] === true; }
+
+  #byte(b) {
+    if (this.inStr) {
+      if (this.esc) { this.esc = false; if (this.readingKey || this.readingValue) this.buf.push(b); return; }
+      if (b === 0x5c) { this.esc = true; if (this.readingKey || this.readingValue) this.buf.push(b); return; } // backslash
+      if (b === 0x22) {                                            // closing quote
+        this.inStr = false;
+        if (this.readingKey) {
+          this.curKey = Buffer.from(this.buf).toString('utf8'); this.buf = []; this.readingKey = false;
+        } else if (this.readingValue) {
+          this.value = Buffer.from(this.buf).toString('utf8'); this.buf = [];
+          this.readingValue = false; this.done = true;             // the one top-level field we want
+        }
+        return;
+      }
+      if (this.readingKey || this.readingValue) this.buf.push(b);
+      return;
+    }
+
+    switch (b) {
+      case 0x7b: this.isObj.push(true); this.awaitingKey = true; this.curKey = null; break;   // {
+      case 0x5b: this.isObj.push(false); this.awaitingKey = false; break;                     // [
+      case 0x7d: case 0x5d:                                                                    // } ]
+        this.isObj.pop(); this.curKey = null;
+        if (this.isObj.length === 0) this.done = true;             // root closed → field absent
+        break;
+      case 0x3a: this.awaitingKey = false; break;                  // :
+      case 0x2c: this.awaitingKey = this.isObj[this.isObj.length - 1] === true; break;        // ,
+      case 0x22:                                                   // string begins
+        if (this.awaitingKey && this.isObj[this.isObj.length - 1]) {
+          this.readingKey = true; this.buf = [];
+        } else if (this.#atRoot() && this.curKey === this.field) {
+          this.readingValue = true; this.buf = [];
+        }
+        this.inStr = true; this.esc = false;
+        break;
+      default: break;                                              // scalars / whitespace
+    }
+  }
+}
+
+// Extract the requested model id from a JSON request body (Buffer or string).
+// Uses the streaming top-level finder so it is exact (never matches a `model`
+// key nested in conversation content) and cheap on large bodies (it stops as
+// soon as the top-level field resolves). Returns null if absent.
+export function parseRequestModel(body) {
+  if (!body) return null;
+  try {
+    const buf = Buffer.isBuffer(body) ? body : Buffer.from(String(body), 'utf8');
+    return new TopLevelFieldFinder('model').push(buf);
+  } catch { return null; }
+}

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -159,6 +159,20 @@ export async function fetchProfile(accessToken) {
   }
 }
 
+// Pull a per-model weekly limit out of the payload's `limits[]` array, which is
+// where the endpoint now reports model-scoped quota (a `weekly_scoped` entry
+// carrying `scope.model.display_name`). Returns a bucket-shaped object
+// { utilization, resets_at } ready for normalizeUsageBucket, or null if absent.
+// The legacy top-level `seven_day_<model>` keys read null on current plans.
+export function findScopedWeeklyLimit(data, modelNamePattern) {
+  const limits = Array.isArray(data?.limits) ? data.limits : [];
+  const entry = limits.find((l) =>
+    l && l.group === 'weekly' && l.scope?.model?.display_name
+    && modelNamePattern.test(l.scope.model.display_name));
+  if (!entry) return null;
+  return { utilization: entry.percent, resets_at: entry.resets_at };
+}
+
 // Normalize one usage bucket from the /api/oauth/usage payload into
 // { utilization: 0-1, resetAt: ms-epoch }. The endpoint reports utilization
 // as a percentage in the 0-100 range, so 1 means 1%, not 100%.
@@ -191,7 +205,7 @@ export function normalizeUsageBucket(bucket) {
 /**
  * Fetch OAuth subscription usage from the usage endpoint. This reports quota
  * utilization WITHOUT spending message quota, which is what makes it safe to
- * poll. Returns normalized { fiveHour, sevenDay, sevenDaySonnet } buckets, or
+ * poll. Returns normalized { fiveHour, sevenDay, sevenDaySonnet, sevenDayFable } buckets, or
  * { error, status } on failure.
  */
 export async function fetchUsage(accessToken) {
@@ -220,6 +234,7 @@ export async function fetchUsage(accessToken) {
       fiveHour: normalizeUsageBucket(data?.five_hour),
       sevenDay: normalizeUsageBucket(data?.seven_day),
       sevenDaySonnet: normalizeUsageBucket(data?.seven_day_sonnet),
+      sevenDayFable: normalizeUsageBucket(findScopedWeeklyLimit(data, /fable/i)),
     };
   } catch (err) {
     return { error: err.message || String(err), status: null };

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
+import { parseRequestModel } from './account-manager.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 
@@ -84,7 +85,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       }
       const body = Buffer.concat(bodyChunks);
 
-      const ctx = { account: null, status: null, tried: new Set() };
+      const ctx = { account: null, status: null, tried: new Set(), model: parseRequestModel(body) };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -208,7 +209,9 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
   const route = useSx === undefined ? !!(sx?.useByDefault()) : useSx;
 
   // Select account, skipping any already tried (and failed) this request.
-  const account = accountManager.getActiveAccount(ctx.tried);
+  // The model scopes availability so a Fable-exhausted account is skipped only
+  // for Fable requests (it still serves other models).
+  const account = accountManager.getActiveAccount(ctx.tried, ctx.model);
   if (!account) {
     ctx.status = 429;
     ctx.account = '(none available)';
@@ -308,9 +311,35 @@ async function forwardRequest(req, res, body, accountManager, upstream, retryCou
       // markRateLimited would set rateLimitedUntil in the past.
       let retryAfter = parseInt(upstreamRes.headers.get('retry-after'), 10);
       if (Number.isNaN(retryAfter)) retryAfter = 60;
-      retryAfter = Math.min(Math.max(retryAfter, 1), 300);
       // Discard the 429 response body
       await upstreamRes.body?.cancel();
+
+      // Durable quota exhaustion vs. a transient rate limit. A "rejected" unified
+      // status means a quota bucket is spent, so waiting and retrying the SAME
+      // account is futile — switch to another account now (updateQuota above
+      // already recorded the spent bucket's utilization from the headers).
+      const rl = rateLimitHeaders;
+      const generalRejected = rl['anthropic-ratelimit-unified-5h-status'] === 'rejected'
+        || rl['anthropic-ratelimit-unified-7d-status'] === 'rejected';
+      const fableRejected = rl['anthropic-ratelimit-unified-7d_oi-status'] === 'rejected' && !generalRejected;
+      if ((generalRejected || fableRejected) && retryCount < maxRetries) {
+        // A Fable-only rejection leaves the account fine for other models, so we
+        // do NOT throttle it globally — the recorded Fable utilization makes
+        // selection skip it for Fable requests only. A general rejection spends a
+        // shared bucket, so hold the whole account for its reset window.
+        if (fableRejected) {
+          console.log(`[TeamClaude] Fable weekly exhausted on "${account.name}" — switching account for this Fable request`);
+        } else {
+          const hold = Math.min(Math.max(retryAfter, 1), 3600);
+          console.log(`[TeamClaude] Quota rejection (429) on "${account.name}" — throttling ${hold}s and switching account`);
+          accountManager.markRateLimited(account.index, hold);
+        }
+        ctx.tried.add(account.index);
+        if (res.destroyed) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+      }
+
+      retryAfter = Math.min(Math.max(retryAfter, 1), 300);
 
       // sx.org failover: 429s are IP-based, so retry via the proxy's egress IP.
       // 'always' is already on sx; '429' switches direct→sx now and skips the

--- a/src/tui.js
+++ b/src/tui.js
@@ -735,7 +735,7 @@ export class TUI {
     const q = a.quota;
     let r1 = null, r2 = null, l1 = 'Ses', l2 = 'Wk ', t1 = null, t2 = null;
 
-    if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null) {
+    if (q.unified5h != null || q.unified7d != null || q.unified7dSonnet != null || q.unified7dFable != null) {
       r1 = q.unified5h;
       r2 = q.unified7d;
       t1 = q.unified5hReset;
@@ -757,6 +757,10 @@ export class TUI {
       // Sonnet weekly bar — only shown when the usage probe has populated it.
       if (q.unified7dSonnet != null) {
         line += `  S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset)}`;
+      }
+      // Fable weekly bar — only shown when the usage probe has populated it.
+      if (q.unified7dFable != null) {
+        line += `  F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset)}`;
       }
     }
     return line;

--- a/test/h1-relay.test.js
+++ b/test/h1-relay.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { h1Relay } from '../src/h2/relay.js';
+
+function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
+
+test('h1 relay peeks the top-level model before binding, relays body intact', { timeout: 30000 }, async () => {
+  // Upstream: read the full content-length request, echo the body + the auth it saw.
+  const upstream = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on('data', (c) => {
+      buf = Buffer.concat([buf, c]);
+      const i = buf.indexOf('\r\n\r\n');
+      if (i < 0) return;
+      const head = buf.subarray(0, i).toString('latin1');
+      const need = parseInt(/content-length:\s*(\d+)/i.exec(head)?.[1] || '0', 10);
+      if (buf.length < i + 4 + need) return;
+      const body = buf.subarray(i + 4, i + 4 + need).toString('utf8');
+      const auth = /authorization:\s*(.+)\r\n/i.exec(head)?.[1] || 'none';
+      sock.write(`HTTP/1.1 200 OK\r\nx-saw-auth: ${auth}\r\ncontent-length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+    });
+  });
+  const upPort = await listen(upstream);
+
+  let sawModel = 'UNSET';
+  const conns = [];
+  const front = net.createServer((clientSock) => {
+    conns.push(clientSock);
+    const upSock = net.connect(upPort, '127.0.0.1', () => {
+      h1Relay(clientSock, upSock, {
+        peekModel: true,
+        rewriteHead: (head, _id, model) => {
+          sawModel = model;
+          const acct = model === 'claude-fable-5' ? 'Bearer FABLE' : 'Bearer OTHER';
+          return head.replace(/authorization:.*\r\n/i, `authorization: ${acct}\r\n`);
+        },
+        makeBodyPatcher: () => null,
+        onResponseHeaders: () => {},
+      });
+    });
+    conns.push(upSock);
+  });
+  const frontPort = await listen(front);
+
+  // Decoy "model" inside message content; the real field is top-level.
+  const reqBody = JSON.stringify({ messages: [{ role: 'user', content: '{"model":"DECOY"}' }], model: 'claude-fable-5' });
+  const raw = `POST /v1/messages HTTP/1.1\r\nhost: api\r\nauthorization: Bearer FAKE\r\ncontent-type: application/json\r\ncontent-length: ${Buffer.byteLength(reqBody)}\r\n\r\n${reqBody}`;
+
+  const client = net.connect(frontPort, '127.0.0.1');
+  let resp = '';
+  client.setEncoding('utf8');
+  await new Promise((resolve) => {
+    client.on('data', (d) => { resp += d; if (resp.endsWith(reqBody)) resolve(); });
+    client.on('connect', () => client.write(raw));
+    setTimeout(resolve, 3000); // safety net so a regression fails fast, not hangs
+  });
+
+  assert.equal(sawModel, 'claude-fable-5');           // top-level, not the decoy
+  assert.match(resp, /x-saw-auth: Bearer FABLE/);     // routed on the peeked model
+  assert.ok(resp.endsWith(reqBody));                  // body relayed intact
+
+  try { client.destroy(); } catch { /* */ }
+  for (const c of conns) { try { c.destroy(); } catch { /* */ } }
+  front.close(); upstream.close();
+});

--- a/test/h2-relay.test.js
+++ b/test/h2-relay.test.js
@@ -91,6 +91,70 @@ test('h2 relay rewrites only authorization, drops x-api-key, observes response',
   }
 });
 
+test('h2 relay peeks the top-level model before binding (model-aware)', T, async () => {
+  // Upstream echoes the body it received and the account header the relay injected.
+  const upstream = http2.createServer();
+  const sessions = [];
+  upstream.on('session', (s) => sessions.push(s));
+  upstream.on('stream', (s, h) => {
+    let got = '';
+    s.setEncoding('utf8');
+    s.on('data', (d) => { got += d; });
+    s.on('end', () => {
+      s.respond({ ':status': 200, 'x-saw-account': h.authorization || 'none' });
+      s.end(got); // echo body back so we can assert it relayed intact
+    });
+  });
+  const upPort = await listen(upstream);
+
+  const conns = [];
+  let sawModel = 'UNSET';
+  const front = net.createServer((clientSock) => {
+    conns.push(clientSock);
+    const upSock = net.connect(upPort, '127.0.0.1', () => {
+      h2Relay(clientSock, upSock, {
+        peekModel: true,
+        // The relay passes the peeked model as the 3rd arg; route on it.
+        rewriteRequest: (fields, _id, model) => {
+          sawModel = model;
+          const account = model === 'claude-fable-5' ? 'Bearer FABLE-ACCT' : 'Bearer OTHER-ACCT';
+          return fields.map(f => f.name.toString().toLowerCase() === 'authorization'
+            ? { name: Buffer.from('authorization'), value: Buffer.from(account), sensitive: true }
+            : f);
+        },
+        makeBodyPatcher: () => null, // no account_uuid patch in this test
+        onResponseHeaders: () => {},
+      });
+    });
+    conns.push(upSock);
+  });
+  const frontPort = await listen(front);
+
+  // Body carries a decoy "model" inside message content; the real one is top-level.
+  const reqBody = JSON.stringify({
+    messages: [{ role: 'user', content: 'pasted: {"model":"DECOY"}' }],
+    model: 'claude-fable-5',
+    max_tokens: 1,
+  });
+
+  const client = http2.connect(`http://127.0.0.1:${frontPort}`);
+  try {
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages', authorization: 'Bearer FAKE' });
+    let respHeaders, body = '';
+    req.on('response', (h) => { respHeaders = h; });
+    req.setEncoding('utf8');
+    req.on('data', (d) => { body += d; });
+    req.end(reqBody);
+    await once(req, 'close');
+
+    assert.equal(sawModel, 'claude-fable-5');                 // top-level, not the decoy
+    assert.equal(respHeaders['x-saw-account'], 'Bearer FABLE-ACCT'); // routed on the peeked model
+    assert.equal(body, reqBody);                              // body relayed byte-for-byte
+  } finally {
+    teardown({ client, conns, sessions, servers: [front, upstream] });
+  }
+});
+
 test('h2 relay streams a larger body intact (backpressure path)', T, async () => {
   const upstream = http2.createServer();
   const sessions = [];

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isFableModel, parseRequestModel, TopLevelFieldFinder } from '../src/model.js';
+
+test('isFableModel matches the Fable family only', () => {
+  assert.equal(isFableModel('claude-fable-5'), true);
+  assert.equal(isFableModel('claude-opus-4-8'), false);
+  assert.equal(isFableModel('claude-sonnet-5'), false);
+  assert.equal(isFableModel(null), false);
+  assert.equal(isFableModel(undefined), false);
+});
+
+test('parseRequestModel reads the top-level model', () => {
+  assert.equal(parseRequestModel('{"model":"claude-fable-5","max_tokens":1}'), 'claude-fable-5');
+  assert.equal(parseRequestModel(Buffer.from('{ "model" : "claude-opus-4-8" }')), 'claude-opus-4-8');
+  assert.equal(parseRequestModel('{"max_tokens":1}'), null);
+  assert.equal(parseRequestModel(''), null);
+  assert.equal(parseRequestModel(null), null);
+});
+
+test('parseRequestModel ignores a "model" key nested in conversation content', () => {
+  // A user message literally contains `"model":"DECOY"`; the real field comes
+  // after it at the top level. A regex would grab DECOY — the structural finder
+  // must return the top-level value.
+  const body = JSON.stringify({
+    messages: [{ role: 'user', content: 'here is json: {"model":"DECOY-should-be-ignored"}' }],
+    system: [{ type: 'text', text: '"model": "ALSO-DECOY"' }],
+    model: 'claude-fable-5',
+  });
+  assert.equal(parseRequestModel(body), 'claude-fable-5');
+});
+
+test('parseRequestModel ignores a nested model even when it appears first', () => {
+  const body = '{"metadata":{"model":"nested-decoy"},"model":"claude-opus-4-8"}';
+  assert.equal(parseRequestModel(body), 'claude-opus-4-8');
+});
+
+test('TopLevelFieldFinder resolves across chunk boundaries', () => {
+  // Split the body mid-key and mid-value to exercise the streaming state.
+  const full = '{"max_tokens":1,"model":"claude-fable-5","stream":true}';
+  const finder = new TopLevelFieldFinder('model');
+  let out = null;
+  for (let i = 0; i < full.length; i += 3) {
+    out = finder.push(Buffer.from(full.slice(i, i + 3), 'utf8'));
+    if (finder.done) break;
+  }
+  assert.equal(out, 'claude-fable-5');
+  assert.equal(finder.done, true);
+});
+
+test('TopLevelFieldFinder marks done (absent) once the root object closes', () => {
+  const finder = new TopLevelFieldFinder('model');
+  assert.equal(finder.push(Buffer.from('{"max_tokens":1}')), null);
+  assert.equal(finder.done, true); // root closed without the field → stop early
+});

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeUsageBucket } from '../src/oauth.js';
-import { AccountManager } from '../src/account-manager.js';
+import { normalizeUsageBucket, findScopedWeeklyLimit } from '../src/oauth.js';
+import { AccountManager, isFableModel, parseRequestModel } from '../src/account-manager.js';
 import { Prober } from '../src/prober.js';
 
 function oauth(name, extra = {}) {
@@ -30,32 +30,124 @@ test('normalizeUsageBucket normalizes resets to ms epoch', () => {
   assert.equal(normalizeUsageBucket({ resets_at: '2026-01-01T00:00:00Z' }).resetAt, Date.parse('2026-01-01T00:00:00Z'));
 });
 
+// ── findScopedWeeklyLimit ─────────────────────────────────────
+
+test('findScopedWeeklyLimit pulls a per-model weekly bucket from limits[]', () => {
+  // Shape mirrors the real /api/oauth/usage payload: model-scoped weekly quota
+  // lives in limits[] (the legacy seven_day_<model> top-level keys read null).
+  const data = { limits: [
+    { kind: 'session', group: 'session', percent: 47, scope: null },
+    { kind: 'weekly_all', group: 'weekly', percent: 8, scope: null },
+    { kind: 'weekly_scoped', group: 'weekly', percent: 100,
+      resets_at: '2026-07-03T17:00:00Z', scope: { model: { display_name: 'Fable' } } },
+  ]};
+  const b = normalizeUsageBucket(findScopedWeeklyLimit(data, /fable/i));
+  assert.equal(b.utilization, 1);
+  assert.equal(b.resetAt, Date.parse('2026-07-03T17:00:00Z'));
+
+  assert.equal(findScopedWeeklyLimit(data, /sonnet/i), null);   // no Sonnet-scoped entry
+  assert.equal(findScopedWeeklyLimit({}, /fable/i), null);      // no limits[] at all
+  assert.equal(findScopedWeeklyLimit({ limits: [] }, /fable/i), null);
+});
+
 // ── applyUsageData ────────────────────────────────────────────
 
-test('applyUsageData populates 5h/7d/sonnet without counting a request', () => {
+test('applyUsageData populates 5h/7d/sonnet/fable without counting a request', () => {
   const am = new AccountManager([oauth('a')], 0.98);
   am.applyUsageData(0, {
     fiveHour: { utilization: 0.2, resetAt: 111 },
     sevenDay: { utilization: 0.4, resetAt: 222 },
     sevenDaySonnet: { utilization: 0.6, resetAt: 333 },
+    sevenDayFable: { utilization: 0.5, resetAt: 444 },
   });
   const a = am.accounts[0];
   assert.equal(a.quota.unified5h, 0.2);
   assert.equal(a.quota.unified7d, 0.4);
   assert.equal(a.quota.unified7dSonnet, 0.6);
   assert.equal(a.quota.unified7dSonnetReset, 333);
+  assert.equal(a.quota.unified7dFable, 0.5);
+  assert.equal(a.quota.unified7dFableReset, 444);
   assert.equal(a.usage.totalRequests, 0);   // a probe is not real traffic
   assert.equal(a.probing, false);            // learned the weekly window…
   assert.equal(a.requalify, true);           // …so re-evaluate selection
 });
 
-test('sonnet quota survives the persistence round-trip', () => {
+test('sonnet + fable quota survive the persistence round-trip', () => {
   const am1 = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
-  am1.applyUsageData(0, { sevenDaySonnet: { utilization: 0.7, resetAt: 999 } });
+  am1.applyUsageData(0, {
+    sevenDaySonnet: { utilization: 0.7, resetAt: 999 },
+    sevenDayFable: { utilization: 0.3, resetAt: 888 },
+  });
   const am2 = new AccountManager([oauth('a', { accountUuid: 'p1' })], 0.98);
   am2.restoreQuotaState(am1.exportQuotaState());
   assert.equal(am2.accounts[0].quota.unified7dSonnet, 0.7);
   assert.equal(am2.accounts[0].quota.unified7dSonnetReset, 999);
+  assert.equal(am2.accounts[0].quota.unified7dFable, 0.3);
+  assert.equal(am2.accounts[0].quota.unified7dFableReset, 888);
+});
+
+// ── updateQuota: Fable weekly from response headers ───────────
+
+test('updateQuota records the Fable weekly bucket from the 7d_oi header', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-7d-utilization': '0.56',
+    'anthropic-ratelimit-unified-7d-reset': '1783098000',
+    'anthropic-ratelimit-unified-7d_oi-utilization': '1.01',   // Fable, in overage
+    'anthropic-ratelimit-unified-7d_oi-reset': '1783098000',
+  });
+  const q = am.accounts[0].quota;
+  assert.equal(q.unified7d, 0.56);
+  assert.equal(q.unified7dFable, 1.01);                        // stored as a 0-1 fraction, can exceed 1
+  assert.equal(q.unified7dFableReset, 1783098000 * 1000);      // seconds → ms
+});
+
+// ── model-aware selection: Fable exhaustion is model-scoped ───
+
+test('isFableModel / parseRequestModel', () => {
+  assert.equal(isFableModel('claude-fable-5'), true);
+  assert.equal(isFableModel('claude-opus-4-8'), false);
+  assert.equal(isFableModel(null), false);
+  assert.equal(parseRequestModel(Buffer.from('{"model":"claude-fable-5","max_tokens":1}')), 'claude-fable-5');
+  assert.equal(parseRequestModel('{ "model" : "claude-opus-4-8" }'), 'claude-opus-4-8');
+  assert.equal(parseRequestModel('{"max_tokens":1}'), null);
+  assert.equal(parseRequestModel(null), null);
+});
+
+test('a Fable-exhausted account is skipped for Fable but used for other models', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  // Account a: Fable weekly spent (from a prior 429's 7d_oi header); everything else fine.
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-7d_oi-utilization': '1.01',
+    'anthropic-ratelimit-unified-7d_oi-reset': String(Math.floor((Date.now() + 3600_000) / 1000)),
+  });
+  am.currentIndex = 0;
+
+  // A Fable request must NOT land on the exhausted account…
+  const forFable = am.getActiveAccount(null, 'claude-fable-5');
+  assert.equal(forFable.name, 'b');
+
+  // …but a non-Fable request still uses it (its Fable cap is irrelevant).
+  am.currentIndex = 0;
+  const forOpus = am.getActiveAccount(null, 'claude-opus-4-8');
+  assert.equal(forOpus.name, 'a');
+
+  // No model context → behaves as before (account a is available).
+  am.currentIndex = 0;
+  assert.equal(am.getActiveAccount().name, 'a');
+});
+
+test('all accounts Fable-exhausted → no account for a Fable request', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const reset = String(Math.floor((Date.now() + 3600_000) / 1000));
+  for (const i of [0, 1]) am.updateQuota(i, {
+    'anthropic-ratelimit-unified-7d_oi-utilization': '1.0',
+    'anthropic-ratelimit-unified-7d_oi-reset': reset,
+  });
+  // Probe is throttled off by default here, so a Fable request finds nothing…
+  assert.equal(am.getActiveAccount(null, 'claude-fable-5'), null);
+  // …while an Opus request is unaffected.
+  assert.ok(am.getActiveAccount(null, 'claude-opus-4-8'));
 });
 
 // ── Prober ────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Adds first-class tracking of the **per-model (Fable) weekly limit** and — the point of the change — stops routing **Fable** requests to accounts whose Fable weekly cap is spent, while still using those same accounts for **Opus/Sonnet**. Previously a Fable-exhausted account would keep getting picked for Fable and surface `You've reached your Fable 5 limit` to the client (in MITM mode the 429 passed straight through).

## Quota tracking

- **Usage endpoint** (`oauth.js`): the Fable weekly bucket now comes from the payload's `limits[]` array (a `weekly_scoped` entry whose `scope.model.display_name` is `"Fable"`). Verified against live accounts — the legacy top-level `seven_day_<model>` keys read `null` on current plans.
- **Response headers** (`account-manager.js`): passively records the Fable weekly bucket from `anthropic-ratelimit-unified-7d_oi-*` (the overage-included weekly bucket, which correlates exactly with the usage endpoint's Fable-scoped weekly). New `unified7dFable(+Reset)` fields — persisted, cleared on expiry.
- **Display** (`index.js`/`tui.js`): a `Fable7d` line / `F7` bar, mirroring the existing Sonnet bucket (no-op when absent).

## Model-aware routing

- **`model.js`** (new): `isFableModel` + a streaming, byte-exact `TopLevelFieldFinder` that locates the request's **top-level** `model` — **no regex**, so a `"model"` string inside conversation content is never mistaken for the real field.
- **Selection** (`account-manager.js`): `getActiveAccount` & friends take an optional model; a Fable-exhausted account is skipped **only** for Fable requests.
- **`server.js`**: parses the body's model; a Fable-only 429 switches accounts immediately (no global throttle), a general rejection still throttles the whole account.
- **MITM** (`h2/relay.js`, `mitm.js`): new opt-in `peekModel` mode holds the request after its HEADERS until the body's top-level `model` is peeked (streaming, 64 KB cap), then binds the account and replays the buffered body. Implemented for both h2 and h1 request paths; **off by default**, so non-MITM/existing relay behavior is unchanged.

## Tests

158 passing (+ lint clean). New coverage: the model finder (nested decoys, chunk boundaries, absence), Fable detection from the real 429 headers, model-scoped selection, and end-to-end **h1 & h2 relay peek** (body relayed byte-for-byte, routed on the top-level model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)