### PR TITLE
[codex] Stabilize Fable quota reset test

### DIFF
--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -90,16 +90,17 @@ test('sonnet + fable quota survive the persistence round-trip', () => {
 
 test('updateQuota records the Fable weekly bucket from the 7d_oi header', () => {
   const am = new AccountManager([oauth('a')], 0.98);
+  const reset = Math.floor((Date.now() + 3600_000) / 1000);
   am.updateQuota(0, {
     'anthropic-ratelimit-unified-7d-utilization': '0.56',
-    'anthropic-ratelimit-unified-7d-reset': '1783098000',
+    'anthropic-ratelimit-unified-7d-reset': String(reset),
     'anthropic-ratelimit-unified-7d_oi-utilization': '1.01',   // Fable, in overage
-    'anthropic-ratelimit-unified-7d_oi-reset': '1783098000',
+    'anthropic-ratelimit-unified-7d_oi-reset': String(reset),
   });
   const q = am.accounts[0].quota;
   assert.equal(q.unified7d, 0.56);
   assert.equal(q.unified7dFable, 1.01);                        // stored as a 0-1 fraction, can exceed 1
-  assert.equal(q.unified7dFableReset, 1783098000 * 1000);      // seconds → ms
+  assert.equal(q.unified7dFableReset, reset * 1000);           // seconds → ms
 });
 
 // ── model-aware selection: Fable exhaustion is model-scoped ───


### PR DESCRIPTION
## Summary

Stabilizes the Fable quota header test by using a reset timestamp relative to the current clock instead of a fixed timestamp that is now expired.

## Why this is needed

Current `master` fails `test/quota-probe.test.js` on July 4, 2026 because the test fixture uses `1783098000`, which is July 3, 2026. `updateQuota()` correctly records the quota header, then the normal expired-quota cleanup sees the reset time is already past and clears it before the assertion.

## What changed

- Computes `reset` as one hour in the future.
- Reuses that value for both 7-day reset headers.
- Keeps the same assertions about Fable utilization and seconds-to-milliseconds conversion.

## Impact

- The test now verifies the intended Fable quota behavior without depending on a calendar date.
- No runtime code changes.

## Validation

- `node --test test/quota-probe.test.js`: 12 pass, 0 fail
- `node --test`: 131 pass, 0 fail
- `npm run lint` attempted, blocked because local `eslint` is not installed: `sh: eslint: command not found`
