### PR TITLE
[codex] Bound 429 retry recovery

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ export const HOP_BY_HOP_HEADERS = new Set([
   'host', 'connection', 'keep-alive', 'transfer-encoding',
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
+const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
 
 // Response header names that are connection-specific and thus illegal on an
 // HTTP/2 response (Node's Http2ServerResponse.writeHead rejects them). Also
@@ -276,6 +277,14 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ctx.account = '(none available)';
     const status = accountManager.getStatus();
     const retryAfter = computeRetryAfter(status.accounts);
+    const exhaustedRetries = ctx.exhaustedRetries || 0;
+    if (exhaustedRetries < 1 && retryAfter <= INLINE_RETRY_AFTER_MAX_SECONDS) {
+      ctx.exhaustedRetries = exhaustedRetries + 1;
+      console.log(`[TeamClaude] All accounts exhausted — waiting ${retryAfter}s before retry`);
+      await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+      if (res.destroyed) return;
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
+    }
     res.writeHead(429, {
       'Content-Type': 'application/json',
       'retry-after': String(retryAfter),
@@ -418,12 +427,20 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       if (retryCount >= maxRetries) {
         console.log(`[TeamClaude] Persistent 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching`);
         accountManager.markRateLimited(account.index, retryAfter);
+        if (res.destroyed) return;
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
 
-      if (switchingToSx) {
-        console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
-      } else {
+    if (!switchingToSx && retryAfter > INLINE_RETRY_AFTER_MAX_SECONDS) {
+      console.log(`[TeamClaude] 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching without waiting`);
+      accountManager.markRateLimited(account.index, retryAfter);
+      if (res.destroyed) return;
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
+    }
+
+    if (switchingToSx) {
+      console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
+    } else {
         console.log(`[TeamClaude] 429 on "${account.name}" — waiting ${retryAfter}s before retry`);
         await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
       }

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -62,6 +62,89 @@ test('negative Retry-After is clamped and still terminates', async () => {
   assert.equal(accountStatus, 'throttled');
 });
 
+test('long upstream Retry-After is surfaced without sleeping in client request', async () => {
+  let upstreamHits = 0;
+  const upstream = http.createServer((_req, res) => {
+    upstreamHits++;
+    res.writeHead(429, { 'retry-after': '300', 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }],
+    0.98,
+  );
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const started = Date.now();
+    let res;
+    try {
+      res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'x', messages: [] }),
+        signal: AbortSignal.timeout(2000),
+      });
+    } catch (err) {
+      assert.fail(`request should return 429 promptly, got ${err.name}`);
+    }
+
+    await res.text();
+    assert.equal(res.status, 429);
+    assert.equal(upstreamHits, 1, 'long Retry-After should not be retried inline');
+    assert.ok(Date.now() - started < 2000, 'request should not sleep for upstream retry window');
+    assert.equal(am.accounts[0].status, 'throttled');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+test('temporarily exhausted fleet waits and retries instead of surfacing synthetic 429', async () => {
+  let upstreamHits = 0;
+  const upstream = http.createServer((_req, res) => {
+    upstreamHits++;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'message', role: 'assistant', content: [] }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }],
+    0.98,
+  );
+  am.markRateLimited(0, 1);
+
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const started = Date.now();
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    const text = await res.text();
+
+    assert.equal(res.status, 200, text);
+    assert.equal(upstreamHits, 1, 'request should reach upstream after throttle expires');
+    assert.ok(Date.now() - started >= 900, 'request should wait for retry window');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
 // Regression for #46: a stale/poisoned cached quota (e.g. 0.98 from before a
 // plan upgrade, with a reset still in the future) must NOT pin the proxy in a
 // permanent synthetic 429. The next request should probe upstream, succeed, and


### PR DESCRIPTION
## Summary

Bound TeamClaude's 429 recovery so client requests do not get stuck sleeping through long upstream throttle windows, while still waiting through short temporary fleet exhaustion.

## Why this is needed

There were two separate retry paths with different failure modes:

- When every account was temporarily rate-limited, `getActiveAccount()` returned no usable account and the server could emit a local synthetic 429 even when the first account would recover almost immediately.
- When an upstream request returned a long `Retry-After`, the request path could wait inside the client connection instead of surfacing the throttle and freeing the connection.

The minimal fix is to treat short and long retry windows differently in the existing request-dispatch loop.

## What changed

- Added `INLINE_RETRY_AFTER_MAX_SECONDS = 15` as the boundary for waits that are safe to do inline.
- In the "no active account" path, short retry windows wait once and retry selection before returning a synthetic 429.
- In the upstream 429 path, long retry windows mark the account rate-limited and redispatch or return the 429 promptly instead of sleeping.
- Kept the existing retry counters so persistent 429s still terminate in a bounded number of attempts.

## Impact

- Short-lived fleet exhaustion can recover without making callers retry manually.
- Long upstream throttles return promptly and do not pin a request for minutes.
- Existing sx.org proxy fallback behavior is left intact.

## Validation

- `node --check src/server.js`
- `node --test test/server-429.test.js`: 5 pass, 0 fail
- Full `node --test` currently fails on current `master` in `test/quota-probe.test.js` because a Fable quota fixture reset timestamp is now expired. Reproduced on clean `origin/master`; split fix is #70.
- `npm run lint` attempted, blocked because local `eslint` is not installed: `sh: eslint: command not found`
