### PR TITLE
feat: inline routing markers + per-route colors and manual pinning (TUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,25 +309,30 @@ To go further you can pin model patterns to an **exclusive** set of accounts wit
 
 ```json
 "routes": [
-  { "name": "fable", "match": ["*fable*"], "accounts": ["personal-max"] },
-  { "name": "bulk",  "match": ["*opus*", "*sonnet*"], "accounts": ["corp-1", "corp-2"] }
+  { "name": "fable", "match": ["*fable*"], "accounts": ["personal-max"], "color": "magenta" },
+  { "name": "bulk",  "match": ["*opus*", "*sonnet*"], "accounts": ["corp-1", "corp-2"], "color": "blue" }
 ]
 ```
 
 - **`match`** — one or more model globs; the first route whose globs match wins.
 - **`accounts`** — account names (or indices) that may serve matching models. **Exclusive**: only these are used (and they 429/rotate among themselves when spent). Omit to route to all accounts — e.g. to only set a `bucket` override.
 - **`bucket`** — optional: force which quota bucket governs eligibility (`unified7dFable`, `unified7dSonnet`, `unified7d`), for the rare case the family can't be inferred from the model id.
+- **`color`** — optional: `red`/`green`/`yellow`/`blue`/`magenta`/`cyan`, tinting this route's inline marker in the TUI (see below). Display only.
 
 Manage routes from the shell (changes apply to a running server immediately):
 
 ```bash
 teamclaude route list
-teamclaude route add fable --match '*fable*' --accounts personal-max
+teamclaude route add fable --match '*fable*' --accounts personal-max --color magenta
 teamclaude route add bulk  --match '*opus*,*sonnet*' --accounts corp-1,corp-2
 teamclaude route rm fable
 ```
 
-…or interactively in the TUI: open settings (**`g`**) → **Manage routing**, then `a` add / `e` edit / `d` delete. The routes table (configured + auto-detected) is shown in both the TUI and `teamclaude status`.
+…or interactively in the TUI: open settings (**`g`**) → **Manage routing**, then `a` add / `e` edit / `d` delete (the editor prompts for a marker color too).
+
+**Inline markers (TUI).** Instead of a separate list, each route surfaces on the account rows as a colored `►`: next to the **`F7`/`S7`** bar for a Fable/Sonnet route, or at the **start of the row** for a general route (one fixed column per route so its position is stable). The marker is bold on the account a route is pinned to, dim when that account is currently ineligible. `teamclaude status` (the CLI text dump) still prints the routes as a list, now colored and annotated with any pin.
+
+**Manual per-route switching (TUI).** Press **`s`** to switch accounts, then **`Tab`** to choose *what* you're switching: the global **default** account, or a specific **route**. Pick an account with `↑/↓` and **`Enter`** to pin that route to it; `Enter` again on the current pin clears it. Pins are a **runtime preference** — not saved to config — and routing **falls back** to normal best-available selection whenever the pinned account is throttled or over quota, so a pin never stalls requests.
 
 ### Quota probe (optional, off by default)
 

--- a/config.example.json
+++ b/config.example.json
@@ -30,5 +30,13 @@
       "disabled": false,
       "apiKey": "sk-ant-api03-your-api-key"
     }
+  ],
+  "routes": [
+    {
+      "name": "fable",
+      "match": ["*fable*"],
+      "accounts": ["primary-max"],
+      "color": "magenta"
+    }
   ]
 }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -95,6 +95,11 @@ export class AccountManager {
     this._refreshFn = refreshFn;
     this.accounts = accounts.map((acct, index) => makeAccount(acct, index));
     this.currentIndex = 0;
+    // Ephemeral per-route manual pins (routeName → account index). Not persisted:
+    // like the global manual switch (currentIndex) these are runtime overrides that
+    // bias selection for a route's models and reset on restart. A pinned account
+    // that becomes ineligible is skipped — routing falls back to best-available.
+    this.routePins = new Map();
     this.switchThreshold = switchThreshold;
     this.setRoutes(routes);
     // Storm control: when rotation switches to a fresh account, a burst of
@@ -206,6 +211,11 @@ export class AccountManager {
     // session reset made a sooner-expiring account the better choice. This runs
     // on every request so the behaviour holds without the TUI render loop.
     this.refreshExpiredQuotas();
+    // A manual per-route pin biases selection for that route's models (independent
+    // of the global currentIndex). Honored only while eligible — otherwise we fall
+    // through to normal best-available selection so requests keep flowing.
+    const pinned = this._pinnedAccountForModel(model);
+    if (pinned && this._isAvailable(pinned, model) && !exclude?.has(pinned.index)) return pinned;
     const current = this.accounts[this.currentIndex];
     // `model` scopes availability: an account whose Fable weekly bucket is spent
     // is still fully usable for other models, so it is only excluded when THIS
@@ -414,7 +424,15 @@ export class AccountManager {
       match: (Array.isArray(r.match) ? r.match : [r.match]).filter(g => typeof g === 'string' && g),
       accounts: Array.isArray(r.accounts) ? r.accounts.map(String) : [],
       bucket: r.bucket || null,
+      color: r.color || null, // display-only accent for the route's inline marker
     })).filter(r => r.match.length);
