### PR TITLE
feat: opt-in keep-warm for idle accounts + per-account pin endpoint (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
+- **Optional keep-warm** — off by default; when enabled, periodically starts idle accounts' 5h session timers with a minimal request (`teamclaude warmup`) so the next account isn't cold when rotation reaches it (spends a little quota, unlike the probe)
+- **Account pinning** — force a request onto one account via an `ANTHROPIC_BASE_URL=.../tc-acct/<name>` prefix, bypassing rotation
 - **MITM proxy mode (default)** — `teamclaude run` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected; pass `--no-mitm` for base-URL routing only
 - **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
@@ -264,6 +266,7 @@ After a host network drop and reconnect, Node's shared connection pool can hold 
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts (TUI: `g` → `t`) |
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |
+| `warmupSeconds` | Keep-warm interval in seconds (`0` = off, the default; CLI `warmup`). Spawns a minimal `claude` per idle account to start its 5h timer — **spends a little quota**, unlike the probe |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
@@ -289,6 +292,31 @@ teamclaude probe        # show current setting
 You can also set the interval live from the TUI settings screen (`g` → `p`), alongside the rotation threshold (`t`).
 
 It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. Minimum interval is 30s. Changing it takes effect on a running server immediately (no restart). When enabled, it also surfaces the **Sonnet 7-day** and **Fable 7-day** buckets as extra bars in the TUI / `status` (when your plan exposes them).
+
+### Keep-warm: start idle accounts' 5h timers (optional, off by default)
+
+The rolling **5-hour session window** only starts once an account sends a real message. So when your active account runs out and rotation moves to a cold account, that account's 5h window starts *then* — right when you need its full headroom. Keep-warm ([#76](https://github.com/KarpelesLab/teamclaude/issues/76)) starts the timer on idle accounts ahead of time, so the next account is already partway (or fully) through a fresh window when it's needed.
+
+```bash
+teamclaude warmup 600    # warm idle accounts every 600s
+teamclaude warmup off    # disabled (default)
+teamclaude warmup        # show current setting
+```
+
+> ⚠️ **This spends a little quota — unlike the passive quota probe.** The 5h timer can't be started by a read-only call, so keep-warm sends a real (minimal) message: for each eligible idle account it spawns a one-shot `claude -p --bare --model haiku "hi"` pointed at this proxy, pinned to that account (see below). It only warms accounts whose 5h window is **not already running**, skips disabled/throttled/errored and third-party-backend accounts, and uses the cheapest model — but it does consume a few tokens and a slice of the 5h/weekly buckets per account per window. Requires the `claude` CLI on `PATH`. Minimum interval 60s; changes apply live (no restart). Status shows under `warm` in `teamclaude status --json`.
+
+### Pin a request to a specific account
+
+`ANTHROPIC_BASE_URL` with a `/tc-acct/<name-or-index>` prefix forces every request onto **one** account, bypassing rotation (and never failing over to another). This is what keep-warm uses internally, and it doubles as a manual way to exercise a specific account:
+
+```bash
+# Route this whole claude session to the account named "work (Acme)" (index also works)
+ANTHROPIC_BASE_URL='http://127.0.0.1:3456/tc-acct/1' \
+ANTHROPIC_API_KEY='<your teamclaude proxy key>' \
+  claude -p --bare 'say hi'
+```
+
+The `<name>` matches an account's display name exactly (URL-encode spaces/parens), or a numeric rotation index. An unknown pin returns `404`. The prefix is stripped before the request is forwarded upstream.
 
 ### Third-party backend accounts
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import { sameIdentity, orgKey, matchAccounts } from './identity.js';
 import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
+import { Warmer } from './warmer.js';
 import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
@@ -72,6 +73,10 @@ switch (command) {
     break;
   case 'probe':
     await probeCommand();
+    process.exit(0);
+    break;
+  case 'warmup':
+    await warmupCommand();
     process.exit(0);
     break;
   case 'update':
@@ -182,6 +187,8 @@ async function serverCommand() {
 
   // Opt-in background quota probe (config.quotaProbeSeconds, default 0 = off).
   let prober = null;
+  // Opt-in keep-warm scheduler (config.warmupSeconds, default 0 = off).
+  let warmer = null;
   const serverStartedAt = Date.now();
 
   // sx.org proxy (IP-based-429 workaround). Dormant unless an API key is set in
@@ -217,6 +224,13 @@ async function serverCommand() {
         prober.reschedule(ms);
       }
     }
+    if (warmer) {
+      const ms = (diskConfig.warmupSeconds || 0) * 1000;
+      if (ms !== warmer.intervalMs) {
+        config.warmupSeconds = diskConfig.warmupSeconds || 0;
+        warmer.reschedule(ms);
+      }
+    }
     return added;
   };
 
@@ -246,10 +260,12 @@ async function serverCommand() {
         // Persist other runtime-tunable settings edited from the TUI.
         if (config.switchThreshold != null) diskConfig.switchThreshold = config.switchThreshold;
         if (config.quotaProbeSeconds != null) diskConfig.quotaProbeSeconds = config.quotaProbeSeconds;
+        if (config.warmupSeconds != null) diskConfig.warmupSeconds = config.warmupSeconds;
       }),
       syncAccounts: reloadAccounts,
       onQuit: async () => {
         prober?.stop();
+        warmer?.stop();
         if (quotaSaveInterval) clearInterval(quotaSaveInterval);
         await persistQuotaState();
         server.close(() => process.exit(0));
@@ -279,6 +295,19 @@ async function serverCommand() {
         name: account.name,
         status: account.type === 'oauth' ? 'never' : 'not-applicable',
         lastProbedAt: null,
+        startedAt: null,
+        durationMs: null,
+        error: null,
+      })),
+    },
+    warm: warmer?.getStatus() || {
+      enabled: false,
+      intervalSeconds: config.warmupSeconds || 0,
+      running: false,
+      accounts: accountManager.accounts.map(account => ({
+        name: account.name,
+        status: (account.type === 'oauth' && !account.upstream) ? 'never' : 'not-applicable',
+        lastWarmedAt: null,
         startedAt: null,
         durationMs: null,
         error: null,
@@ -331,6 +360,16 @@ async function serverCommand() {
   prober = new Prober(accountManager, { intervalMs: (config.quotaProbeSeconds || 0) * 1000 });
   prober.start();
 
+  // Start the opt-in keep-warm scheduler (no-op when warmupSeconds is 0). It
+  // spawns a minimal `claude` per idle account through this proxy, pinned via
+  // /tc-acct/<index>, so needs our own port and proxy key.
+  warmer = new Warmer(accountManager, {
+    intervalMs: (config.warmupSeconds || 0) * 1000,
+    port,
+    apiKey: config.proxy?.apiKey,
+  });
+  warmer.start();
+
   // Background self-update for a backgrounded (headless) server. Skipped under
   // the TUI, where npm's install output would corrupt the display — interactive
   // users update via `teamclaude run` (post-session) or `teamclaude update`.
@@ -340,6 +379,7 @@ async function serverCommand() {
     const shutdown = async () => {
       console.log('\n[TeamClaude] Shutting down...');
       prober?.stop();
+      warmer?.stop();
       clearInterval(quotaSaveInterval);
       await persistQuotaState();
       server.close(() => process.exit(0));
@@ -793,6 +833,44 @@ async function probeCommand() {
   await notifyRunningServer(config);
 }
 
+// ── warmup ──────────────────────────────────────────────────
+
+async function warmupCommand() {
+  const config = await loadOrCreateConfig();
+  const arg = args[1];
+
+  if (arg === undefined) {
+    const cur = config.warmupSeconds || 0;
+    console.log(cur > 0 ? `Keep-warm: every ${cur}s` : 'Keep-warm: off');
+    console.log('Set with: teamclaude warmup <off|seconds>   e.g. teamclaude warmup 600');
+    console.log('Note: warming spawns a minimal `claude` per idle account and DOES spend a little quota');
+    console.log('(unlike the passive quota probe). It only warms accounts whose 5h window is idle.');
+    return;
+  }
+
+  let seconds;
+  if (arg === 'off' || arg === '0') {
+    seconds = 0;
+  } else {
+    seconds = parseInt(arg, 10);
+    if (Number.isNaN(seconds) || seconds < 0) {
+      console.error('Usage: teamclaude warmup <off|seconds>');
+      process.exit(1);
+    }
+    if (seconds > 0 && seconds < 60) {
+      console.error('Minimum keep-warm interval is 60s.');
+      process.exit(1);
+    }
+  }
+
+  config.warmupSeconds = seconds;
+  await saveConfig(config);
+  console.log(seconds > 0
+    ? `Keep-warm set to every ${seconds}s (spawns a minimal \`claude\` per idle account; spends a little quota).`
+    : 'Keep-warm disabled.');
+  await notifyRunningServer(config);
+}
+
 // ── update ──────────────────────────────────────────────────
 
 async function updateCommand() {
@@ -965,6 +1043,9 @@ Commands:
   priority <name> <n> Set rotation priority (lower = preferred; --first/--last)
   probe [off|secs]    Opt-in background quota refresh for idle accounts
                       (off by default; reads usage endpoint, spends no quota)
+  warmup [off|secs]   Opt-in: keep idle accounts' 5h timers running by sending
+                      a minimal claude request to each (off by default; spends
+                      a little quota, unlike probe)
   api <path>          Call an API endpoint with account credentials
   update              Check npm for a newer teamclaude and install it
   version             Print the installed version

--- a/src/prober.js
+++ b/src/prober.js
@@ -3,7 +3,9 @@
 // DISABLED BY DEFAULT. When enabled (config.quotaProbeSeconds > 0), periodically
 // reads an OAuth account's quota zero-spend /api/oauth/usage endpoint so idle
 // accounts' utilization/reset stay fresh without waiting to rotate onto them.
-// This is the one sanctioned active-upstream feature; proxy otherwise passive.
+// A sanctioned active-upstream feature (the other is the opt-in keep-warm
+// scheduler, warmer.js); the proxy is otherwise passive. Unlike keep-warm, this
+// probe reads a zero-spend endpoint and never consumes message quota.
 
 import { fetchUsage } from './oauth.js';
 

--- a/src/server.js
+++ b/src/server.js
@@ -109,6 +109,19 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
+// Resolve an account-pin token (from a `/tc-acct/<token>` URL) to an account
+// index, or null if it matches nothing. Matches by exact account name first,
+// then by numeric index. Exported for tests.
+export function resolveAccountPin(accountManager, token) {
+  const byName = accountManager.accounts.findIndex(a => a.name === token);
+  if (byName >= 0) return byName;
+  if (/^\d+$/.test(token)) {
+    const i = Number(token);
+    if (i >= 0 && i < accountManager.accounts.length) return i;
+  }
+  return null;
+}
+
 export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null }) {
   let counter = 0;
   return async (req, res) => {
@@ -121,6 +134,23 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // rotated account token, which would 403 the worker event stream.
       if ((req.url || '').startsWith('/v1/code/')) { await relayStream(req, res, upstream, sx); return; }
 
+      // Account pin: a request to `/tc-acct/<name-or-index>/...` (e.g. via
+      // ANTHROPIC_BASE_URL=http://host:port/tc-acct/deepseek) is forced onto that
+      // one account, bypassing rotation. Used by the keep-warm scheduler and for
+      // manual per-account testing. The prefix is stripped before forwarding.
+      let pinnedIndex = null;
+      const pin = (req.url || '').match(/^\/tc-acct\/([^/]+)(\/.*)$/);
+      if (pin) {
+        const token = decodeURIComponent(pin[1]);
+        pinnedIndex = resolveAccountPin(accountManager, token);
+        if (pinnedIndex == null) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
+          return;
+        }
+        req.url = pin[2];
+      }
+
       const reqId = ++counter;
       hooks.onRequestStart?.(reqId, { method: req.method, path: req.url });
 
@@ -129,7 +159,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       for await (const chunk of req) bodyChunks.push(chunk);
       const body = Buffer.concat(bodyChunks);
 
-      const ctx = { account: null, status: null, tried: new Set(), model: parseRequestModel(body) };
+      const ctx = { account: null, status: null, tried: new Set(), model: parseRequestModel(body), pinnedIndex };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -273,7 +303,12 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // Select account, skipping any already tried (and failed) this request.
   // The model scopes availability so a Fable-exhausted account is skipped only
   // for Fable requests (it still serves other models).
-  const account = accountManager.getActiveAccount(ctx.tried, ctx.model);
+  // A pinned request (via /tc-acct/<name>) forces one exact account and never
+  // rotates or fails over: once that account has been tried, `account` is null
+  // and the caller gets the exhausted response rather than leaking to another.
+  const account = ctx.pinnedIndex != null
+    ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
+    : accountManager.getActiveAccount(ctx.tried, ctx.model);
   if (!account) {
     ctx.status = 429;
     ctx.account = '(none available)';

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -1,0 +1,213 @@
+// Opt-in "keep-warm" scheduler (issue #76).
+//
+// DISABLED BY DEFAULT. When enabled (config.warmupSeconds > 0), periodically
+// starts the rolling 5-hour session window on idle accounts, so that when the
+// active account runs out the next one is not stone cold.
+//
+// This is the SECOND sanctioned active-upstream feature (the quota probe is the
+// first). It differs in an important way and is why it is strictly opt-in: the
+// 5h timer only starts on *real usage*, so — unlike the zero-spend
+// /api/oauth/usage probe — warming genuinely consumes a little quota (a few
+// tokens, a slice of the 5h window, a touch of the weekly bucket) per account
+// per window. To keep that cost minimal we warm an account only when its 5h
+// window is not already running, and we use the cheapest model.
+//
+// Mechanism (chosen in #76): for each eligible idle account we spawn a one-shot,
+// minimal `claude` (`--bare -p`) pointed at THIS proxy with the account pinned
+// via the `/tc-acct/<index>` path prefix. Using the real client means the
+// warm-up request is byte-identical to normal Claude Code traffic, routed to
+// exactly the account we want to warm.
+
+import { spawn } from 'node:child_process';
+
+export class Warmer {
+  constructor(accountManager, {
+    intervalMs = 0,
+    port,
+    apiKey = null,
+    model = 'haiku',
+    prompt = 'hi',
+    spawnFn = defaultSpawn,
+    timeoutMs = 120_000,
+    log = console.log,
+  } = {}) {
+    this.am = accountManager;
+    this.intervalMs = intervalMs;
+    this.port = port;
+    this.apiKey = apiKey;
+    this.model = model;
+    this.prompt = prompt;
+    this.spawnFn = spawnFn;
+    this.timeoutMs = timeoutMs;
+    this.log = log;
+    this.timer = null;
+    this._running = false;
+    this.lastRunStartedAt = null;
+    this.lastRunFinishedAt = null;
+    this.nextRunAt = intervalMs > 0 ? Date.now() + intervalMs : null;
+    this.accountStatus = new Map();
+  }
+
+  start() {
+    if (this.intervalMs > 0) this.reschedule(this.intervalMs);
+  }
+
+  /** Change interval at runtime (0 = off). Warms once immediately when turned on. */
+  reschedule(intervalMs) {
+    const wasOn = this.intervalMs > 0 && this.timer;
+    this.intervalMs = intervalMs;
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+
+    if (intervalMs > 0) {
+      this.nextRunAt = Date.now() + intervalMs;
+      this.warmAll().catch(() => {});
+      this.timer = setInterval(() => this.warmAll().catch(() => {}), intervalMs);
+      this.timer.unref?.();
+      this.log(`[TeamClaude] Keep-warm enabled (every ${Math.round(intervalMs / 1000)}s)`);
+    } else if (wasOn) {
+      this.nextRunAt = null;
+      this.log('[TeamClaude] Keep-warm disabled');
+    }
+  }
+
+  stop() {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    this.nextRunAt = null;
+  }
+
+  /**
+   * True when `account` is a healthy, idle Anthropic OAuth account whose 5h
+   * window is NOT already running. We skip:
+   *  - non-OAuth and third-party-backend accounts (`upstream` set) — the 5h
+   *    concept is Anthropic-specific;
+   *  - disabled / errored / exhausted / throttled accounts — warming them is
+   *    pointless or would just 429;
+   *  - accounts with a live 5h window — already warm, so warming again only burns
+   *    quota for nothing.
+   */
+  _isWarmTarget(account) {
+    if (account.type !== 'oauth' || !account.credential) return false;
+    if (account.upstream) return false;
+    if (account.disabled) return false;
+    if (account.status === 'error' || account.status === 'exhausted' || account.status === 'throttled') return false;
+    const reset = account.quota?.unified5hReset;
+    return !(reset && Date.now() < reset); // a future reset ⇒ session already running
+  }
+
+  /** Warm every eligible account once. Overlapping cycles are skipped. Sequential
+   *  on purpose: one subprocess at a time keeps load and the quota burst gentle. */
+  async warmAll() {
+    if (this._running) return;
+    this._running = true;
+    this.lastRunStartedAt = Date.now();
+    this.nextRunAt = this.intervalMs > 0 ? this.lastRunStartedAt + this.intervalMs : null;
+    try {
+      const targets = this.am.accounts.filter(account => this._isWarmTarget(account));
+      for (const account of targets) {
+        await this.warmAccount(account);
+      }
+    } finally {
+      this.lastRunFinishedAt = Date.now();
+      this._running = false;
+    }
+  }
+
+  async warmAccount(account) {
+    const startedAt = Date.now();
+    this._record(account, { status: 'running', startedAt });
+    try {
+      await this.am.ensureTokenFresh(account.index);
+      const code = await this.spawnFn(this._spawnSpec(account));
+      const finishedAt = Date.now();
+      this._record(account, {
+        status: code === 0 ? 'ok' : 'error',
+        error: code === 0 ? null : `claude exited ${code}`,
+        startedAt, finishedAt, durationMs: finishedAt - startedAt,
+      });
+    } catch (err) {
+      const finishedAt = Date.now();
+      this._record(account, {
+        status: 'error',
+        error: err?.message || String(err),
+        startedAt, finishedAt, durationMs: finishedAt - startedAt,
+      });
+    }
+  }
+
+  /** The `claude` invocation for one account. Pure/deterministic so tests can
+   *  assert the args and env without spawning anything. */
+  _spawnSpec(account) {
+    // Pin by INDEX (stable, and free of the spaces/parens real account names
+    // carry, which would otherwise need URL-encoding).
+    const baseUrl = `http://127.0.0.1:${this.port}/tc-acct/${account.index}`;
+    return {
+      command: 'claude',
+      // `--bare -p`: minimal, non-interactive, auth strictly via ANTHROPIC_API_KEY
+      // (which this proxy strips and replaces with the pinned account's token).
+      args: ['-p', '--bare', '--model', this.model, '--output-format', 'text', this.prompt],
+      env: {
+        ...process.env,
+        ANTHROPIC_BASE_URL: baseUrl,
+        ANTHROPIC_API_KEY: this.apiKey || 'tc-warm',
+      },
+      timeoutMs: this.timeoutMs,
+    };
+  }
+
+  getStatus() {
+    return {
+      enabled: this.intervalMs > 0,
+      intervalSeconds: Math.round(this.intervalMs / 1000),
+      running: this._running,
+      lastRunStartedAt: iso(this.lastRunStartedAt),
+      lastRunFinishedAt: iso(this.lastRunFinishedAt),
+      nextRunAt: iso(this.nextRunAt),
+      accounts: this.am.accounts.map(account => {
+        const status = this.accountStatus.get(account.name);
+        const applicable = account.type === 'oauth' && !account.upstream;
+        return {
+          name: account.name,
+          status: applicable ? (status?.status || 'never') : 'not-applicable',
+          lastWarmedAt: iso(status?.finishedAt),
+          startedAt: iso(status?.startedAt),
+          durationMs: status?.durationMs ?? null,
+          error: status?.error || null,
+        };
+      }),
+    };
+  }
+
+  _record(account, status) {
+    this.accountStatus.set(account.name, {
+      ...(this.accountStatus.get(account.name) || {}),
+      ...status,
+    });
+  }
+}
+
+// Spawn a one-shot `claude`, resolving with its exit code (non-zero ⇒ recorded as
+// an error) or rejecting if the binary can't launch (e.g. not on PATH) or the
+// warm-up overruns its timeout. stdio is ignored: we only care that a request
+// went through to start the timer.
+function defaultSpawn({ command, args, env, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(command, args, { env, stdio: 'ignore' });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`warm-up timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+    child.once('error', (err) => { clearTimeout(timer); reject(err); });
+    child.once('exit', (code) => { clearTimeout(timer); resolve(code ?? 0); });
+  });
+}
+
+function iso(ts) {
+  return ts ? new Date(ts).toISOString() : null;
+}

--- a/test/account-pin.test.js
+++ b/test/account-pin.test.js
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, resolveAccountPin } from '../src/server.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+function oauth(name) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000 };
+}
+
+// ── resolveAccountPin (unit) ─────────────────────────────────────────────────
+
+test('resolveAccountPin matches by exact name, then by numeric index', () => {
+  const am = new AccountManager([oauth('alpha'), oauth('beta')], 0.98);
+  assert.equal(resolveAccountPin(am, 'alpha'), 0);
+  assert.equal(resolveAccountPin(am, 'beta'), 1);
+  assert.equal(resolveAccountPin(am, '0'), 0);
+  assert.equal(resolveAccountPin(am, '1'), 1);
+});
+
+test('resolveAccountPin returns null for an unknown name or out-of-range index', () => {
+  const am = new AccountManager([oauth('alpha')], 0.98);
+  assert.equal(resolveAccountPin(am, 'nope'), null);
+  assert.equal(resolveAccountPin(am, '9'), null);
+  assert.equal(resolveAccountPin(am, '-1'), null); // not matched by \d+
+});
+
+test('a name that looks numeric is matched as a name before falling back to index', () => {
+  const am = new AccountManager([oauth('x'), { ...oauth('y'), name: '0' }], 0.98);
+  // The account literally named "0" (index 1) wins over index 0.
+  assert.equal(resolveAccountPin(am, '0'), 1);
+});
+
+// ── end-to-end pin routing (integration) ─────────────────────────────────────
+
+// Stand up a mock upstream that records the path and Authorization it received,
+// so we can prove which account a pinned request was routed to and that the
+// /tc-acct/<pin> prefix was stripped before forwarding.
+async function withProxy(run) {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push({ path: req.url, auth: req.headers.authorization });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([oauth('alpha'), oauth('beta')], 0.98);
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const proxyPort = await listen(proxy);
+  try {
+    return await run({ proxyPort, seen, am });
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+const post = (url) => fetch(url, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ model: 'x', messages: [] }),
+});
+
+test('a /tc-acct/<name> request is routed to that exact account, prefix stripped', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/beta/v1/messages`);
+    await res.text();
+    assert.equal(res.status, 200);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].path, '/v1/messages');          // prefix stripped
+    assert.equal(seen[0].auth, 'Bearer t-beta');         // routed to 'beta', not rotation default
+  });
+});
+
+test('pinning by numeric index also works', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/0/v1/messages`);
+    await res.text();
+    assert.equal(res.status, 200);
+    assert.equal(seen[0].auth, 'Bearer t-alpha');
+  });
+});
+
+test('an unknown pin returns 404 and never reaches upstream', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/ghost/v1/messages`);
+    const body = await res.json();
+    assert.equal(res.status, 404);
+    assert.equal(body.error.type, 'not_found_error');
+    assert.equal(seen.length, 0);
+  });
+});
+
+test('pinning overrides rotation even when another account is the active one', async () => {
+  await withProxy(async ({ proxyPort, seen, am }) => {
+    am.currentIndex = 0; // rotation would pick 'alpha'
+    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/beta/v1/messages`);
+    await res.text();
+    assert.equal(seen[0].auth, 'Bearer t-beta'); // pin wins over the active account
+  });
+});
+
+test('a normal (unpinned) request still rotates as before', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    const res = await post(`http://127.0.0.1:${proxyPort}/v1/messages`);
+    await res.text();
+    assert.equal(res.status, 200);
+    assert.equal(seen[0].path, '/v1/messages');
+    assert.equal(seen[0].auth, 'Bearer t-alpha'); // default rotation → first account
+  });
+});

