### PR TITLE
fix: harden proxy security, account selection, and scheduler lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ After a host network drop and reconnect, Node's shared connection pool can hold 
 | Field | Description |
 |-------|-------------|
 | `proxy.port` | Local port the proxy listens on |
-| `proxy.apiKey` | API key clients use to authenticate with the proxy |
+| `proxy.host` | Interface to bind. Defaults to `127.0.0.1` (localhost only). Set to `0.0.0.0` (or override with env `TEAMCLAUDE_HOST`) to accept off-box clients — in which case **set `proxy.apiKey`**, since remote clients must present it (via `x-api-key`, or `Proxy-Authorization` for CONNECT/HTTPS-proxy usage); loopback is always exempt |
+| `proxy.apiKey` | API key clients use to authenticate with the proxy (required for any non-loopback client; the proxy injects real account tokens, so an unauthenticated open port would leak them) |
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts (TUI: `g` → `t`) |
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -35,6 +35,14 @@ function emptyQuota() {
   };
 }
 
+// Does a declared `models` entry name `model`? The declared side may carry a
+// trailing [Nm] context-length suffix (e.g. "deepseek-v4-pro[1m]"); we match it
+// against a bare request too. Shared by _accountOwnsModel's two lookups so the
+// predicate can't drift.
+function modelMatches(declared, model) {
+  return declared === model || declared.replace(/\[\d+m\]$/, '') === model;
+}
+
 export class AccountManager {
   constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs } = {}) {
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
@@ -200,6 +208,9 @@ export class AccountManager {
       // it would just 429 again — so skip it for Fable and let the caller emit
       // the synthetic 429 when no other account is available.
       if (isFableModel(model) && this._fableExhausted(account)) continue;
+      // Same for model-ownership: a probe for an owned model must not land on a
+      // non-owner (it would just reject the unknown model id).
+      if (model && !this._accountOwnsModel(account, model)) continue;
       const priority = account.priority || 0;
       const usage = this._maxUtilization(account);
       if (priority < bestPriority ||
@@ -263,9 +274,9 @@ export class AccountManager {
   /** Returns true if no account claims model ownership, or this account does. */
   _accountOwnsModel(account, model) {
     for (const a of this.accounts) {
-      if (a.models && a.models.some(m => m === model || m.replace(/\[\d+m\]$/, '') === model)) {
+      if (a.models && a.models.some(m => modelMatches(m, model))) {
         // Some other account owns this model — this account must own it too.
-        return account.models && account.models.some(m => m === model || m.replace(/\[\d+m\]$/, '') === model);
+        return !!(account.models && account.models.some(m => modelMatches(m, model)));
       }
     }
     return true; // no one claims ownership → any account is fine
@@ -476,6 +487,13 @@ export class AccountManager {
 
     for (const account of this.accounts) {
       if (exclude?.has(account.index)) continue;
+      // Never resurrect a hard-state account: `disabled` is an operator decision
+      // and `error` means the token is broken (needs re-login). Selecting either
+      // here would send a live request on an account that must not be used and,
+      // below, silently clear its throttle/error state. (Mirrors _isAvailable.)
+      if (account.disabled || account.status === 'error') continue;
+      // A request for an owned model must not fall back to a non-owner account.
+      if (model && !this._accountOwnsModel(account, model)) continue;
       const resetTime = account.rateLimitedUntil
         || account.quota.unified5hReset
         || account.quota.unified7dReset
@@ -752,6 +770,7 @@ export class AccountManager {
       quota: emptyQuota(),
       usage: { totalInputTokens: 0, totalOutputTokens: 0, totalRequests: 0, lastUsed: null },
       rateLimitedUntil: null,
+      throttledAt: null,
     });
     return index;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -33,6 +33,9 @@ export async function saveState(state) {
   const path = getStatePath();
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  // `mode` only applies when the file is CREATED; enforce 0600 on every save so
+  // a pre-existing state file (holding quota + tokens) can't linger world-readable.
+  await chmod(path, 0o600).catch(() => {});
 }
 
 export function createDefaultConfig() {
@@ -71,6 +74,9 @@ export async function saveConfig(config) {
   const path = getConfigPath();
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
+  // Enforce 0600 even if the file already existed (the proxy apiKey + account
+  // tokens live here); `mode` above is honored only on creation.
+  await chmod(path, 0o600).catch(() => {});
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,11 @@ async function serverCommand() {
     }).catch(err => console.error(`[TeamClaude] Failed to save refreshed token: ${err.message}`));
   });
   const port = config.proxy.port;
+  // Bind loopback by default so the proxy isn't reachable off-box (it injects
+  // account tokens and — via CONNECT — can relay arbitrarily). Opt into a wider
+  // bind explicitly with TEAMCLAUDE_HOST or config.proxy.host (e.g. '0.0.0.0'),
+  // in which case set proxy.apiKey so the auth gate protects remote clients.
+  const bindHost = process.env.TEAMCLAUDE_HOST || config.proxy.host || '127.0.0.1';
   const headless = args.includes('--headless') || args.includes('--no-tui');
   const useTUI = !headless && process.stdout.isTTY && process.stdin.isTTY;
 
@@ -322,7 +327,7 @@ async function serverCommand() {
   const onListenError = err => handleServerListenError(err, port);
   server.once('error', onListenError);
 
-  server.listen(port, () => {
+  server.listen(port, bindHost, () => {
     // Bind succeeded: stop treating errors as listen failures, but keep a
     // benign runtime handler so a later 'error' is logged rather than thrown.
     server.removeListener('error', onListenError);
@@ -336,7 +341,7 @@ async function serverCommand() {
       console.log(sep);
       console.log('  TeamClaude Proxy');
       console.log(sep);
-      console.log(`  Port:       ${port}`);
+      console.log(`  Bind:       ${bindHost}:${port}${bindHost === '127.0.0.1' ? ' (localhost only)' : ' (reachable off-box — ensure proxy.apiKey is set)'}`);
       console.log(`  Accounts:   ${accounts.length}`);
       console.log(`  Threshold:  ${(threshold * 100).toFixed(0)}%`);
       console.log(`  Upstream:   ${config.upstream || 'https://api.anthropic.com'}`);
@@ -375,18 +380,23 @@ async function serverCommand() {
   // users update via `teamclaude run` (post-session) or `teamclaude update`.
   if (!tui) autoUpdate({ config }).catch(() => {});
 
-  if (!tui) {
-    const shutdown = async () => {
-      console.log('\n[TeamClaude] Shutting down...');
-      prober?.stop();
-      warmer?.stop();
-      clearInterval(quotaSaveInterval);
-      await persistQuotaState();
-      server.close(() => process.exit(0));
-    };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
-  }
+  // Graceful shutdown on signals in BOTH modes. In TUI mode this previously
+  // existed only as a keypress path, so a SIGTERM (systemd/kill) bypassed it and
+  // dropped up-to-a-minute of unsaved quota state and orphaned schedulers.
+  const shutdown = async () => {
+    try { tui?.stop(); } catch { /* terminal already restored */ }
+    if (!tui) console.log('\n[TeamClaude] Shutting down...');
+    prober?.stop();
+    warmer?.stop();
+    if (quotaSaveInterval) clearInterval(quotaSaveInterval);
+    await persistQuotaState();
+    // Force-exit if open connections keep server.close from completing, so a
+    // signal can't hang the process indefinitely.
+    setTimeout(() => process.exit(0), 3000).unref?.();
+    server.close(() => process.exit(0));
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 }
 
 // ── import ──────────────────────────────────────────────────

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -20,7 +20,7 @@ import tls from 'node:tls';
 import http2 from 'node:http2';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
-import { createProxyRequestListener } from './server.js';
+import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr } from './server.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -112,6 +112,7 @@ export function hostMode(host, config) {
  */
 export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
+  const proxyApiKey = config.proxy?.apiKey;
   const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx });
 
   // One terminating h2/h1 server, minted lazily on the first intercepted CONNECT.
@@ -128,10 +129,30 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     srv.on('sessionError', (e) => log(`[TeamClaude] MITM session error: ${e.message}`));
     srv.on('clientError', (e, sock) => { try { sock.destroy(); } catch { /* already gone */ } });
     return srv;
-  })());
+  })().catch((err) => {
+    // Don't let a transient cert/disk failure poison the memo forever: reset it
+    // so the next intercepted CONNECT retries instead of re-awaiting a cached
+    // rejection (which would leave the MITM path dead until a restart).
+    serverPromise = null;
+    throw err;
+  }));
 
   return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
+
+    // Auth gate — mirror the HTTP path: loopback is exempt, everything else must
+    // present the proxy apiKey via Proxy-Authorization. Without this, a remote
+    // client can CONNECT api.anthropic.com and have a rotated ACCOUNT TOKEN
+    // injected (token theft), or blind-tunnel to arbitrary hosts (open relay /
+    // SSRF) — the HTTP path already blocks the equivalent for remote clients.
+    if (!connectAuthorized(req, clientSocket, proxyApiKey)) {
+      try {
+        clientSocket.write('HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="teamclaude"\r\nConnection: close\r\n\r\n');
+      } catch { /* client already gone */ }
+      clientSocket.destroy();
+      return;
+    }
+
     const [host, portStr] = (req.url || '').split(':');
     const port = parseInt(portStr, 10) || 443;
     const mode = hostMode(host, config);
@@ -142,7 +163,12 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
         if (head && head.length) up.write(head);
         up.pipe(clientSocket); clientSocket.pipe(up);
       });
-      up.on('error', () => clientSocket.destroy());
+      // Tear down BOTH sockets when either errors or closes, so a one-sided
+      // failure can't leave the paired socket lingering (FD leak).
+      const teardown = () => { up.destroy(); clientSocket.destroy(); };
+      up.on('error', teardown); up.on('close', teardown);
+      clientSocket.on('close', teardown);
+      up.setTimeout(30_000, teardown); // bound a stalled connect/idle tunnel
       return;
     }
 
@@ -164,6 +190,26 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
       srv.emit('connection', clientSocket);
     }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
   };