+    // Drop pins for routes that no longer exist after a reload.
+    if (this.routePins?.size) {
+      const names = new Set(this.routes.map(r => r.name));
+      for (const name of [...this.routePins.keys()]) {
+        if (name !== 'fable' && name !== 'sonnet' && !names.has(name)) this.routePins.delete(name);
+      }
+    }
   }
 
   /** The first configured route whose globs match `model`, or null. */
@@ -463,7 +481,8 @@ export class AccountManager {
    */
   getRoutes() {
     const out = this.routes.map(r => ({
-      name: r.name, match: r.match, bucket: r.bucket, autocreated: false,
+      name: r.name, match: r.match, bucket: r.bucket, color: r.color || null, autocreated: false,
+      pinned: this._pinnedName(r.name),
       accounts: this._routeAccountsView(r),
     }));
 
@@ -477,11 +496,18 @@ export class AccountManager {
     for (const d of detected) {
       if (this._routeForModel(d.sample)) continue; // already covered by a configured route
       out.push({
-        name: d.name, match: d.match, bucket: null, autocreated: true,
+        name: d.name, match: d.match, bucket: null, color: null, autocreated: true,
+        pinned: this._pinnedName(d.name),
         accounts: this.accounts.map(a => ({ name: a.name, eligible: this._isAvailable(a, d.sample) })),
       });
     }
     return out;
+  }
+
+  /** The name of the account this route is manually pinned to, or null. */
+  _pinnedName(routeName) {
+    const idx = this.routePins.get(routeName);
+    return idx == null ? null : (this.accounts[idx]?.name ?? null);
   }
 
   /** Accounts a configured route can use (all accounts when it lists none), each
@@ -491,6 +517,60 @@ export class AccountManager {
     const inRoute = a => !route.accounts.length
       || route.accounts.includes(a.name) || route.accounts.includes(String(a.index));
     return this.accounts.filter(inRoute).map(a => ({ name: a.name, eligible: this._isAvailable(a, sample) }));
+  }
+
+  /** A representative model id for a route name (configured or auto fable/sonnet),
+   * used to test route-allowance when pinning. Null for an unknown route. */
+  _routeSample(routeName) {
+    const r = this.routes.find(x => x.name === routeName);
+    if (r) return r.match[0]?.replace(/\*/g, '') || 'model';
+    if (routeName === 'fable') return 'claude-fable-5';
+    if (routeName === 'sonnet') return 'claude-sonnet-4-6';
+    return null;
+  }
+
+  /**
+   * Manually pin a route to an account (ephemeral runtime override). Rejects an
+   * account the route's exclusivity/ownership rules disallow. Pinning an account
+   * that is merely near-quota/throttled is allowed — it acts as a preference and
+   * routing falls back to best-available until the pinned account is eligible.
+   * Returns { ok, reason? }.
+   */
+  setRoutePin(routeName, accountIndex) {
+    const account = this.accounts[accountIndex];
+    if (!account) return { ok: false, reason: 'no such account' };
+    const sample = this._routeSample(routeName);
+    if (sample && !this._routeAllows(account, sample)) {
+      return { ok: false, reason: `route "${routeName}" does not allow "${account.name}"` };
+    }
+    this.routePins.set(routeName, accountIndex);
+    return { ok: true };
+  }
+
+  clearRoutePin(routeName) { this.routePins.delete(routeName); }
+
+  /** The account a route is pinned to, or null. */
+  getRoutePin(routeName) {
+    const idx = this.routePins.get(routeName);
+    return idx == null ? null : (this.accounts[idx] || null);
+  }
+
+  /** The manually-pinned account governing `model`, if any: a configured route's
+   * pin wins, else an auto fable/sonnet family pin (only when no configured route
+   * covers the model). Returns null when nothing is pinned for this model. */
+  _pinnedAccountForModel(model) {
+    if (!model || !this.routePins.size) return null;
+    const route = this._routeForModel(model);
+    if (route) {
+      const idx = this.routePins.get(route.name);
+      return idx == null ? null : (this.accounts[idx] || null);
+    }
+    for (const name of ['fable', 'sonnet']) {
+      if (this.routePins.has(name) && modelGlobMatches(`*${name}*`, model)) {
+        return this.accounts[this.routePins.get(name)] || null;
+      }
+    }
+    return null;
   }
 
   /**
@@ -989,6 +1069,12 @@ export class AccountManager {
       this.currentIndex = Math.max(0, this.accounts.length - 1);
     } else if (this.currentIndex > index) {
       this.currentIndex--;
+    }
+    // Keep route pins pointing at the right account after the index shift: drop a
+    // pin on the removed account, decrement pins that sat above it.
+    for (const [name, idx] of [...this.routePins.entries()]) {
+      if (idx === index) this.routePins.delete(name);
+      else if (idx > index) this.routePins.set(name, idx - 1);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -975,13 +975,16 @@ async function removeCommand() {
 
 const ROUTE_USAGE = [
   'Usage: teamclaude route [list]',
-  '       teamclaude route add <name> --match "<glob>[,<glob>]" [--accounts "<name-or-index>[,...]"] [--bucket <quota-bucket>]',
+  '       teamclaude route add <name> --match "<glob>[,<glob>]" [--accounts "<name-or-index>[,...]"] [--bucket <quota-bucket>] [--color <name>]',
   '       teamclaude route rm <name>',
   '',
   'A route pins model ids matching its globs to an exclusive set of accounts.',
   'Omit --accounts to route to all accounts (e.g. just to override --bucket).',
+  '--color (red/green/yellow/blue/magenta/cyan) tints the route\'s inline marker in the TUI.',
   'First matching route wins. Changes apply to a running server immediately.',
 ].join('\n');
+
+const ROUTE_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
 
 function splitList(value) {
   return (value || '').split(',').map(s => s.trim()).filter(Boolean);
@@ -998,7 +1001,8 @@ async function routeCommand() {
       const match = (Array.isArray(r.match) ? r.match : [r.match]).join(', ');
       const accts = (r.accounts && r.accounts.length) ? r.accounts.join(', ') : '(all accounts)';
       const bucket = r.bucket ? `  bucket=${r.bucket}` : '';
-      console.log(`${r.name || '(unnamed)'}: ${match} → ${accts}${bucket}`);
+      const color = r.color ? `  color=${r.color}` : '';
+      console.log(`${r.name || '(unnamed)'}: ${match} → ${accts}${bucket}${color}`);
     }
     return;
   }
@@ -1008,8 +1012,13 @@ async function routeCommand() {
     const match = splitList(argValue('--match'));
     const accounts = splitList(argValue('--accounts'));
     const bucket = argValue('--bucket');
+    const color = argValue('--color');
     if (!name || !match.length) {
       console.error(ROUTE_USAGE);
+      process.exit(1);
+    }
+    if (color && !ROUTE_COLORS.includes(color.toLowerCase())) {
+      console.error(`Unknown color "${color}" — expected one of: ${ROUTE_COLORS.join(', ')}`);
       process.exit(1);
     }
     const known = new Set(config.accounts.map(a => a.name));
@@ -1019,6 +1028,7 @@ async function routeCommand() {
     const route = { name, match };
     if (accounts.length) route.accounts = accounts;
     if (bucket) route.bucket = bucket;
+    if (color) route.color = color.toLowerCase();
     const at = config.routes.findIndex(r => r.name === name);
     if (at >= 0) { config.routes[at] = route; console.log(`Updated route "${name}"`); }
     else { config.routes.push(route); console.log(`Added route "${name}"`); }

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -47,8 +47,17 @@ function colors(enabled) {
     green: wrap(32),
     yellow: wrap(33),
     red: wrap(31),
+    blue: wrap(34),
+    magenta: wrap(35),
     cyan: wrap(36),
   };
+}
+
+// Paint a route's name/globs in its configured color, defaulting to cyan.
+const ROUTE_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+function paintRoute(paint, color, value) {
+  const fn = ROUTE_COLORS.includes(String(color || '').toLowerCase()) ? paint[color.toLowerCase()] : paint.cyan;
+  return fn(value);
 }
 
 // The routing table: one line per route (configured first, then auto-detected),
@@ -63,7 +72,10 @@ function routingLines(routes, paint) {
     const accounts = (route.accounts || [])
       .map(a => (a.eligible ? paint.green(a.name) : paint.red(a.name))).join(' ') || paint.gray('(none)');
     const tag = route.autocreated ? paint.dim(' (auto)') : route.bucket ? paint.dim(` [${route.bucket}]`) : '';
-    lines.push(`  ${match.padEnd(16)} ${paint.dim('→')} ${accounts}${tag}`);
+    const pin = route.pinned ? paint.dim(` [pinned: ${route.pinned}]`) : '';
+    // padEnd on the raw text, color after, so ANSI codes don't throw off alignment.
+    const label = paintRoute(paint, route.color, match.padEnd(16));
+    lines.push(`  ${label} ${paint.dim('→')} ${accounts}${tag}${pin}`);
   }
   lines.push('');
   return lines;

--- a/src/tui.js
+++ b/src/tui.js
@@ -19,6 +19,38 @@ const red = s => fg(31, s);
 const cyan = s => fg(36, s);
 const gray = s => fg(90, s);
 
+// Named foreground colors selectable per route (config `color`). Bright variants
+// let a user distinguish several routes at a glance.
+const NAMED_FG = {
+  red: 31, green: 32, yellow: 33, blue: 34, magenta: 35, cyan: 36, white: 37,
+  brightred: 91, brightgreen: 92, brightyellow: 93, brightblue: 94,
+  brightmagenta: 95, brightcyan: 96,
+};
+// Ordered list of the plain names, offered in the editor prompt / help.
+const ROUTE_COLOR_NAMES = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+const isRouteColor = name => Object.prototype.hasOwnProperty.call(NAMED_FG, String(name || '').toLowerCase());
+// A paint function for a route's color, falling back to cyan for blank/unknown.
+const routeColorFn = name => {
+  const code = NAMED_FG[String(name || '').toLowerCase()];
+  return code ? (s => fg(code, s)) : cyan;
+};
+
+// Which quota-family bar (F7/S7) a route binds to, or null for a general route.
+// Auto routes are named 'fable'/'sonnet'; a configured route is classified by its
+// globs so e.g. `*fable*` sits next to the F7 bar.
+const routeFamily = route => {
+  const hay = `${route.name} ${(route.match || []).join(' ')}`.toLowerCase();
+  if (/fable/.test(hay)) return 'fable';
+  if (/sonnet/.test(hay)) return 'sonnet';
+  return null;
+};
+
+// The inline ► for a route on an account: bold when it's the route's manual pin,
+// plain when an eligible member, dim when the member is currently ineligible. The
+// route's own color is kept in every case so the marker stays identifiable.
+const routeGlyph = (paint, eligible, pinned) =>
+  pinned ? bold(paint('►')) : eligible ? paint('►') : dim(paint('►'));
+
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const strip = s => s.replace(ANSI_RE, '');
 const vw = s => strip(s).length;
@@ -134,8 +166,9 @@ export class TUI {
     this.log = [];           // completed activity entries
     this.active = new Map(); // in-flight requests
     this.mode = 'normal';    // normal | select | add | input | settings
-    this.selAction = null;   // switch | remove
+    this.selAction = null;   // switch | remove | toggle
     this.selIdx = 0;
+    this.selRoute = null;    // in switch mode: null = global default, else a getRoutes() entry to pin
     this.setIdx = 0;         // cursor row on the settings screen (BIOS-style nav)
     this.inputPrompt = '';
     this.inputBuf = '';
@@ -227,6 +260,7 @@ export class TUI {
     if (d === '\x1b[D') return this._key('left');
     if (d === '\x1b') return this._key('esc');
     if (d === '\r' || d === '\n') return this._key('enter');
+    if (d === '\t') return this._key('tab');
     if (d === '\x03') return this._key('ctrl-c');
     if (d === '\x7f' || d === '\x08') return this._key('bs');
     if (d.length === 1 && d >= ' ') return this._key(d);
@@ -249,7 +283,7 @@ export class TUI {
   _keyNormal(k) {
     if (k === 'q') { this.stop(); this.onQuit?.(); }
     else if (k === 's' && this.am.accounts.length > 0) {
-      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = this.am.currentIndex;
+      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = this.am.currentIndex; this.selRoute = null;
     }
     else if (k === 'r' && this.am.accounts.length > 0) {
       this.mode = 'select'; this.selAction = 'remove'; this.selIdx = 0;
@@ -418,18 +452,53 @@ export class TUI {
     const len = this.am.accounts.length;
     if (k === 'up' || k === 'k') this.selIdx = Math.max(0, this.selIdx - 1);
     else if (k === 'down' || k === 'j') this.selIdx = Math.min(len - 1, this.selIdx + 1);
+    // Tab (switch only): cycle which route the pick applies to. null = the global
+    // default account; each getRoutes() entry = a per-route manual pin.
+    else if (k === 'tab' && this.selAction === 'switch') {
+      const routes = this.am.getRoutes();
+      const cycle = [null, ...routes];
+      const at = this.selRoute ? routes.findIndex(r => r.name === this.selRoute.name) + 1 : 0;
+      this.selRoute = cycle[(at + 1) % cycle.length];
+    }
     else if (k === 'enter') {
       if (this.selAction === 'switch') {
-        this.am.currentIndex = this.selIdx;
-        this._addLog(`Switched to "${this.am.accounts[this.selIdx].name}"`);
+        this._doSwitchSelection();
       } else if (this.selAction === 'toggle') {
         this._doToggleDisabled(this.selIdx);
       } else {
         this._doRemove(this.selIdx);
       }
-      this.mode = 'normal';
+      if (this.mode === 'select') this.mode = 'normal';
     }
     else if (k === 'esc' || k === 'q') { this.mode = 'normal'; }
+  }
+
+  // Apply an Enter in switch mode: with no route selected this sets the global
+  // default account; with a route selected it pins/unpins that route to the
+  // highlighted account. On a rejected pin we stay in select mode so the user can
+  // retry, rather than silently returning to normal.
+  _doSwitchSelection() {
+    const acct = this.am.accounts[this.selIdx];
+    if (this.selRoute === null) {
+      this.am.currentIndex = this.selIdx;
+      this._addLog(`Switched to "${acct.name}"`);
+      this.mode = 'normal';
+      return;
+    }
+    const name = this.selRoute.name;
+    if (this.am.getRoutePin(name) === acct) {
+      this.am.clearRoutePin(name); // Enter on the current pin toggles it off
+      this._addLog(`Unpinned route "${name}"`);
+      this.mode = 'normal';
+      return;
+    }
+    const res = this.am.setRoutePin(name, this.selIdx);
+    if (res.ok) {
+      this._addLog(`Pinned "${acct.name}" for route "${name}"`);
+      this.mode = 'normal';
+    } else {
+      this._addLog(`Can't pin: ${res.reason}`); // stay in select mode to retry
+    }
   }
 
   _keyAdd(k) {
@@ -686,22 +755,18 @@ export class TUI {
         ? Math.max(5, Math.min(20, Math.floor((W - 56) / 2)))
         : Math.max(5, Math.min(20, W - 45));
 
+      // Routes drive the inline markers; general (non-family) routes get a stable
+      // column each at the row start so the marker's position identifies the route.
+      const routes = this.am.getRoutes();
+      const genRoutes = routes.filter(r => routeFamily(r) === null);
       for (let i = 0; i < this.am.accounts.length; i++) {
-        lines.push(this._renderAcct(i, bw, showBoth));
+        lines.push(this._renderAcct(i, bw, showBoth, routes, genRoutes));
       }
     }
 
-    // ── Routing (configured + auto-detected routes, when any exist)
-    const routes = this.am.getRoutes();
-    if (routes.length) {
-      lines.push('');
-      lines.push(dim(' Routing'));
-      for (const r of routes) {
-        const accts = r.accounts.map(a => (a.eligible ? green(a.name) : red(a.name))).join(' ') || gray('(none)');
-        const tag = r.autocreated ? dim(' (auto)') : r.bucket ? dim(` [${r.bucket}]`) : '';
-        lines.push(`   ${cyan(r.match.join(','))} ${dim('→')} ${accts}${tag}`);
-      }
-    }
+    // Routing is surfaced inline on each account row (see _renderAcct): a colored
+    // ► marks a route the account serves — next to the F7/S7 bar for a Fable/Sonnet
+    // route, at the row start for a general route — bold when it's the route's pin.
 
     // ── Activity header
     lines.push('');
@@ -745,7 +810,7 @@ export class TUI {
     process.stdout.write(buf);
   }
 
-  _renderAcct(idx, bw, showBoth) {
+  _renderAcct(idx, bw, showBoth, routes = this.am.getRoutes(), genRoutes = routes.filter(r => routeFamily(r) === null)) {
     const a = this.am.accounts[idx];
     const isCur = idx === this.am.currentIndex;
     const isSel = this.mode === 'select' && idx === this.selIdx;
@@ -753,6 +818,25 @@ export class TUI {
     // Prefix: selection marker + current marker
     const sel = isSel ? cyan('>') : ' ';
     const cur = isCur ? green('►') : ' ';
+
+    // General-route markers: one fixed column per general route (stable order), so
+    // the same route always sits in the same slot across accounts. A member shows
+    // its colored ►, others a blank. Family routes (fable/sonnet) are drawn by the
+    // F7/S7 bars below instead.
+    const memberOf = (route) => route.accounts.find(x => x.name === a.name);
+    const startCells = genRoutes.map(r => {
+      const m = memberOf(r);
+      return m ? routeGlyph(routeColorFn(r.color), m.eligible, r.pinned === a.name) : ' ';
+    });
+    const startSlot = genRoutes.length ? `${startCells.join('')} ` : '';
+
+    // Family-route markers for this account's F7/S7 bars.
+    const familyMark = (fam) => {
+      const r = routes.find(x => routeFamily(x) === fam && memberOf(x));
+      if (!r) return ' ';
+      const m = memberOf(r);
+      return routeGlyph(routeColorFn(r.color), m.eligible, r.pinned === a.name);
+    };
 
     // Name (bold if selected)
     const rawName = a.name.slice(0, 12).padEnd(12);
@@ -794,16 +878,17 @@ export class TUI {
       t2 = t1;
     }
 
-    let line = ` ${sel}${cur} ${name} ${type} ${status} ${l1} ${bar(r1, bw, t1)}`;
+    let line = ` ${sel}${cur} ${startSlot}${name} ${type} ${status} ${l1} ${bar(r1, bw, t1)}`;
     if (showBoth) {
       line += `  ${l2} ${bar(r2, bw, t2)}`;
-      // Sonnet weekly bar — only shown when the usage probe has populated it.
+      // Sonnet weekly bar — only shown when the usage probe has populated it. A
+      // leading ► (in place of a padding space) marks a Sonnet route on this account.
       if (q.unified7dSonnet != null) {
-        line += `  S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset)}`;
+        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset)}`;
       }
       // Fable weekly bar — only shown when the usage probe has populated it.
       if (q.unified7dFable != null) {
-        line += `  F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset)}`;
+        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset)}`;
       }
     }
     // Explicit "disabled for these models" tag (issue #85): a family whose own
@@ -910,6 +995,7 @@ export class TUI {
       match: (orig ? (Array.isArray(orig.match) ? orig.match : [orig.match]) : []).join(', '),
       accounts: (orig?.accounts || []).join(', '),
       bucket: orig?.bucket || '',
+      color: orig?.color || '',
     };
     this._routePrompt('Route name', orig?.name || '', name => {
       if (!name) { this._addLog('Route name required — cancelled'); this.mode = 'routes'; return; }
@@ -922,7 +1008,10 @@ export class TUI {
           draft.accounts = accts;
           this._routePrompt('Quota bucket override (blank = auto)', draft.bucket, bucket => {
             draft.bucket = bucket;
-            this._routeSave(draft, orig);
+            this._routePrompt(`Marker color (${ROUTE_COLOR_NAMES.join('/')}, blank = default)`, draft.color, color => {
+              draft.color = color;
+              this._routeSave(draft, orig);
+            });
           });
         });
       });
@@ -934,6 +1023,10 @@ export class TUI {
     const accounts = splitCsv(draft.accounts);
     if (accounts.length) route.accounts = accounts;
     if (draft.bucket) route.bucket = draft.bucket;
+    if (draft.color) {
+      if (isRouteColor(draft.color)) route.color = draft.color.toLowerCase();
+      else this._addLog(`Unknown color "${draft.color}" — using default`);
+    }
 
     this.config.routes = this.config.routes || [];
     const at = orig ? this.config.routes.indexOf(orig)
@@ -999,9 +1092,13 @@ export class TUI {
       case 'routes':
         return ` ${dim('↑↓')} select  ${bold('a')}dd  ${bold('e')}dit  ${bold('d')}elete  ${bold('Esc')} back`;
       case 'select': {
-        const act = this.selAction === 'switch' ? 'switch'
-          : this.selAction === 'toggle' ? 'enable/disable'
-          : 'remove';
+        if (this.selAction === 'switch') {
+          const target = this.selRoute
+            ? routeColorFn(this.selRoute.color)(`route ${this.selRoute.name}`)
+            : 'default';
+          return ` ${dim('↑↓')} select  ${bold('Tab')} target: ${target}  ${bold('Enter')} pin  ${bold('Esc')} cancel`;
+        }
+        const act = this.selAction === 'toggle' ? 'enable/disable' : 'remove';
         return ` ${dim('↑↓')} select  ${bold('Enter')} ${act}  ${bold('Esc')} cancel`;
       }
       case 'add':

--- a/test/route-pin.test.js
+++ b/test/route-pin.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// Ephemeral per-route manual pins (distinct from the keep-warm account pin in
+// account-pin.test.js): a pin biases selection for a route's models while the
+// pinned account is eligible, and falls back to best-available otherwise.
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+test('a route pin biases getActiveAccount toward the pinned account for matching models', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  // Without a pin, selection lands on the default (index 0).
+  assert.equal(am.getActiveAccount(null, 'claude-opus-4').name, 'a');
+
+  assert.deepEqual(am.setRoutePin('bulk', 1), { ok: true });
+  assert.equal(am.getActiveAccount(null, 'claude-opus-4').name, 'b'); // pin wins
+  // A model the route does NOT match is unaffected by the pin.
+  assert.equal(am.getActiveAccount(null, 'claude-sonnet-4-6').name, 'a');
+});
+
+test('a pinned account that is ineligible falls back to best-available', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  am.setRoutePin('bulk', 1);
+  // b's shared 5h bucket is spent → ineligible for everything.
+  am.accounts[1].quota.unified5h = 0.999;
+  am.accounts[1].quota.unified5hReset = Date.now() + 3600_000;
+
+  assert.equal(am.getActiveAccount(null, 'claude-opus-4').name, 'a'); // fell back
+});
+
+test('setRoutePin rejects an account the route does not allow', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'], accounts: ['a'] }], // only a
+  });
+  const res = am.setRoutePin('bulk', 1); // b is not in the route
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /does not allow/);
+  assert.equal(am.getRoutePin('bulk'), null);
+});
+
+test('an auto fable route is pinnable by its family name', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  for (const acc of am.accounts) { acc.quota.unified7dFable = 0.1; acc.quota.unified7dFableReset = Date.now() + 3600_000; }
+  assert.ok(am.getRoutes().some(r => r.name === 'fable' && r.autocreated), 'auto fable route detected');
+
+  assert.deepEqual(am.setRoutePin('fable', 1), { ok: true });
+  assert.equal(am.getActiveAccount(null, 'claude-fable-5').name, 'b');
+  assert.equal(am.getRoutes().find(r => r.name === 'fable').pinned, 'b');
+});
+
+test('clearRoutePin removes the bias', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  am.setRoutePin('bulk', 1);
+  am.clearRoutePin('bulk');
+  assert.equal(am.getActiveAccount(null, 'claude-opus-4').name, 'a');
+});
+
+test('removing an account keeps route pins pointing at the right account', () => {
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  am.setRoutePin('bulk', 2);        // pin c
+  am.removeAccount(0);              // drop a → indices shift down
+  assert.equal(am.getRoutePin('bulk')?.name, 'c'); // still c, now at index 1
+
+  am.removeAccount(am.accounts.findIndex(x => x.name === 'c')); // remove the pinned account
+  assert.equal(am.getRoutePin('bulk'), null);       // pin dropped
+});
+
+test('reloading routes drops pins for routes that no longer exist', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  am.setRoutePin('bulk', 1);
+  am.setRoutes([{ name: 'other', match: ['*haiku*'] }]); // 'bulk' gone
+  assert.equal(am.getRoutePin('bulk'), null);
+});

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -80,6 +80,20 @@ test('renderStatus prints the routing table with configured and auto routes', ()
   assert.match(output, /\*sonnet\*\s+→ a \(auto\)/);
 });
 
+test('renderStatus shows a route color and pinned account', () => {
+  const status = sampleStatus();
+  status.routes = [
+    { name: 'fable', match: ['*fable*'], autocreated: false, bucket: null, color: 'magenta', pinned: 'personal',
+      accounts: [{ name: 'personal', eligible: true }, { name: 'a', eligible: true }] },
+  ];
+  // Plain text: the pin annotation is visible.
+  const plain = renderStatus(status, { color: false, now });
+  assert.match(plain, /\*fable\*\s+→ personal a \[pinned: personal\]/);
+  // Colored: the magenta SGR code (35) wraps the route label.
+  const colored = renderStatus(status, { color: true, now });
+  assert.match(colored, /\x1b\[35m\*fable\*/);
+});
+
 test('renderStatus omits the routing table when there are no routes', () => {
   const output = renderStatus(sampleStatus(), { color: false, now });
   assert.doesNotMatch(output, /Routing/);

--- a/test/tui-routes.test.js
+++ b/test/tui-routes.test.js
@@ -5,14 +5,18 @@ import { TUI } from '../src/tui.js';
 // Minimal AccountManager stand-in for the routes editor: it only needs the
 // surface the editor touches (accounts, setRoutes). render() is stubbed out so
 // these tests exercise the editor state machine, not the terminal renderer.
-function makeTUI() {
+function makeTUI({ routes = [] } = {}) {
   const applied = { routes: null };
+  const pins = { calls: [], byName: new Map() };
   const am = {
     accounts: [{ name: 'a', index: 0 }, { name: 'b', index: 1 }],
     currentIndex: 0,
     switchThreshold: 0.98,
     setRoutes(r) { applied.routes = r; },
-    getRoutes() { return []; },
+    getRoutes() { return routes; },
+    setRoutePin(name, idx) { pins.calls.push(['set', name, idx]); pins.byName.set(name, this.accounts[idx]); return { ok: true }; },
+    clearRoutePin(name) { pins.calls.push(['clear', name]); pins.byName.delete(name); },
+    getRoutePin(name) { return pins.byName.get(name) || null; },
   };
   const saved = { routes: null };
   const config = { proxy: { port: 1 }, routes: [] };
@@ -22,7 +26,7 @@ function makeTUI() {
     syncAccounts: async () => 0, onQuit: () => {},
   });
   tui.render = () => {}; // bypass terminal rendering
-  return { tui, config, applied, saved };
+  return { tui, config, applied, saved, pins };
 }
 
 const type = (tui, s) => { for (const ch of s) tui._key(ch); };
@@ -51,7 +55,9 @@ test('TUI routes editor: add walks name → glob → accounts → bucket and per
   assert.match(tui.inputPrompt, /Accounts/);
   type(tui, 'b'); tui._key('enter');
   assert.match(tui.inputPrompt, /bucket/i);
-  tui._key('enter'); // blank bucket → save
+  tui._key('enter'); // blank bucket → color prompt
+  assert.match(tui.inputPrompt, /color/i);
+  tui._key('enter'); // blank color → save
   await settle();
 
   assert.deepEqual(config.routes, [{ name: 'fable', match: ['*fable*'], accounts: ['b'] }]);
@@ -81,11 +87,65 @@ test('TUI routes editor: edit prefills, and backspace clears a field before rety
   assert.equal(tui.inputBuf, 'b');               // accounts prefilled
   tui._key('bs'); type(tui, 'a,b'); tui._key('enter');
   type(tui, 'unified7dFable'); tui._key('enter');
+  type(tui, 'magenta'); tui._key('enter'); // color
   await settle();
 
   assert.deepEqual(config.routes, [
-    { name: 'fable', match: ['*fable*'], accounts: ['a', 'b'], bucket: 'unified7dFable' },
+    { name: 'fable', match: ['*fable*'], accounts: ['a', 'b'], bucket: 'unified7dFable', color: 'magenta' },
   ]);
+});
+
+test('TUI routes editor: an unknown color is dropped (route still saves)', async () => {
+  const { tui, config } = makeTUI();
+  openRoutes(tui); tui._key('a');
+  type(tui, 'r'); tui._key('enter');           // name
+  type(tui, '*opus*'); tui._key('enter');      // glob
+  tui._key('enter');                            // accounts (all)
+  tui._key('enter');                            // bucket (auto)
+  type(tui, 'chartreuse'); tui._key('enter');   // unknown color
+  await settle();
+  assert.deepEqual(config.routes, [{ name: 'r', match: ['*opus*'] }]); // no color key
+});
+
+test('TUI switch mode: Tab targets a route and Enter pins the highlighted account', () => {
+  const routes = [{
+    name: 'fable', match: ['*fable*'], color: 'red', autocreated: true, pinned: null,
+    accounts: [{ name: 'a', eligible: true }, { name: 'b', eligible: true }],
+  }];
+  const { tui, pins } = makeTUI({ routes });
+
+  tui._key('s');                       // enter switch mode (selRoute = null = default)
+  assert.equal(tui.mode, 'select');
+  assert.equal(tui.selRoute, null);
+  tui._key('tab');                     // cycle to the fable route
+  assert.equal(tui.selRoute?.name, 'fable');
+  tui._key('down');                    // highlight account b (index 1)
+  tui._key('enter');
+  assert.deepEqual(pins.calls, [['set', 'fable', 1]]);
+  assert.equal(tui.mode, 'normal');
+});
+
+test('TUI switch mode: Enter on the current pin clears it (toggle off)', () => {
+  const routes = [{
+    name: 'fable', match: ['*fable*'], color: 'red', autocreated: true, pinned: 'a',
+    accounts: [{ name: 'a', eligible: true }, { name: 'b', eligible: true }],
+  }];
+  const { tui, pins } = makeTUI({ routes });
+  pins.byName.set('fable', tui.am.accounts[0]); // a is already pinned
+
+  tui._key('s');
+  tui._key('tab');                     // target fable
+  tui._key('enter');                   // Enter on account a (the current pin)
+  assert.deepEqual(pins.calls, [['clear', 'fable']]);
+  assert.equal(tui.mode, 'normal');
+});
+
+test('TUI switch mode: Tab is inert for remove/toggle actions', () => {
+  const routes = [{ name: 'fable', match: ['*fable*'], accounts: [{ name: 'a', eligible: true }] }];
+  const { tui } = makeTUI({ routes });
+  tui._key('r');                       // remove action
+  tui._key('tab');
+  assert.equal(tui.selRoute, null);    // unchanged — Tab only cycles in switch mode
 });
 
 test('TUI routes editor: delete removes the selected route', async () => {


### PR DESCRIPTION
## Summary

Reworks how multi-model routing surfaces in the TUI, per user feedback: instead of a separate "Routing" list below the accounts, routing is shown **inline on the account rows** with a colored `►` marker, plus the ability to **manually pin which account a specific route uses**.

## What changed

**Inline markers replace the TUI list** (`src/tui.js`)
- Family routes (Fable/Sonnet) draw their `►` next to the account's `F7`/`S7` bar.
- General routes get a stable start-of-row column each (marker position identifies the route).
- Marker is **bold** on a route's pinned account, **dim** when that member is currently ineligible, and keeps the route's own color throughout (preserving the old list's eligibility signal). Column alignment is unchanged when no general routes exist.

**Per-route color** (`red`/`green`/`yellow`/`blue`/`magenta`/`cyan`)
- Config field, TUI route-editor prompt, `teamclaude route add --color`, and shown in the `teamclaude status` list (which stays a list — no bars / runtime state there).

**Manual per-route switching (Tab)** — press `s` then `Tab` to choose the target: the global **default** account → each configured route → each auto fable/sonnet route. `↑/↓` + `Enter` pins the route to an account; `Enter` again on the current pin clears it.

**Per-route pins** (`src/account-manager.js`), per agreed semantics:
- **Ephemeral** runtime overrides (a `routePins` Map) — not persisted, reset on restart, like the global manual switch.
- **Auto-fallback** — `getActiveAccount` honors a pin only while the pinned account is eligible; otherwise it falls through to normal best-available selection, so a pin never stalls requests.
- `setRoutePin` rejects a route-disallowed account; pins are remapped/dropped on account removal and route reload.

## Tests
- `test/route-pin.test.js` (new): pin bias, ineligible→fallback, reject disallowed, index remap on removal, drop on reload.
- `test/tui-routes.test.js`: color prompt in add/edit, unknown-color drop, Tab-to-target + pin, Enter-toggles-off, Tab inert for remove/toggle.
- `test/status-renderer.test.js`: route color + `[pinned: …]` annotation.

All 243 tests pass; lint clean.

## Notes
- Scope is the interactive TUI; the CLI `teamclaude status` intentionally keeps a list (colored + pin-annotated).
- No color legend for general-route markers — the user picks the colors, and the start-of-row column position is stable. Easy to add a compact legend if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)