### PR TITLE
feat: add third-party backend account support (upstream, modelMap, models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
+- **Third-party backend accounts** — route requests to any Anthropic-compatible API (e.g. DeepSeek, GLM) as a fallback when Claude accounts are exhausted; a per-account `upstream` URL and `modelMap` translate model names transparently. Accounts with a `models` list are reserved for requests that explicitly name those models, enabling per-session backend selection without touching other sessions
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
@@ -259,6 +260,9 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
+| `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only |
+| `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |
+| `accounts[].models` | Array of model names this account exclusively handles. When any account declares a `models` list, requests for those models are routed only to accounts that list them — use this to reserve a third-party account for sessions that pass `--model <name>` explicitly |
 
 ### Quota probe (optional, off by default)
 
@@ -275,6 +279,36 @@ teamclaude probe        # show current setting
 You can also set the interval live from the TUI settings screen (`g` → `p`), alongside the rotation threshold (`t`).
 
 It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** and **Fable 7-day** buckets as extra bars in the TUI / `status` (when your plan exposes them).
+
+### Third-party backend accounts
+
+Any Anthropic-compatible API can be added as an account alongside your Claude accounts. Give it a higher `priority` value (lower = preferred, so use e.g. `100`) and it will be used as a fallback when all Claude accounts are exhausted.
+
+```json
+{
+  "name": "deepseek",
+  "type": "oauth",
+  "accessToken": "sk-your-deepseek-api-key",
+  "upstream": "https://api.deepseek.com/anthropic",
+  "priority": 100,
+  "modelMap": {
+    "claude-haiku-4-5-20251001": "deepseek-v4-flash",
+    "claude-sonnet-4-6": "deepseek-v4-pro[1m]"
+  },
+  "models": ["deepseek-v4-pro[1m]", "deepseek-v4-pro", "deepseek-v4-flash"]
+}
+```
+
+- **`upstream`** — base URL of the target API. Requests are sent to `upstream + /v1/messages` (etc.) for this account only.
+- **`modelMap`** — when a Claude model name arrives in the request body, it is rewritten to the mapped name before forwarding.
+- **`models`** — model names this account exclusively handles. Once any account declares a `models` list, requests for those model names are locked to matching accounts. This lets you send a specific session to a third-party backend without touching others — use `--model` on launch or `/model` inside a session:
+
+```bash
+# This session routes to DeepSeek; all other sessions still use Claude accounts.
+claude --model 'deepseek-v4-pro[1m]'
+```
+
+Note: model names with brackets (e.g. `deepseek-v4-pro[1m]`) must be quoted in the shell.
 
 ### MITM proxy mode (default)
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -49,6 +49,9 @@ export class AccountManager {
       orgName: acct.orgName || null,
       priority: acct.priority || 0,
       disabled: acct.disabled || false,
+      upstream: acct.upstream || null,
+      modelMap: acct.modelMap || null,
+      models: acct.models || null,
       credential: acct.accessToken || acct.apiKey,
       refreshToken: acct.refreshToken || null,
       expiresAt: acct.expiresAt || null,
@@ -221,6 +224,12 @@ export class AccountManager {
     // requests. Non-Fable requests still route here normally.
     if (isFableModel(model) && this._fableExhausted(account)) return false;
 
+    // Model-ownership routing: if any account has declared ownership of `model`
+    // via its `models` field, only those accounts are available for this request.
+    // This lets e.g. a DeepSeek account claim deepseek-* model names so those
+    // requests never land on Claude accounts (which don't recognize the model).
+    if (model && !this._accountOwnsModel(account, model)) return false;
+
     return true;
   }
 
@@ -230,6 +239,17 @@ export class AccountManager {
   _fableExhausted(account) {
     const q = account.quota;
     return q.unified7dFable != null && q.unified7dFable >= this.switchThreshold;
+  }
+
+  /** Returns true if no account claims model ownership, or this account does. */
+  _accountOwnsModel(account, model) {
+    for (const a of this.accounts) {
+      if (a.models && a.models.some(m => m === model || m.replace(/\[\d+m\]$/, '') === model)) {
+        // Some other account owns this model — this account must own it too.
+        return account.models && account.models.some(m => m === model || m.replace(/\[\d+m\]$/, '') === model);
+      }
+    }
+    return true; // no one claims ownership → any account is fine
   }
 
   /**
@@ -683,6 +703,9 @@ export class AccountManager {
       orgName: acctData.orgName || null,
       priority: acctData.priority || 0,
       disabled: acctData.disabled || false,
+      upstream: acctData.upstream || null,
+      modelMap: acctData.modelMap || null,
+      models: acctData.models || null,
       credential: acctData.accessToken || acctData.apiKey,
       refreshToken: acctData.refreshToken || null,
       expiresAt: acctData.expiresAt || null,

--- a/src/server.js
+++ b/src/server.js
@@ -334,12 +334,18 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     headers['x-api-key'] = account.credential;
   }
 
-  const upstreamUrl = `${upstream}${req.url}`;
+  const upstreamUrl = `${account.upstream || upstream}${req.url}`;
   const method = req.method;
 
   // Align the body's account_uuid (in metadata.user_id) with the account whose
   // token we're injecting (same-length patch; no-op if absent).
-  const sendBody = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
+  let sendBody = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
+  // Rewrite the model name for accounts that target a different upstream (e.g.
+  // GLM), which uses different model identifiers than Anthropic.
+  if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);
+  // If the body changed length (model name rewrite), update Content-Length so the
+  // upstream doesn't receive a mismatched framing and truncate or stall.
+  if (sendBody !== body) headers['content-length'] = String(sendBody.length);
 
   // Streaming request log, opened lazily on the first terminal outcome (a
   // pure-429-then-retry attempt writes no file, matching prior behavior). The
@@ -614,6 +620,20 @@ function extractUsageFromBody(buffer, accountIndex, accountManager) {
   } catch {
     // not JSON or no usage
   }
+}
+
+// Rewrite the `model` field in a JSON request body using a per-account map.
+// Returns the original buffer unchanged if the model isn't in the map or the
+// body isn't valid JSON, so non-messages endpoints pass through safely.
+function rewriteModel(body, modelMap) {
+  try {
+    const obj = JSON.parse(body.toString('utf8'));
+    if (obj.model && modelMap[obj.model]) {
+      obj.model = modelMap[obj.model];
+      return Buffer.from(JSON.stringify(obj), 'utf8');
+    }
+  } catch { /* not JSON — pass through unchanged */ }
+  return body;
 }
 
 function computeRetryAfter(accounts) {


### PR DESCRIPTION
## Changes

### `src/account-manager.js`
- Added `upstream`, `modelMap`, and `models` fields to the account object
  (both the constructor map and `addAccount`)
- Added `_accountOwnsModel(account, model)`: when any account declares a
  `models` list, only accounts that also list the requested model are eligible
  for that request — accounts without a matching entry are skipped at selection
  time, alongside the existing `disabled`/quota/Fable checks
- Wired the check into `_isAvailable` after the existing Fable-exhaustion gate

### `src/server.js`
- Per-account upstream URL: `account.upstream || upstream` so each account can
  target a different base URL without touching the global config
- `rewriteModel(body, modelMap)`: parses the request body as JSON, rewrites
  the `model` field using the account's `modelMap`, and re-serializes; returns
  the original buffer unchanged if the model isn't in the map or the body isn't
  valid JSON
- Fixes `Content-Length` after rewriting: the model name change shifts the body
  size, so the header is updated to match before the request is forwarded

## Behavior

**Fallback:** a third-party account with a higher `priority` value (lower =
preferred) sits idle while Claude accounts have headroom. When they're
exhausted it takes over, and `modelMap` translates e.g. `claude-sonnet-4-6` →
`deepseek-v4-pro[1m]` transparently — no change needed in the claude session.

**Explicit routing:** a `models` list lets a session opt in to a specific
backend by naming one of its models directly (`--model "deepseek-v4-pro[1m]"` on launch or `/model deepseek-v4-pro[1m]` inside a session). Other sessions are unaffected.

## Example config

```json
{
  "name": "deepseek",
  "type": "oauth",
  "accessToken": "sk-...",
  "upstream": "https://api.deepseek.com/anthropic",
  "priority": 100,
  "modelMap": {
    "claude-haiku-4-5-20251001": "deepseek-v4-flash",
    "claude-sonnet-4-6": "deepseek-v4-pro[1m]"
  },
  "models": ["deepseek-v4-pro[1m]", "deepseek-v4-pro", "deepseek-v4-flash"]
}
```