--- a/test/warmer.test.js
+++ b/test/warmer.test.js
@@ -1,0 +1,132 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { Warmer } from '../src/warmer.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// A fake spawner: records each spawn spec and resolves like a clean `claude` run
+// (exit 0). Lets us assert the warmer's behavior without launching anything.
+function fakeSpawner(result = 0) {
+  const calls = [];
+  const fn = async (spec) => {
+    calls.push(spec);
+    if (result instanceof Error) throw result;
+    return result;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeWarmer(am, spawnFn, opts = {}) {
+  return new Warmer(am, { intervalMs: 0, port: 3456, apiKey: 'tc-key', spawnFn, log: () => {}, ...opts });
+}
+
+// ── eligibility ──────────────────────────────────────────────────────────────
+
+test('warms only healthy, idle Anthropic OAuth accounts with no live 5h window', async () => {
+  const am = new AccountManager([
+    oauth('idle'),                                   // ✓ target
+    oauth('active'),                                 // ✗ 5h window already running
+    oauth('third-party', { upstream: 'https://api.deepseek.com/anthropic' }), // ✗ not Anthropic
+    oauth('disabled', { disabled: true }),           // ✗ disabled
+    oauth('throttled'),                              // ✗ throttled
+  ], 0.98);
+  am.accounts[1].quota.unified5hReset = Date.now() + 3600_000; // 'active' has a live window
+  am.accounts[4].status = 'throttled';
+
+  const spawn = fakeSpawner();
+  await makeWarmer(am, spawn).warmAll();
+
+  assert.equal(spawn.calls.length, 1, 'exactly one account warmed');
+  assert.match(spawn.calls[0].env.ANTHROPIC_BASE_URL, /\/tc-acct\/0$/, 'pinned the idle account (index 0)');
+});
+
+test('an expired 5h window is a warm target again (keeps the timer going)', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].quota.unified5hReset = Date.now() - 1000; // window already reset
+  const spawn = fakeSpawner();
+  await makeWarmer(am, spawn).warmAll();
+  assert.equal(spawn.calls.length, 1);
+});
+
+test('errored and exhausted accounts are skipped', async () => {
+  const am = new AccountManager([oauth('err'), oauth('spent')], 0.98);
+  am.accounts[0].status = 'error';
+  am.accounts[1].status = 'exhausted';
+  const spawn = fakeSpawner();
+  await makeWarmer(am, spawn).warmAll();
+  assert.equal(spawn.calls.length, 0);
+});
+
+// ── spawn spec ───────────────────────────────────────────────────────────────
+
+test('the spawn invocation is a minimal non-interactive claude pinned to the account', async () => {
+  const am = new AccountManager([oauth('solo')], 0.98);
+  const spawn = fakeSpawner();
+  await makeWarmer(am, spawn, { port: 9999, apiKey: 'tc-secret', model: 'haiku' }).warmAll();
+
+  const spec = spawn.calls[0];
+  assert.equal(spec.command, 'claude');
+  assert.deepEqual(spec.args, ['-p', '--bare', '--model', 'haiku', '--output-format', 'text', 'hi']);
+  assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/0');
+  assert.equal(spec.env.ANTHROPIC_API_KEY, 'tc-secret');
+});
+
+// ── status ───────────────────────────────────────────────────────────────────
+
+test('status reflects a successful warm and marks third-party accounts not-applicable', async () => {
+  const am = new AccountManager([
+    oauth('idle'),
+    oauth('ds', { upstream: 'https://api.deepseek.com/anthropic' }),
+  ], 0.98);
+  const warmer = makeWarmer(am, fakeSpawner());
+  await warmer.warmAll();
+
+  const st = warmer.getStatus();
+  const idle = st.accounts.find(a => a.name === 'idle');
+  const ds = st.accounts.find(a => a.name === 'ds');
+  assert.equal(idle.status, 'ok');
+  assert.ok(idle.lastWarmedAt);
+  assert.equal(ds.status, 'not-applicable');
+});
+
+test('a non-zero exit is recorded as an error', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const warmer = makeWarmer(am, fakeSpawner(1));
+  await warmer.warmAll();
+  const st = warmer.getStatus().accounts.find(a => a.name === 'a');
+  assert.equal(st.status, 'error');
+  assert.match(st.error, /exited 1/);
+});
+
+test('a spawn failure (e.g. claude not on PATH) is recorded as an error, not thrown', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const warmer = makeWarmer(am, fakeSpawner(new Error('spawn claude ENOENT')));
+  await warmer.warmAll(); // must not reject
+  const st = warmer.getStatus().accounts.find(a => a.name === 'a');
+  assert.equal(st.status, 'error');
+  assert.match(st.error, /ENOENT/);
+});
+
+// ── scheduling ───────────────────────────────────────────────────────────────
+
+test('getStatus reports enabled/interval and reschedule(0) turns it off', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const warmer = makeWarmer(am, fakeSpawner(), { intervalMs: 600_000 });
+  assert.equal(warmer.getStatus().enabled, true);
+  assert.equal(warmer.getStatus().intervalSeconds, 600);
+  warmer.reschedule(0);
+  assert.equal(warmer.getStatus().enabled, false);
+  assert.equal(warmer.timer, null);
+});
+
+test('overlapping warm cycles are skipped while one is running', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const warmer = makeWarmer(am, fakeSpawner());
+  warmer._running = true;              // pretend a cycle is in flight
+  await warmer.warmAll();              // must be a no-op
+  assert.equal(warmer.lastRunStartedAt, null);
+});