+}
+
+// Authorize a CONNECT: no key configured → open (matches the HTTP path); a
+// loopback client is exempt; otherwise the proxy apiKey must be presented via
+// `Proxy-Authorization` (Bearer <key>, or Basic where the key is the username
+// or password — so `--proxy http://<key>@host:port` works). Exported for tests.
+export function connectAuthorized(req, socket, proxyApiKey) {
+  if (!proxyApiKey) return true;
+  if (isLoopbackAddr(socket?.remoteAddress)) return true;
+  const m = /^\s*(basic|bearer)\s+(.+?)\s*$/i.exec(req?.headers?.['proxy-authorization'] || '');
+  if (!m) return false;
+  let presented = m[2];
+  if (m[1].toLowerCase() === 'basic') {
+    const dec = Buffer.from(m[2], 'base64').toString('utf8'); // "user:pass"
+    const i = dec.indexOf(':');
+    const user = i >= 0 ? dec.slice(0, i) : dec;
+    const pass = i >= 0 ? dec.slice(i + 1) : '';
+    presented = pass || user;
+  }
+  return safeKeyEqual(presented, proxyApiKey);
 }
 
 function reply200Raw(sock) { sock.write('HTTP/1.1 200 Connection Established\r\n\r\n'); }

--- a/src/prober.js
+++ b/src/prober.js
@@ -36,7 +36,9 @@ export class Prober {
 
     if (intervalMs > 0) {
       this.nextRunAt = Date.now() + intervalMs;
-      this.probeAll().catch(() => {});
+      // Immediate probe only on an off→on transition — not on every interval
+      // change (mirrors warmer.js; avoids an extra burst when the interval is edited).
+      if (!wasOn) this.probeAll().catch(() => {});
       this.timer = setInterval(() => this.probeAll().catch(() => {}), intervalMs);
       this.timer.unref?.();
       this.log(`[TeamClaude] Quota probe enabled (every ${Math.round(intervalMs / 1000)}s)`);

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -23,6 +24,22 @@ const CONNECTION_SPECIFIC_HEADERS = new Set([
   'proxy-connection', 'te', 'trailer',
 ]);
 
+// Constant-time proxy-API-key comparison (both the HTTP gate and the CONNECT
+// gate use it). Returns false on any type/length mismatch without leaking timing.
+export function safeKeyEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+// True if a socket's remote address is loopback — the proxy-key gate exempts
+// localhost on both the HTTP and CONNECT paths.
+export function isLoopbackAddr(addr) {
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
 export function createProxyServer(accountManager, config, hooks = {}, sx = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
@@ -36,9 +53,8 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
     try {
       // Auth check — skip for localhost connections.
       const clientKey = req.headers['x-api-key'];
-      const remoteAddr = req.socket.remoteAddress;
-      const isLocal = remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1';
-      if (proxyApiKey && clientKey !== proxyApiKey && !isLocal) {
+      const isLocal = isLoopbackAddr(req.socket.remoteAddress);
+      if (proxyApiKey && !safeKeyEqual(clientKey, proxyApiKey) && !isLocal) {
         res.writeHead(401, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           type: 'error',
@@ -93,7 +109,9 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   const mitmHost = (() => { try { return new URL(upstream).hostname; } catch { return 'api.anthropic.com'; } })();
   let certsPromise = null;
   const ensureLeaf = async () => {
-    certsPromise ||= ensureCerts(mitmHost);
+    // Reset the memo on failure so a transient cert error doesn't wedge the MITM
+    // path permanently (a cached rejected promise would re-throw on every CONNECT).
+    certsPromise ||= ensureCerts(mitmHost).catch((err) => { certsPromise = null; throw err; });
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
@@ -310,6 +328,20 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
     : accountManager.getActiveAccount(ctx.tried, ctx.model);
   if (!account) {
+    // A pinned request concerns exactly one account: don't compute a fleet-wide
+    // retry-after or sleep on other accounts' windows — return immediately.
+    if (ctx.pinnedIndex != null) {
+      ctx.status = 429;
+      ctx.account = '(pinned account unavailable)';
+      if (!res.headersSent) {
+        res.writeHead(429, { 'Content-Type': 'application/json', 'retry-after': '5' });
+        res.end(JSON.stringify({
+          type: 'error',
+          error: { type: 'rate_limit_error', message: 'Pinned account is unavailable (rate-limited, errored, or already tried). Retry shortly.' },
+        }));
+      }
+      return;
+    }
     ctx.status = 429;
     ctx.account = '(none available)';
     const status = accountManager.getStatus();
@@ -584,6 +616,12 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
         type: 'error',
         error: { type: 'proxy_error', message: `Upstream error: ${err.message}` },
       }));
+    } else if (!res.writableEnded) {
+      // Error after headers were already sent (mid-stream) and it wasn't
+      // classified transient: we can't send a status or fail over, and
+      // streamResponse deliberately skipped res.end(). Destroy so the client
+      // sees a broken response and retries instead of hanging on an open socket.
+      res.destroy();
     }
   }
 }
@@ -619,7 +657,11 @@ export function readWithIdleTimeout(reader, ms) {
     }, ms);
     timer.unref?.();
   });
-  return Promise.race([reader.read(), timeout]).finally(() => clearTimeout(timer));
+  const read = reader.read();
+  // If the timeout wins the race, `read` is abandoned; swallow any later
+  // rejection so it can't surface as an unhandledRejection.
+  read.catch(() => {});
+  return Promise.race([read, timeout]).finally(() => clearTimeout(timer));
 }
 
 /**
@@ -661,8 +703,12 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
       // because 'drain' will never fire on a destroyed socket
       if (!ok) {
         await new Promise(resolve => {
-          res.once('drain', resolve);
-          res.once('close', resolve);
+          // Remove BOTH listeners when either fires: otherwise the un-fired one
+          // (usually 'close') stays attached and accumulates one leaked listener
+          // per backpressure cycle over a long SSE stream to a slow client.
+          const done = () => { res.off('drain', done); res.off('close', done); resolve(); };
+          res.once('drain', done);
+          res.once('close', done);
         });
         if (res.destroyed) break;
       }

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -5,12 +5,16 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   const paint = colors(color);
   const lines = [];
   const probe = status.probe || { enabled: false, intervalSeconds: 0, accounts: [] };
+  const warm = status.warm || { enabled: false, intervalSeconds: 0, accounts: [] };
   const accounts = status.accounts || [];
 
   lines.push(paint.bold('TeamClaude status'));
   lines.push(`${paint.dim('Active'.padEnd(12))} ${paint.cyan(status.currentAccount || 'none')}`);
   lines.push(`${paint.dim('Switch at'.padEnd(12))} ${formatPercent(status.switchThreshold)}`);
   lines.push(`${paint.dim('Probe'.padEnd(12))} ${formatProbeSummary(probe, now, paint)}`);
+  if (warm.enabled) {
+    lines.push(`${paint.dim('Keep-warm'.padEnd(12))} ${formatProbeSummary(warm, now, paint)}`);
+  }
   if (status.server?.startedAt || status.server?.uptimeSeconds != null) {
     lines.push(`${paint.dim('Server'.padEnd(12))} ${formatServerSummary(status.server, now)}`);
   }

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -88,8 +88,11 @@ function proxiedFetch(url, opts, sx, timeoutMs) {
   const u = new URL(url);
   const proxy = sx.getProxy();
 
-  // Custom agent: every socket is a TLS connection tunneled through sx.org.
-  const agent = new https.Agent({ keepAlive: true });
+  // Custom agent: every socket is a TLS connection tunneled through sx.org. This
+  // agent is created per request (its createConnection closes over this call's
+  // target), so keep-alive would give no reuse — it would only park the tunneled
+  // socket in a soon-orphaned pool and leak an open sx.org connection per request.
+  const agent = new https.Agent({ keepAlive: false });
   agent.createConnection = (_options, cb) => {
     // sx.tlsOptions is undefined in production (system CAs verify api.anthropic.com);
     // tests inject a CA here to reach a self-signed upstream.

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -42,6 +42,7 @@ export class Warmer {
     this.log = log;
     this.timer = null;
     this._running = false;
+    this._abort = null; // AbortController for the in-flight sweep (see warmAll/stop)
     this.lastRunStartedAt = null;
     this.lastRunFinishedAt = null;
     this.nextRunAt = intervalMs > 0 ? Date.now() + intervalMs : null;
@@ -60,7 +61,9 @@ export class Warmer {
 
     if (intervalMs > 0) {
       this.nextRunAt = Date.now() + intervalMs;
-      this.warmAll().catch(() => {});
+      // Immediate sweep only on an off→on transition. Re-running it on every
+      // interval *change* would spend quota each time the interval is edited.
+      if (!wasOn) this.warmAll().catch(() => {});
       this.timer = setInterval(() => this.warmAll().catch(() => {}), intervalMs);
       this.timer.unref?.();
       this.log(`[TeamClaude] Keep-warm enabled (every ${Math.round(intervalMs / 1000)}s)`);
@@ -73,6 +76,9 @@ export class Warmer {
   stop() {
     if (this.timer) { clearInterval(this.timer); this.timer = null; }
     this.nextRunAt = null;
+    // Cancel an in-flight sweep and kill any child it spawned, so shutdown /
+    // `warmup off` doesn't block on a running warm-up or orphan a `claude`.
+    this._abort?.abort();
   }
 
   /**
@@ -99,25 +105,28 @@ export class Warmer {
   async warmAll() {
     if (this._running) return;
     this._running = true;
+    const abort = this._abort = new AbortController();
     this.lastRunStartedAt = Date.now();
     this.nextRunAt = this.intervalMs > 0 ? this.lastRunStartedAt + this.intervalMs : null;
     try {
       const targets = this.am.accounts.filter(account => this._isWarmTarget(account));
       for (const account of targets) {
-        await this.warmAccount(account);
+        if (abort.signal.aborted) break; // stopped mid-sweep (shutdown / warmup off)
+        await this.warmAccount(account, abort.signal);
       }
     } finally {
       this.lastRunFinishedAt = Date.now();
       this._running = false;
+      if (this._abort === abort) this._abort = null;
     }
   }
 
-  async warmAccount(account) {
+  async warmAccount(account, signal) {
     const startedAt = Date.now();
     this._record(account, { status: 'running', startedAt });
     try {
       await this.am.ensureTokenFresh(account.index);
-      const code = await this.spawnFn(this._spawnSpec(account));
+      const code = await this.spawnFn(this._spawnSpec(account, signal));
       const finishedAt = Date.now();
       this._record(account, {
         status: code === 0 ? 'ok' : 'error',
@@ -136,7 +145,7 @@ export class Warmer {
 
   /** The `claude` invocation for one account. Pure/deterministic so tests can
    *  assert the args and env without spawning anything. */
