### PR TITLE
feat: don't rotate accounts on a rate-limit 429 (pause + staggered release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 
 - **Automatic account rotation** — switches to the next account when session (5h) or weekly (7d) quota reaches the configured threshold (default 98%)
 - **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes). Optional **[model routes](#model-routes)** pin model patterns to a specific set of accounts (config, `teamclaude route`, or the TUI settings screen → Manage routing)
-- **Auto-retry on 429** — waits the `retry-after` duration and retries the same account; a quota rejection (a spent weekly bucket) switches accounts immediately instead of waiting, and switches to the next on persistent errors
+- **Auto-retry on 429** — distinguishes the two kinds of 429: a **quota rejection** (a spent 5h/weekly bucket, `unified-…-status: rejected`) switches accounts immediately; a **rate-limit 429** (the per-minute throttle) does **not** switch — it [pauses the account](#storm-control-switchover-ramp-up) so concurrent requests wait instead of flooding, retries the same account (absorbing short `retry-after`s inline), and only surfaces a 429 to the client for longer waits. Rotating on a rate-limit 429 would just move the burst to the next account and throw away the first account's cache
 - **Storm control** — when many agents fail over to a fresh account at once, requests are [paced onto it](#storm-control-switchover-ramp-up) with a short ramp-up so the herd doesn't instantly throttle it and cascade down the fleet
 - **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
@@ -250,6 +250,8 @@ On by default. Tune or disable via `stormRamp` in the config:
 - **`stepConc` / `stepMs`** — the cap grows by `stepConc` every `stepMs` (default +1 every 250ms ≈ 4 req/s).
 - **`windowMs`** — after this long, pacing stops entirely (default 30s).
 - **`enabled: false`** — turn storm control off (send the full burst immediately, pre-#84 behavior).
+
+The same gate handles **rate-limit 429s** (the per-minute throttle, not quota exhaustion): teamclaude pauses the account for the `retry-after` window so new queries wait instead of piling on, then releases the held queries through a fresh ramp (staggered, not all at once). It **never rotates** on a rate-limit 429 — that would just move the burst to the next account and drop the first account's cache. Short waits are absorbed inline on the same account (default ≤ 60s, `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`); longer ones return a 429 + `retry-after` so the client backs off. Only a **quota rejection** (`unified-…-status: rejected`) rotates.
 
 ### Config format
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -80,6 +80,11 @@ export class AccountManager {
       // time this account last became the current one (starts a ramp window).
       inFlight: 0,
       rampStartedAt: null,
+      // Rate-limit pause (see pauseAccount): a short window during which new
+      // requests wait in admit() rather than flooding — set from a 429's
+      // retry-after. Distinct from `throttled`/rateLimitedUntil: it does NOT
+      // make the account unavailable, so selection never rotates away from it.
+      pausedUntil: null,
     }));
     this.currentIndex = 0;
     this.switchThreshold = switchThreshold;
@@ -128,18 +133,28 @@ export class AccountManager {
   }
 
   /**
-   * Reserve a concurrency slot on `account` before sending upstream, waiting
-   * while the account is over its current ramp cap. Fail-open: returns true once
-   * a slot is taken (always eventually, since the cap grows and the window
-   * expires), or false if `isAborted()` reports the client went away while
-   * waiting. Pair every `true` with a `release(index)`.
+   * Reserve a concurrency slot on `account` before sending upstream. Waits while
+   * the account is in a rate-limit pause (a 429's retry-after window) and while
+   * it is over its current ramp cap. Fail-open: returns true once a slot is taken
+   * (always eventually — the pause ends and the ramp cap grows), or false if
+   * `isAborted()` reports the client went away while waiting. Pair every `true`
+   * with a `release(index)`.
    */
   async admit(index, isAborted) {
     const account = this.accounts[index];
-    if (!account || !this.ramp.enabled) { if (account) account.inFlight++; return true; }
+    if (!account) return true;
     while (true) {
       if (isAborted?.()) return false;
-      if (account.inFlight < this._rampCap(account)) { account.inFlight++; return true; }
+      const now = Date.now();
+      // Rate-limit pause: hold new requests off this account until the window
+      // passes instead of flooding it (which would deepen the 429). Not a
+      // rotation trigger — the account stays selectable the whole time.
+      if (account.pausedUntil && now < account.pausedUntil) {
+        await new Promise(r => setTimeout(r, Math.min(account.pausedUntil - now, this.ramp.pollMs * 4)));
+        continue;
+      }
+      const cap = this.ramp.enabled ? this._rampCap(account, now) : Infinity;
+      if (account.inFlight < cap) { account.inFlight++; return true; }
       await new Promise(r => setTimeout(r, this.ramp.pollMs));
     }
   }
@@ -148,6 +163,26 @@ export class AccountManager {
   release(index) {
     const account = this.accounts[index];
     if (account && account.inFlight > 0) account.inFlight--;
+  }
+
+  /**
+   * Pause an account after a rate-limit (non-quota) 429 so concurrent requests
+   * wait in admit() instead of piling on. Unlike markRateLimited this does NOT
+   * set `throttled`/rateLimitedUntil, so _isAvailable still returns true and
+   * selection never rotates away — rotation is reserved for quota exhaustion.
+   * When the pause lifts, the held requests are released through a fresh ramp
+   * window (storm control) so they trickle out rather than flood. Extends an
+   * existing pause rather than shortening it.
+   */
+  pauseAccount(index, seconds) {
+    const account = this.accounts[index];
+    if (!account) return;
+    const until = Date.now() + Math.max(0, seconds) * 1000;
+    account.pausedUntil = Math.max(account.pausedUntil || 0, until);
+    // Arm the ramp to begin when the pause ends: while paused, admit() holds on
+    // the pause branch; once it lifts, _rampCap counts from here and releases the
+    // backlog gradually (startConc, then +stepConc per step).
+    if (this.ramp.enabled) account.rampStartedAt = account.pausedUntil;
   }
 
   /**
@@ -1016,6 +1051,9 @@ export class AccountManager {
         usage: { ...a.usage },
         rateLimitedUntil: a.rateLimitedUntil
           ? new Date(a.rateLimitedUntil).toISOString()
+          : null,
+        pausedUntil: a.pausedUntil && a.pausedUntil > Date.now()
+          ? new Date(a.pausedUntil).toISOString()
           : null,
       })),
     };

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,12 @@ export const HOP_BY_HOP_HEADERS = new Set([
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
 const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
+// How long the proxy will absorb a rate-limit 429's retry-after inline (waiting
+// on the SAME account) before surfacing a 429 + retry-after to the client. A
+// rate-limit 429 never rotates accounts (that just moves the burst); it pauses
+// the account so concurrent requests wait, then retries the same account.
+const RATE_LIMIT_ABSORB_MAX_SECONDS =
+  Number(process.env.TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS) || 60;
 
 // Response header names that are connection-specific and thus illegal on an
 // HTTP/2 response (Node's Http2ServerResponse.writeHead rejects them). Also
@@ -530,34 +536,43 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       const switchingToSx = nextUseSx && !route;
       sx?.noteRateLimited(retryAfter);
 
-      // Bound the retries: a persistently-throttled upstream must not loop
-      // forever (that would tie up the client connection indefinitely).
-      // Once retries are exhausted, throttle this account and re-dispatch —
-      // getActiveAccount then picks another account, or returns 429 to the
-      // client if every account is throttled.
-      if (retryCount >= maxRetries) {
-        console.log(`[TeamClaude] Persistent 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching`);
-        accountManager.markRateLimited(account.index, retryAfter);
+      // This is a rate-limit 429 (per-minute throttle), NOT quota exhaustion —
+      // quota rejection is handled above and is the only thing that rotates.
+      // Do NOT switch accounts here: moving the burst to the next account just
+      // throttles it too (thundering herd, #84) and discards this account's KV
+      // cache. Instead PAUSE this account so concurrent requests wait in admit()
+      // (capped, then released through a fresh ramp) instead of piling on, and
+      // retry the SAME account. The pause never marks the account throttled, so
+      // selection keeps choosing it.
+      accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
+
+      // sx fresh-IP retry (still the same account) takes precedence over waiting.
+      if (switchingToSx) {
+        console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
         if (res.destroyed) return;
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
 
-    if (!switchingToSx && retryAfter > INLINE_RETRY_AFTER_MAX_SECONDS) {
-      console.log(`[TeamClaude] 429 on "${account.name}" — throttling ${retryAfter}s and re-dispatching without waiting`);
-      accountManager.markRateLimited(account.index, retryAfter);
-      if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
-    }
-
-    if (switchingToSx) {
-      console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
-    } else {
-        console.log(`[TeamClaude] 429 on "${account.name}" — waiting ${retryAfter}s before retry`);
+      // Absorb short waits inline on the same account — the client never sees the
+      // 429. Bounded by retryCount (maxRetries = account count) so a persistently
+      // rate-limited account can't loop forever tying up the connection.
+      if (retryAfter <= RATE_LIMIT_ABSORB_MAX_SECONDS && retryCount < maxRetries) {
+        console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — waiting ${retryAfter}s, retrying same account (no switch)`);
         await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+        if (res.destroyed) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
-      // Client may have disconnected during the wait
-      if (res.destroyed) return;
-      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
+
+      // Longer retry-after (or retries exhausted): don't hold the connection and
+      // don't rotate — surface the 429 with retry-after so the client backs off.
+      // The pause above keeps other requests off this account meanwhile.
+      console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — retry-after ${retryAfter}s over inline cap; returning 429 to client (no switch)`);
+      ctx.status = 429;
+      if (!res.headersSent && !res.destroyed) {
+        res.writeHead(429, { 'Content-Type': 'application/json', 'retry-after': String(retryAfter) });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: `Rate limited; retry in ${retryAfter}s.` } }));
+      }
+      return;
     }
 
     // Log the request head (once) followed by the response headers, streaming

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -36,30 +36,38 @@ async function runAgainstThrottlingUpstream(retryAfterHeader) {
       body: JSON.stringify({ model: 'x', messages: [] }),
     });
     await res.text();
-    return { status: res.status, upstreamHits, accountStatus: am.accounts[0].status };
+    return {
+      status: res.status, upstreamHits,
+      accountStatus: am.accounts[0].status,
+      paused: am.accounts[0].pausedUntil != null && am.accounts[0].pausedUntil > Date.now(),
+    };
   } finally {
     proxy.close();
     upstream.close();
   }
 }
 
-// Regression: a persistently-throttled upstream must terminate (bounded retries),
-// not loop forever tying up the client connection.
+// Regression: a persistently rate-limited upstream must terminate (bounded
+// retries), not loop forever tying up the client connection. A rate-limit 429
+// does NOT rotate/throttle the account (#84) — it pauses it (so concurrent
+// requests wait) and retries the same account, then surfaces a 429.
 test('persistent upstream 429 terminates with a bounded number of retries', async () => {
-  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('1');
+  const { status, upstreamHits, accountStatus, paused } = await runAgainstThrottlingUpstream('1');
   assert.equal(status, 429);                                   // returns 429 instead of hanging
   assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
-  assert.equal(accountStatus, 'throttled');                    // account throttled, not retried forever
+  assert.equal(accountStatus, 'active');                       // NOT throttled — no rotation on a rate-limit 429
+  assert.ok(paused, 'account should be paused, so concurrent requests wait');
 });
 
 // A negative (or otherwise out-of-range) Retry-After must not bypass the cap:
-// it would make setTimeout return immediately and mark the account rate-limited
-// in the past, reactivating it instantly.
+// it would make setTimeout return immediately (and previously mark the account
+// rate-limited in the past, reactivating it instantly).
 test('negative Retry-After is clamped and still terminates', async () => {
-  const { status, upstreamHits, accountStatus } = await runAgainstThrottlingUpstream('-1');
+  const { status, upstreamHits, accountStatus, paused } = await runAgainstThrottlingUpstream('-1');
   assert.equal(status, 429);
   assert.ok(upstreamHits >= 1 && upstreamHits <= 4, `expected bounded retries, got ${upstreamHits}`);
-  assert.equal(accountStatus, 'throttled');
+  assert.equal(accountStatus, 'active');
+  assert.ok(paused);
 });
 
 test('long upstream Retry-After is surfaced without sleeping in client request', async () => {
@@ -99,7 +107,87 @@ test('long upstream Retry-After is surfaced without sleeping in client request',
     assert.equal(res.status, 429);
     assert.equal(upstreamHits, 1, 'long Retry-After should not be retried inline');
     assert.ok(Date.now() - started < 2000, 'request should not sleep for upstream retry window');
-    assert.equal(am.accounts[0].status, 'throttled');
+    assert.equal(am.accounts[0].status, 'active', 'rate-limit 429 must not throttle/rotate the account');
+    assert.ok(am.accounts[0].pausedUntil > Date.now(), 'account should be paused so concurrent requests wait');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A rate-limit 429 (no quota-rejected status) must NOT rotate to another
+// account — every retry stays on the same one (#84: rotating just moves the
+// burst and drops the KV cache).
+test('a rate-limit 429 never rotates to another account', async () => {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.headers.authorization);
+    res.writeHead(429, { 'retry-after': '1', 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([
+    { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 429);
+    const accounts = new Set(seen);
+    assert.equal(accounts.size, 1, `all hits should be on one account, saw ${[...accounts]}`);
+    assert.equal(am.accounts[0].status, 'active', 'current account not throttled');
+    assert.equal(am.accounts[1].status, 'active');
+    assert.equal(am.accounts[1].pausedUntil, null, 'the other account is untouched — no rotation');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A quota-rejection 429 (unified status "rejected") is durable exhaustion, so it
+// DOES rotate — account a is throttled and the request succeeds on account b.
+test('a quota-rejection 429 rotates to the next account', async () => {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.headers.authorization);
+    if (req.headers.authorization === 'Bearer t-a') {
+      res.writeHead(429, {
+        'retry-after': '60',
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'content-type': 'application/json',
+      });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+    } else {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'message', role: 'assistant', content: [] }));
+    }
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([
+    { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 200, 'should succeed on the second account');
+    assert.equal(am.accounts[0].status, 'throttled', 'exhausted account is throttled (rotated away)');
+    assert.ok(seen.includes('Bearer t-b'), 'request rotated to account b');
   } finally {
     proxy.close();
     upstream.close();

--- a/test/storm-control.test.js
+++ b/test/storm-control.test.js
@@ -81,3 +81,62 @@ test('release never drives inFlight negative', () => {
   am.release(0);
   assert.equal(am.accounts[0].inFlight, 0);
 });
+
+// ── rate-limit pause (no-switch on 429) ───────────────────────
+
+test('pauseAccount pauses without throttling — account stays selectable (no rotation)', () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { pollMs: 5 } });
+  am.pauseAccount(0, 30);
+  const acct = am.accounts[0];
+  assert.ok(acct.pausedUntil > Date.now(), 'pausedUntil set');
+  assert.notEqual(acct.status, 'throttled', 'pause must not throttle');
+  assert.equal(acct.rateLimitedUntil, null, 'pause is not a rate-limit hold');
+  assert.equal(am._isAvailable(acct, 'claude-opus-4-6'), true, 'account stays available → selection never rotates away');
+});
+
+test('pauseAccount extends an existing pause, never shortens it', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.pauseAccount(0, 30);
+  const long = am.accounts[0].pausedUntil;
+  am.pauseAccount(0, 1); // shorter — must not shorten
+  assert.equal(am.accounts[0].pausedUntil, long);
+});
+
+test('admit holds a request during a pause, then admits once it lifts', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 10, stepConc: 1, stepMs: 10, windowMs: 60_000, pollMs: 5 },
+  });
+  am.accounts[0].pausedUntil = Date.now() + 120; // ~120ms pause
+
+  const start = Date.now();
+  const admitted = await am.admit(0);
+  const waited = Date.now() - start;
+
+  assert.equal(admitted, true);
+  assert.ok(waited >= 100, `admit should wait out the pause, waited ${waited}ms`);
+  assert.equal(am.accounts[0].inFlight, 1);
+});
+
+test('admit aborts (returns false) if the client disconnects during a pause', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { pollMs: 5 } });
+  am.accounts[0].pausedUntil = Date.now() + 10_000; // long pause
+  let gone = false;
+  const p = am.admit(0, () => gone);
+  await sleep(20);
+  gone = true;
+  assert.equal(await p, false, 'aborted admit returns false');
+  assert.equal(am.accounts[0].inFlight, 0, 'no slot taken');
+});
+
+test('pauseAccount arms the ramp at pause-end so held requests release staggered', () => {
+  const am = new AccountManager([oauth('a')], 0.98, {
+    ramp: { startConc: 1, stepConc: 1, stepMs: 250, windowMs: 30_000, pollMs: 5 },
+  });
+  am.pauseAccount(0, 30);
+  const acct = am.accounts[0];
+  // Ramp is armed to begin exactly when the pause lifts.
+  assert.equal(acct.rampStartedAt, acct.pausedUntil);
+  // At the instant the pause lifts, the cap starts low (staggered release).
+  assert.equal(am._rampCap(acct, acct.pausedUntil), 1);
+  assert.equal(am._rampCap(acct, acct.pausedUntil + 250), 2);
+});


### PR DESCRIPTION
**Stacks on #89** (storm control) — base is `feat/storm-control`; GitHub will retarget to `master` when #89 merges.

## Problem

teamclaude treats two very different 429s the same way when it comes to rotation:
- **Quota exhaustion** — a spent 5h/weekly bucket (`anthropic-ratelimit-unified-…-status: rejected`). Rotating is correct: the account is done for the window.
- **Rate-limit 429** — the *per-minute* throttle (RPM/ITPM/OTPM token-bucket, `retry-after` in seconds). This is what a parallel-agent burst trips, and what you hit yourself even at low overall usage.

On a rate-limit 429, the old code eventually calls `markRateLimited()` (retry-after > 15s, or retries exhausted) → the account goes `throttled` → selection **rotates to another account**. That just moves the same burst to the next account (thundering herd, #84) and throws away the first account's KV cache.

## Change

A rate-limit 429 now **never rotates**. Instead it:
1. **Pauses the account** (new `pausedUntil` — *not* `throttled`, so `_isAvailable` keeps it selectable and selection never rotates away). Concurrent requests wait in the storm-control `admit()` gate instead of flooding the account.
2. **Releases the held requests through a fresh ramp** when the pause lifts — staggered, not all at once (`pauseAccount` re-arms the ramp to start at pause-end).
3. **Retries the same account**, absorbing short `retry-after`s inline (≤ 60s, `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`) so Claude Code never sees them.
4. For longer waits or exhausted retries, **returns 429 + retry-after to the client** (it backs off) — still no rotation.

Only a **quota rejection** rotates (unchanged). The sx.org fresh-IP retry (same account) is preserved.

Verified end-to-end — 8 queries arriving during a ~300ms pause are all held until pause-end, then released staggered:
```
admitted at (ms since 429): 300, 422, 513, 543, 623, 666, 727, 758
```

## Tradeoff

Not rotating means a rate-limited account won't borrow an idle account's separate per-minute budget — this deliberately favors cache locality + no-cascade over that extra throughput. Tunable via the absorb-window env var; the pause/ramp is the storm-control gate.

## Tests

- account-manager: pause ≠ throttle (stays selectable), pause extends-not-shortens, `admit()` holds-then-releases + aborts on client disconnect, ramp armed at pause-end.
- server: a rate-limit 429 never rotates (all hits one account); a quota-rejection 429 does rotate (succeeds on account b). Updated the existing 429 regression tests (now assert active + paused, not throttled).

Full suite green (230), lint clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)