### PR TITLE
WIP Fix: recover from network drops without restarting

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -36,6 +36,11 @@ const DEFAULT_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_ENDPOINT) {
   const maxRetries = 2;
   const baseDelayMs = 500;
+  // Bound each attempt so a dead pooled socket (after a network drop/reconnect)
+  // can't hang the refresh forever. A hung refresh is especially harmful here:
+  // ensureTokenFresh coalesces callers into a single _refreshPromise, so one
+  // stuck refresh wedges every request for that account until a restart.
+  const timeoutMs = Number(process.env.TEAMCLAUDE_REFRESH_TIMEOUT_MS) || 30_000;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -56,6 +61,7 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
           refresh_token: refreshToken,
           client_id: DEFAULT_CLIENT_ID,
         }),
+        signal: AbortSignal.timeout(timeoutMs),
       });
 
       if (!res.ok) {
@@ -81,7 +87,8 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
       };
     } catch (err) {
       const isNetworkError = err instanceof Error &&
-        (err.message.includes('fetch failed') ||
+        (err.name === 'TimeoutError' || err.name === 'AbortError' ||
+          err.message.includes('fetch failed') ||
           (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
            err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT'));
 

--- a/src/server.js
+++ b/src/server.js
@@ -503,11 +503,17 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     if (l) { l.write(`\n\n=== ERROR ===\n${err.stack || err.message}`); l.end(); }
 
     const isTransient = err instanceof Error &&
-      (err.message.includes('fetch failed') ||
+      (err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT' ||
+        err.name === 'TimeoutError' || err.name === 'AbortError' ||
+        err.message.includes('fetch failed') ||
         err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
-        err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT');
+        err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT' ||
+        err.code === 'UND_ERR_HEADERS_TIMEOUT' || err.code === 'UND_ERR_BODY_TIMEOUT');
 
-    // Transient network errors: just close the connection and let the client retry
+    // Transient network errors (including a stale-socket headers timeout): close
+    // the connection and let the client retry. Failing over to another account
+    // would not help (the poisoned fetch pool is process-wide), but the fast
+    // failure lets Node evict the dead socket so the retry reconnects cleanly.
     if (isTransient) {
       res.destroy();
       return;

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -15,17 +15,30 @@ import { tunnelTls } from './sx.js';
 
 // Time to wait for RESPONSE HEADERS before treating the upstream socket as dead.
 // This is NOT a limit on the response body (SSE completions can stream for
-// minutes); the deadline is cleared the instant headers arrive. Its job is to
-// convert an indefinite hang on a half-dead pooled socket (e.g. after the host's
-// network drops and reconnects, leaving Node's global fetch pool holding stale
-// keep-alive connections) into a fast, retryable failure. Without it a reused
-// dead socket hangs until Node's 300s default, long past the point the client
-// gave up, and only a full process restart clears the poisoned pool. Each
-// aborted request evicts one dead socket, so a burst of stale connections drains
-// over the next few retries rather than all at once. Override with
-// TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS (or per-call opts) if a legitimate slow
-// first-byte ever trips it.
-const DEFAULT_HEADERS_TIMEOUT_MS = 60_000;
+// minutes); the deadline is cleared the instant headers arrive, so a slow, long
+// answer is never cut. It measures time-to-first-byte only, which streaming
+// delivers within seconds, and its job is to convert an indefinite hang on a
+// half-dead pooled socket (e.g. after the host's network drops and reconnects,
+// leaving Node's global fetch pool holding stale keep-alive connections) into a
+// fast, retryable failure. Without it a reused dead socket hangs until Node's
+// 300s default, long past the point the client gave up, and only a full process
+// restart clears the poisoned pool. Each aborted request evicts one dead socket,
+// so a burst of stale connections drains over the next few retries.
+//
+// We abort ONLY in the pre-headers window and clear the timer once the body
+// starts, so we never abort mid-stream. That matters: an AbortSignal fired after
+// data has started leaves the socket occupied and leaks a "zombie" connection
+// that drains the pool over time; aborting before the first byte lets undici
+// destroy the socket cleanly instead. The textbook fix is dispatcher-level
+// timeouts via undici's setGlobalDispatcher(new Agent({ headersTimeout,
+// keepAliveTimeout })); we stay zero-dependency, so this reactive guard is the
+// stand-in.
+//
+// Default is generous (well above Claude's realistic first-byte, even when
+// queued or under load) so a slow-but-legitimate response is never mistaken for
+// a dead socket. Override with TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS (or
+// per-call opts).
+const DEFAULT_HEADERS_TIMEOUT_MS = 120_000;
 
 function resolveHeadersTimeout(perCall) {
   if (perCall != null) return perCall;

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -13,14 +13,58 @@ import https from 'node:https';
 import { Readable } from 'node:stream';
 import { tunnelTls } from './sx.js';
 
-// `useProxy` is decided by the caller (it varies per attempt — e.g. direct first,
-// then via sx after a 429). With it false, or sx unprovisioned, this is plain fetch.
-export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
-  if (!sx || !useProxy || !sx.isProvisioned()) return fetch(url, opts);
-  return proxiedFetch(url, opts, sx);
+// Time to wait for RESPONSE HEADERS before treating the upstream socket as dead.
+// This is NOT a limit on the response body (SSE completions can stream for
+// minutes); the deadline is cleared the instant headers arrive. Its job is to
+// convert an indefinite hang on a half-dead pooled socket (e.g. after the host's
+// network drops and reconnects, leaving Node's global fetch pool holding stale
+// keep-alive connections) into a fast, retryable failure. Without it a reused
+// dead socket hangs until Node's 300s default, long past the point the client
+// gave up, and only a full process restart clears the poisoned pool. Each
+// aborted request evicts one dead socket, so a burst of stale connections drains
+// over the next few retries rather than all at once. Override with
+// TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS (or per-call opts) if a legitimate slow
+// first-byte ever trips it.
+const DEFAULT_HEADERS_TIMEOUT_MS = 60_000;
+
+function resolveHeadersTimeout(perCall) {
+  if (perCall != null) return perCall;
+  const env = Number(process.env.TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS);
+  return env > 0 ? env : DEFAULT_HEADERS_TIMEOUT_MS;
 }
 
-function proxiedFetch(url, opts, sx) {
+function headersTimeoutError(ms) {
+  const err = new Error(`upstream response headers timed out after ${ms}ms`);
+  // Recognized by server.js isTransient → fail fast + let the client retry, so
+  // Node's fetch pool evicts the stale connection instead of wedging.
+  err.code = 'TEAMCLAUDE_HEADERS_TIMEOUT';
+  return err;
+}
+
+// `useProxy` is decided by the caller (it varies per attempt — e.g. direct first,
+// then via sx after a 429). With it false, or sx unprovisioned, this is plain fetch
+// (plus the headers-timeout guard).
+export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
+  const { headersTimeoutMs, ...fetchOpts } = opts;
+  const timeoutMs = resolveHeadersTimeout(headersTimeoutMs);
+  if (!sx || !useProxy || !sx.isProvisioned()) return directFetch(url, fetchOpts, timeoutMs);
+  return proxiedFetch(url, fetchOpts, sx, timeoutMs);
+}
+
+// Global fetch driven by our own AbortController so we can arm a headers-only
+// deadline and disarm it the moment headers arrive (letting the body stream with
+// no deadline). AbortSignal.timeout can't do this — it would also kill the body.
+function directFetch(url, opts, timeoutMs) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(headersTimeoutError(timeoutMs)), timeoutMs);
+  timer.unref?.();
+  return fetch(url, { ...opts, signal: ctrl.signal }).then(
+    (res) => { clearTimeout(timer); return res; },
+    (err) => { clearTimeout(timer); throw err; },
+  );
+}
+
+function proxiedFetch(url, opts, sx, timeoutMs) {
   const u = new URL(url);
   const proxy = sx.getProxy();
 
@@ -36,12 +80,19 @@ function proxiedFetch(url, opts, sx) {
   };
 
   return new Promise((resolve, reject) => {
+    // Headers-only deadline (same as the direct path): fires before headers
+    // arrive and tears the tunneled request down; cleared once the response
+    // starts. `req` is created BEFORE the timer so a synchronous https.request
+    // throw (e.g. an invalid client header) can't leave a scheduled timer that
+    // fires later and dereferences an uninitialized binding.
     const req = https.request(
       u,
       { method: opts.method || 'GET', headers: opts.headers || {}, agent },
-      (res) => resolve(makeResponse(res)),
+      (res) => { clearTimeout(timer); resolve(makeResponse(res)); },
     );
-    req.once('error', reject);
+    const timer = setTimeout(() => req.destroy(headersTimeoutError(timeoutMs)), timeoutMs);
+    timer.unref?.();
+    req.once('error', (err) => { clearTimeout(timer); reject(err); });
 
     const body = opts.body;
     const method = (opts.method || 'GET').toUpperCase();

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { upstreamFetch } from '../src/upstream-fetch.js';
+
+// Bring up an HTTP server on an ephemeral port and hand back {server, port}.
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0);
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+// A half-dead upstream: it accepts the connection but never sends a response —
+// exactly what a keep-alive socket becomes after the host's network drops and
+// reconnects. Without the headers timeout this hangs until Node's 300s default.
+test('fails fast (does not hang) when upstream never sends headers', async () => {
+  const { server, port } = await listen(() => { /* never respond */ });
+
+  const start = Date.now();
+  await assert.rejects(
+    () => upstreamFetch(`http://127.0.0.1:${port}/v1/messages`,
+      { method: 'POST', body: '{}', headersTimeoutMs: 200 }),
+    (err) => err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT',
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 2000, `expected fast-fail, took ${elapsed}ms`);
+
+  server.close();
+});
+
+// The mechanism the whole fix rests on: after a hung request the dead socket is
+// dropped from the pool, so the next request to the SAME origin opens a fresh
+// connection and succeeds. Same origin is the point: two ports would be two
+// pools and prove nothing about eviction. We count TCP connections and assert
+// the second request opened a new one rather than reusing the dead keep-alive.
+test('evicts the dead socket and reconnects on the same origin', async () => {
+  let conns = 0;
+  let mode = 'hang';
+  const { server, port } = await listen((req, res) => {
+    if (mode === 'respond') { res.writeHead(200); res.end('ok'); }
+    // else: never respond, simulating a half-dead socket after a network drop
+  });
+  server.on('connection', () => { conns += 1; });
+  const origin = `http://127.0.0.1:${port}/`;
+
+  await assert.rejects(
+    () => upstreamFetch(origin, { headersTimeoutMs: 150 }),
+    (err) => err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT',
+  );
+
+  mode = 'respond';
+  const res = await upstreamFetch(origin, { headersTimeoutMs: 5000 });
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), 'ok');
+  // >1 connection proves the dead socket was evicted and a fresh one opened; a
+  // reuse of the aborted socket would leave the count at 1 (and hang). undici may
+  // open more than one on the abort path, so assert the invariant, not an exact n.
+  assert.ok(conns >= 2, `expected a fresh socket after eviction, saw ${conns} connection(s)`);
+
+  server.close();
+});
+
+// The deadline is headers-only: once headers arrive it is disarmed, so a body
+// that streams well past the timeout window is NOT cut off (SSE completions run
+// for minutes). Headers here return instantly; the body finishes at ~400ms with
+// a 150ms headers timeout.
+test('does not cut a slow body once headers have arrived', async () => {
+  const { server, port } = await listen(async (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: ping\n\n');
+    await new Promise((r) => setTimeout(r, 400));
+    res.write('event: done\n\n');
+    res.end();
+  });
+
+  const res = await upstreamFetch(`http://127.0.0.1:${port}/`, { headersTimeoutMs: 150 });
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /done/); // full body read, not aborted at 150ms
+
+  server.close();
+});


### PR DESCRIPTION
## Problem

After the network drops and comes back, teamclaude keeps failing every request
until you restart it. Accounts show as throttled or errored and Claude reports
API errors, even though nothing is actually rate limited.

The cause is a poisoned connection pool. teamclaude reuses a shared pool of
connections to the API across all requests and all accounts. When the network
drops the connections die, but nothing tells teamclaude they died, and because a
request has no time limit it waits on a dead connection forever instead of
failing. A hung request never errors, so the dead connection is never dropped
from the pool, and every retry and every account keeps landing on the same poison.

```mermaid
sequenceDiagram
    participant C as Claude
    participant T as teamclaude
    participant P as Connection pool
    participant A as API

    Note over P,A: network drops, pooled connections die silently

    C->>T: request
    T->>P: get a connection
    P-->>T: dead connection (looks alive)
    T->>A: send request on dead connection
    Note over T,A: no response, no time limit
    A--xT: nothing ever comes back (hangs)

    C->>T: times out, retries
    T->>P: get a connection
    P-->>T: another dead connection
    Note over T,A: hangs again, same poison

    Note over C,A: only restarting teamclaude builds a fresh pool
```

## Fix

Add time limits so a stuck request fails quickly instead of hanging. The failure
lets teamclaude drop the dead connection from the pool, the client retries, and
the next request connects fresh. No restart needed.

- API requests now fail if no response starts within 120 seconds. The limit only
  covers the start of the response, so long replies keep streaming normally. It
  measures time to the first byte, which streaming delivers within seconds, so a
  slow or overloaded upstream that still answers (including a 429) is unaffected.
- Token refresh now fails after 30 seconds instead of hanging.

Both limits are adjustable with `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS` and
`TEAMCLAUDE_REFRESH_TIMEOUT_MS`. No new dependencies.

```mermaid
sequenceDiagram
    participant C as Claude
    participant T as teamclaude
    participant P as Connection pool
    participant A as API

    C->>T: request
    T->>A: send request on dead connection
    Note over T,A: no response within 120s
    T->>P: drop dead connection from pool
    T-->>C: fail fast (error)
    C->>T: retry
    T->>A: send request on a fresh connection
    A-->>T: response
    T-->>C: response
```

## Notes

Recovery is per-socket: each fast failure evicts one dead connection, so after a
flap with several in-flight requests it can take a few failed-then-retried
requests to fully drain. It always converges without a restart.

Tests added in `test/upstream-timeout.test.js` cover fast-fail on a dead socket,
same-origin socket eviction and reconnect, and that a slow response body is not
cut off once headers arrive. Full suite passes (141) and lint is clean.
