### PR TITLE
fix: recover from network drops without restarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ Override the config path with `TEAMCLAUDE_CONFIG`:
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 ```
 
+### Network resilience
+
+After a host network drop and reconnect, Node's shared connection pool can hold dead keep-alive sockets. Because a request has no default time limit, a retry can land on a dead socket and hang forever — every account and every retry keeps hitting the same poison, so the proxy appears wedged until you restart it. teamclaude bounds each stage so a stuck request fails fast instead: the failure lets Node evict the dead socket, the client retries, and the next request connects fresh — no restart needed. Recovery is per-socket, so after a flap it can take a few failed-then-retried requests to fully drain, but it always converges.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS` | `120000` | Max wait for upstream **response headers** (time-to-first-byte). Cleared the instant headers arrive, so a long streaming body is never cut. Streamed completions deliver first byte in seconds; a non-streaming (`stream:false`) request that legitimately generates for longer than this could trip it — raise it for such callers. |
+| `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS` | `120000` | Max **idle** gap between response-body chunks. Resets on every chunk, so a slow-but-healthy stream is fine; it fires only when the socket goes silent mid-stream (a drop after headers), turning a hang into a fast, retryable failure. |
+| `TEAMCLAUDE_REFRESH_TIMEOUT_MS` | `30000` | Max wait for an OAuth token refresh. A hung refresh is coalesced across all callers, so it would otherwise wedge every request for that account. |
+
 ### Config format
 
 ```json

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -36,6 +36,11 @@ const DEFAULT_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_ENDPOINT) {
   const maxRetries = 2;
   const baseDelayMs = 500;
+  // Bound each attempt so a dead pooled socket (after a network drop/reconnect)
+  // can't hang the refresh forever. A hung refresh is especially harmful here:
+  // ensureTokenFresh coalesces callers into a single _refreshPromise, so one
+  // stuck refresh wedges every request for that account until a restart.
+  const timeoutMs = Number(process.env.TEAMCLAUDE_REFRESH_TIMEOUT_MS) || 30_000;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -56,6 +61,7 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
           refresh_token: refreshToken,
           client_id: DEFAULT_CLIENT_ID,
         }),
+        signal: AbortSignal.timeout(timeoutMs),
       });
 
       if (!res.ok) {
@@ -81,7 +87,8 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
       };
     } catch (err) {
       const isNetworkError = err instanceof Error &&
-        (err.message.includes('fetch failed') ||
+        (err.name === 'TimeoutError' || err.name === 'AbortError' ||
+          err.message.includes('fetch failed') ||
           (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
            err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT'));
 

--- a/src/server.js
+++ b/src/server.js
@@ -503,11 +503,19 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     if (l) { l.write(`\n\n=== ERROR ===\n${err.stack || err.message}`); l.end(); }
 
     const isTransient = err instanceof Error &&
-      (err.message.includes('fetch failed') ||
+      (err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT' || err.code === 'TEAMCLAUDE_BODY_TIMEOUT' ||
+        err.name === 'TimeoutError' || err.name === 'AbortError' ||
+        err.message.includes('fetch failed') ||
         err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
-        err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT');
+        err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT' ||
+        err.code === 'UND_ERR_HEADERS_TIMEOUT' || err.code === 'UND_ERR_BODY_TIMEOUT');
 
-    // Transient network errors: just close the connection and let the client retry
+    // Transient network errors (including a stale-socket headers/body timeout):
+    // close the connection and let the client retry. Failing over to another
+    // account would not help (the poisoned fetch pool is process-wide), but the
+    // fast failure lets Node evict the dead socket so the retry reconnects
+    // cleanly. If headers were already sent (a mid-stream body timeout), destroy
+    // is the only option — the client sees a broken response and retries.
     if (isTransient) {
       res.destroy();
       return;
@@ -534,17 +542,53 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   }
 }
 
+// Idle deadline for the RESPONSE BODY, complementing the headers timeout in
+// upstream-fetch.js. The headers guard only covers time-to-first-byte; once
+// headers arrive it is disarmed, so a network drop AFTER the stream starts would
+// otherwise hang the read forever (the SSE completion just goes silent mid-way).
+// This watchdog resets on every chunk, so a long but healthy stream is never
+// cut — it fires only when the socket produces nothing for the whole window,
+// converting a mid-stream hang into a fast failure that evicts the dead socket
+// (reader.cancel destroys the underlying connection on both the direct-fetch and
+// the sx-tunnel path, since both hand back a web ReadableStream). Override with
+// TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS.
+const DEFAULT_BODY_IDLE_TIMEOUT_MS = 120_000;
+
+function resolveBodyIdleTimeout() {
+  const env = Number(process.env.TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS);
+  return env > 0 ? env : DEFAULT_BODY_IDLE_TIMEOUT_MS;
+}
+
+// Race a single reader.read() against an inactivity deadline. Resolves to the
+// read result, or rejects with a transient TEAMCLAUDE_BODY_TIMEOUT if no chunk
+// arrives within `ms`. The pending read is abandoned on timeout; the caller
+// cancels the reader (evicting the socket) in its finally block.
+export function readWithIdleTimeout(reader, ms) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`upstream stream idle for ${ms}ms`);
+      err.code = 'TEAMCLAUDE_BODY_TIMEOUT';
+      reject(err);
+    }, ms);
+    timer.unref?.();
+  });
+  return Promise.race([reader.read(), timeout]).finally(() => clearTimeout(timer));
+}
+
 /**
  * Stream an SSE response to the client, parsing usage data along the way.
  */
 async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter) {
   const reader = webStream.getReader();
+  const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
   let sseBuffer = '';
+  let errored = false;
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout(reader, idleMs);
       if (done) break;
 
       // Client disconnected — stop reading from upstream
@@ -582,10 +626,19 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
     if (sseBuffer.trim()) {
       parseSSEUsage(sseBuffer, accountIndex, accountManager);
     }
+  } catch (err) {
+    // A mid-stream idle timeout (or any read error) means the upstream went
+    // silent after headers. Rethrow to the caller's transient handler, which
+    // destroys the client connection so the truncated stream is NOT ended
+    // cleanly (a clean res.end() would look like a complete response and
+    // suppress the client's retry). reader.cancel() in finally evicts the socket.
+    errored = true;
+    throw err;
   } finally {
-    // Cancel upstream reader to stop consuming data nobody needs
+    // Cancel upstream reader to stop consuming data nobody needs (and, on the
+    // timeout path, to destroy the dead socket so the pool drops it).
     reader.cancel().catch(() => {});
-    if (!res.writableEnded) res.end();
+    if (!errored && !res.writableEnded) res.end();
   }
 }
 

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -13,14 +13,78 @@ import https from 'node:https';
 import { Readable } from 'node:stream';
 import { tunnelTls } from './sx.js';
 
-// `useProxy` is decided by the caller (it varies per attempt — e.g. direct first,
-// then via sx after a 429). With it false, or sx unprovisioned, this is plain fetch.
-export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
-  if (!sx || !useProxy || !sx.isProvisioned()) return fetch(url, opts);
-  return proxiedFetch(url, opts, sx);
+// Time to wait for RESPONSE HEADERS before treating the upstream socket as dead.
+// This is NOT a limit on the response body (SSE completions can stream for
+// minutes); the deadline is cleared the instant headers arrive, so a slow, long
+// answer is never cut. It measures time-to-first-byte only, which streaming
+// delivers within seconds, and its job is to convert an indefinite hang on a
+// half-dead pooled socket (e.g. after the host's network drops and reconnects,
+// leaving Node's global fetch pool holding stale keep-alive connections) into a
+// fast, retryable failure. Without it a reused dead socket hangs until Node's
+// 300s default, long past the point the client gave up, and only a full process
+// restart clears the poisoned pool. Each aborted request evicts one dead socket,
+// so a burst of stale connections drains over the next few retries.
+//
+// NOTE (non-streaming requests): for a request without `stream: true`, the whole
+// response arrives as the "headers+body" unit, so first-byte ≈ full generation.
+// Claude Code's completions stream, so this is safe in practice, but a very long
+// non-streaming generation could trip this — raise it per-call or via the env var
+// for such callers. Mid-stream stalls (a drop AFTER headers) are handled
+// separately by the body-idle watchdog in server.js's streamResponse.
+//
+// We abort ONLY in the pre-headers window and clear the timer once the body
+// starts, so we never abort mid-stream. That matters: an AbortSignal fired after
+// data has started leaves the socket occupied and leaks a "zombie" connection
+// that drains the pool over time; aborting before the first byte lets undici
+// destroy the socket cleanly instead. The textbook fix is dispatcher-level
+// timeouts via undici's setGlobalDispatcher(new Agent({ headersTimeout,
+// keepAliveTimeout })); we stay zero-dependency, so this reactive guard is the
+// stand-in.
+//
+// Default is generous (well above Claude's realistic first-byte, even when
+// queued or under load) so a slow-but-legitimate response is never mistaken for
+// a dead socket. Override with TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS (or
+// per-call opts).
+const DEFAULT_HEADERS_TIMEOUT_MS = 120_000;
+
+function resolveHeadersTimeout(perCall) {
+  if (perCall != null) return perCall;
+  const env = Number(process.env.TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS);
+  return env > 0 ? env : DEFAULT_HEADERS_TIMEOUT_MS;
 }
 
-function proxiedFetch(url, opts, sx) {
+function headersTimeoutError(ms) {
+  const err = new Error(`upstream response headers timed out after ${ms}ms`);
+  // Recognized by server.js isTransient → fail fast + let the client retry, so
+  // Node's fetch pool evicts the stale connection instead of wedging.
+  err.code = 'TEAMCLAUDE_HEADERS_TIMEOUT';
+  return err;
+}
+
+// `useProxy` is decided by the caller (it varies per attempt — e.g. direct first,
+// then via sx after a 429). With it false, or sx unprovisioned, this is plain fetch
+// (plus the headers-timeout guard).
+export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
+  const { headersTimeoutMs, ...fetchOpts } = opts;
+  const timeoutMs = resolveHeadersTimeout(headersTimeoutMs);
+  if (!sx || !useProxy || !sx.isProvisioned()) return directFetch(url, fetchOpts, timeoutMs);
+  return proxiedFetch(url, fetchOpts, sx, timeoutMs);
+}
+
+// Global fetch driven by our own AbortController so we can arm a headers-only
+// deadline and disarm it the moment headers arrive (letting the body stream with
+// no deadline). AbortSignal.timeout can't do this — it would also kill the body.
+function directFetch(url, opts, timeoutMs) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(headersTimeoutError(timeoutMs)), timeoutMs);
+  timer.unref?.();
+  return fetch(url, { ...opts, signal: ctrl.signal }).then(
+    (res) => { clearTimeout(timer); return res; },
+    (err) => { clearTimeout(timer); throw err; },
+  );
+}
+
+function proxiedFetch(url, opts, sx, timeoutMs) {
   const u = new URL(url);
   const proxy = sx.getProxy();
 
@@ -36,12 +100,19 @@ function proxiedFetch(url, opts, sx) {
   };
 
   return new Promise((resolve, reject) => {
+    // Headers-only deadline (same as the direct path): fires before headers
+    // arrive and tears the tunneled request down; cleared once the response
+    // starts. `req` is created BEFORE the timer so a synchronous https.request
+    // throw (e.g. an invalid client header) can't leave a scheduled timer that
+    // fires later and dereferences an uninitialized binding.
     const req = https.request(
       u,
       { method: opts.method || 'GET', headers: opts.headers || {}, agent },
-      (res) => resolve(makeResponse(res)),
+      (res) => { clearTimeout(timer); resolve(makeResponse(res)); },
     );
-    req.once('error', reject);
+    const timer = setTimeout(() => req.destroy(headersTimeoutError(timeoutMs)), timeoutMs);
+    timer.unref?.();
+    req.once('error', (err) => { clearTimeout(timer); reject(err); });
 
     const body = opts.body;
     const method = (opts.method || 'GET').toUpperCase();

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { ReadableStream } from 'node:stream/web';
+import { TextEncoder, TextDecoder } from 'node:util';
+import { upstreamFetch } from '../src/upstream-fetch.js';
+import { readWithIdleTimeout } from '../src/server.js';
+
+// Bring up an HTTP server on an ephemeral port and hand back {server, port}.
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0);
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+// A half-dead upstream: it accepts the connection but never sends a response —
+// exactly what a keep-alive socket becomes after the host's network drops and
+// reconnects. Without the headers timeout this hangs until Node's 300s default.
+test('fails fast (does not hang) when upstream never sends headers', async () => {
+  const { server, port } = await listen(() => { /* never respond */ });
+
+  const start = Date.now();
+  await assert.rejects(
+    () => upstreamFetch(`http://127.0.0.1:${port}/v1/messages`,
+      { method: 'POST', body: '{}', headersTimeoutMs: 200 }),
+    (err) => err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT',
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 2000, `expected fast-fail, took ${elapsed}ms`);
+
+  server.close();
+});
+
+// The mechanism the whole fix rests on: after a hung request the dead socket is
+// dropped from the pool, so the next request to the SAME origin opens a fresh
+// connection and succeeds. Same origin is the point: two ports would be two
+// pools and prove nothing about eviction. We count TCP connections and assert
+// the second request opened a new one rather than reusing the dead keep-alive.
+test('evicts the dead socket and reconnects on the same origin', async () => {
+  let conns = 0;
+  let mode = 'hang';
+  const { server, port } = await listen((req, res) => {
+    if (mode === 'respond') { res.writeHead(200); res.end('ok'); }
+    // else: never respond, simulating a half-dead socket after a network drop
+  });
+  server.on('connection', () => { conns += 1; });
+  const origin = `http://127.0.0.1:${port}/`;
+
+  await assert.rejects(
+    () => upstreamFetch(origin, { headersTimeoutMs: 150 }),
+    (err) => err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT',
+  );
+
+  mode = 'respond';
+  const res = await upstreamFetch(origin, { headersTimeoutMs: 5000 });
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), 'ok');
+  // >1 connection proves the dead socket was evicted and a fresh one opened; a
+  // reuse of the aborted socket would leave the count at 1 (and hang). undici may
+  // open more than one on the abort path, so assert the invariant, not an exact n.
+  assert.ok(conns >= 2, `expected a fresh socket after eviction, saw ${conns} connection(s)`);
+
+  server.close();
+});
+
+// The headers deadline is headers-only: once headers arrive it is disarmed, so a
+// body that streams well past the timeout window is NOT cut off (SSE completions
+// run for minutes). Headers here return instantly; the body finishes at ~400ms
+// with a 150ms headers timeout.
+test('does not cut a slow body once headers have arrived', async () => {
+  const { server, port } = await listen(async (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: ping\n\n');
+    await new Promise((r) => setTimeout(r, 400));
+    res.write('event: done\n\n');
+    res.end();
+  });
+
+  const res = await upstreamFetch(`http://127.0.0.1:${port}/`, { headersTimeoutMs: 150 });
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /done/); // full body read, not aborted at 150ms
+
+  server.close();
+});
+
+// Mid-stream recovery (extends the PR): once headers have arrived the headers
+// timeout is disarmed, so a drop DURING the body would hang forever. The
+// body-idle watchdog in streamResponse guards each read. Here the stream yields
+// one chunk then goes silent; the second read must fail fast with a transient
+// TEAMCLAUDE_BODY_TIMEOUT (which server.js treats as retryable) rather than hang.
+test('body watchdog fails fast when the stream goes silent mid-body', async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('event: ping\n\n'));
+      // never enqueue again and never close — a mid-stream network drop
+    },
+  });
+  const reader = stream.getReader();
+
+  // First chunk is already buffered: resolves immediately, no timeout.
+  const first = await readWithIdleTimeout(reader, 200);
+  assert.equal(first.done, false);
+  assert.equal(new TextDecoder().decode(first.value), 'event: ping\n\n');
+
+  // Second read: the stream is silent, so the watchdog fires fast.
+  const start = Date.now();
+  await assert.rejects(
+    () => readWithIdleTimeout(reader, 200),
+    (err) => err.code === 'TEAMCLAUDE_BODY_TIMEOUT',
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 2000, `expected fast body-timeout, took ${elapsed}ms`);
+});
+
+// The watchdog must not fire on a healthy-but-slow stream: a chunk that arrives
+// within the window resets nothing artificially — it simply resolves.
+test('body watchdog does not fire when chunks keep arriving', async () => {
+  let pushed = false;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (pushed) { controller.close(); return; }
+      pushed = true;
+      return new Promise((resolve) => setTimeout(() => {
+        controller.enqueue(new TextEncoder().encode('event: ok\n\n'));
+        resolve();
+      }, 100));
+    },
+  });
+  const reader = stream.getReader();
+
+  const r = await readWithIdleTimeout(reader, 500); // 100ms chunk < 500ms window
+  assert.equal(r.done, false);
+  assert.match(new TextDecoder().decode(r.value), /ok/);
+});


