### PR TITLE
Bump to 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch version bump `1.1.4` → `1.1.5`.

Rolls up this batch of merged work:
- #78 network-drop recovery timeouts
- #77 throttled-account revalidation
- #74/#79 third-party backend accounts (+ tests)
- #80 opt-in keep-warm + per-account pin endpoint
- #81 security/selection/lifecycle hardening (localhost-default bind, CONNECT auth gate, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)