### PR TITLE
Bump to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch release bundling the changes merged since 1.1.2:

- **MITM as a terminating proxy with transparent cross-account retry** (#65) — a quota `429` on one account is now resent on another instead of surfacing to Claude; removed the dead hand-rolled h2 stack.
- **Model-aware routing** (#64) — Fable weekly cap tracked separately; Fable-exhausted accounts skipped for Fable only.
- **Show the requested model in the TUI query log** (#66).

Merging this to master triggers the Publish workflow, which publishes `@karpeleslab/teamclaude@1.1.3` to npm (Trusted Publishing/OIDC) and tags the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)