### PR TITLE
Fix: revalidate throttled accounts so a stale 429 hold cannot require a restart

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -36,7 +36,7 @@ function emptyQuota() {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs } = {}) {
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
@@ -64,6 +64,7 @@ export class AccountManager {
         lastUsed: null,
       },
       rateLimitedUntil: null,
+      throttledAt: null,
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
@@ -73,6 +74,11 @@ export class AccountManager {
     // often to refresh the cached quota. See _selectProbe.
     this.probeIntervalMs = 60_000;
     this._nextProbeAt = 0;
+    // Minimum time a 429 hold is respected verbatim before a throttled account
+    // becomes probe-eligible (see _isProbeable). Long enough to honor a genuine
+    // retry-after, short enough that a stale hold cannot pin the fleet.
+    this.throttleProbeFloorMs = throttleProbeFloorMs
+      ?? (Number(process.env.TEAMCLAUDE_THROTTLE_PROBE_FLOOR_MS) || 60_000);
   }
 
   /**
@@ -135,13 +141,21 @@ export class AccountManager {
 
   _isProbeable(account) {
     if (!account) return false;
-    // Never probe an account the operator has taken out of rotation, one whose
-    // token is broken, or one upstream has explicitly rate-limited — those are
-    // hard states, not stale soft-quota guesses.
+    // Never probe an account the operator has taken out of rotation or one
+    // whose token is broken — those are hard states, not stale guesses.
     if (account.disabled) return false;
     if (account.status === 'error' || account.status === 'exhausted') return false;
+    // A 429 hold is respected verbatim at first, but a hold is a snapshot: the
+    // 429 that armed it may itself have been transient (e.g. the retry burst
+    // after a network flap), and while it lasts NOTHING revalidates it — so a
+    // stale hold pins the fleet in synthetic 429s for up to an hour and only a
+    // restart (which wipes the in-memory hold) recovers. After the floor, let
+    // the account be probed: the probe's real response either clears the hold
+    // (any non-429 → clearRateLimited) or re-arms it with a fresh retry-after.
     if (account.status === 'throttled' && account.rateLimitedUntil
-        && Date.now() < account.rateLimitedUntil) return false;
+        && Date.now() < account.rateLimitedUntil) {
+      return Date.now() >= (account.throttledAt || 0) + this.throttleProbeFloorMs;
+    }
     return true;
   }
 
@@ -196,7 +210,11 @@ export class AccountManager {
 
     this._nextProbeAt = now + this.probeIntervalMs;
     this.currentIndex = best.index;
-    console.log(`[TeamClaude] All accounts over threshold — probing "${best.name}" to refresh quota`);
+    if (best.status === 'throttled') {
+      console.log(`[TeamClaude] All accounts unavailable — revalidating throttled "${best.name}" with a live request`);
+    } else {
+      console.log(`[TeamClaude] All accounts over threshold — probing "${best.name}" to refresh quota`);
+    }
     return best;
   }
 
@@ -211,6 +229,7 @@ export class AccountManager {
       if (Date.now() < account.rateLimitedUntil) return false;
       account.status = 'active';
       account.rateLimitedUntil = null;
+      account.throttledAt = null;
       console.log(`[TeamClaude] Account "${account.name}" rate limit expired, marking active`);
     }
 
@@ -596,7 +615,25 @@ export class AccountManager {
     if (!account) return;
     account.status = 'throttled';
     account.rateLimitedUntil = Date.now() + (retryAfterSeconds * 1000);
+    // Marks when the hold was (re-)armed: a revalidation probe is allowed only
+    // after throttleProbeFloorMs from here, so a probe that 429s again pushes
+    // the next probe out by a full floor rather than hammering upstream.
+    account.throttledAt = Date.now();
     console.log(`[TeamClaude] Account "${account.name}" rate limited for ${retryAfterSeconds}s`);
+  }
+
+  /**
+   * Clear a rate-limit hold after live proof it no longer binds: any non-429
+   * upstream response on a throttled account (a revalidation probe reaching
+   * here, or a hold armed moments before traffic resumed). No-op otherwise.
+   */
+  clearRateLimited(accountIndex) {
+    const account = this.accounts[accountIndex];
+    if (!account || account.status !== 'throttled') return;
+    account.status = 'active';
+    account.rateLimitedUntil = null;
+    account.throttledAt = null;
+    console.log(`[TeamClaude] Account "${account.name}" revalidated — rate limit no longer applies, back in rotation`);
   }
 
   /**

--- a/src/server.js
+++ b/src/server.js
@@ -375,6 +375,11 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     }
     accountManager.updateQuota(account.index, rateLimitHeaders);
 
+    // Any non-429 response is live proof a rate-limit hold no longer binds —
+    // this is what lets a revalidation probe (a throttled account selected by
+    // _selectProbe) clear its own hold and return the fleet to service.
+    if (upstreamRes.status !== 429) accountManager.clearRateLimited(account.index);
+
     // On 429, wait the retry-after duration and retry on the same account
     // (this is a transient rate limit, not quota exhaustion).
     if (upstreamRes.status === 429) {

--- a/test/throttle-revalidation.test.js
+++ b/test/throttle-revalidation.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// The scenario these tests guard against (reproduced live in a sandbox): a 429
+// burst throttles every account with a long retry-after hold; the hold lives
+// only in memory and nothing revalidates it, so teamclaude keeps refusing with
+// synthetic 429s even after upstream is healthy again, until a restart wipes
+// the holds. Revalidation lets a live probe clear a stale hold instead.
+
+test('within the floor, a rate-limit hold is respected verbatim (no probe)', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.markRateLimited(0, 3600);
+  am.markRateLimited(1, 3600);
+  assert.equal(am.getActiveAccount(), null, 'freshly throttled fleet must refuse');
+});
+
+test('after the floor, a throttled account becomes a revalidation probe target', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.markRateLimited(0, 3600);
+  am.markRateLimited(1, 3600);
+  // Simulate the floor having elapsed (holds still far in the future).
+  am.accounts[0].throttledAt = Date.now() - am.throttleProbeFloorMs - 1;
+  am.accounts[1].throttledAt = Date.now() - am.throttleProbeFloorMs - 1;
+
+  const probe = am.getActiveAccount();
+  assert.ok(probe, 'expected a revalidation probe, not a refusal');
+  assert.equal(probe.status, 'throttled', 'probe target is still formally throttled');
+
+  // Probing stays rate-limited to one per probe interval.
+  assert.equal(am.getActiveAccount(exclude(probe)), null, 'second probe inside the interval must refuse');
+});
+
+test('a non-429 response clears the hold and returns the account to rotation', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.markRateLimited(0, 3600);
+  am.accounts[0].throttledAt = Date.now() - am.throttleProbeFloorMs - 1;
+  const probe = am.getActiveAccount();
+  assert.ok(probe);
+
+  // server.js calls this on any non-429 upstream response.
+  am.clearRateLimited(probe.index);
+  assert.equal(am.accounts[0].status, 'active');
+  assert.equal(am.accounts[0].rateLimitedUntil, null);
+  assert.equal(am.accounts[0].throttledAt, null);
+  // Normal selection works again with no probe gate involved.
+  assert.equal(am.getActiveAccount()?.name, 'a');
+});
+
+test('a probe that 429s again re-arms the hold and pushes the next probe out a full floor', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.markRateLimited(0, 3600);
+  am.accounts[0].throttledAt = Date.now() - am.throttleProbeFloorMs - 1;
+  assert.ok(am.getActiveAccount(), 'probe allowed after floor');
+
+  // Upstream said 429 again: forwardRequest re-arms via markRateLimited.
+  am.markRateLimited(0, 3600);
+  am._nextProbeAt = 0; // even with the probe interval open...
+  assert.equal(am.getActiveAccount(), null, '...the fresh floor blocks an immediate re-probe');
+});
+
+test('clearRateLimited is a no-op on accounts that are not throttled', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].status = 'error';
+  am.clearRateLimited(0);
+  assert.equal(am.accounts[0].status, 'error', 'must not resurrect an errored account');
+  am.clearRateLimited(99); // out of range: must not throw
+});
+
+test('constructor floor option is honored', () => {
+  const am = new AccountManager([oauth('a')], 0.98, { throttleProbeFloorMs: 5 });
+  am.markRateLimited(0, 3600);
+  assert.equal(am.getActiveAccount(), null, 'inside the tiny floor');
+  am.accounts[0].throttledAt = Date.now() - 6;
+  assert.ok(am.getActiveAccount(), 'past the tiny floor');
+});
+
+test('natural hold expiry still clears state fully', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.markRateLimited(0, 1);
+  am.accounts[0].rateLimitedUntil = Date.now() - 1; // expired
+  const acct = am.getActiveAccount();
+  assert.equal(acct?.name, 'a');
+  assert.equal(am.accounts[0].throttledAt, null, 'expiry must reset throttledAt too');
+});
+
+function exclude(account) {
+  return new Set([account.index]);
+}


### PR DESCRIPTION
## Symptom

After an internet drop and reconnect, teamclaude sometimes keeps failing every request even though the network and the API are fine again. All accounts show `throttled`, Claude reports API errors, and the only thing that helps is restarting teamclaude.

This replaces #73, which blamed dead pooled connections. Sandbox testing (below) disproved that diagnosis and found the real one.

## What testing showed

All of this was measured in a Docker sandbox: a mock Anthropic upstream, teamclaude in a container, and a true silent network blackhole (iptables dropping all packets, no RST or FIN, exactly what a wifi drop looks like).

| Belief | Measured reality |
|---|---|
| Dead pooled connections poison the pool until restart | False. After reconnect, the next request opened a fresh connection and succeeded in 10ms, same process |
| Idle sockets go stale during long idle periods | False. Node closes idle pooled sockets after about 4s, so an idle drop leaves nothing to poison |
| Restart is needed because of sockets | False at the socket layer. The restart ritual is explained by in-memory account state, below |

## The actual bug

A 429 response arms an in-memory hold on the account (`rateLimitedUntil`, up to 1 hour from `retry-after`). Two properties turn that into a lockout:

1. **Failover amplifies.** One client request during a 429 burst gets retried across accounts, so a single request can throttle every account at once.
2. **Nothing revalidates a hold.** While it lasts, the account is excluded from routing and from probing. If the 429s were transient (for example the retry burst right after a reconnect), the fleet stays locked long after upstream is healthy.

The hold is not persisted. That is the whole reason restarting "fixes" it: the restart wipes the hold, nothing else.

```mermaid
sequenceDiagram
    participant C as Client
    participant T as teamclaude
    participant A as API

    Note over C,A: network drops, then reconnects
    C->>T: request (retry burst)
    T->>A: try account alpha
    A-->>T: 429, retry-after 3600
    T->>A: failover to account beta
    A-->>T: 429, retry-after 3600
    Note over T: both accounts held in memory for 1h
    T-->>C: 429 "all accounts exhausted"

    Note over A: API fully healthy again
    C->>T: request
    T-->>C: 429 (hold still active, nothing rechecks it)
    Note over C,T: dead until hold expires or teamclaude restarts
```

Reproduced end to end in the sandbox: healthy → 200, then 429 burst → both accounts held 3600s, then upstream healthy again → still refused every request, then restart → instant 200.

## Fix

Reuse the existing quota-probe machinery (the same mechanism that revalidates stale soft-quota reads). After a floor (`TEAMCLAUDE_THROTTLE_PROBE_FLOOR_MS`, default 60s), a throttled account becomes probe-eligible when no account is available, limited to one probe per probe interval. The probe is a real client request, so it costs nothing extra:

- any non-429 response clears the hold and puts the account back in rotation
- another 429 re-arms the hold with a fresh `retry-after` and pushes the next probe out a full floor

A genuine long rate limit is still respected: the fleet sends at most one request per minute against it, and every re-arm is based on what upstream just said rather than a stale snapshot.

Same sandbox, with the fix:

```
[TeamClaude] Account "acct-alpha" rate limited for 3600s
[TeamClaude] Account "acct-beta" rate limited for 3600s
[TeamClaude] All accounts unavailable — revalidating throttled "acct-beta" with a live request
[TeamClaude] Account "acct-beta" revalidated — rate limit no longer applies, back in rotation
```

Recovery without restart, on the first request past the floor. Unit tests cover the floor, the probe gating, clearing on non-429, re-arming on 429, and hold expiry.
