### PR TITLE
feat: per-model routing with configurable routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 ## Features
 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
-- **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes)
+- **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes). Optional **[model routes](#model-routes)** pin model patterns to a specific set of accounts (config, `teamclaude route`, or the TUI settings screen → Manage routing)
 - **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; a quota rejection (a spent weekly bucket) switches accounts immediately instead of waiting, and switches to the next on persistent errors
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
@@ -176,6 +176,7 @@ teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
 teamclaude enable <name>     # Re-enable it (also clears a stuck error state)
 teamclaude priority <name> 1 # Set rotation priority (lower = preferred)
+teamclaude route list        # Manage per-model routes (add/rm); see Model routes
 teamclaude probe 300         # Enable background quota refresh (off by default)
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude api <path>        # Call an API endpoint with account credentials
@@ -277,6 +278,35 @@ After a host network drop and reconnect, Node's shared connection pool can hold 
 | `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only |
 | `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |
 | `accounts[].models` | Array of model names this account exclusively handles. When any account declares a `models` list, requests for those models are routed only to accounts that list them — use this to reserve a third-party account for sessions that pass `--model <name>` explicitly |
+| `routes` | Optional list of routing rules that pin model patterns to specific accounts — see [Model routes](#model-routes) |
+
+### Model routes
+
+By default every request routes through the same pool, and per-model quota is respected automatically: a family with its own weekly bucket (Fable, Sonnet) only blocks that family, so an account whose Fable quota is spent still serves Opus/Sonnet. `teamclaude status` shows this per account (a `Models` line) and any families it detects appear as **auto** routes.
+
+To go further you can pin model patterns to an **exclusive** set of accounts with a `routes` table. Each route matches the request's `model` id against shell-style globs (`*` is the only wildcard) and, on the **first matching** route, restricts the request to the listed accounts:
+
+```json
+"routes": [
+  { "name": "fable", "match": ["*fable*"], "accounts": ["personal-max"] },
+  { "name": "bulk",  "match": ["*opus*", "*sonnet*"], "accounts": ["corp-1", "corp-2"] }
+]
+```
+
+- **`match`** — one or more model globs; the first route whose globs match wins.
+- **`accounts`** — account names (or indices) that may serve matching models. **Exclusive**: only these are used (and they 429/rotate among themselves when spent). Omit to route to all accounts — e.g. to only set a `bucket` override.
+- **`bucket`** — optional: force which quota bucket governs eligibility (`unified7dFable`, `unified7dSonnet`, `unified7d`), for the rare case the family can't be inferred from the model id.
+
+Manage routes from the shell (changes apply to a running server immediately):
+
+```bash
+teamclaude route list
+teamclaude route add fable --match '*fable*' --accounts personal-max
+teamclaude route add bulk  --match '*opus*,*sonnet*' --accounts corp-1,corp-2
+teamclaude route rm fable
+```
+
+…or interactively in the TUI: open settings (**`g`**) → **Manage routing**, then `a` add / `e` edit / `d` delete. The routes table (configured + auto-detected) is shown in both the TUI and `teamclaude status`.
 
 ### Quota probe (optional, off by default)
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,9 +1,9 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { sameIdentity } from './identity.js';
-import { isFableModel } from './model.js';
+import { weeklyBucketForModel, modelGlobMatches } from './model.js';
 
 // Re-exported for callers that already import model helpers from here.
-export { isFableModel, parseRequestModel } from './model.js';
+export { isFableModel, modelFamily, parseRequestModel, weeklyBucketForModel, modelGlobMatches } from './model.js';
 
 // Quota fields that survive a restart: utilization levels and their reset
 // windows, learned passively from upstream responses. Transient/derived state
@@ -44,7 +44,7 @@ function modelMatches(declared, model) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes } = {}) {
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
@@ -79,6 +79,7 @@ export class AccountManager {
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
+    this.setRoutes(routes);
     // When every account reads as over-quota we would otherwise refuse locally
     // forever (a stale cached utilization is never re-validated because no
     // request is ever sent). Instead, allow one real upstream probe at most this
@@ -170,13 +171,16 @@ export class AccountManager {
     return true;
   }
 
-  /** Highest utilization across all known quota dimensions (0-1), used to pick
-   * the least-exhausted probe target. Mirrors the ratios in _isNearQuota. */
-  _maxUtilization(account) {
+  /** Highest utilization across the quota dimensions that govern `model` (0-1),
+   * used to pick the least-exhausted probe target. Mirrors _isNearQuota: the
+   * shared 5-hour bucket plus the model's governing weekly bucket. With no model
+   * it falls back to the shared weekly. */
+  _maxUtilization(account, model = null) {
     const q = account.quota;
     let max = 0;
     if (q.unified5h != null) max = Math.max(max, q.unified5h);
-    if (q.unified7d != null) max = Math.max(max, q.unified7d);
+    const weeklyVal = this._governingWeekly(account, model);
+    if (weeklyVal != null) max = Math.max(max, weeklyVal);
     if (q.tokensLimit != null && q.tokensRemaining != null) {
       max = Math.max(max, 1 - q.tokensRemaining / q.tokensLimit);
     }
@@ -184,6 +188,37 @@ export class AccountManager {
       max = Math.max(max, 1 - q.requestsRemaining / q.requestsLimit);
     }
     return max;
+  }
+
+  /** Utilization (0-1) of the weekly bucket that governs `model` on this account:
+   * unified7dFable for Fable, unified7dSonnet for Sonnet, unified7d otherwise.
+   * Falls back to the shared unified7d when a family-specific bucket isn't
+   * reported. Returns null when nothing is known. */
+  _governingWeekly(account, model) {
+    const q = account.quota;
+    const key = this._weeklyBucketFor(model);
+    if (q[key] != null) return q[key];
+    return key !== 'unified7d' ? q.unified7d : null;
+  }
+
+  /** Reset timestamp (ms) of the weekly bucket that governs `model`, falling back
+   * to the shared weekly reset. Used to spend the soonest-expiring quota first. */
+  _governingWeeklyReset(account, model) {
+    const q = account.quota;
+    const key = this._weeklyBucketFor(model);
+    return q[`${key}Reset`] || q.unified7dReset || null;
+  }
+
+  /** True when the family-specific weekly bucket that governs `model` is spent.
+   * Unlike _isNearQuota this ignores the shared 5h/weekly caps — it is only used
+   * to skip an account for a probe of a model it definitely can't serve. Returns
+   * false for families without a dedicated bucket (they share unified7d, already
+   * covered by _isNearQuota). */
+  _modelWeeklyExhausted(account, model) {
+    const q = account.quota;
+    const key = this._weeklyBucketFor(model);
+    if (key === 'unified7d') return false;
+    return q[key] != null && q[key] >= this.switchThreshold;
   }
 
   /**
@@ -204,15 +239,15 @@ export class AccountManager {
     for (const account of this.accounts) {
       if (exclude?.has(account.index)) continue;
       if (!this._isProbeable(account)) continue;
-      // A Fable-exhausted account can't serve a Fable request even as a probe —
-      // it would just 429 again — so skip it for Fable and let the caller emit
+      // A family-exhausted account can't serve that family even as a probe — it
+      // would just 429 again — so skip it (Fable/Sonnet) and let the caller emit
       // the synthetic 429 when no other account is available.
-      if (isFableModel(model) && this._fableExhausted(account)) continue;
-      // Same for model-ownership: a probe for an owned model must not land on a
-      // non-owner (it would just reject the unknown model id).
-      if (model && !this._accountOwnsModel(account, model)) continue;
+      if (model && this._modelWeeklyExhausted(account, model)) continue;
+      // Same for routing/ownership: a probe for a routed or owned model must not
+      // land on an ineligible account (it would just reject the unknown model id).
+      if (model && !this._routeAllows(account, model)) continue;
       const priority = account.priority || 0;
-      const usage = this._maxUtilization(account);
+      const usage = this._maxUtilization(account, model);
       if (priority < bestPriority ||
           (priority === bestPriority && usage < bestUsage)) {
         bestPriority = priority;
@@ -248,27 +283,58 @@ export class AccountManager {
     }
 
     if (account.status === 'exhausted' || account.status === 'error') return false;
-    if (this._isNearQuota(account)) return false;
+    // Model-scoped: _isNearQuota checks the shared 5h bucket plus only the weekly
+    // bucket that governs this model, so a spent Fable/Sonnet bucket bars just
+    // that family — the account still serves every other model normally.
+    if (this._isNearQuota(account, model)) return false;
 
-    // Model-scoped exhaustion: a spent Fable weekly bucket only bars Fable
-    // requests. Non-Fable requests still route here normally.
-    if (isFableModel(model) && this._fableExhausted(account)) return false;
-
-    // Model-ownership routing: if any account has declared ownership of `model`
-    // via its `models` field, only those accounts are available for this request.
-    // This lets e.g. a DeepSeek account claim deepseek-* model names so those
-    // requests never land on Claude accounts (which don't recognize the model).
-    if (model && !this._accountOwnsModel(account, model)) return false;
+    // Route/ownership restriction: a configured route can pin a model pattern to
+    // an exclusive set of accounts; failing that, a per-account `models` claim
+    // restricts an owned model to its owners. Either way an account not eligible
+    // for this model is skipped so the request never lands somewhere it can't run.
+    if (model && !this._routeAllows(account, model)) return false;
 
     return true;
   }
 
-  /** True when this account's Fable weekly bucket is at/over the switch
-   * threshold. The reset is cleared by refreshExpiredQuotas before selection, so
-   * a non-null value here is still live. Model-scoped: only gates Fable requests. */
-  _fableExhausted(account) {
-    const q = account.quota;
-    return q.unified7dFable != null && q.unified7dFable >= this.switchThreshold;
+  /**
+   * Normalize and store the configurable routing table. A route pins a set of
+   * model globs to an exclusive set of accounts (and may override the governing
+   * quota bucket). Called from the constructor and on config reload.
+   *   { name, match: string|string[], accounts?: (name|index)[], bucket? }
+   */
+  setRoutes(routes) {
+    this.routes = (Array.isArray(routes) ? routes : []).map((r, i) => ({
+      name: r.name || `route-${i + 1}`,
+      match: (Array.isArray(r.match) ? r.match : [r.match]).filter(g => typeof g === 'string' && g),
+      accounts: Array.isArray(r.accounts) ? r.accounts.map(String) : [],
+      bucket: r.bucket || null,
+    })).filter(r => r.match.length);
+  }
+
+  /** The first configured route whose globs match `model`, or null. */
+  _routeForModel(model) {
+    if (!model || !this.routes?.length) return null;
+    return this.routes.find(r => r.match.some(g => modelGlobMatches(g, model))) || null;
+  }
+
+  /** The weekly quota bucket that governs `model` — a matching route's `bucket`
+   * override wins, otherwise the model family's default bucket. */
+  _weeklyBucketFor(model) {
+    const route = this._routeForModel(model);
+    return route?.bucket || weeklyBucketForModel(model);
+  }
+
+  /** Whether `account` may serve `model`. A matching route with an `accounts`
+   * list is exclusive (only listed accounts, by name or index). With no matching
+   * route — or a route that lists no accounts — it falls back to the per-account
+   * `models` ownership claim so PR #74 configs keep working. */
+  _routeAllows(account, model) {
+    const route = this._routeForModel(model);
+    if (route && route.accounts.length) {
+      return route.accounts.includes(account.name) || route.accounts.includes(String(account.index));
+    }
+    return this._accountOwnsModel(account, model);
   }
 
   /** Returns true if no account claims model ownership, or this account does. */
@@ -280,6 +346,46 @@ export class AccountManager {
       }
     }
     return true; // no one claims ownership → any account is fine
+  }
+
+  /**
+   * The routing table for display: every configured route plus an ephemeral,
+   * auto-created route for each model family that some account meters with its
+   * own weekly bucket but no configured route already covers. Auto-created routes
+   * carry `autocreated: true` and are never persisted — they simply surface the
+   * per-model quota the server already respects. Each route lists the accounts it
+   * can use with a live eligibility flag.
+   */
+  getRoutes() {
+    const out = this.routes.map(r => ({
+      name: r.name, match: r.match, bucket: r.bucket, autocreated: false,
+      accounts: this._routeAccountsView(r),
+    }));
+
+    const detected = [];
+    if (this.accounts.some(a => a.quota.unified7dFable != null)) {
+      detected.push({ name: 'fable', match: ['*fable*'], sample: 'claude-fable-5' });
+    }
+    if (this.accounts.some(a => a.quota.unified7dSonnet != null)) {
+      detected.push({ name: 'sonnet', match: ['*sonnet*'], sample: 'claude-sonnet-4-6' });
+    }
+    for (const d of detected) {
+      if (this._routeForModel(d.sample)) continue; // already covered by a configured route
+      out.push({
+        name: d.name, match: d.match, bucket: null, autocreated: true,
+        accounts: this.accounts.map(a => ({ name: a.name, eligible: this._isAvailable(a, d.sample) })),
+      });
+    }
+    return out;
+  }
+
+  /** Accounts a configured route can use (all accounts when it lists none), each
+   * with a live eligibility flag for a representative model of the route. */
+  _routeAccountsView(route) {
+    const sample = route.match[0].replace(/\*/g, '') || 'model';
+    const inRoute = a => !route.accounts.length
+      || route.accounts.includes(a.name) || route.accounts.includes(String(a.index));
+    return this.accounts.filter(inRoute).map(a => ({ name: a.name, eligible: this._isAvailable(a, sample) }));
   }
 
   /**
@@ -388,13 +494,20 @@ export class AccountManager {
     }
   }
 
-  _isNearQuota(account) {
+  _isNearQuota(account, model = null) {
     const q = account.quota;
     this._clearExpiredQuotas(account);
 
-    // Unified quotas (Claude Max) — utilization is already 0-1
+    // Shared 5-hour bucket gates every request regardless of model.
     if (q.unified5h != null && q.unified5h >= this.switchThreshold) return true;
-    if (q.unified7d != null && q.unified7d >= this.switchThreshold) return true;
+
+    // Only the weekly bucket that GOVERNS this model is checked: Fable and Sonnet
+    // meter their own weekly quota, so a spent Fable bucket must not bar an Opus
+    // or Sonnet request (and vice versa). When the family bucket isn't reported
+    // (e.g. the plan doesn't expose it), fall back to the shared weekly so an
+    // account over its overall cap is still treated as near-quota.
+    const weeklyVal = this._governingWeekly(account, model);
+    if (weeklyVal != null && weeklyVal >= this.switchThreshold) return true;
 
     // Standard quotas (API key accounts)
     if (q.tokensLimit != null && q.tokensRemaining != null) {
@@ -435,8 +548,11 @@ export class AccountManager {
       if (!this._isAvailable(account, model)) continue;
 
       const priority = account.priority || 0;
-      // Unknown weekly reset sorts first so we fill it in.
-      const weeklyReset = account.quota.unified7dReset || -Infinity;
+      // Rank by the reset of the weekly bucket that governs THIS model (Fable and
+      // Sonnet have their own), so a Fable request spends the account whose Fable
+      // window refreshes soonest while preserving accounts that reset later for
+      // Opus/Sonnet. Unknown reset sorts first so we probe and fill it in.
+      const weeklyReset = this._governingWeeklyReset(account, model) || -Infinity;
       if (priority < bestPriority ||
           (priority === bestPriority && weeklyReset < bestReset)) {
         bestPriority = priority;
@@ -492,8 +608,8 @@ export class AccountManager {
       // here would send a live request on an account that must not be used and,
       // below, silently clear its throttle/error state. (Mirrors _isAvailable.)
       if (account.disabled || account.status === 'error') continue;
-      // A request for an owned model must not fall back to a non-owner account.
-      if (model && !this._accountOwnsModel(account, model)) continue;
+      // A routed/owned model must not fall back to an ineligible account.
+      if (model && !this._routeAllows(account, model)) continue;
       const resetTime = account.rateLimitedUntil
         || account.quota.unified5hReset
         || account.quota.unified7dReset
@@ -826,6 +942,7 @@ export class AccountManager {
     return {
       currentAccount: this.accounts[this.currentIndex]?.name,
       switchThreshold: this.switchThreshold,
+      routes: this.getRoutes(),
       accounts: this.accounts.map(a => ({
         name: a.name,
         type: a.type,

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,11 @@ switch (command) {
     await warmupCommand();
     process.exit(0);
     break;
+  case 'route':
+  case 'routes':
+    await routeCommand();
+    process.exit(0);
+    break;
   case 'update':
     await updateCommand();
     process.exit(0);
@@ -130,7 +135,7 @@ async function serverCommand() {
   }
 
   const threshold = config.switchThreshold || 0.98;
-  const accountManager = new AccountManager(accounts, threshold);
+  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes });
 
   // Restore quota observed in a previous run so a restart doesn't lose rotation
   // state (passive — we never call the API to re-learn it). Stale windows are
@@ -214,6 +219,9 @@ async function serverCommand() {
     const diskConfig = await loadConfig();
     if (!diskConfig) return 0;
     const added = await syncAccountsFromDisk(diskConfig, config, accountManager);
+    // Pick up route table edits (teamclaude route …, TUI editor, or a hand edit).
+    config.routes = diskConfig.routes || [];
+    accountManager.setRoutes(config.routes);
     // Apply an sx.org key/mode change made on disk (e.g. via POST /teamclaude/reload).
     const diskSxKey = diskConfig.sx?.apiKey || null;
     const diskSxMode = diskConfig.sx?.mode || 'always';
@@ -266,6 +274,8 @@ async function serverCommand() {
         if (config.switchThreshold != null) diskConfig.switchThreshold = config.switchThreshold;
         if (config.quotaProbeSeconds != null) diskConfig.quotaProbeSeconds = config.quotaProbeSeconds;
         if (config.warmupSeconds != null) diskConfig.warmupSeconds = config.warmupSeconds;
+        // Persist the route table (edited from the TUI routes screen).
+        if (config.routes != null) diskConfig.routes = config.routes;
       }),
       syncAccounts: reloadAccounts,
       onQuit: async () => {
@@ -278,6 +288,7 @@ async function serverCommand() {
     });
     hooks = {
       onRequestStart: (id, info) => tui.onRequestStart(id, info),
+      onRequestModel: (id, info) => tui.onRequestModel(id, info),
       onRequestRouted: (id, info) => tui.onRequestRouted(id, info),
       onRequestEnd: (id, info) => tui.onRequestEnd(id, info),
     };
@@ -955,6 +966,77 @@ async function removeCommand() {
   console.log(`Removed account "${account.name}"`);
 }
 
+// ── route ───────────────────────────────────────────────────
+
+const ROUTE_USAGE = [
+  'Usage: teamclaude route [list]',
+  '       teamclaude route add <name> --match "<glob>[,<glob>]" [--accounts "<name-or-index>[,...]"] [--bucket <quota-bucket>]',
+  '       teamclaude route rm <name>',
+  '',
+  'A route pins model ids matching its globs to an exclusive set of accounts.',
+  'Omit --accounts to route to all accounts (e.g. just to override --bucket).',
+  'First matching route wins. Changes apply to a running server immediately.',
+].join('\n');
+
+function splitList(value) {
+  return (value || '').split(',').map(s => s.trim()).filter(Boolean);
+}
+
+async function routeCommand() {
+  const sub = args[1] || 'list';
+  const config = await loadOrCreateConfig();
+  config.routes = Array.isArray(config.routes) ? config.routes : [];
+
+  if (sub === 'list') {
+    if (!config.routes.length) { console.log('No routes configured.'); return; }
+    for (const r of config.routes) {
+      const match = (Array.isArray(r.match) ? r.match : [r.match]).join(', ');
+      const accts = (r.accounts && r.accounts.length) ? r.accounts.join(', ') : '(all accounts)';
+      const bucket = r.bucket ? `  bucket=${r.bucket}` : '';
+      console.log(`${r.name || '(unnamed)'}: ${match} → ${accts}${bucket}`);
+    }
+    return;
+  }
+
+  if (sub === 'add') {
+    const name = args[2] && !args[2].startsWith('--') ? args[2] : null;
+    const match = splitList(argValue('--match'));
+    const accounts = splitList(argValue('--accounts'));
+    const bucket = argValue('--bucket');
+    if (!name || !match.length) {
+      console.error(ROUTE_USAGE);
+      process.exit(1);
+    }
+    const known = new Set(config.accounts.map(a => a.name));
+    for (const a of accounts) {
+      if (!known.has(a) && !/^\d+$/.test(a)) console.error(`Warning: no account named "${a}" (yet)`);
+    }
+    const route = { name, match };
+    if (accounts.length) route.accounts = accounts;
+    if (bucket) route.bucket = bucket;
+    const at = config.routes.findIndex(r => r.name === name);
+    if (at >= 0) { config.routes[at] = route; console.log(`Updated route "${name}"`); }
+    else { config.routes.push(route); console.log(`Added route "${name}"`); }
+    await saveConfig(config);
+    await notifyRunningServer(config);
+    return;
+  }
+
+  if (sub === 'rm' || sub === 'remove' || sub === 'delete') {
+    const name = args[2];
+    const before = config.routes.length;
+    config.routes = config.routes.filter(r => r.name !== name);
+    if (config.routes.length === before) { console.error(`Route "${name}" not found`); process.exit(1); }
+    await saveConfig(config);
+    await notifyRunningServer(config);
+    console.log(`Removed route "${name}"`);
+    return;
+  }
+
+  console.error(ROUTE_USAGE);
+  process.exit(1);
+}
+
 // ── priority ────────────────────────────────────────────────
 
 async function priorityCommand() {
@@ -1051,6 +1133,8 @@ Commands:
   disable <name>      Temporarily exclude an account from rotation
   enable <name>       Re-enable a disabled account (also clears a stuck error)
   priority <name> <n> Set rotation priority (lower = preferred; --first/--last)
+  route [list|add|rm] Per-model routing: pin model globs to specific accounts
+                      (add <name> --match "<glob>" [--accounts "<name>"] [--bucket <b>])
   probe [off|secs]    Opt-in background quota refresh for idle accounts
                       (off by default; reads usage endpoint, spends no quota)
   warmup [off|secs]   Opt-in: keep idle accounts' 5h timers running by sending

--- a/src/model.js
+++ b/src/model.js
@@ -9,6 +9,49 @@ export function isFableModel(model) {
   return typeof model === 'string' && /fable/i.test(model);
 }
 
+// The model "family" a request belongs to. Anthropic meters some families with
+// their own weekly quota bucket (Fable, Sonnet) on top of the shared 5-hour and
+// weekly buckets, so the family decides which bucket governs a given request —
+// letting an account whose Fable bucket is spent keep serving Opus/Sonnet.
+// Returns a stable lowercase tag; unknown ids fall back to 'other'.
+export function modelFamily(model) {
+  if (typeof model !== 'string' || !model) return 'other';
+  if (/fable/i.test(model)) return 'fable';
+  if (/sonnet/i.test(model)) return 'sonnet';
+  if (/opus/i.test(model)) return 'opus';
+  if (/haiku/i.test(model)) return 'haiku';
+  return 'other';
+}
+
+// Quota buckets on an account (see AccountManager emptyQuota). The shared 5-hour
+// bucket applies to every request; the weekly bucket depends on the family.
+// A family with no dedicated weekly bucket falls back to the shared 'unified7d'.
+const FAMILY_WEEKLY_BUCKET = {
+  fable: 'unified7dFable',
+  sonnet: 'unified7dSonnet',
+};
+
+// The weekly quota bucket key that governs a model, e.g. a Fable request is
+// gated by 'unified7dFable' rather than the shared 'unified7d'. Used by account
+// selection so a spent family bucket only bars that family's requests.
+export function weeklyBucketForModel(model) {
+  return FAMILY_WEEKLY_BUCKET[modelFamily(model)] || 'unified7d';
+}
+
+// Match a shell-style glob against a model id. Only `*` is special (matches any
+// run of characters, including none); every other character is literal. The
+// comparison is case-insensitive. Used by configurable routes so a pattern like
+// `*fable*` or `claude-opus-*` selects the models a route handles.
+export function modelGlobMatches(glob, model) {
+  if (typeof glob !== 'string' || typeof model !== 'string') return false;
+  const re = '^' + glob.split('*').map(escapeRegExp).join('.*') + '$';
+  return new RegExp(re, 'i').test(model);
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Streaming, byte-exact locator for a TOP-LEVEL string field of a JSON object,
 // fed incrementally. It tracks JSON structure (container stack, key/value,
 // string/escape) so it ONLY matches the field at depth 1 of the root object —

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
 import { parseRequestModel } from './account-manager.js';
+import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 
@@ -173,11 +174,22 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       hooks.onRequestStart?.(reqId, { method: req.method, path: req.url });
 
       // Buffer request body (needed to resend on a different account after a 429).
+      // Peek the top-level `model` field incrementally as chunks arrive so the
+      // TUI can show it the instant it appears in the stream — usually the first
+      // frame — rather than waiting for the whole body and the request to finish.
       const bodyChunks = [];
-      for await (const chunk of req) bodyChunks.push(chunk);
+      const modelFinder = new TopLevelFieldFinder('model');
+      for await (const chunk of req) {
+        bodyChunks.push(chunk);
+        if (!modelFinder.done) {
+          const found = modelFinder.push(chunk);
+          if (found) hooks.onRequestModel?.(reqId, { model: found });
+        }
+      }
       const body = Buffer.concat(bodyChunks);
 
-      const ctx = { account: null, status: null, tried: new Set(), model: parseRequestModel(body), pinnedIndex };
+      const model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
+      const ctx = { account: null, status: null, tried: new Set(), model, pinnedIndex };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -20,11 +20,15 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   }
   lines.push('');
 
+  for (const line of routingLines(status.routes, paint)) lines.push(line);
+
   for (const account of accounts) {
     lines.push(renderAccountHeader(account, status.currentAccount, paint, now));
     for (const quotaLine of quotaLines(account, now, paint)) {
       lines.push(`  ${quotaLine}`);
     }
+    const routing = modelRoutingLine(account, status.switchThreshold, now, paint);
+    if (routing) lines.push(`  ${routing}`);
     lines.push(`  ${paint.dim('Usage'.padEnd(8))} ${formatUsage(account.usage, now)}`);
     lines.push(`  ${paint.dim('Probe'.padEnd(8))} ${formatAccountProbe(account.name, probe, now, paint)}`);
     lines.push('');
@@ -45,6 +49,24 @@ function colors(enabled) {
     red: wrap(31),
     cyan: wrap(36),
   };
+}
+
+// The routing table: one line per route (configured first, then auto-detected),
+// listing the model globs it matches and the accounts it can use, each colored
+// by live eligibility. Auto-created routes (a family metered separately with no
+// configured route) are tagged (auto); a bucket override shows in [brackets].
+function routingLines(routes, paint) {
+  if (!Array.isArray(routes) || routes.length === 0) return [];
+  const lines = [paint.bold('Routing')];
+  for (const route of routes) {
+    const match = (route.match || []).join(', ');
+    const accounts = (route.accounts || [])
+      .map(a => (a.eligible ? paint.green(a.name) : paint.red(a.name))).join(' ') || paint.gray('(none)');
+    const tag = route.autocreated ? paint.dim(' (auto)') : route.bucket ? paint.dim(` [${route.bucket}]`) : '';
+    lines.push(`  ${match.padEnd(16)} ${paint.dim('→')} ${accounts}${tag}`);
+  }
+  lines.push('');
+  return lines;
 }
 
 function renderAccountHeader(account, currentAccount, paint, now) {
@@ -76,6 +98,33 @@ function formatAccountStatus(account, now, paint) {
   }
 
   return parts.join(' / ');
+}
+
+// Per-account, per-family eligibility — the "some accounts are disabled for
+// specific models" view. Only rendered for accounts that meter a family
+// separately (a Sonnet or Fable weekly bucket), since that is the only case
+// where a request's model changes where it can route. A family reads ✗ when the
+// shared 5h bucket is spent (blocks everything) or when its own weekly bucket is
+// over the switch threshold; the reset is shown when the family bucket is the
+// blocker so it's clear when that model becomes available on this account again.
+function modelRoutingLine(account, threshold, now, paint) {
+  const q = account.quota || {};
+  if (q.unified7dSonnet == null && q.unified7dFable == null) return null;
+  const t = Number(threshold);
+  const fiveOver = q.unified5h != null && !Number.isNaN(t) && q.unified5h >= t;
+
+  const cell = (label, weekly, reset) => {
+    const weeklyOver = weekly != null && !Number.isNaN(t) && weekly >= t;
+    const mark = fiveOver || weeklyOver ? paint.red('✗') : paint.green('✓');
+    const resetTs = parseTs(reset);
+    const when = weeklyOver && resetTs && resetTs > now ? paint.dim(` ${formatDuration(resetTs - now)}`) : '';
+    return `${label} ${mark}${when}`;
+  };
+
+  const cells = [cell('Opus', q.unified7d, q.unified7dReset)];
+  if (q.unified7dSonnet != null) cells.push(cell('Sonnet', q.unified7dSonnet, q.unified7dSonnetReset));
+  if (q.unified7dFable != null) cells.push(cell('Fable', q.unified7dFable, q.unified7dFableReset));
+  return `${paint.dim('Models'.padEnd(8))} ${cells.join('   ')}`;
 }
 
 function quotaLines(account, now, paint) {

--- a/src/tui.js
+++ b/src/tui.js
@@ -28,6 +28,12 @@ function rpad(s, w) {
   return gap > 0 ? s + ' '.repeat(gap) : s;
 }
 
+// Split a comma-separated input (route globs / account names) into trimmed,
+// non-empty tokens. Shared by the routes editor prompts.
+function splitCsv(value) {
+  return (value || '').split(',').map(s => s.trim()).filter(Boolean);
+}
+
 /** Truncate a string with ANSI codes to exactly w visible characters, then reset. */
 function truncate(s, w) {
   let visible = 0;
@@ -186,6 +192,11 @@ export class TUI {
     this.render();
   }
 
+  onRequestModel(id, info) {
+    const r = this.active.get(id);
+    if (r && info.model) { r.model = info.model; this.render(); }
+  }
+
   onRequestRouted(id, info) {
     const r = this.active.get(id);
     if (r) r.account = info.account;
@@ -230,6 +241,7 @@ export class TUI {
       case 'add':    this._keyAdd(k); break;
       case 'input':  this._keyInput(k); break;
       case 'settings': this._keySettings(k); break;
+      case 'routes': this._keyRoutes(k); break;
     }
     this.render();
   }
@@ -247,7 +259,7 @@ export class TUI {
     }
     else if (k === 'a') { this.mode = 'add'; }
     else if (k === 'R') { this._doSync(); }
-    else if (k === 'g' && this.sx) { this.mode = 'settings'; this.setIdx = 0; this._loadSxBalance(); }
+    else if (k === 'g') { this.mode = 'settings'; this.setIdx = 0; this._loadSxBalance(); }
   }
 
   // Navigable rows on the settings screen, top to bottom. Both the renderer and
@@ -281,6 +293,17 @@ export class TUI {
       left: () => this._nudgeProbe(-30),
       right: () => this._nudgeProbe(+30),
       enter: () => this._promptInput('Quota probe seconds (0=off, min 30)', v => this._doSetProbe(v.trim())),
+    });
+
+    fields.push({
+      id: 'routes',
+      label: 'Manage routing',
+      hint: 'Enter to open',
+      value: () => {
+        const n = (this.config.routes || []).length;
+        return n ? green(`${n} route${n === 1 ? '' : 's'}`) : gray('none');
+      },
+      enter: () => { this.mode = 'routes'; this.routeIdx = 0; },
     });
 
     if (this.sx) {
@@ -645,6 +668,8 @@ export class TUI {
     const footerH = 2;
     if (this.mode === 'settings') {
       this._renderSettings(lines);
+    } else if (this.mode === 'routes') {
+      this._renderRoutes(lines);
     } else {
     // ── Accounts
     if (this.am.accounts.length === 0) {
@@ -662,6 +687,18 @@ export class TUI {
       }
     }
 
+    // ── Routing (configured + auto-detected routes, when any exist)
+    const routes = this.am.getRoutes();
+    if (routes.length) {
+      lines.push('');
+      lines.push(dim(' Routing'));
+      for (const r of routes) {
+        const accts = r.accounts.map(a => (a.eligible ? green(a.name) : red(a.name))).join(' ') || gray('(none)');
+        const tag = r.autocreated ? dim(' (auto)') : r.bucket ? dim(` [${r.bucket}]`) : '';
+        lines.push(`   ${cyan(r.match.join(','))} ${dim('→')} ${accts}${tag}`);
+      }
+    }
+
     // ── Activity header
     lines.push('');
     const ac = this.active.size;
@@ -674,8 +711,9 @@ export class TUI {
     for (const [, r] of this.active) {
       const el = ((now - r.started) / 1000).toFixed(1);
       const sp = cyan(SPINNER[this.frame]);
+      const m = r.model ? dim(` (${r.model})`) : ''; // filled in as soon as the model is peeked from the stream
       const a = r.account ? ` → ${r.account}` : '';
-      lines.push(` ${sp} ${gray(r.t)}  ${r.method} ${r.path}${a} ${dim(`(${el}s...)`)}`);
+      lines.push(` ${sp} ${gray(r.t)}  ${r.method} ${r.path}${m}${a} ${dim(`(${el}s...)`)}`);
     }
 
     // Completed log
@@ -764,6 +802,15 @@ export class TUI {
         line += `  F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset)}`;
       }
     }
+    // Explicit "disabled for these models" tag (issue #85): a family whose own
+    // weekly bucket is over the switch threshold can't serve that model even
+    // while the account is otherwise active. A spent shared 5h blocks everything
+    // and is already conveyed by the Ses bar + status, so it's not repeated here.
+    const th = this.am.switchThreshold;
+    const blocked = [];
+    if (q.unified7dSonnet != null && q.unified7dSonnet >= th) blocked.push('Sonnet');
+    if (q.unified7dFable != null && q.unified7dFable >= th) blocked.push('Fable');
+    if (blocked.length) line += `  ${red('⊘ ' + blocked.join(' '))}`;
     return line;
   }
 
@@ -798,6 +845,10 @@ export class TUI {
     lines.push(bold('  Quota probe') + dim('  — refresh idle accounts from the usage endpoint'));
     lines.push(row(byId('probe')));
     lines.push('');
+    // ── Routing
+    lines.push(bold('  Routing') + dim('  — pin model families to specific accounts'));
+    lines.push(row(byId('routes')));
+    lines.push('');
     // ── sx.org
     lines.push(bold('  sx.org proxy') + dim('  — route upstream via a residential IP (429 workaround)'));
     lines.push('');
@@ -823,12 +874,126 @@ export class TUI {
     lines.push(dim('  TLS stays end-to-end; residential traffic is metered by sx.org.'));
   }
 
+  // ── routes editor ──────────────────────────────────
+
+  _keyRoutes(k) {
+    const routes = this.config.routes || [];
+    const n = routes.length;
+    if (this.routeIdx >= n) this.routeIdx = Math.max(0, n - 1);
+    if ((k === 'up' || k === 'k') && n) this.routeIdx = (this.routeIdx - 1 + n) % n;
+    else if ((k === 'down' || k === 'j') && n) this.routeIdx = (this.routeIdx + 1) % n;
+    else if (k === 'a') this._routeEdit(null);
+    else if (k === 'e' && n) this._routeEdit(routes[this.routeIdx]);
+    else if (k === 'd' && n) this._routeDelete(this.routeIdx);
+    else if (k === 'esc' || k === 'q') { this.mode = 'settings'; this.setIdx = 0; }
+  }
+
+  // Prompt for one route field, prefilled, returning to the routes screen.
+  // Unlike _promptInput this passes empty values through (so optional fields can
+  // be left blank) and lets the caller chain the next prompt.
+  _routePrompt(label, prefill, cb) {
+    this.mode = 'input';
+    this.inputReturn = 'routes';
+    this.inputPrompt = label;
+    this.inputBuf = prefill || '';
+    this.inputCb = v => cb((v || '').trim());
+  }
+
+  // Guided add/edit: name → glob(s) → accounts → bucket → save. `orig` is the
+  // existing route being edited, or null when adding.
+  _routeEdit(orig) {
+    const draft = {
+      match: (orig ? (Array.isArray(orig.match) ? orig.match : [orig.match]) : []).join(', '),
+      accounts: (orig?.accounts || []).join(', '),
+      bucket: orig?.bucket || '',
+    };
+    this._routePrompt('Route name', orig?.name || '', name => {
+      if (!name) { this._addLog('Route name required — cancelled'); this.mode = 'routes'; return; }
+      draft.name = name;
+      this._routePrompt('Model glob(s), comma-separated (e.g. *fable*)', draft.match, match => {
+        if (!match) { this._addLog('At least one glob required — cancelled'); this.mode = 'routes'; return; }
+        draft.match = match;
+        const names = this.am.accounts.map(a => a.name).join(', ');
+        this._routePrompt(`Accounts (comma; blank = all) [${names}]`, draft.accounts, accts => {
+          draft.accounts = accts;
+          this._routePrompt('Quota bucket override (blank = auto)', draft.bucket, bucket => {
+            draft.bucket = bucket;
+            this._routeSave(draft, orig);
+          });
+        });
+      });
+    });
+  }
+
+  async _routeSave(draft, orig) {
+    const route = { name: draft.name, match: splitCsv(draft.match) };
+    const accounts = splitCsv(draft.accounts);
+    if (accounts.length) route.accounts = accounts;
+    if (draft.bucket) route.bucket = draft.bucket;
+
+    this.config.routes = this.config.routes || [];
+    const at = orig ? this.config.routes.indexOf(orig)
+      : this.config.routes.findIndex(r => r.name === route.name);
+    if (at >= 0) this.config.routes[at] = route; else this.config.routes.push(route);
+
+    this.am.setRoutes(this.config.routes); // apply to the running rotation immediately
+    try { await this.saveConfig(this.config); this._addLog(`Route "${route.name}" saved`); }
+    catch (e) { this._addLog(`Failed to save route: ${e.message}`); }
+    this.mode = 'routes';
+    this.routeIdx = at >= 0 ? at : this.config.routes.length - 1;
+    if (this.running) this.render();
+  }
+
+  async _routeDelete(idx) {
+    const routes = this.config.routes || [];
+    const r = routes[idx];
+    if (!r) return;
+    routes.splice(idx, 1);
+    this.am.setRoutes(routes);
+    try { await this.saveConfig(this.config); this._addLog(`Route "${r.name}" deleted`); }
+    catch (e) { this._addLog(`Failed to save: ${e.message}`); }
+    this.routeIdx = Math.max(0, Math.min(idx, routes.length - 1));
+    if (this.running) this.render();
+  }
+
+  _renderRoutes(lines) {
+    const routes = this.config.routes || [];
+    lines.push('');
+    lines.push(bold('  Routes') + dim('  — pin model globs to specific accounts (first match wins)'));
+    lines.push('');
+    if (!routes.length) {
+      lines.push(gray('    No routes configured. Press [a] to add one.'));
+    } else {
+      routes.forEach((r, i) => {
+        const sel = i === this.routeIdx;
+        const cursor = sel ? cyan('▸') : ' ';
+        const match = (Array.isArray(r.match) ? r.match : [r.match]).join(', ');
+        const accts = (r.accounts && r.accounts.length) ? r.accounts.join(' ') : dim('(all accounts)');
+        const bucket = r.bucket ? dim(`  [${r.bucket}]`) : '';
+        const name = rpad(r.name || '(unnamed)', 14);
+        lines.push(`   ${cursor} ${sel ? bold(name) : name} ${cyan(rpad(match, 22))} ${dim('→')} ${accts}${bucket}`);
+      });
+    }
+    // Auto-detected routes (read-only) for context — a family metered separately
+    // with no configured route. Pin one by adding a route with the same glob.
+    const auto = this.am.getRoutes().filter(r => r.autocreated);
+    if (auto.length) {
+      lines.push('');
+      lines.push(dim('  Auto-detected (not saved):'));
+      for (const r of auto) {
+        lines.push(dim(`     ${r.match.join(', ')} → ${r.accounts.map(a => a.name).join(' ')}`));
+      }
+    }
+  }
+
   _renderFooter() {
     switch (this.mode) {
       case 'normal':
         return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
       case 'settings':
         return ` ${dim('↑↓')} navigate  ${dim('←→')} change  ${bold('Enter')} edit  ${bold('Esc')} back`;
+      case 'routes':
+        return ` ${dim('↑↓')} select  ${bold('a')}dd  ${bold('e')}dit  ${bold('d')}elete  ${bold('Esc')} back`;
       case 'select': {
         const act = this.selAction === 'switch' ? 'switch'
           : this.selAction === 'toggle' ? 'enable/disable'

--- a/src/tui.js
+++ b/src/tui.js
@@ -666,9 +666,13 @@ export class TUI {
     lines.push(' ' + dim('─'.repeat(W - 2)));
 
     const footerH = 2;
-    if (this.mode === 'settings') {
+    // While a prompt is open (mode 'input') keep showing the screen it was
+    // launched from, so e.g. adding a route stays on the routes screen rather
+    // than flashing back to the main dashboard with just the footer prompt.
+    const view = this.mode === 'input' ? this.inputReturn : this.mode;
+    if (view === 'settings') {
       this._renderSettings(lines);
-    } else if (this.mode === 'routes') {
+    } else if (view === 'routes') {
       this._renderRoutes(lines);
     } else {
     // ── Accounts

--- a/test/per-model-routing.test.js
+++ b/test/per-model-routing.test.js
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { modelFamily, weeklyBucketForModel, modelGlobMatches, TopLevelFieldFinder } from '../src/model.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+const OPUS = 'claude-opus-4-6';
+const SONNET = 'claude-sonnet-4-6';
+const FABLE = 'claude-fable-5';
+
+// ── model family / governing bucket ───────────────────────────
+
+test('modelFamily classifies the known families and falls back to other', () => {
+  assert.equal(modelFamily(FABLE), 'fable');
+  assert.equal(modelFamily(SONNET), 'sonnet');
+  assert.equal(modelFamily(OPUS), 'opus');
+  assert.equal(modelFamily('claude-haiku-4-5-20251001'), 'haiku');
+  assert.equal(modelFamily('deepseek-v4-pro[1m]'), 'other');
+  assert.equal(modelFamily(null), 'other');
+});
+
+test('weeklyBucketForModel maps each family to the bucket that governs it', () => {
+  assert.equal(weeklyBucketForModel(FABLE), 'unified7dFable');
+  assert.equal(weeklyBucketForModel(SONNET), 'unified7dSonnet');
+  assert.equal(weeklyBucketForModel(OPUS), 'unified7d');       // shared weekly
+  assert.equal(weeklyBucketForModel('deepseek-x'), 'unified7d');
+});
+
+// ── per-model availability (issue #85) ────────────────────────
+
+test('a spent Fable weekly bucket bars only Fable — Opus/Sonnet still route there', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.1;          // shared 5h has headroom
+  q.unified7d = 0.2;          // shared weekly has headroom
+  q.unified7dFable = 1.0;     // Fable weekly is spent
+
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), false, 'Fable is blocked');
+  assert.equal(am._isAvailable(am.accounts[0], OPUS), true, 'Opus still available');
+  assert.equal(am._isAvailable(am.accounts[0], SONNET), true, 'Sonnet still available');
+});
+
+test('a spent Sonnet weekly bucket bars only Sonnet — Opus/Fable unaffected', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.1;
+  q.unified7d = 0.2;
+  q.unified7dSonnet = 1.0;    // Sonnet weekly spent
+
+  assert.equal(am._isAvailable(am.accounts[0], SONNET), false);
+  assert.equal(am._isAvailable(am.accounts[0], OPUS), true);
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), true);
+});
+
+test('the shared 5h bucket still gates every model', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].quota.unified5h = 0.99; // over threshold → nothing routes
+  for (const m of [OPUS, SONNET, FABLE, null]) {
+    assert.equal(am._isAvailable(am.accounts[0], m), false, `blocked for ${m}`);
+  }
+});
+
+test('a spent family bucket with no shared-weekly value falls back to the shared weekly', () => {
+  // When the plan does not expose a Fable-specific bucket, a Fable request must
+  // still honor the shared weekly cap rather than sail past it.
+  const am = new AccountManager([oauth('a')], 0.98);
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.1;
+  q.unified7d = 1.0;          // shared weekly spent, no unified7dFable reported
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), false);
+  assert.equal(am._isAvailable(am.accounts[0], OPUS), false);
+});
+
+// ── per-model reset ranking ───────────────────────────────────
+
+test('selection spends the account whose GOVERNING weekly resets soonest', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const a = am.accounts[0].quota, b = am.accounts[1].quota;
+  const soon = Date.now() + 60_000, later = Date.now() + 600_000; // future so they aren't cleared as expired
+  // a: general weekly resets soonest; b: Fable weekly resets soonest.
+  a.unified7d = 0.3; a.unified7dReset = soon;  a.unified7dFable = 0.3; a.unified7dFableReset = later;
+  b.unified7d = 0.3; b.unified7dReset = later; b.unified7dFable = 0.3; b.unified7dFableReset = soon;
+
+  assert.equal(am._pickBestAvailable(null, OPUS).name, 'a', 'Opus spends soonest general weekly');
+  assert.equal(am._pickBestAvailable(null, FABLE).name, 'b', 'Fable spends soonest Fable weekly');
+});
+
+// ── streaming model peek (shown immediately) ──────────────────
+
+test('the top-level model resolves from the first streamed chunk, before the full body', () => {
+  // A realistic messages body: `model` is an early top-level field, the bulk is
+  // the messages array. The finder must resolve on the first chunk.
+  const head = Buffer.from('{"model":"claude-opus-4-6","messages":[');
+  const tail = Buffer.from('{"role":"user","content":"' + 'x'.repeat(10_000) + '"}]}');
+
+  const f = new TopLevelFieldFinder('model');
+  const found = f.push(head);
+  assert.equal(found, 'claude-opus-4-6', 'model known from the first chunk');
+  assert.equal(f.done, true, 'no need to read the rest of the body');
+  // Feeding the (large) tail changes nothing — we already have the answer.
+  assert.equal(f.push(tail), 'claude-opus-4-6');
+});
+
+test('a model key nested in conversation content is never mistaken for the request model', () => {
+  const body = Buffer.from(JSON.stringify({
+    messages: [{ role: 'user', content: 'here is some json: {"model":"decoy"}' }],
+    model: 'claude-sonnet-4-6',
+  }));
+  const f = new TopLevelFieldFinder('model');
+  assert.equal(f.push(body), 'claude-sonnet-4-6');
+});
+
+// ── configurable routes ───────────────────────────────────────
+
+test('modelGlobMatches supports * and is case-insensitive, literal otherwise', () => {
+  assert.ok(modelGlobMatches('*fable*', FABLE));
+  assert.ok(modelGlobMatches('claude-opus-*', OPUS));
+  assert.ok(modelGlobMatches('CLAUDE-SONNET-4-6', SONNET));
+  assert.ok(modelGlobMatches('*', 'anything'));
+  assert.ok(!modelGlobMatches('*fable*', OPUS));
+  assert.ok(!modelGlobMatches('claude-opus', OPUS));       // no implicit prefix match
+  assert.ok(!modelGlobMatches('deepseek.v4', 'deepseekXv4')); // '.' is literal, not any-char
+});
+
+test('a route pins a model glob to an exclusive set of accounts', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'fable', match: ['*fable*'], accounts: ['b'] }],
+  });
+  // Fable is locked to account b; a is ineligible even though it has full quota.
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), false, 'a barred from Fable');
+  assert.equal(am._isAvailable(am.accounts[1], FABLE), true, 'b serves Fable');
+  // Other models are unaffected by the route.
+  assert.equal(am._isAvailable(am.accounts[0], OPUS), true);
+  assert.equal(am._isAvailable(am.accounts[1], OPUS), true);
+  // getActiveAccount honors the route: a Fable request only ever returns b.
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+});
+
+test('a route can be matched by account index as well as name', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'fable', match: ['*fable*'], accounts: [1] }],
+  });
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), false);
+  assert.equal(am._isAvailable(am.accounts[1], FABLE), true);
+});
+
+test('a route bucket override governs eligibility for a custom model id', () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    routes: [{ name: 'custom', match: ['deepseek-*'], bucket: 'unified7dFable' }],
+  });
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.1; q.unified7d = 0.1; q.unified7dFable = 1.0; // Fable bucket spent
+  // The custom model is gated by the overridden bucket, so it's blocked...
+  assert.equal(am._isAvailable(am.accounts[0], 'deepseek-v4-pro'), false);
+  // ...while a model with no route still uses its own family bucket (unaffected).
+  assert.equal(am._isAvailable(am.accounts[0], OPUS), true);
+});
+
+test('routes with no account list fall back to the legacy per-account models claim', () => {
+  // No route restricts accounts, but account b claims Fable via models[] (PR #74).
+  const am = new AccountManager([oauth('a'), oauth('b', { models: ['claude-fable-5'] })], 0.98);
+  assert.equal(am._isAvailable(am.accounts[0], FABLE), false, 'a not an owner');
+  assert.equal(am._isAvailable(am.accounts[1], FABLE), true, 'b owns Fable');
+});
+
+test('setRoutes normalizes shapes and is re-appliable on reload', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  assert.deepEqual(am.routes, []);
+  am.setRoutes([{ match: '*fable*', accounts: ['a', 2] }]); // string match, mixed account types
+  assert.equal(am.routes.length, 1);
+  assert.equal(am.routes[0].name, 'route-1');              // defaulted
+  assert.deepEqual(am.routes[0].match, ['*fable*']);        // wrapped to array
+  assert.deepEqual(am.routes[0].accounts, ['a', '2']);      // stringified
+  am.setRoutes(undefined);                                  // reload with none
+  assert.deepEqual(am.routes, []);
+});

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -46,6 +46,45 @@ test('renderStatus colors active accounts and bars', () => {
   assert.ok(cells.at(-1)[0] > cells.at(-1)[1], 'bar should end red');
 });
 
