### PR TITLE
Bump to 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release **v1.1.6**. Merging this to `master` triggers `publish.yml` (npm publish via OIDC → git tag `v1.1.6` → GitHub release with generated notes).

Ships two fixes merged since 1.1.5:
- **#91** — code-quality cleanup: fixes `addAccount` hanging runtime-added accounts, `relayRaw` dropping `content-encoding`/`content-length`, and the missing Fable weekly line; removes dead code and dedups.
- **#92** — shutdown fix: TUI `q` / Ctrl+C no longer hangs and no longer leaks server `'close'` listeners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)