### PR TITLE
feat: show the requested model in the TUI query log

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -137,7 +137,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
         }
       } finally {
-        hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status });
+        hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model });
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);

--- a/src/tui.js
+++ b/src/tui.js
@@ -196,7 +196,8 @@ export class TUI {
     this.active.delete(id);
     const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
     const acct = info.account || r?.account || '?';
-    this._addLog(`${info.method} ${info.path} → ${acct} (${info.status}, ${dur}s)`);
+    const model = info.model ? ` (${info.model})` : ''; // shown when the request named a model
+    this._addLog(`${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
   }
 
   _addLog(msg) {

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -254,6 +254,7 @@ test('MITM h2: relayed requests fire the TUI activity hooks with the injected ac
     assert.equal(routed?.account, 'acct@x');
     assert.ok(end && end.id === start.id);
     assert.equal(String(end.status), '201');
+    assert.equal(end.model, 'x'); // the requested model is reported for the query log
   } finally {
     tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
   }


### PR DESCRIPTION
Requests that carry a `model` now show it in the live activity feed:

```
POST /v1/messages (claude-fable-5) → acct@x (200, 1.2s)
```

`ctx.model` is already parsed (for model-aware routing), so this just threads it through the `onRequestEnd` hook and renders it after the path when present — nothing shown for requests with no model (GETs, control endpoints).

Covered by the existing MITM activity-hooks integration test (now asserts `end.model`). Full suite green (131), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)