### PR TITLE
fix: exclude localhost from NO_PROXY in MITM mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -510,7 +510,7 @@ async function runCommand() {
       const { caPath } = await ensureCerts(host);
       const proxyUrl = `http://127.0.0.1:${port}`;
       env.HTTPS_PROXY = env.HTTP_PROXY = env.https_proxy = env.http_proxy = proxyUrl;
-      env.NO_PROXY = env.no_proxy = ''; // ensure nothing (esp. the upstream host) bypasses us
+      env.NO_PROXY = env.no_proxy = 'localhost,127.0.0.1,::1';
       env.NODE_EXTRA_CA_CERTS = caPath;
       delete env.ANTHROPIC_BASE_URL;
     } else {


### PR DESCRIPTION
Previously NO_PROXY was set to empty string, forcing all traffic (including plain-HTTP requests to local services such as MCP servers at 127.0.0.1) through the proxy. This caused fetch failures for local MCP SSE connections (e.g. http://127.0.0.1:15001/sse) that appear in Claude Code's activity log as repeated "Upstream error: fetch failed".

Set NO_PROXY to localhost,127.0.0.1,::1 so local connections bypass the proxy while external traffic (api.anthropic.com) still goes through the MITM interception.