-  _spawnSpec(account) {
+  _spawnSpec(account, signal) {
     // Pin by INDEX (stable, and free of the spaces/parens real account names
     // carry, which would otherwise need URL-encoding).
     const baseUrl = `http://127.0.0.1:${this.port}/tc-acct/${account.index}`;
@@ -151,6 +160,7 @@ export class Warmer {
         ANTHROPIC_API_KEY: this.apiKey || 'tc-warm',
       },
       timeoutMs: this.timeoutMs,
+      signal, // aborts (and kills the child) when the warmer is stopped
     };
   }
 
@@ -189,8 +199,9 @@ export class Warmer {
 // an error) or rejecting if the binary can't launch (e.g. not on PATH) or the
 // warm-up overruns its timeout. stdio is ignored: we only care that a request
 // went through to start the timer.
-function defaultSpawn({ command, args, env, timeoutMs }) {
+function defaultSpawn({ command, args, env, timeoutMs, signal }) {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) { reject(new Error('warm-up aborted')); return; }
     let child;
     try {
       child = spawn(command, args, { env, stdio: 'ignore' });
@@ -198,13 +209,22 @@ function defaultSpawn({ command, args, env, timeoutMs }) {
       reject(err);
       return;
     }
+    const onAbort = () => child.kill('SIGKILL');
+    signal?.addEventListener('abort', onAbort, { once: true });
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
       reject(new Error(`warm-up timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     timer.unref?.();
-    child.once('error', (err) => { clearTimeout(timer); reject(err); });
-    child.once('exit', (code) => { clearTimeout(timer); resolve(code ?? 0); });
+    const cleanup = () => { clearTimeout(timer); signal?.removeEventListener('abort', onAbort); };
+    child.once('error', (err) => { cleanup(); reject(err); });
+    child.once('exit', (code, sigName) => {
+      cleanup();
+      // A signal-killed child (OOM, external kill, our own abort) did NOT
+      // complete a warm-up — report it as an error, not a success (code null).
+      if (sigName) { reject(new Error(`claude terminated by ${sigName}`)); return; }
+      resolve(code ?? 0);
+    });
   });
 }
 

--- a/test/connect-auth.test.js
+++ b/test/connect-auth.test.js
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { connectAuthorized } from '../src/mitm.js';
+import { safeKeyEqual, isLoopbackAddr } from '../src/server.js';
+
+// The CONNECT auth gate is the fix for the unauthenticated-MITM token-theft /
+// open-relay hole: without it, a remote client can CONNECT api.anthropic.com and
+// have an account token injected, or blind-tunnel anywhere.
+
+const sock = (remoteAddress) => ({ remoteAddress });
+const req = (auth) => ({ headers: auth ? { 'proxy-authorization': auth } : {} });
+
+test('no proxy key configured → CONNECT is open (matches the HTTP path)', () => {
+  assert.equal(connectAuthorized(req(), sock('203.0.113.9'), null), true);
+});
+
+test('loopback clients are exempt even when a key is set', () => {
+  for (const a of ['127.0.0.1', '::1', '::ffff:127.0.0.1']) {
+    assert.equal(connectAuthorized(req(), sock(a), 'secret'), true, a);
+  }
+});
+
+test('a remote client with no Proxy-Authorization is denied', () => {
+  assert.equal(connectAuthorized(req(), sock('203.0.113.9'), 'secret'), false);
+});
+
+test('a remote client with the correct Bearer key is allowed', () => {
+  assert.equal(connectAuthorized(req('Bearer secret'), sock('203.0.113.9'), 'secret'), true);
+});
+
+test('a remote client with a wrong key is denied', () => {
+  assert.equal(connectAuthorized(req('Bearer nope'), sock('203.0.113.9'), 'secret'), false);
+});
+
+test('Basic auth carrying the key as username or password is accepted', () => {
+  const asUser = 'Basic ' + Buffer.from('secret:').toString('base64');  // curl http://secret@host
+  const asPass = 'Basic ' + Buffer.from('x:secret').toString('base64'); // curl http://x:secret@host
+  assert.equal(connectAuthorized(req(asUser), sock('10.0.0.5'), 'secret'), true);
+  assert.equal(connectAuthorized(req(asPass), sock('10.0.0.5'), 'secret'), true);
+});
+
+test('safeKeyEqual is value-correct and length/type-safe', () => {
+  assert.equal(safeKeyEqual('abc', 'abc'), true);
+  assert.equal(safeKeyEqual('abc', 'abd'), false);
+  assert.equal(safeKeyEqual('abc', 'abcd'), false); // different length, no throw
+  assert.equal(safeKeyEqual(undefined, 'abc'), false);
+  assert.equal(safeKeyEqual('abc', null), false);
+});
+
+test('isLoopbackAddr recognizes the three loopback forms only', () => {
+  assert.equal(isLoopbackAddr('127.0.0.1'), true);
+  assert.equal(isLoopbackAddr('::1'), true);
+  assert.equal(isLoopbackAddr('::ffff:127.0.0.1'), true);
+  assert.equal(isLoopbackAddr('10.0.0.1'), false);
+  assert.equal(isLoopbackAddr(undefined), false);
+});

--- a/test/selection-hardening.test.js
+++ b/test/selection-hardening.test.js
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+// Make an account genuinely unavailable via near-quota with a FUTURE reset, so
+// selection has to fall through to the probe/soonest-reset fallback paths.
+function nearQuotaFutureReset(am, i) {
+  am.accounts[i].quota.unified7d = 0.999;
+  am.accounts[i].quota.unified7dReset = Date.now() + 3600_000;
+}
+
+// F1: the "all unavailable → soonest reset" fallback in _selectNext must not
+// resurrect a DISABLED account. The disabled check in _isAvailable short-circuits
+// before the expired-hold clear, so a disabled account with a past hold slips
+// into the fallback and (pre-fix) got force-reactivated.
+test('the soonest-reset fallback never resurrects a disabled account', () => {
+  const am = new AccountManager([oauth('disabled'), oauth('busy')], 0.98);
+  am.markRateLimited(0, 1);
+  am.accounts[0].rateLimitedUntil = Date.now() - 5000; // hold already expired…
+  am.accounts[0].disabled = true;                      // …but operator-disabled
+  nearQuotaFutureReset(am, 1);                          // the other account is genuinely busy
+
+  const acct = am.getActiveAccount();
+  assert.notEqual(acct?.name, 'disabled');             // never selected
+  assert.equal(am.accounts[0].disabled, true);         // still disabled
+  assert.equal(am.accounts[0].status, 'throttled');    // NOT flipped to active
+  assert.notEqual(am.accounts[0].rateLimitedUntil, null); // hold NOT cleared
+});
+
+// F1 (sibling): the same must hold for an errored (dead-token) account.
+test('the soonest-reset fallback never resurrects an errored account', () => {
+  const am = new AccountManager([oauth('broken'), oauth('busy')], 0.98);
+  am.markRateLimited(0, 1);
+  am.accounts[0].rateLimitedUntil = Date.now() - 5000;
+  am.accounts[0].status = 'error'; // token needs re-login
+  nearQuotaFutureReset(am, 1);
+
+  const acct = am.getActiveAccount();
+  assert.notEqual(acct?.name, 'broken');
+  assert.equal(am.accounts[0].status, 'error'); // not silently reactivated
+});
+
+// F2: a request for an OWNED model must never fall back / probe onto a non-owner
+// account (which would just reject the unknown model id). When the owner is
+// unavailable, the correct result is "nothing" (→ synthetic 429), not a Claude
+// account.
+test('an owned-model request never falls back to a non-owner account', () => {
+  const am = new AccountManager([
+    oauth('claude'),
+    oauth('deepseek', { models: ['deepseek-chat'], priority: 100 }),
+  ], 0.98);
+  am.markRateLimited(1, 3600);        // the sole owner is throttled (future hold)
+  nearQuotaFutureReset(am, 0);        // the Claude account is busy too
+
+  const acct = am.getActiveAccount(null, 'deepseek-chat');
+  assert.notEqual(acct?.name, 'claude'); // the deepseek model must not hit Claude
+});
+
+// Positive control: with no owner declared, the probe/fallback still works
+// normally (ownership routing is inert unless someone declares a models list).
+test('ownership guard is inert when no account claims the model', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  nearQuotaFutureReset(am, 0);
+  nearQuotaFutureReset(am, 1);
+  // Every account near quota → a probe is allowed; some account is returned.
+  const acct = am.getActiveAccount(null, 'claude-sonnet-4-6');
+  assert.ok(acct, 'a probe target should still be selectable');
+});

--- a/test/warmer.test.js
+++ b/test/warmer.test.js
@@ -130,3 +130,35 @@ test('overlapping warm cycles are skipped while one is running', async () => {
   await warmer.warmAll();              // must be a no-op
   assert.equal(warmer.lastRunStartedAt, null);
 });
+
+test('stop() aborts an in-flight sweep (kills the warm child, skips the rest)', async () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  let aborts = 0;
+  let started = 0;
+  // A spawner that hangs until its abort signal fires (models a live `claude`).
+  const spawnFn = (spec) => new Promise((_resolve, reject) => {
+    started += 1;
+    spec.signal.addEventListener('abort', () => { aborts += 1; reject(new Error('aborted')); }, { once: true });
+  });
+  const warmer = makeWarmer(am, spawnFn);
+
+  const sweep = warmer.warmAll();          // don't await — it's mid-flight
+  await new Promise(r => setTimeout(r, 10));
+  warmer.stop();                           // must abort the hanging child
+  await sweep;
+
+  assert.equal(aborts, 1, 'the in-flight child was aborted');
+  assert.equal(started, 1, 'the second account was not started after stop()');
+});
+
+test('reschedule to a new interval does NOT trigger an extra (quota-spending) sweep', async () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const spawn = fakeSpawner();
+  const warmer = makeWarmer(am, spawn, { intervalMs: 600_000 });
+  warmer.start();                          // off→on: one immediate sweep
+  await new Promise(r => setTimeout(r, 5));
+  const afterStart = spawn.calls.length;
+  warmer.reschedule(300_000);              // interval CHANGE, already on
+  await new Promise(r => setTimeout(r, 5));
+  assert.equal(spawn.calls.length, afterStart, 'no extra sweep on an interval change');
+});


### PR DESCRIPTION
Full-codebase review (fanned out across subsystems; every finding verified against the code before fixing). Grouped by area.

## 🔒 Security — MITM/CONNECT path
- **Unauthenticated CONNECT → account-token theft / open relay (HIGH).** The proxy-apiKey gate lived only on the HTTP handler. A remote client could `CONNECT api.anthropic.com:443` and get one of your **account tokens injected** (`curl -k --proxy victim:3456 …`), or blind-tunnel to any host (open relay / SSRF to cloud metadata). Fix: gate the CONNECT handler with the same key check the HTTP path uses (loopback-exempt, else `Proxy-Authorization`).
- **Bind `127.0.0.1` by default** (opt into a wider bind with `TEAMCLAUDE_HOST` / `config.proxy.host`) — defense-in-depth so the port isn't reachable off-box unless you ask for it.
- **Constant-time** proxy-key comparison on both gates; **`chmod 0600`** config/state on every save (`mode` is ignored when the file already exists).

## 🐞 Correctness
- **`_selectNext` fallback resurrected disabled/errored accounts** — the "all unavailable → soonest reset" path force-cleared their state and routed a live request to an operator-disabled or dead-token account. Now skips hard-state accounts.
- **Model-ownership bypass** — the probe and soonest-reset fallbacks ignored `models` ownership, so an owned model could be routed to a non-owner (which just rejects it). Both paths now honor ownership. `_accountOwnsModel` returns a real boolean; the match predicate is shared; `addAccount` sets `throttledAt`.
- **server**: a non-transient error after headers hangs the client → now destroyed; a pinned request whose account is unavailable did a pointless fleet-wide wait → short-circuits; backpressure wait leaked a `close` listener per drain cycle on long SSE → mutual cleanup; the idle-timeout read could surface as an `unhandledRejection` → swallowed.
- **upstream-fetch**: per-call sx `Agent` used `keepAlive:true`, leaking a tunneled socket per request with no reuse benefit → `keepAlive:false`.
- **mitm**: a transient cert error poisoned the memoized promise and killed the MITM path until restart → reset on failure; tunnel sockets leaked on one-sided errors → both torn down on error/close (+ connect/idle timeout).

## ♻️ Lifecycle
- **No SIGTERM handler in TUI mode** — a `systemd`/`kill` bypassed cleanup, losing up to ~1 min of unsaved quota state and orphaning schedulers. Now both modes register SIGINT/SIGTERM with a forced-exit backstop.
- **warmer**: `stop()` now aborts an in-flight sweep and kills the `claude` child (no orphan, no shutdown hang); a signal-killed child is an **error**, not a success; an interval *change* no longer triggers an extra **quota-spending** sweep (only off→on does). Same off→on fix in **prober**.
- **status-renderer** surfaces the keep-warm summary (was `--json`-only).

## Tests
`connect-auth.test.js` (the CONNECT gate + `safeKeyEqual`), `selection-hardening.test.js` (resurrection + ownership-fallback guards), warmer stop/abort + no-extra-sweep. **194 tests pass, lint clean.** Boot smoke-tested: binds `127.0.0.1`, status carries `warm`, pin 404s.

## Not fixed (noted, low/edge or deferred)
- Unbounded request-body buffering (DoS) — much lower risk now that the default bind is loopback; skipped to avoid capping legitimately large requests.
- `AccountUuidPatcher` 36-byte overwrite assumes a 36-char value (real Claude Code always sends one) — left the delicate state machine untouched.
- `warmer.js`↔`prober.js` share a scheduler skeleton — worth extracting a base class, but deferred (didn't want a structural refactor mixed into these fixes).
- prober fires all accounts concurrently; `_withTimeout` doesn't abort the fetch — low, opt-in path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)