### PR TITLE
Pass attachment transfers (/api/oauth/files/*) through with the client's own credential (fixes silently dropped images)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -140,6 +140,10 @@ export function resolveAccountPin(accountManager, token) {
   return null;
 }
 
+// Paths that must reach upstream with the client's own credential (never a
+// rotated account token): the Remote Control channel and attachment transfers.
+const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/file_upload'];
+
 export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null }) {
   let counter = 0;
   return async (req, res) => {
@@ -150,7 +154,11 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // Remote Control (/v1/code/*) is bound to the session's paired claude.ai
       // identity — forward with the client's OWN credential (streamed), never a
       // rotated account token, which would 403 the worker event stream.
-      if ((req.url || '').startsWith('/v1/code/')) { await relayStream(req, res, upstream, sx); return; }
+      // Attachment transfers (/api/oauth/files/*, /api/oauth/file_upload) are
+      // likewise account-bound: files uploaded from claude.ai belong to the
+      // paired identity, so fetching them with a rotated token 403s and Claude
+      // Code silently drops the image from the message.
+      if (CLIENT_CREDENTIAL_PATHS.some((p) => (req.url || '').startsWith(p))) { await relayStream(req, res, upstream, sx); return; }
 
       // Account pin: a request to `/tc-acct/<name-or-index>/...` (e.g. via
       // ANTHROPIC_BASE_URL=http://host:port/tc-acct/deepseek) is forced onto that


### PR DESCRIPTION
## Problem

An image attached to a message for a teleoperated Claude Code session (claude.ai / desktop app → session behind teamclaude) is silently lost: the message arrives as plain text, with no image block and not even an `[Image #N]` placeholder.

## Cause

The attachment is uploaded to the backend under the user's claude.ai identity, and the CLI then downloads it with a separate request — `GET /api/oauth/files/<uuid>/content` — using its own OAuth token. This path is not covered by the `/v1/code/` passthrough (#58): the proxy rewrites `Authorization` to the rotated account's token, upstream responds 403, and Claude Code silently drops the image (in the CLI code this is a buried skip with no error surfaced to the user).

The same logic applies to `/api/oauth/file_upload`.

## Fix

`/api/oauth/files/` and `/api/oauth/file_upload` now go through `relayStream` with the client's own credential — exactly like the Remote Control channel. The prefixes are extracted into a shared `CLIENT_CREDENTIAL_PATHS` list.

## Verification

Verified end-to-end on a live install (Contabo VPS, 3-account rotation): before the patch, attachments never reached server-side sessions (while sessions without the proxy received them fine). After the patch, an image attached from the desktop app arrived in the server-side session as a full base64 image block, and file attachments landed in `~/.claude/uploads/<session>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)