### PR DESCRIPTION
## Problem

After the host network drops and reconnects, teamclaude keeps failing every request until you restart it. Accounts show as throttled or errored and Claude reports API errors, even though nothing is actually rate limited.

The cause is a poisoned connection pool. Node's shared `fetch` pool holds dead keep-alive sockets across all requests and accounts. When the network drops the connections die silently, and because a request has no time limit it waits on a dead connection forever instead of failing. A hung request never errors, so the dead socket is never dropped from the pool, and every retry and every account keeps landing on the same poison — only a restart builds a fresh pool.

## Fix

Bound each stage so a stuck request fails fast instead of hanging. The fast failure lets Node evict the dead socket, the client retries, and the next request connects fresh — no restart needed.

- **Headers timeout** (`src/upstream-fetch.js`): a headers-only deadline (time-to-first-byte) on both the direct-`fetch` path and the sx-tunnel path. It is cleared the instant headers arrive, so a long streaming body is never cut — it only converts an indefinite pre-headers hang into a fast, retryable failure. `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS`, default 120s.
- **Body-idle watchdog** (`src/server.js` `streamResponse`): the headers timeout is disarmed once headers arrive, so a drop *during* the body would still hang. This watchdog guards each `reader.read()`, resets on every chunk (a slow-but-healthy stream is fine), and fires only when the stream goes silent mid-body. On timeout the truncated stream is torn down rather than cleanly ended, so the client retries instead of accepting a partial response. Covers both fetch paths, since both hand back a web `ReadableStream`. `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS`, default 120s.
- **Transient classification** (`src/server.js`): broadened to recognize the new timeout codes plus undici's `UND_ERR_HEADERS_TIMEOUT` / `UND_ERR_BODY_TIMEOUT`.
- **Refresh timeout** (`src/oauth.js`): token refresh now fails after 30s instead of hanging. A hung refresh is especially harmful — `ensureTokenFresh` coalesces callers into a single promise, so one stuck refresh wedges every request for that account. `TEAMCLAUDE_REFRESH_TIMEOUT_MS`, default 30s.

No new dependencies.

## Notes

Recovery is per-socket: each fast failure evicts one dead connection, so after a flap with several in-flight requests it can take a few failed-then-retried requests to fully drain. It always converges without a restart.

**Non-streaming caveat:** the headers timeout is time-to-first-byte, which is cheap for streamed completions (Claude Code's default). A non-streaming (`stream: false`) request that legitimately generates for longer than the window could trip it — raise the env var for such callers. Documented in the README.

## Relationship to #73

Based on #73 by @teocns. The headers-timeout and refresh-timeout are reimplemented from that PR (reviewed, not blindly cherry-picked). Extended here with a **zero-dependency mid-stream body watchdog** — #73's suggested dispatcher-level alternative (`setGlobalDispatcher(new Agent({ headersTimeout, bodyTimeout }))`) would add the `undici` runtime dependency the project deliberately avoids and would not cover the sx-tunnel path. Merging this closes #73.

## Tests

`test/upstream-timeout.test.js`: fast-fail on a dead socket, same-origin socket eviction + reconnect, a slow body not cut once headers arrive, the mid-stream body watchdog firing fast, and the watchdog *not* firing on a healthy slow stream. Full suite passes (143) and lint is clean.

Closes #73

Co-authored-by: teocns <teocns@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)