### PR DESCRIPTION
Implements [#76](https://github.com/KarpelesLab/teamclaude/issues/76): keep idle accounts' 5-hour session timers running so the next account isn't cold when rotation reaches it.

## Why
The rolling 5h window only starts on **real usage**. So when the active account runs out and rotation moves to a cold account, that account's 5h window starts *then* — right when you need its full headroom. Keep-warm starts the timer ahead of time.

## What
- **`src/warmer.js`** — opt-in `Warmer` (mirrors `Prober`). On an interval, for each eligible idle account it spawns a minimal one-shot `claude -p --bare --model haiku "hi"` pointed at this proxy, pinned to that account. Warms **only** healthy, idle, Anthropic OAuth accounts whose 5h window is **not already running** (skips disabled/throttled/errored + third-party backends) and uses the cheapest model, to keep the cost minimal. Injectable `spawnFn` for tests; per-account status via `getStatus()`.
- **`src/server.js`** — account-pin routing. A request to `/tc-acct/<name-or-index>/...` is forced onto that one account, **no rotation and no failover**; the prefix is stripped before forwarding. `resolveAccountPin()` exported for tests. This is what the warmer uses, and it doubles as a manual way to target one account.
- **`src/index.js`** — wire the Warmer (start/stop/reschedule/status), gated on `config.warmupSeconds` (default `0` = off); `teamclaude warmup <off|secs>` CLI, live-reschedulable.

## ⚠️ This is a deliberate departure from passive-only
The quota probe is a zero-spend usage read. Keep-warm is different: the 5h timer **cannot** be started by a read-only call, so it sends a real (minimal) message and therefore **spends a little quota** (a few tokens + a slice of the 5h/weekly buckets per account per window). That's why it's strictly opt-in, window-aware, and cheapest-model. `prober.js`'s "one sanctioned active feature" note is updated to reflect there are now two.

## Manual test
```bash
ANTHROPIC_BASE_URL='http://127.0.0.1:3456/tc-acct/1' \
ANTHROPIC_API_KEY='<teamclaude proxy key>' \
  claude -p --bare 'say hi'
# → routed only to account index 1; that account's 5h timer starts
```

## Tests
`account-pin.test.js` (resolver + end-to-end routing, prefix strip, 404, rotation override) and `warmer.test.js` (eligibility, spawn spec, status, error paths, scheduling). **180 tests pass, lint clean.**

## Note for review
Unit/integration tests fully cover the pin routing and the warmer's decision/spawn logic, but CI can't exercise the *real* `claude --bare` subprocess end-to-end (no live accounts). I verified the CLI flags exist (`--bare`, `-p`, `--model`, `--output-format`); a live smoke test against a running server is worth doing before relying on it.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)