### PR TITLE
Bump to 1.1.4

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default [
         TextDecoder: 'readonly',
         fetch: 'readonly',
         AbortController: 'readonly',
+        AbortSignal: 'readonly',
       },
     },
     rules: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to **1.1.4** (patch), triggering the npm publish + release workflow.
- Fix master's red **Lint** job: declare `AbortSignal` as an eslint global. `test/server-429.test.js` (merged in #68) uses `AbortSignal.timeout(...)`, which the flat config didn't allow, producing `no-undef` on the node-24 Lint leg.

## Included since 1.1.3
- #70 Stabilize Fable quota reset test
- #68 Bound 429 retry recovery
- #69 Rich `teamclaude status` output

## Validation
- `npm run lint`: clean
- `node --test`: 138 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)