+test('renderStatus shows per-model eligibility when a family is metered separately', () => {
+  const status = sampleStatus();
+  // Shared 5h has headroom, general/Opus weekly is fine, but the Fable weekly is
+  // spent: Fable should read ✗ (with its reset) while Opus stays ✓ — the
+  // "some accounts are disabled for specific models" view of issue #85.
+  status.accounts[0].quota = {
+    unified5h: 0.2, unified5hReset: now + 60_000,
+    unified7d: 0.3, unified7dReset: now + 600_000,
+    unified7dFable: 1.0, unified7dFableReset: now + 86_400_000,
+  };
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /Models\s+Opus ✓/);
+  assert.match(output, /Fable ✗ 1d/);
+});
+
+test('renderStatus omits the Models line for accounts with no family-specific bucket', () => {
+  const output = renderStatus(sampleStatus(), { color: false, now });
+  assert.doesNotMatch(output, /Models/);
+});
+
+test('renderStatus prints the routing table with configured and auto routes', () => {
+  const status = sampleStatus();
+  status.routes = [
+    { name: 'fable', match: ['*fable*'], autocreated: false, bucket: null,
+      accounts: [{ name: 'personal', eligible: true }, { name: 'a', eligible: false }] },
+    { name: 'sonnet', match: ['*sonnet*'], autocreated: true, bucket: null,
+      accounts: [{ name: 'a', eligible: true }] },
+  ];
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /Routing/);
+  assert.match(output, /\*fable\*\s+→ personal a/);
+  assert.match(output, /\*sonnet\*\s+→ a \(auto\)/);
+});
+
+test('renderStatus omits the routing table when there are no routes', () => {
+  const output = renderStatus(sampleStatus(), { color: false, now });
+  assert.doesNotMatch(output, /Routing/);
+});
+
 test('renderStatus sanitizes probe errors', () => {
   const status = sampleStatus();
   status.probe.accounts[0] = {

--- a/test/tui-routes.test.js
+++ b/test/tui-routes.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TUI } from '../src/tui.js';
+
+// Minimal AccountManager stand-in for the routes editor: it only needs the
+// surface the editor touches (accounts, setRoutes). render() is stubbed out so
+// these tests exercise the editor state machine, not the terminal renderer.
+function makeTUI() {
+  const applied = { routes: null };
+  const am = {
+    accounts: [{ name: 'a', index: 0 }, { name: 'b', index: 1 }],
+    currentIndex: 0,
+    switchThreshold: 0.98,
+    setRoutes(r) { applied.routes = r; },
+    getRoutes() { return []; },
+  };
+  const saved = { routes: null };
+  const config = { proxy: { port: 1 }, routes: [] };
+  const tui = new TUI({
+    accountManager: am, config, sx: null,
+    saveConfig: async (c) => { saved.routes = JSON.parse(JSON.stringify(c.routes)); },
+    syncAccounts: async () => 0, onQuit: () => {},
+  });
+  tui.render = () => {}; // bypass terminal rendering
+  return { tui, config, applied, saved };
+}
+
+const type = (tui, s) => { for (const ch of s) tui._key(ch); };
+const settle = () => new Promise(r => setTimeout(r, 5)); // let async save finish
+
+// Routing lives under the settings screen (g → "Manage routing"): open settings,
+// move the cursor to the routes row (threshold, probe, routes), press Enter.
+function openRoutes(tui) {
+  tui._key('g');
+  tui._key('down'); tui._key('down');
+  tui._key('enter');
+}
+
+test('TUI routes editor: add walks name → glob → accounts → bucket and persists', async () => {
+  const { tui, config, applied, saved } = makeTUI();
+
+  openRoutes(tui);
+  assert.equal(tui.mode, 'routes');
+  tui._key('a');
+  assert.equal(tui.mode, 'input');
+  assert.match(tui.inputPrompt, /Route name/);
+
+  type(tui, 'fable'); tui._key('enter');
+  assert.match(tui.inputPrompt, /glob/);
+  type(tui, '*fable*'); tui._key('enter');
+  assert.match(tui.inputPrompt, /Accounts/);
+  type(tui, 'b'); tui._key('enter');
+  assert.match(tui.inputPrompt, /bucket/i);
+  tui._key('enter'); // blank bucket → save
+  await settle();
+
+  assert.deepEqual(config.routes, [{ name: 'fable', match: ['*fable*'], accounts: ['b'] }]);
+  assert.deepEqual(applied.routes, config.routes, 'applied to the running rotation live');
+  assert.deepEqual(saved.routes, config.routes, 'persisted via saveConfig');
+  assert.equal(tui.mode, 'routes');
+});
+
+test('TUI routes editor: a blank name cancels without creating a route', async () => {
+  const { tui, config } = makeTUI();
+  openRoutes(tui); tui._key('a');
+  tui._key('enter'); // empty name
+  await settle();
+  assert.deepEqual(config.routes, []);
+  assert.equal(tui.mode, 'routes');
+});
+
+test('TUI routes editor: edit prefills, and backspace clears a field before retyping', async () => {
+  const { tui, config } = makeTUI();
+  config.routes = [{ name: 'fable', match: ['*fable*'], accounts: ['b'] }];
+
+  openRoutes(tui); tui.routeIdx = 0; tui._key('e');
+  assert.equal(tui.inputBuf, 'fable');          // name prefilled
+  tui._key('enter');
+  assert.equal(tui.inputBuf, '*fable*');         // glob prefilled
+  tui._key('enter');
+  assert.equal(tui.inputBuf, 'b');               // accounts prefilled
+  tui._key('bs'); type(tui, 'a,b'); tui._key('enter');
+  type(tui, 'unified7dFable'); tui._key('enter');
+  await settle();
+
+  assert.deepEqual(config.routes, [
+    { name: 'fable', match: ['*fable*'], accounts: ['a', 'b'], bucket: 'unified7dFable' },
+  ]);
+});
+
+test('TUI routes editor: delete removes the selected route', async () => {
+  const { tui, config, applied } = makeTUI();
+  config.routes = [{ name: 'fable', match: ['*fable*'] }, { name: 'bulk', match: ['*opus*'] }];
+
+  openRoutes(tui); tui.routeIdx = 0; tui._key('d');
+  await settle();
+  assert.deepEqual(config.routes, [{ name: 'bulk', match: ['*opus*'] }]);
+  assert.deepEqual(applied.routes, config.routes);
+});


### PR DESCRIPTION
## What

Turns model routing from a single implicit pipe into per-model routing over one shared account pool, and makes the model categories **configurable**. Addresses #85 (per-model routing) and the "show the request model immediately" gap.

## Behavior (works with zero config)

Selection used to gate/rank every request on the **shared** `unified5h`/`unified7d` buckets, so an account whose Fable bucket was spent looked busy for *everything*. Now each request is gated and ranked on the bucket that governs its **family**:

- `fable → unified7dFable`, `sonnet → unified7dSonnet`, `opus/other → unified7d`, all still under the shared 5h.
- A spent Fable/Sonnet weekly bucket bars **only** that family; the account keeps serving the others.
- Selection spends the account whose **governing** weekly resets soonest, preserving accounts that reset later for other families.
- Falls back to the shared weekly when a family bucket isn't reported, so nothing sails past an overall cap.

This generalizes (and removes) the old Fable-only special case, and Sonnet is now consulted the same way.

## Configurable routes

A `routes` table pins model globs to an **exclusive** set of accounts (first match wins), with an optional quota-bucket override:

```json
"routes": [
  { "name": "fable", "match": ["*fable*"], "accounts": ["personal-max"] },
  { "name": "bulk",  "match": ["*opus*","*sonnet*"], "accounts": ["corp-1","corp-2"], "bucket": "unified7d" }
]
```

- No matching route → falls back to PR #74's per-account `models` claim, so existing configs keep working (routes supersede it).
- Applied **live** on config reload.
- Manage three ways: config file, `teamclaude route list|add|rm`, or the TUI settings screen (`g` → **Manage routing**; `a`/`e`/`d`).

## Show the request model live

The model now streams into the TUI in-flight rows the instant the top-level `model` field is peeked from the request body (via the existing streaming finder), on both the base and MITM paths — previously it only appeared once the request finished.

## Console

`status` and the TUI show a **Routing** table (configured routes + **auto-detected** family routes tagged `(auto)`, derived live and never persisted) plus a per-account per-model eligibility line (`Models  Opus ✓  Fable ✗ 2d` / `⊘ Fable`).

## Tests

+17 tests: glob matching, exclusive routing + index match + bucket override + legacy fallback + reload, streaming model peek, status routing/eligibility rendering, and the TUI routes editor (add/edit/delete). Full suite green (217), lint clean.

## Notes

- Stacks on current `master` (1.1.5), which already merged #73/#74/#76/#77.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)