### PR TITLE
feat: storm control — no thundering-herd on switchover or rate-limit 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
 - **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes). Optional **[model routes](#model-routes)** pin model patterns to a specific set of accounts (config, `teamclaude route`, or the TUI settings screen → Manage routing)
 - **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; a quota rejection (a spent weekly bucket) switches accounts immediately instead of waiting, and switches to the next on persistent errors
+- **Storm control** — when many agents fail over to a fresh account at once, requests are [paced onto it](#storm-control-switchover-ramp-up) with a short ramp-up so the herd doesn't instantly throttle it and cascade down the fleet
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
@@ -233,6 +234,23 @@ After a host network drop and reconnect, Node's shared connection pool can hold 
 | `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS` | `120000` | Max **idle** gap between response-body chunks. Resets on every chunk, so a slow-but-healthy stream is fine; it fires only when the socket goes silent mid-stream (a drop after headers), turning a hang into a fast, retryable failure. |
 | `TEAMCLAUDE_REFRESH_TIMEOUT_MS` | `30000` | Max wait for an OAuth token refresh. A hung refresh is coalesced across all callers, so it would otherwise wedge every request for that account. |
 
+### Storm control (switchover ramp-up)
+
+When you run many agents at once and the active account runs out, every in-flight request fails over to the next account **at the same instant** — a thundering herd that can spend a big chunk of the fresh account's quota (large contexts) and instantly throttle it, cascading down the fleet ([#84](https://github.com/KarpelesLab/teamclaude/issues/84)).
+
+To prevent this, requests onto a **just-switched-to account** are paced: concurrency starts at 1 and the cap ramps up over a few seconds, then lifts. The first request or two reveal whether the new account is also near-exhausted **before** the whole herd commits to it, so a cascade is broken up hop by hop. The gate is **fail-open** — a request never blocks longer than the ramp window, and a client that disconnects while waiting just drops out — and the slot is held only until response headers arrive, so streaming replies don't tie up concurrency.
+
+On by default. Tune or disable via `stormRamp` in the config:
+
+```json
+"stormRamp": { "enabled": true, "startConc": 1, "stepConc": 1, "stepMs": 250, "windowMs": 30000 }
+```
+
+- **`startConc`** — concurrent requests allowed the instant a switch happens (default 1).
+- **`stepConc` / `stepMs`** — the cap grows by `stepConc` every `stepMs` (default +1 every 250ms ≈ 4 req/s).
+- **`windowMs`** — after this long, pacing stops entirely (default 30s).
+- **`enabled: false`** — turn storm control off (send the full burst immediately, pre-#84 behavior).
+
 ### Config format
 
 ```json
@@ -269,6 +287,7 @@ After a host network drop and reconnect, Node's shared connection pool can hold 
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts (TUI: `g` → `t`) |
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |
 | `warmupSeconds` | Keep-warm interval in seconds (`0` = off, the default; CLI `warmup`). Spawns a minimal `claude` per idle account to start its 5h timer — **spends a little quota**, unlike the probe |
+| `stormRamp` | Optional storm-control tuning (on by default) — see [Storm control](#storm-control-switchover-ramp-up). Object: `{ enabled, startConc, stepConc, stepMs, windowMs }` |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
 - **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes). Optional **[model routes](#model-routes)** pin model patterns to a specific set of accounts (config, `teamclaude route`, or the TUI settings screen → Manage routing)
-- **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; a quota rejection (a spent weekly bucket) switches accounts immediately instead of waiting, and switches to the next on persistent errors
+- **Auto-retry on 429** — distinguishes the two kinds of 429: a **quota rejection** (a spent 5h/weekly bucket, `unified-…-status: rejected`) switches accounts immediately; a **rate-limit 429** (the per-minute throttle) does **not** switch — it [pauses the account](#storm-control-switchover-ramp-up) so concurrent requests wait instead of flooding, retries the same account (absorbing short `retry-after`s inline), and only surfaces a 429 to the client for longer waits. Rotating on a rate-limit 429 would just move the burst to the next account and throw away the first account's cache
 - **Storm control** — when many agents fail over to a fresh account at once, requests are [paced onto it](#storm-control-switchover-ramp-up) with a short ramp-up so the herd doesn't instantly throttle it and cascade down the fleet
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
@@ -250,6 +250,8 @@ On by default. Tune or disable via `stormRamp` in the config:
 - **`stepConc` / `stepMs`** — the cap grows by `stepConc` every `stepMs` (default +1 every 250ms ≈ 4 req/s).
 - **`windowMs`** — after this long, pacing stops entirely (default 30s).
 - **`enabled: false`** — turn storm control off (send the full burst immediately, pre-#84 behavior).
+
+The same gate handles **rate-limit 429s** (the per-minute throttle, not quota exhaustion): teamclaude pauses the account for the `retry-after` window so new queries wait instead of piling on, then releases the held queries through a fresh ramp (staggered, not all at once). It **never rotates** on a rate-limit 429 — that would just move the burst to the next account and drop the first account's cache. Short waits are absorbed inline on the same account (default ≤ 60s, `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`); longer ones return a 429 + `retry-after` so the client backs off. Only a **quota rejection** (`unified-…-status: rejected`) rotates.
 
 ### Config format
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -127,7 +127,11 @@ export class AccountManager {
    * once the ramp window has elapsed (or ramping is off / never started). */
   _rampCap(account, now = Date.now()) {
     if (!this.ramp.enabled || account.rampStartedAt == null) return Infinity;
-    const elapsed = now - account.rampStartedAt;
+    // Clamp to 0: pauseAccount arms rampStartedAt in the FUTURE (pause-end), so a
+    // call during the pause would otherwise yield a negative elapsed → negative
+    // cap. admit()'s pause branch already guards this, but keep _rampCap sound on
+    // its own — a future start simply means "cap is at its floor (startConc)".
+    const elapsed = Math.max(0, now - account.rampStartedAt);
     if (elapsed >= this.ramp.windowMs) { account.rampStartedAt = null; return Infinity; }
     return this.ramp.startConc + Math.floor(elapsed / this.ramp.stepMs) * this.ramp.stepConc;
   }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -44,7 +44,7 @@ function modelMatches(declared, model) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes, ramp } = {}) {
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
@@ -76,10 +76,29 @@ export class AccountManager {
       },
       rateLimitedUntil: null,
       throttledAt: null,
+      // Storm control (see admit/release): in-flight upstream requests and the
+      // time this account last became the current one (starts a ramp window).
+      inFlight: 0,
+      rampStartedAt: null,
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
     this.setRoutes(routes);
+    // Storm control: when rotation switches to a fresh account, a burst of
+    // in-flight requests (e.g. dozens of agents failing over together) would all
+    // hit it at once and instantly throttle it — cascading down the fleet
+    // (issue #84). admit() caps concurrent requests to a just-switched account
+    // and ramps the cap up over a short window, so the first few reveal whether
+    // it's also near-exhausted before the whole herd commits.
+    this.ramp = {
+      enabled: true,
+      startConc: 1,       // concurrent requests allowed at the instant of a switch
+      stepConc: 1,        // cap increase per stepMs
+      stepMs: 250,        // → +stepConc every 250ms (default ramps ~4 req/s)
+      windowMs: 30_000,   // after this, pacing stops entirely (cap = Infinity)
+      pollMs: 50,         // how often a waiting request re-checks the cap
+      ...ramp,
+    };
     // When every account reads as over-quota we would otherwise refuse locally
     // forever (a stale cached utilization is never re-validated because no
     // request is ever sent). Instead, allow one real upstream probe at most this
@@ -91,6 +110,44 @@ export class AccountManager {
     // retry-after, short enough that a stale hold cannot pin the fleet.
     this.throttleProbeFloorMs = throttleProbeFloorMs
       ?? (Number(process.env.TEAMCLAUDE_THROTTLE_PROBE_FLOOR_MS) || 60_000);
+  }
+
+  /** Start (or restart) the ramp window for an account that just became current,
+   * so a failover burst is paced onto it rather than all landing at once. */
+  _beginRamp(account) {
+    if (account && this.ramp.enabled) account.rampStartedAt = Date.now();
+  }
+
+  /** Max concurrent upstream requests allowed to `account` right now. Infinity
+   * once the ramp window has elapsed (or ramping is off / never started). */
+  _rampCap(account, now = Date.now()) {
+    if (!this.ramp.enabled || account.rampStartedAt == null) return Infinity;
+    const elapsed = now - account.rampStartedAt;
+    if (elapsed >= this.ramp.windowMs) { account.rampStartedAt = null; return Infinity; }
+    return this.ramp.startConc + Math.floor(elapsed / this.ramp.stepMs) * this.ramp.stepConc;
+  }
+
+  /**
+   * Reserve a concurrency slot on `account` before sending upstream, waiting
+   * while the account is over its current ramp cap. Fail-open: returns true once
+   * a slot is taken (always eventually, since the cap grows and the window
+   * expires), or false if `isAborted()` reports the client went away while
+   * waiting. Pair every `true` with a `release(index)`.
+   */
+  async admit(index, isAborted) {
+    const account = this.accounts[index];
+    if (!account || !this.ramp.enabled) { if (account) account.inFlight++; return true; }
+    while (true) {
+      if (isAborted?.()) return false;
+      if (account.inFlight < this._rampCap(account)) { account.inFlight++; return true; }
+      await new Promise(r => setTimeout(r, this.ramp.pollMs));
+    }
+  }
+
+  /** Release a slot taken by admit(). Safe to call once per successful admit. */
+  release(index) {
+    const account = this.accounts[index];
+    if (account && account.inFlight > 0) account.inFlight--;
   }
 
   /**
@@ -259,6 +316,7 @@ export class AccountManager {
 
     this._nextProbeAt = now + this.probeIntervalMs;
     this.currentIndex = best.index;
+    this._beginRamp(best);
     if (best.status === 'throttled') {
       console.log(`[TeamClaude] All accounts unavailable — revalidating throttled "${best.name}" with a live request`);
     } else {
@@ -490,6 +548,7 @@ export class AccountManager {
 
     if (best) {
       this.currentIndex = best.index;
+      this._beginRamp(best);
       console.log(`[TeamClaude] Account "${best.name}" session quota reset and weekly expires sooner — switching to it`);
     }
   }
@@ -575,6 +634,7 @@ export class AccountManager {
     const best = this._pickBestAvailable();
     if (!best) return this.accounts[this.currentIndex] || null;
     this.currentIndex = best.index;
+    this._beginRamp(best);
     best.probing = best.quota.unified7dReset == null;
     const wk = best.quota.unified7d != null
       ? `${(best.quota.unified7d * 100).toFixed(1)}% weekly used`
@@ -592,6 +652,7 @@ export class AccountManager {
       // it so we re-evaluate once that quota is learned (see updateQuota).
       best.probing = best.quota.unified7dReset == null;
       if (switched) {
+        this._beginRamp(best);
         console.log(`[TeamClaude] Switched to account "${best.name}"`);
       }
       return best;
@@ -625,6 +686,7 @@ export class AccountManager {
       soonestAccount.status = 'active';
       soonestAccount.rateLimitedUntil = null;
       this.currentIndex = soonestAccount.index;
+      this._beginRamp(soonestAccount);
       console.log(`[TeamClaude] Account "${soonestAccount.name}" reset, switching to it`);
       return soonestAccount;
     }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -80,6 +80,11 @@ export class AccountManager {
       // time this account last became the current one (starts a ramp window).
       inFlight: 0,
       rampStartedAt: null,
+      // Rate-limit pause (see pauseAccount): a short window during which new
+      // requests wait in admit() rather than flooding — set from a 429's
+      // retry-after. Distinct from `throttled`/rateLimitedUntil: it does NOT
+      // make the account unavailable, so selection never rotates away from it.
+      pausedUntil: null,
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
@@ -128,18 +133,28 @@ export class AccountManager {
   }
 
   /**
-   * Reserve a concurrency slot on `account` before sending upstream, waiting
-   * while the account is over its current ramp cap. Fail-open: returns true once
-   * a slot is taken (always eventually, since the cap grows and the window
-   * expires), or false if `isAborted()` reports the client went away while
-   * waiting. Pair every `true` with a `release(index)`.
+   * Reserve a concurrency slot on `account` before sending upstream. Waits while
+   * the account is in a rate-limit pause (a 429's retry-after window) and while
+   * it is over its current ramp cap. Fail-open: returns true once a slot is taken
+   * (always eventually — the pause ends and the ramp cap grows), or false if
+   * `isAborted()` reports the client went away while waiting. Pair every `true`
+   * with a `release(index)`.
    */
   async admit(index, isAborted) {
     const account = this.accounts[index];
-    if (!account || !this.ramp.enabled) { if (account) account.inFlight++; return true; }
+    if (!account) return true;
     while (true) {
       if (isAborted?.()) return false;
-      if (account.inFlight < this._rampCap(account)) { account.inFlight++; return true; }
+      const now = Date.now();
+      // Rate-limit pause: hold new requests off this account until the window
+      // passes instead of flooding it (which would deepen the 429). Not a
+      // rotation trigger — the account stays selectable the whole time.
+      if (account.pausedUntil && now < account.pausedUntil) {
+        await new Promise(r => setTimeout(r, Math.min(account.pausedUntil - now, this.ramp.pollMs * 4)));
+        continue;
+      }
+      const cap = this.ramp.enabled ? this._rampCap(account, now) : Infinity;
+      if (account.inFlight < cap) { account.inFlight++; return true; }
       await new Promise(r => setTimeout(r, this.ramp.pollMs));
     }
   }
@@ -148,6 +163,26 @@ export class AccountManager {
   release(index) {
     const account = this.accounts[index];
     if (account && account.inFlight > 0) account.inFlight--;
+  }
+
+  /**
+   * Pause an account after a rate-limit (non-quota) 429 so concurrent requests
+   * wait in admit() instead of piling on. Unlike markRateLimited this does NOT
+   * set `throttled`/rateLimitedUntil, so _isAvailable still returns true and
+   * selection never rotates away — rotation is reserved for quota exhaustion.
+   * When the pause lifts, the held requests are released through a fresh ramp
+   * window (storm control) so they trickle out rather than flood. Extends an
+   * existing pause rather than shortening it.
+   */
+  pauseAccount(index, seconds) {
+    const account = this.accounts[index];
+    if (!account) return;
+    const until = Date.now() + Math.max(0, seconds) * 1000;
+    account.pausedUntil = Math.max(account.pausedUntil || 0, until);
+    // Arm the ramp to begin when the pause ends: while paused, admit() holds on
+    // the pause branch; once it lifts, _rampCap counts from here and releases the
+    // backlog gradually (startConc, then +stepConc per step).
+    if (this.ramp.enabled) account.rampStartedAt = account.pausedUntil;
   }
 
   /**
@@ -1016,6 +1051,9 @@ export class AccountManager {
         usage: { ...a.usage },
         rateLimitedUntil: a.rateLimitedUntil
           ? new Date(a.rateLimitedUntil).toISOString()
+          : null,
+        pausedUntil: a.pausedUntil && a.pausedUntil > Date.now()
+          ? new Date(a.pausedUntil).toISOString()
           : null,
       })),
     };

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ async function serverCommand() {
   }
 
   const threshold = config.switchThreshold || 0.98;
-  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes });
+  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes, ramp: config.stormRamp });
 
   // Restore quota observed in a previous run so a restart doesn't lose rotation
   // state (passive — we never call the API to re-learn it). Stale windows are

--- a/src/server.js
+++ b/src/server.js
@@ -490,13 +490,14 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // _selectProbe) clear its own hold and return the fleet to service.
     if (upstreamRes.status !== 429) accountManager.clearRateLimited(account.index);
 
-    // On 429, wait the retry-after duration and retry on the same account
-    // (this is a transient rate limit, not quota exhaustion).
+    // Two kinds of 429 are handled differently below: a quota rejection rotates
+    // to another account; a transient rate-limit throttle pauses + retries the
+    // same account (never rotates — see #84).
     if (upstreamRes.status === 429) {
       // Clamp Retry-After to a sane window: missing/invalid falls back to 60s,
       // and out-of-range values are bounded to [1, 300]. A negative value would
-      // otherwise bypass the retry cap — setTimeout returns immediately and
-      // markRateLimited would set rateLimitedUntil in the past.
+      // otherwise bypass the wait cap — setTimeout returns immediately and a
+      // pause/hold would be armed in the past.
       let retryAfter = parseInt(upstreamRes.headers.get('retry-after'), 10);
       if (Number.isNaN(retryAfter)) retryAfter = 60;
       // Discard the 429 response body
@@ -547,7 +548,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
 
       // sx fresh-IP retry (still the same account) takes precedence over waiting.
-      if (switchingToSx) {
+      // Bounded by retryCount like the inline-wait path below, so a persistently
+      // 429ing upstream can't loop forever through sx.
+      if (switchingToSx && retryCount < maxRetries) {
         console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
         if (res.destroyed) return;
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);

--- a/src/server.js
+++ b/src/server.js
@@ -452,12 +452,23 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   };
 
   try {
-    const upstreamRes = await upstreamFetch(upstreamUrl, {
-      method,
-      headers,
-      body: ['GET', 'HEAD'].includes(method) ? undefined : sendBody,
-      redirect: 'manual',
-    }, sx, route);
+    // Storm control: pace requests onto a freshly-switched account so a failover
+    // burst doesn't slam it all at once and cascade (issue #84). The slot is held
+    // only until the response headers arrive — long enough to stagger the burst,
+    // then released so streaming bodies don't tie up concurrency. Fail-open: a
+    // client that disconnects while waiting just drops out.
+    if (!await accountManager.admit(account.index, () => res.destroyed)) return;
+    let upstreamRes;
+    try {
+      upstreamRes = await upstreamFetch(upstreamUrl, {
+        method,
+        headers,
+        body: ['GET', 'HEAD'].includes(method) ? undefined : sendBody,
+        redirect: 'manual',
+      }, sx, route);
+    } finally {
+      accountManager.release(account.index);
+    }
 
     // Extract rate limit headers
     const rateLimitHeaders = {};

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,12 @@ export const HOP_BY_HOP_HEADERS = new Set([
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
 const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
+// How long the proxy will absorb a rate-limit 429's retry-after inline (waiting
+// on the SAME account) before surfacing a 429 + retry-after to the client. A
+// rate-limit 429 never rotates accounts (that just moves the burst); it pauses
+// the account so concurrent requests wait, then retries the same account.
+const RATE_LIMIT_ABSORB_MAX_SECONDS =
+  Number(process.env.TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS) || 60;
 
 // Response header names that are connection-specific and thus illegal on an
 // HTTP/2 response (Node's Http2ServerResponse.writeHead rejects them). Also
@@ -530,34 +536,43 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       const switchingToSx = nextUseSx && !route;
       sx?.noteRateLimited(retryAfter);
 
-      // Bound the retries: a persistently-throttled upstream must not loop
-      // forever (that would tie up the client connection indefinitely).
-      // Once retries are exhausted, throttle this account and re-dispatch —
-      // getActiveAccount then picks another account, or returns 429 to the
-      // client if every account is throttled.
-      if (retryCount >= maxRetries) {
-        console.log(`[TeamClaude] Persistent 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching`);
-        accountManager.markRateLimited(account.index, retryAfter);
+      // This is a rate-limit 429 (per-minute throttle), NOT quota exhaustion —
+      // quota rejection is handled above and is the only thing that rotates.
+      // Do NOT switch accounts here: moving the burst to the next account just
+      // throttles it too (thundering herd, #84) and discards this account's KV
+      // cache. Instead PAUSE this account so concurrent requests wait in admit()
+      // (capped, then released through a fresh ramp) instead of piling on, and
+      // retry the SAME account. The pause never marks the account throttled, so
+      // selection keeps choosing it.
+      accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
+
+      // sx fresh-IP retry (still the same account) takes precedence over waiting.
+      if (switchingToSx) {
+        console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
         if (res.destroyed) return;
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
 
-    if (!switchingToSx && retryAfter > INLINE_RETRY_AFTER_MAX_SECONDS) {
-      console.log(`[TeamClaude] 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching without waiting`);
-      accountManager.markRateLimited(account.index, retryAfter);
-      if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
-    }
-
-    if (switchingToSx) {
-      console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
-    } else {
-        console.log(`[TeamClaude] 429 on "${account.name}" — waiting ${retryAfter}s before retry`);
+      // Absorb short waits inline on the same account — the client never sees the
+      // 429. Bounded by retryCount (maxRetries = account count) so a persistently
+      // rate-limited account can't loop forever tying up the connection.
+      if (retryAfter <= RATE_LIMIT_ABSORB_MAX_SECONDS && retryCount < maxRetries) {
+        console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — waiting ${retryAfter}s, retrying same account (no switch)`);
         await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+        if (res.destroyed) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
-      // Client may have disconnected during the wait
-      if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
+
+      // Longer retry-after (or retries exhausted): don't hold the connection and
+      // don't rotate — surface the 429 with retry-after so the client backs off.
+      // The pause above keeps other requests off this account meanwhile.
+      console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — retry-after ${retryAfter}s over inline cap; returning 429 to client (no switch)`);
+      ctx.status = 429;
+      if (!res.headersSent && !res.destroyed) {
+        res.writeHead(429, { 'Content-Type': 'application/json', 'retry-after': String(retryAfter) });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: `Rate limited; retry in ${retryAfter}s.` } }));
+      }
+      return;
     }
 
     // Log the request head (once) followed by the response headers, streaming

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -36,30 +36,38 @@ async function runAgainstThrottlingUpstream(retryAfterHeader) {
       body: JSON.stringify({ model: 'x', messages: [] }),
     });
     await res.text();
-    return { status: res.status, upstreamHits, accountStatus: am.accounts[0].status };
+    return {
+      status: res.status, upstreamHits,
+      accountStatus: am.accounts[0].status,
+      paused: am.accounts[0].pausedUntil != null && am.accounts[0].pausedUntil > Date.now(),
+    };
   } finally {
     proxy.close();
     upstream.close();
   }
 }
 
-// Regression: a persistently-throttled upstream must terminate (bounded retries),
-// not loop forever tying up the client connection.
+// Regression: a persistently rate-limited upstream must terminate (bounded
+// retries), not loop forever tying up the client connection. A rate-limit 429
+// does NOT rotate/throttle the account (#84) — it pauses it (so concurrent
+// requests wait) and retries the same account, then surfaces a 429.
 test('persistent upstream 429 terminates with a bounded number of retries', async () => {
-  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('1');
+  const { status, upstreamHits, accountStatus, paused } = await runAgainstThrottlingUpstream('1');
   assert.equal(status, 429);                                   // returns 429 instead of hanging
   assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
-  assert.equal(accountStatus, 'throttled');                    // account throttled, not retried forever
+  assert.equal(accountStatus, 'active');                       // NOT throttled — no rotation on a rate-limit 429
+  assert.ok(paused, 'account should be paused, so concurrent requests wait');
 });
 
 // A negative (or otherwise out-of-range) Retry-After must not bypass the cap:
-// it would make setTimeout return immediately and mark the account rate-limited
-// in the past, reactivating it instantly.
+// it would make setTimeout return immediately (and previously mark the account
+// rate-limited in the past, reactivating it instantly).
 test('negative Retry-After is clamped and still terminates', async () => {
-  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('-1');
+  const { status, upstreamHits, accountStatus, paused } = await runAgainstThrottlingUpstream('-1');
   assert.equal(status, 429);
   assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
-  assert.equal(accountStatus, 'throttled');
+  assert.equal(accountStatus, 'active');
+  assert.ok(paused);
 });
 
 test('long upstream Retry-After is surfaced without sleeping in client request', async () => {
@@ -99,7 +107,87 @@ test('long upstream Retry-After is surfaced without sleeping in client request',
     assert.equal(res.status, 429);
     assert.equal(upstreamHits, 1, 'long Retry-After should not be retried inline');
     assert.ok(Date.now() - started < 2000, 'request should not sleep for upstream retry window');
-    assert.equal(am.accounts[0].status, 'throttled');
+    assert.equal(am.accounts[0].status, 'active', 'rate-limit 429 must not throttle/rotate the account');
+    assert.ok(am.accounts[0].pausedUntil > Date.now(), 'account should be paused so concurrent requests wait');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A rate-limit 429 (no quota-rejected status) must NOT rotate to another
+// account — every retry stays on the same one (#84: rotating just moves the
+// burst and drops the KV cache).
+test('a rate-limit 429 never rotates to another account', async () => {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.headers.authorization);
+    res.writeHead(429, { 'retry-after': '1', 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([
+    { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 429);
+    const accounts = new Set(seen);
+    assert.equal(accounts.size, 1, `all hits should be on one account, saw ${[...accounts]}`);
+    assert.equal(am.accounts[0].status, 'active', 'current account not throttled');
+    assert.equal(am.accounts[1].status, 'active');
+    assert.equal(am.accounts[1].pausedUntil, null, 'the other account is untouched — no rotation');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A quota-rejection 429 (unified status "rejected") is durable exhaustion, so it
+// DOES rotate — account a is throttled and the request succeeds on account b.
+test('a quota-rejection 429 rotates to the next account', async () => {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.headers.authorization);
+    if (req.headers.authorization === 'Bearer t-a') {
+      res.writeHead(429, {
+        'retry-after': '60',
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'content-type': 'application/json',
+      });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+    } else {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'message', role: 'assistant', content: [] }));
+    }
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([
+    { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 200, 'should succeed on the second account');
+    assert.equal(am.accounts[0].status, 'throttled', 'exhausted account is throttled (rotated away)');
+    assert.ok(seen.includes('Bearer t-b'), 'request rotated to account b');
   } finally {
     proxy.close();
     upstream.close();

--- a/test/storm-control.test.js
+++ b/test/storm-control.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+test('_rampCap grows linearly during the window and lifts after it', () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 1, stepConc: 2, stepMs: 100, windowMs: 1000, pollMs: 5 },
+  });
+  const acct = am.accounts[0];
+
+  assert.equal(am._rampCap(acct, 0), Infinity, 'no ramp until one starts');
+  acct.rampStartedAt = 1000;
+  assert.equal(am._rampCap(acct, 1000), 1, 'startConc at t=0');
+  assert.equal(am._rampCap(acct, 1000 + 100), 3, '+stepConc after one step');
+  assert.equal(am._rampCap(acct, 1000 + 250), 5, '+2*stepConc after two steps');
+  assert.equal(am._rampCap(acct, 1000 + 1000), Infinity, 'unbounded past the window');
+  assert.equal(acct.rampStartedAt, null, 'window expiry clears the ramp');
+});
+
+test('admit caps concurrency to a freshly-switched account; release frees a slot', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 1, stepConc: 1, stepMs: 10_000, windowMs: 60_000, pollMs: 5 },
+  });
+  am._beginRamp(am.accounts[0]); // cap pinned at 1 for the length of this test
+
+  assert.equal(await am.admit(0), true);
+  assert.equal(am.accounts[0].inFlight, 1);
+
+  // A second request must wait — the cap is 1 and a slot is taken.
+  let second = false;
+  const p = am.admit(0).then(() => { second = true; });
+  await sleep(30);
+  assert.equal(second, false, 'second admit blocked by the ramp cap');
+
+  am.release(0);       // free the slot
+  await p;
+  assert.equal(second, true, 'second admit proceeds once a slot frees');
+  assert.equal(am.accounts[0].inFlight, 1);
+});
+
+test('admit is fail-open: aborts (returns false) if the client goes away while waiting', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 1, stepConc: 1, stepMs: 10_000, windowMs: 60_000, pollMs: 5 },
+  });
+  am._beginRamp(am.accounts[0]);
+  await am.admit(0); // take the only slot
+
+  let gone = false;
+  const p = am.admit(0, () => gone); // waits: cap 1, inFlight 1
+  await sleep(20);
+  gone = true;                        // client disconnects
+  assert.equal(await p, false, 'aborted admit returns false, takes no slot');
+  assert.equal(am.accounts[0].inFlight, 1, 'no slot leaked to the aborted request');
+});
+
+test('ramp disabled → admit is immediate and unbounded', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { enabled: false } });
+  am._beginRamp(am.accounts[0]);
+  assert.equal(am.accounts[0].rampStartedAt, null, 'no ramp window when disabled');
+  assert.equal(await am.admit(0), true);
+  assert.equal(await am.admit(0), true);
+  assert.equal(am.accounts[0].inFlight, 2, 'no concurrency cap when disabled');
+});
+
+test('switching to a new account begins a ramp on it', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.accounts[0].status = 'exhausted'; // force selection off the current (index 0)
+  const next = am._selectNext();
+  assert.equal(next.name, 'b');
+  assert.ok(am.accounts[1].rampStartedAt != null, 'the switch armed a ramp on b');
+});
+
+test('release never drives inFlight negative', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.release(0);
+  am.release(0);
+  assert.equal(am.accounts[0].inFlight, 0);
+});

--- a/test/storm-control.test.js
+++ b/test/storm-control.test.js
@@ -81,3 +81,62 @@ test('release never drives inFlight negative', () => {
   am.release(0);
   assert.equal(am.accounts[0].inFlight, 0);
 });
+
+// ── rate-limit pause (no-switch on 429) ───────────────────────
+
+test('pauseAccount pauses without throttling — account stays selectable (no rotation)', () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { pollMs: 5 } });
+  am.pauseAccount(0, 30);
+  const acct = am.accounts[0];
+  assert.ok(acct.pausedUntil > Date.now(), 'pausedUntil set');
+  assert.notEqual(acct.status, 'throttled', 'pause must not throttle');
+  assert.equal(acct.rateLimitedUntil, null, 'pause is not a rate-limit hold');
+  assert.equal(am._isAvailable(acct, 'claude-opus-4-6'), true, 'account stays available → selection never rotates away');
+});
+
+test('pauseAccount extends an existing pause, never shortens it', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.pauseAccount(0, 30);
+  const long = am.accounts[0].pausedUntil;
+  am.pauseAccount(0, 1); // shorter — must not shorten
+  assert.equal(am.accounts[0].pausedUntil, long);
+});
+
+test('admit holds a request during a pause, then admits once it lifts', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 10, stepConc: 1, stepMs: 10, windowMs: 60_000, pollMs: 5 },
+  });
+  am.accounts[0].pausedUntil = Date.now() + 120; // ~120ms pause
+
+  const start = Date.now();
+  const admitted = await am.admit(0);
+  const waited = Date.now() - start;
+
+  assert.equal(admitted, true);
+  assert.ok(waited >= 100, `admit should wait out the pause, waited ${waited}ms`);
+  assert.equal(am.accounts[0].inFlight, 1);
+});
+
+test('admit aborts (returns false) if the client disconnects during a pause', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { pollMs: 5 } });
+  am.accounts[0].pausedUntil = Date.now() + 10_000; // long pause
+  let gone = false;
+  const p = am.admit(0, () => gone);
+  await sleep(20);
+  gone = true;
+  assert.equal(await p, false, 'aborted admit returns false');
+  assert.equal(am.accounts[0].inFlight, 0, 'no slot taken');
+});
+
+test('pauseAccount arms the ramp at pause-end so held requests release staggered', () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 1, stepConc: 1, stepMs: 250, windowMs: 30_000, pollMs: 5 },
+  });
+  am.pauseAccount(0, 30);
+  const acct = am.accounts[0];
+  // Ramp is armed to begin exactly when the pause lifts.
+  assert.equal(acct.rampStartedAt, acct.pausedUntil);
+  // At the instant the pause lifts, the cap starts low (staggered release).
+  assert.equal(am._rampCap(acct, acct.pausedUntil), 1);
+  assert.equal(am._rampCap(acct, acct.pausedUntil + 250), 2);
+});


### PR DESCRIPTION
Closes #84. Consolidates the storm-control gate and the rate-limit-429 handling into one PR.

## Problem

When many agents run at once, two things cause a thundering herd:
1. **Switchover** — when the active account runs out, every in-flight request fails over to the next account *at the same instant*, spending a big chunk of its quota (large contexts) and instantly throttling it → cascade down the fleet.
2. **Rate-limit 429s** — teamclaude used to rotate accounts on *any* persistent/long 429, including the per-minute rate-limit throttle (not quota exhaustion). Rotating just moves the burst to the next account and throws away the first account's KV cache.

## Fix

**A paced admission gate** (`admit`/`release`) plus **pause-don't-rotate on rate-limit 429s**:

- **Switchover ramp** — on a switch, concurrency to the new account starts at 1 and ramps up (`+1 / 250ms` default, 30s window), so the herd trickles on and the first request or two reveal exhaustion before everyone commits. Fail-open; slot released once headers arrive so streams don't tie up concurrency.
- **Rate-limit 429 → pause, never rotate** — a per-minute 429 (`retry-after` in seconds, no `unified-…-status: rejected`) **pauses** the account (`pausedUntil`, *not* throttled → still selectable, so selection never rotates away). Concurrent requests wait in `admit()`; when the pause lifts they're released **through a fresh ramp** (staggered, not all at once). The same account is retried, absorbing short `retry-after`s inline (≤ 60s, `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`); longer → 429 + retry-after to the client so it backs off.
- **Quota rejection still rotates** (unchanged) — that's the only durable "this account is done" signal.

Verified: 12-request switchover burst spread over ~1.2s (vs. all at t=0); 8 queries arriving during a ~300ms rate-limit pause held until pause-end then released staggered (300, 422, 513, … ms).

## Config

`stormRamp: { enabled, startConc, stepConc, stepMs, windowMs }` (on by default; `enabled:false` = pre-#84 behavior). Rate-limit absorb window via `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS` (default 60).

## Tradeoff

Not rotating on a rate-limit 429 favors cache locality + no-cascade over borrowing an idle account's separate per-minute budget — deliberate, and tunable.

## Tests

Storm ramp (cap growth/expiry, concurrency cap + release, fail-open abort, disabled mode, switch-arms-ramp); pause behavior (pause ≠ throttle so still selectable, extend-not-shorten, admit holds-then-releases + aborts on disconnect, ramp armed at pause-end); server 429 (rate-limit 429 never rotates; quota-rejection 429 does; bounded termination). Review pass hardened `_rampCap` (no negative cap) and re-bounded the sx retry path. Full suite green (230), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)