### PR TITLE
Multi-provider support: OpenAI/Codex alongside Claude (Phase 0: provider seam)

### DIFF
--- a/src/account-router.js
+++ b/src/account-router.js
@@ -1,0 +1,139 @@
+// Runs one AccountManager per provider and routes between them. Each pool
+// (Claude, OpenAI/Codex, …) rotates independently; the request path resolves the
+// right pool by upstream host via managerFor(), while lifecycle/UI code sees a
+// flattened view across every pool.
+//
+// With a single provider configured — today's default — the router wraps exactly
+// one manager and is behaviorally a pass-through, which is what keeps the
+// provider seam a no-op until a second provider's accounts are actually added.
+
+import { AccountManager } from './account-manager.js';
+import { providerById, providerForHost, DEFAULT_PROVIDER_ID } from './providers/index.js';
+
+export class AccountRouter {
+  // `accounts` is the flat config list; each account's optional `provider` field
+  // (default 'anthropic') decides which pool it joins. `opts` mirrors the
+  // AccountManager options and is passed through to every manager; a provider
+  // that supplies its own token-refresh gets it injected here.
+  constructor(accounts, switchThreshold = 0.98, opts = {}) {
+    // Partition by provider id, preserving first-seen order so the default
+    // provider (usually the only one) stays at index 0.
+    const groups = new Map();
+    for (const acct of accounts || []) {
+      const id = acct.provider || DEFAULT_PROVIDER_ID;
+      if (!groups.has(id)) groups.set(id, []);
+      groups.get(id).push(acct);
+    }
+    if (groups.size === 0) groups.set(DEFAULT_PROVIDER_ID, []);
+
+    this.entries = [];
+    for (const [id, group] of groups) {
+      const provider = providerById(id);
+      // A provider may override token refresh (OpenAI vs Anthropic); fall back to
+      // whatever the caller passed (or the AccountManager default).
+      const managerOpts = { ...opts };
+      if (provider.refresh && managerOpts.refreshFn === undefined) managerOpts.refreshFn = provider.refresh;
+      this.entries.push({ provider, manager: new AccountManager(group, switchThreshold, managerOpts) });
+    }
+    this.defaultManager = this.entries[0].manager;
+  }
+
+  get managers() {
+    return this.entries.map((e) => e.manager);
+  }
+
+  /** The account pool for a given upstream host, falling back to the default. */
+  managerFor(host) {
+    const provider = providerForHost(host);
+    if (provider) {
+      const e = this.entries.find((x) => x.provider.id === provider.id);
+      if (e) return e.manager;
+    }
+    return this.defaultManager;
+  }
+
+  /** The manager owning a given account object (by reference), or the default. */
+  managerOf(account) {
+    for (const e of this.entries) {
+      if (e.manager.accounts.includes(account)) return e.manager;
+    }
+    return this.defaultManager;
+  }
+
+  /** Flattened view across every pool (status/UI/persistence iteration). */
+  get accounts() {
+    return this.entries.flatMap((e) => e.manager.accounts);
+  }
+
+  // ── aggregate lifecycle (fanned across all pools) ─────────────────────────
+
+  selectActiveAccount() {
+    for (const m of this.managers) m.selectActiveAccount();
+  }
+
+  refreshExpiredQuotas() {
+    for (const m of this.managers) m.refreshExpiredQuotas();
+  }
+
+  onTokenRefresh(cb) {
+    for (const m of this.managers) m.onTokenRefresh(cb);
+  }
+
+  /** Merge each pool's persisted quota into one flat array. */
+  exportQuotaState() {
+    return this.managers.flatMap((m) => m.exportQuotaState());
+  }
+
+  /** Restore into every pool; each manager only adopts its own accounts (by identity). */
+  restoreQuotaState(saved) {
+    for (const m of this.managers) m.restoreQuotaState(saved);
+  }
+
+  /**
+   * Add an account to the pool for its provider (creating that pool if it's the
+   * first account of a new provider). Returns the account's index within its pool.
+   */
+  addAccount(acctData) {
+    const id = acctData.provider || DEFAULT_PROVIDER_ID;
+    let entry = this.entries.find((e) => e.provider.id === id);
+    if (!entry) {
+      const provider = providerById(id);
+      entry = { provider, manager: new AccountManager([], this.defaultManager.switchThreshold, {}) };
+      this.entries.push(entry);
+    }
+    return entry.manager.addAccount(acctData);
+  }
+
+  /**
+   * Aggregate status across pools. With one pool this is exactly that manager's
+   * status; with several, the account lists concatenate and top-level fields come
+   * from the default pool (a richer multi-pool shape is a later-phase concern).
+   */
+  getStatus() {
+    if (this.entries.length === 1) return this.defaultManager.getStatus();
+    const base = this.defaultManager.getStatus();
+    return { ...base, accounts: this.managers.flatMap((m) => m.getStatus().accounts) };
+  }
+
+  // ── config / global state ─────────────────────────────────────────────────
+  // Routes, pins, and switchThreshold are global config; with a single pool they
+  // belong to it. These delegate to the default pool. (Per-pool routing tables
+  // are a later-phase concern once a second provider is live.)
+  get switchThreshold() { return this.defaultManager.switchThreshold; }
+  get currentIndex() { return this.defaultManager.currentIndex; }
+  getRoutes() { return this.defaultManager.getRoutes(); }
+  setRoutes(routes) { this.defaultManager.setRoutes(routes); }
+  setRoutePin(name, idx) { return this.defaultManager.setRoutePin(name, idx); }
+  clearRoutePin(name) { return this.defaultManager.clearRoutePin(name); }
+  getRoutePin(name) { return this.defaultManager.getRoutePin(name); }
+
+  // ── per-account operations addressed by pool-local index ──────────────────
+  // NOTE: these take an index into a single pool. Correct as-is while there's one
+  // pool; the prober/warmer/TUI call sites that iterate the flattened `accounts`
+  // must resolve the owning manager (via managerOf) once a second pool exists.
+  setDisabled(index, disabled) { return this.defaultManager.setDisabled(index, disabled); }
+  removeAccount(index) { return this.defaultManager.removeAccount(index); }
+  updateAccountTokens(index, tokens) { return this.defaultManager.updateAccountTokens(index, tokens); }
+  ensureTokenFresh(index, force) { return this.defaultManager.ensureTokenFresh(index, force); }
+  applyUsageData(index, usage) { return this.defaultManager.applyUsageData(index, usage); }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { anthropic } from './providers/anthropic.js';
 
 export function getConfigPath() {
   if (process.env.TEAMCLAUDE_CONFIG) return process.env.TEAMCLAUDE_CONFIG;
@@ -44,7 +45,7 @@ export function createDefaultConfig() {
       port: 3456,
       apiKey: 'tc-' + randomBytes(24).toString('base64url'),
     },
-    upstream: 'https://api.anthropic.com',
+    upstream: anthropic.upstreamBase,
     switchThreshold: 0.98,
     accounts: [],
   };

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
+import { anthropic } from './providers/anthropic.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -298,7 +299,7 @@ async function serverCommand() {
       startedAt: new Date(serverStartedAt).toISOString(),
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),
       port,
-      upstream: config.upstream || 'https://api.anthropic.com',
+      upstream: config.upstream || anthropic.upstreamBase,
     },
     probe: prober?.getStatus() || {
       enabled: false,
@@ -352,7 +353,7 @@ async function serverCommand() {
       console.log(`  Bind:       ${bindHost}:${port}${bindHost === '127.0.0.1' ? ' (localhost only)' : ' (reachable off-box — ensure proxy.apiKey is set)'}`);
       console.log(`  Accounts:   ${accounts.length}`);
       console.log(`  Threshold:  ${(threshold * 100).toFixed(0)}%`);
-      console.log(`  Upstream:   ${config.upstream || 'https://api.anthropic.com'}`);
+      console.log(`  Upstream:   ${config.upstream || anthropic.upstreamBase}`);
       console.log('');
       accounts.forEach((a, i) => {
         console.log(`  [${i + 1}] ${a.name} (${a.type})`);
@@ -779,7 +780,7 @@ async function apiCommand() {
 
   const credential = account.accessToken || account.apiKey;
   const isOAuth = account.type === 'oauth';
-  const upstream = config.upstream || 'https://api.anthropic.com';
+  const upstream = config.upstream || anthropic.upstreamBase;
   const url = path.startsWith('http') ? path : `${upstream}${path}`;
 
   const headers = isOAuth
@@ -1382,8 +1383,8 @@ function argValue(flag) {
 
 // Hostname of the configured upstream (the host MITM-intercepts under `run`).
 function upstreamHost(config) {
-  try { return new URL(config.upstream || 'https://api.anthropic.com').hostname; }
-  catch { return 'api.anthropic.com'; }
+  try { return new URL(config.upstream || anthropic.upstreamBase).hostname; }
+  catch { return anthropic.hosts[0]; }
 }
 
 // Best-effort: tell a running server (if any) to re-sync accounts from config so

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import net from 'node:net';
 import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, loadState, saveState } from './config.js';
-import { AccountManager } from './account-manager.js';
+import { AccountRouter } from './account-router.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
@@ -136,7 +136,10 @@ async function serverCommand() {
   }
 
   const threshold = config.switchThreshold || 0.98;
-  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes, ramp: config.stormRamp });
+  // One pool per provider (default: a single Anthropic pool). The router is a
+  // drop-in for AccountManager here — it exposes the same lifecycle surface and
+  // resolves the per-request pool by host inside the server.
+  const accountManager = new AccountRouter(accounts, threshold, { routes: config.routes, ramp: config.stormRamp });
 
   // Restore quota observed in a previous run so a restart doesn't lose rotation
   // state (passive — we never call the API to re-learn it). Stale windows are

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -22,6 +22,7 @@ import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr } from './server.js';
 import { anthropic } from './providers/anthropic.js';
+import { providerForHost } from './providers/index.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -102,7 +103,10 @@ function upstreamHostOf(config) {
 /** Per-CONNECT behavior: 'rewrite' (intercept + token inject), 'test', or 'tunnel'. */
 export function hostMode(host, config) {
   if (host === TEST_HOST) return 'test';
-  if (host === upstreamHostOf(config)) return 'rewrite';
+  // Rewrite the configured upstream host (covers custom/self-hosted upstreams)
+  // as well as any known provider host — the latter is what lets a second
+  // provider's traffic (e.g. chatgpt.com) be intercepted once it's registered.
+  if (host === upstreamHostOf(config) || providerForHost(host)) return 'rewrite';
   return 'tunnel';
 }
 

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -21,6 +21,7 @@ import http2 from 'node:http2';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr } from './server.js';
+import { anthropic } from './providers/anthropic.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -94,8 +95,8 @@ export async function ensureCerts(host) {
 }
 
 function upstreamHostOf(config) {
-  try { return new URL(config?.upstream || 'https://api.anthropic.com').hostname; }
-  catch { return 'api.anthropic.com'; }
+  try { return new URL(config?.upstream || anthropic.upstreamBase).hostname; }
+  catch { return anthropic.hosts[0]; }
 }
 
 /** Per-CONNECT behavior: 'rewrite' (intercept + token inject), 'test', or 'tunnel'. */
@@ -111,7 +112,7 @@ export function hostMode(host, config) {
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
 export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null }) {
-  const upstream = config.upstream || 'https://api.anthropic.com';
+  const upstream = config.upstream || anthropic.upstreamBase;
   const proxyApiKey = config.proxy?.apiKey;
   const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx });
 

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -4,6 +4,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { exec } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import http from 'node:http';
+import { anthropic } from './providers/anthropic.js';
 
 /**
  * Import OAuth credentials from a Claude Code credentials file.
@@ -23,11 +24,19 @@ export async function importCredentials(filePath) {
   };
 }
 
-const PROFILE_URL = 'https://api.anthropic.com/api/oauth/profile';
-const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+// Anthropic-specific endpoints + OAuth config live in the provider definition
+// (single source of truth). Aliased to the existing local names to keep the diff
+// minimal and the call sites unchanged.
+const {
+  profileUrl: PROFILE_URL,
+  usageUrl: USAGE_URL,
+  tokenUrl: DEFAULT_TOKEN_ENDPOINT,
+  clientId: DEFAULT_CLIENT_ID,
+  authorizeUrl: OAUTH_AUTHORIZE,
+  scopes: OAUTH_SCOPES,
+  successRedirect: OAUTH_SUCCESS_REDIRECT,
+} = anthropic.oauth;
 const OAUTH_USAGE_BETA = 'oauth-2025-04-20';
-const DEFAULT_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
-const DEFAULT_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
 /**
  * Refresh an expired OAuth access token using the refresh token.
@@ -248,11 +257,6 @@ export async function fetchUsage(accessToken) {
   }
 }
 
-// OAuth config (extracted from Claude Code). Client id + token endpoint are
-// shared with the refresh path — see DEFAULT_CLIENT_ID / DEFAULT_TOKEN_ENDPOINT.
-const OAUTH_AUTHORIZE = 'https://claude.ai/oauth/authorize';
-const OAUTH_SCOPES = 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload';
-
 /**
  * Perform OAuth login via browser with PKCE flow.
  * Opens the user's browser, waits for the callback, exchanges the code for tokens.
@@ -395,7 +399,7 @@ function startCallbackServer(expectedState) {
         }
 
         if (code) {
-          res.writeHead(302, { 'Location': 'https://platform.claude.com/oauth/code/success?app=claude-code' });
+          res.writeHead(302, { 'Location': OAUTH_SUCCESS_REDIRECT });
           res.end();
           resolveCode(code);
           return;

--- a/src/providers/anthropic.js
+++ b/src/providers/anthropic.js
@@ -1,0 +1,43 @@
+// Anthropic (Claude) provider definition — the single source of truth for every
+// Anthropic-specific endpoint, host, and OAuth constant teamclaude relies on.
+// Historically these were scattered as string literals across oauth.js, mitm.js,
+// server.js, config.js and index.js; centralizing them here is the first step of
+// the provider abstraction that lets a second provider (e.g. OpenAI/Codex) plug
+// in alongside without touching the core relay/rotation machinery.
+
+// The upstream origin requests are forwarded to (also the CONNECT host the MITM
+// proxy terminates + rewrites).
+const UPSTREAM_BASE = 'https://api.anthropic.com';
+const API_HOST = 'api.anthropic.com';
+
+export const anthropic = {
+  id: 'anthropic',
+  label: 'Claude',
+
+  // Default upstream origin; a per-account/config `upstream` may override it.
+  upstreamBase: UPSTREAM_BASE,
+
+  // Hosts this provider owns. Used by the MITM host router to decide which
+  // CONNECT targets to terminate + rewrite (vs. blind-tunnel).
+  hosts: [API_HOST],
+  matchHost(host) {
+    return this.hosts.includes(host);
+  },
+
+  // OAuth (extracted from Claude Code). Authorization-code + PKCE login, and a
+  // refresh-token grant; both post JSON to `tokenUrl`.
+  oauth: {
+    authorizeUrl: 'https://claude.ai/oauth/authorize',
+    tokenUrl: 'https://platform.claude.com/v1/oauth/token',
+    clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+    scopes: 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
+    // Zero-spend endpoints used to enrich/probe an account.
+    profileUrl: `${UPSTREAM_BASE}/api/oauth/profile`,
+    usageUrl: `${UPSTREAM_BASE}/api/oauth/usage`,
+    // Where the browser is sent after a successful CLI login so the tab lands on
+    // a friendly page instead of a bare localhost redirect.
+    successRedirect: 'https://platform.claude.com/oauth/code/success?app=claude-code',
+  },
+};
+
+export default anthropic;

--- a/src/providers/anthropic.js
+++ b/src/providers/anthropic.js
@@ -5,10 +5,28 @@
 // the provider abstraction that lets a second provider (e.g. OpenAI/Codex) plug
 // in alongside without touching the core relay/rotation machinery.
 
+import { patchAccountUuid } from '../account-uuid-rewrite.js';
+
 // The upstream origin requests are forwarded to (also the CONNECT host the MITM
 // proxy terminates + rewrites).
 const UPSTREAM_BASE = 'https://api.anthropic.com';
 const API_HOST = 'api.anthropic.com';
+
+// Rewrite the `model` field in a JSON request body using a per-account map.
+// Returns the original buffer unchanged if the model isn't in the map or the
+// body isn't valid JSON, so non-messages endpoints pass through safely. Used for
+// accounts whose upstream (e.g. a GLM-compatible backend) names models
+// differently than Anthropic. Exported (and re-exported from server.js) for tests.
+export function rewriteModel(body, modelMap) {
+  try {
+    const obj = JSON.parse(body.toString('utf8'));
+    if (obj.model && modelMap[obj.model]) {
+      obj.model = modelMap[obj.model];
+      return Buffer.from(JSON.stringify(obj), 'utf8');
+    }
+  } catch { /* not JSON — pass through unchanged */ }
+  return body;
+}
 
 export const anthropic = {
   id: 'anthropic',
@@ -37,6 +55,60 @@ export const anthropic = {
     // Where the browser is sent after a successful CLI login so the tab lands on
     // a friendly page instead of a bare localhost redirect.
     successRedirect: 'https://platform.claude.com/oauth/code/success?app=claude-code',
+  },
+
+  // ── per-request behavior (used by the forward path in server.js) ──────────
+
+  // Inject the account's credential. OAuth accounts get a Bearer token; API-key
+  // accounts get x-api-key. (The relay's header-copy loop already strips the
+  // client's own x-api-key before this runs.)
+  injectAuth(headers, account) {
+    if (account.type === 'oauth') headers['authorization'] = `Bearer ${account.credential}`;
+    else headers['x-api-key'] = account.credential;
+  },
+
+  // Align the request body with the account whose token we inject: patch
+  // account_uuid (metadata.user_id; same-length, no-op if absent) and remap the
+  // model name for third-party upstreams. Returns the original buffer unchanged
+  // when nothing applies (caller compares by identity to fix Content-Length).
+  rewriteBody(body, account) {
+    let out = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
+    if (account.modelMap) out = rewriteModel(out, account.modelMap);
+    return out;
+  },
+
+  // Collect this provider's rate-limit response headers into a plain object, fed
+  // to AccountManager.updateQuota to learn utilization passively from traffic.
+  rateLimitHeaders(headers) {
+    const out = {};
+    for (const [key, value] of headers.entries()) {
+      if (key.startsWith('anthropic-ratelimit-')) out[key] = value;
+    }
+    return out;
+  },
+
+  // Classify a 429 from the unified rate-limit statuses. `quotaExhausted` means a
+  // durable bucket is spent → rotate to another account. `modelScoped` means the
+  // exhaustion is for the current model's weekly bucket only (Fable), so the
+  // account stays usable for other models and must not be throttled wholesale.
+  classify429(rateLimitHeaders) {
+    const rl = rateLimitHeaders;
+    const generalRejected = rl['anthropic-ratelimit-unified-5h-status'] === 'rejected'
+      || rl['anthropic-ratelimit-unified-7d-status'] === 'rejected';
+    const modelScoped = rl['anthropic-ratelimit-unified-7d_oi-status'] === 'rejected' && !generalRejected;
+    return { quotaExhausted: generalRejected || modelScoped, modelScoped };
+  },
+
+  // Passive token accounting. Both an SSE event object and a non-stream JSON body
+  // carry a `usage` object; return { input, output } deltas, or null if absent.
+  parseUsageEvent(data) {
+    if (data.type === 'message_start' && data.message?.usage) return { input: data.message.usage.input_tokens || 0, output: 0 };
+    if (data.type === 'message_delta' && data.usage) return { input: 0, output: data.usage.output_tokens || 0 };
+    return null;
+  },
+  parseUsageBody(json) {
+    if (json.usage) return { input: json.usage.input_tokens || 0, output: json.usage.output_tokens || 0 };
+    return null;
   },
 };
 

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,0 +1,35 @@
+// Provider registry. A "provider" bundles everything specific to one upstream
+// service (Anthropic/Claude today; OpenAI/Codex next): its hosts, OAuth config,
+// and — as the abstraction grows — auth injection, quota parsing, and 429
+// classification. The core relay/rotation code stays provider-agnostic and
+// resolves the right provider per request (by host) or per account (by id).
+
+import { anthropic } from './anthropic.js';
+
+export const DEFAULT_PROVIDER_ID = 'anthropic';
+
+const PROVIDERS = {
+  [anthropic.id]: anthropic,
+};
+
+/** Look up a provider by id, falling back to the default (never returns null). */
+export function providerById(id) {
+  return PROVIDERS[id] || PROVIDERS[DEFAULT_PROVIDER_ID];
+}
+
+/** The provider that owns `host` (e.g. from a CONNECT target), or null. */
+export function providerForHost(host) {
+  if (!host) return null;
+  return Object.values(PROVIDERS).find((p) => p.matchHost(host)) || null;
+}
+
+/** The provider that owns an upstream origin URL, or null if unrecognized. */
+export function providerForUpstream(upstream) {
+  try {
+    return providerForHost(new URL(upstream).hostname);
+  } catch {
+    return null;
+  }
+}
+
+export { PROVIDERS };

--- a/src/server.js
+++ b/src/server.js
@@ -4,12 +4,16 @@ import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
-import { patchAccountUuid } from './account-uuid-rewrite.js';
 import { parseRequestModel } from './account-manager.js';
 import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { anthropic } from './providers/anthropic.js';
+import { providerForUpstream } from './providers/index.js';
+
+// Re-exported so `import { rewriteModel } from './server.js'` (and its tests)
+// keep working now that the implementation lives in the provider module.
+export { rewriteModel } from './providers/anthropic.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -204,7 +208,10 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       const body = Buffer.concat(bodyChunks);
 
       const model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
-      const ctx = { account: null, status: null, tried: new Set(), model, pinnedIndex };
+      // The provider that owns this pool's upstream (Anthropic today). Once the
+      // account router lands this becomes the request's resolved-by-host provider.
+      const provider = providerForUpstream(upstream) || anthropic;
+      const ctx = { account: null, status: null, tried: new Set(), model, pinnedIndex, provider };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -410,8 +417,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
   }
 
+  const provider = ctx.provider;
+
   // Build upstream request headers
-  const isOAuth = account.type === 'oauth';
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -426,21 +434,14 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     headers[key] = value;
   }
 
-  if (isOAuth) {
-    headers['authorization'] = `Bearer ${account.credential}`;
-  } else {
-    headers['x-api-key'] = account.credential;
-  }
+  // Inject the account's credential the way this provider expects.
+  provider.injectAuth(headers, account);
 
   const upstreamUrl = `${account.upstream || upstream}${req.url}`;
   const method = req.method;
 
-  // Align the body's account_uuid (in metadata.user_id) with the account whose
-  // token we're injecting (same-length patch; no-op if absent).
-  let sendBody = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
-  // Rewrite the model name for accounts that target a different upstream (e.g.
-  // GLM), which uses different model identifiers than Anthropic.
-  if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);
+  // Align the body with the injected account (account_uuid patch, model remap).
+  const sendBody = provider.rewriteBody(body, account);
   // If the body changed length (model name rewrite), update Content-Length so the
   // upstream doesn't receive a mismatched framing and truncate or stall.
   if (sendBody !== body) headers['content-length'] = String(sendBody.length);
@@ -481,13 +482,8 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       accountManager.release(account.index);
     }
 
-    // Extract rate limit headers
-    const rateLimitHeaders = {};
-    for (const [key, value] of upstreamRes.headers.entries()) {
-      if (key.startsWith('anthropic-ratelimit-')) {
-        rateLimitHeaders[key] = value;
-      }
-    }
+    // Extract this provider's rate-limit headers and learn utilization from them.
+    const rateLimitHeaders = provider.rateLimitHeaders(upstreamRes.headers);
     accountManager.updateQuota(account.index, rateLimitHeaders);
 
     // Any non-429 response is live proof a rate-limit hold no longer binds —
@@ -508,21 +504,19 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // Discard the 429 response body
       await upstreamRes.body?.cancel();
 
-      // Durable quota exhaustion vs. a transient rate limit. A "rejected" unified
-      // status means a quota bucket is spent, so waiting and retrying the SAME
-      // account is futile — switch to another account now (updateQuota above
-      // already recorded the spent bucket's utilization from the headers).
-      const rl = rateLimitHeaders;
-      const generalRejected = rl['anthropic-ratelimit-unified-5h-status'] === 'rejected'
-        || rl['anthropic-ratelimit-unified-7d-status'] === 'rejected';
-      const fableRejected = rl['anthropic-ratelimit-unified-7d_oi-status'] === 'rejected' && !generalRejected;
-      if ((generalRejected || fableRejected) && retryCount < maxRetries) {
-        // A Fable-only rejection leaves the account fine for other models, so we
-        // do NOT throttle it globally — the recorded Fable utilization makes
-        // selection skip it for Fable requests only. A general rejection spends a
-        // shared bucket, so hold the whole account for its reset window.
-        if (fableRejected) {
-          console.log(`[TeamClaude] Fable weekly exhausted on "${account.name}" — switching account for this Fable request`);
+      // Durable quota exhaustion vs. a transient rate limit. A quota rejection
+      // means a bucket is spent, so waiting and retrying the SAME account is
+      // futile — switch to another account now (updateQuota above already
+      // recorded the spent bucket's utilization from the headers).
+      const { quotaExhausted, modelScoped } = provider.classify429(rateLimitHeaders);
+      if (quotaExhausted && retryCount < maxRetries) {
+        // A model-scoped rejection (e.g. Fable weekly) leaves the account fine for
+        // other models, so we do NOT throttle it globally — the recorded
+        // utilization makes selection skip it for that model only. A general
+        // rejection spends a shared bucket, so hold the whole account for its
+        // reset window.
+        if (modelScoped) {
+          console.log(`[TeamClaude] Model-scoped weekly exhausted on "${account.name}" — switching account for this request`);
         } else {
           const hold = Math.min(Math.max(retryAfter, 1), 3600);
           console.log(`[TeamClaude] Quota rejection (429) on "${account.name}" — throttling ${hold}s and switching account`);
@@ -618,11 +612,11 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // whole (potentially ~1M-token) SSE body in memory.
       const l = getLog();
       const bw = l ? l.bodyWriter('RESPONSE BODY (streamed)', contentType) : null;
-      await streamResponse(upstreamRes.body, res, account.index, accountManager, bw);
+      await streamResponse(upstreamRes.body, res, account.index, accountManager, bw, provider);
       l?.end();
     } else {
       const buf = Buffer.from(await upstreamRes.arrayBuffer());
-      extractUsageFromBody(buf, account.index, accountManager);
+      extractUsageFromBody(buf, account.index, accountManager, provider);
       const l = getLog();
       if (l) { l.body('RESPONSE BODY', buf, contentType); l.end(); }
       res.end(buf);
@@ -721,7 +715,7 @@ export function readWithIdleTimeout(reader, ms) {
 /**
  * Stream an SSE response to the client, parsing usage data along the way.
  */
-async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter) {
+async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, provider) {
   const reader = webStream.getReader();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
@@ -750,7 +744,7 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
       sseBuffer = events.pop(); // keep incomplete event
 
       for (const event of events) {
-        parseSSEUsage(event, accountIndex, accountManager);
+        parseSSEUsage(event, accountIndex, accountManager, provider);
       }
 
       // Handle backpressure — also bail out if client disconnects,
@@ -770,7 +764,7 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
 
     // Parse any remaining buffer
     if (sseBuffer.trim()) {
-      parseSSEUsage(sseBuffer, accountIndex, accountManager);
+      parseSSEUsage(sseBuffer, accountIndex, accountManager, provider);
     }
   } catch (err) {
     // A mid-stream idle timeout (or any read error) means the upstream went
@@ -788,46 +782,25 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
   }
 }
 
-function parseSSEUsage(event, accountIndex, accountManager) {
+function parseSSEUsage(event, accountIndex, accountManager, provider) {
   const dataLine = event.split('\n').find(l => l.startsWith('data: '));
   if (!dataLine) return;
 
   try {
-    const data = JSON.parse(dataLine.slice(6));
-    if (data.type === 'message_start' && data.message?.usage) {
-      accountManager.updateUsage(accountIndex, data.message.usage.input_tokens, 0);
-    } else if (data.type === 'message_delta' && data.usage) {
-      accountManager.updateUsage(accountIndex, 0, data.usage.output_tokens);
-    }
+    const usage = provider.parseUsageEvent(JSON.parse(dataLine.slice(6)));
+    if (usage) accountManager.updateUsage(accountIndex, usage.input, usage.output);
   } catch {
     // not valid JSON, skip
   }
 }
 
-function extractUsageFromBody(buffer, accountIndex, accountManager) {
+function extractUsageFromBody(buffer, accountIndex, accountManager, provider) {
   try {
-    const json = JSON.parse(buffer.toString());
-    if (json.usage) {
-      accountManager.updateUsage(accountIndex, json.usage.input_tokens, json.usage.output_tokens);
-    }
+    const usage = provider.parseUsageBody(JSON.parse(buffer.toString()));
+    if (usage) accountManager.updateUsage(accountIndex, usage.input, usage.output);
   } catch {
     // not JSON or no usage
   }
-}
-
-// Rewrite the `model` field in a JSON request body using a per-account map.
-// Returns the original buffer unchanged if the model isn't in the map or the
-// body isn't valid JSON, so non-messages endpoints pass through safely.
-// Exported for tests.
-export function rewriteModel(body, modelMap) {
-  try {
-    const obj = JSON.parse(body.toString('utf8'));
-    if (obj.model && modelMap[obj.model]) {
-      obj.model = modelMap[obj.model];
-      return Buffer.from(JSON.stringify(obj), 'utf8');
-    }
-  } catch { /* not JSON — pass through unchanged */ }
-  return body;
 }
 
 function computeRetryAfter(accounts) {

--- a/src/server.js
+++ b/src/server.js
@@ -9,7 +9,7 @@ import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { anthropic } from './providers/anthropic.js';
-import { providerForUpstream } from './providers/index.js';
+import { providerForUpstream, providerForHost } from './providers/index.js';
 
 // Re-exported so `import { rewriteModel } from './server.js'` (and its tests)
 // keep working now that the implementation lives in the provider module.
@@ -172,6 +172,15 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // Code silently drops the image from the message.
       if (CLIENT_CREDENTIAL_PATHS.some((p) => (req.url || '').startsWith(p))) { await relayStream(req, res, upstream, sx); return; }
 
+      // Resolve which account pool + provider serve this request by its target
+      // host. In MITM mode the terminated request carries the CONNECT host in
+      // :authority; in reverse-proxy mode there's only our own host, so we fall
+      // back to the configured upstream's provider. Duck-typed: a bare
+      // AccountManager (as tests pass) is treated as the single pool for any host.
+      const host = (req.headers[':authority'] || req.headers['host'] || '').split(':')[0];
+      const accountPool = accountManager.managerFor ? accountManager.managerFor(host) : accountManager;
+      const provider = providerForHost(host) || providerForUpstream(upstream) || anthropic;
+
       // Account pin: a request to `/tc-acct/<name-or-index>/...` (e.g. via
       // ANTHROPIC_BASE_URL=http://host:port/tc-acct/deepseek) is forced onto that
       // one account, bypassing rotation. Used by the keep-warm scheduler and for
@@ -180,7 +189,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       const pin = (req.url || '').match(/^\/tc-acct\/([^/]+)(\/.*)$/);
       if (pin) {
         const token = decodeURIComponent(pin[1]);
-        pinnedIndex = resolveAccountPin(accountManager, token);
+        pinnedIndex = resolveAccountPin(accountPool, token);
         if (pinnedIndex == null) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
@@ -208,12 +217,9 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       const body = Buffer.concat(bodyChunks);
 
       const model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
-      // The provider that owns this pool's upstream (Anthropic today). Once the
-      // account router lands this becomes the request's resolved-by-host provider.
-      const provider = providerForUpstream(upstream) || anthropic;
       const ctx = { account: null, status: null, tried: new Set(), model, pinnedIndex, provider };
       try {
-        await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
+        await forwardRequest(req, res, body, accountPool, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
         ctx.status = ctx.status || 502;
         console.error('[TeamClaude] Unhandled error:', err);

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import { parseRequestModel } from './account-manager.js';
 import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
+import { anthropic } from './providers/anthropic.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -48,7 +49,7 @@ export function isLoopbackAddr(addr) {
 }
 
 export function createProxyServer(accountManager, config, hooks = {}, sx = null) {
-  const upstream = config.upstream || 'https://api.anthropic.com';
+  const upstream = config.upstream || anthropic.upstreamBase;
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
 
@@ -113,7 +114,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   // to the upstream host is a transparent MITM relay (rewrite only auth); the
   // test host is answered locally; anything else is blind-tunneled. Certs are
   // minted lazily on the first intercepted CONNECT.
-  const mitmHost = (() => { try { return new URL(upstream).hostname; } catch { return 'api.anthropic.com'; } })();
+  const mitmHost = (() => { try { return new URL(upstream).hostname; } catch { return anthropic.hosts[0]; } })();
   let certsPromise = null;
   const ensureLeaf = async () => {
     // Reset the memo on failure so a transient cert error doesn't wedge the MITM

--- a/test/account-router.test.js
+++ b/test/account-router.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountRouter } from '../src/account-router.js';
+import { AccountManager } from '../src/account-manager.js';
+
+function acct(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+test('single-provider router wraps exactly one manager (pass-through)', () => {
+  const r = new AccountRouter([acct('a'), acct('b')], 0.9);
+  assert.equal(r.managers.length, 1);
+  assert.equal(r.accounts.length, 2);
+  assert.ok(r.defaultManager instanceof AccountManager);
+  // managerFor always resolves to the one pool, whatever the host.
+  assert.equal(r.managerFor('api.anthropic.com'), r.defaultManager);
+  assert.equal(r.managerFor('chatgpt.com'), r.defaultManager);
+  assert.equal(r.managerFor(undefined), r.defaultManager);
+  // getStatus is exactly the single manager's status.
+  assert.deepEqual(r.getStatus(), r.defaultManager.getStatus());
+});
+
+test('empty account list still yields a default pool', () => {
+  const r = new AccountRouter([], 0.9);
+  assert.equal(r.managers.length, 1);
+  assert.equal(r.accounts.length, 0);
+});
+
+test('accounts are partitioned into one manager per provider group', () => {
+  const r = new AccountRouter([
+    acct('claude1', { provider: 'anthropic' }),
+    acct('codex1', { provider: 'openai' }),
+    acct('claude2'), // no provider → default (anthropic)
+  ], 0.9);
+  assert.equal(r.managers.length, 2, 'two provider groups → two managers');
+  assert.equal(r.accounts.length, 3, 'flattened view spans both pools');
+  const names = r.accounts.map((a) => a.name).sort();
+  assert.deepEqual(names, ['claude1', 'claude2', 'codex1']);
+});
+
+test('managerOf finds the pool that owns an account', () => {
+  const r = new AccountRouter([
+    acct('claude1', { provider: 'anthropic' }),
+    acct('codex1', { provider: 'openai' }),
+  ], 0.9);
+  const [claudeMgr, codexMgr] = r.managers;
+  assert.equal(r.managerOf(claudeMgr.accounts[0]), claudeMgr);
+  assert.equal(r.managerOf(codexMgr.accounts[0]), codexMgr);
+});
+
+test('addAccount routes to the matching provider pool', () => {
+  const r = new AccountRouter([acct('claude1')], 0.9);
+  assert.equal(r.managers.length, 1);
+  r.addAccount(acct('codex1', { provider: 'openai' }));
+  assert.equal(r.managers.length, 2, 'a new provider spins up its own pool');
+  assert.equal(r.accounts.length, 2);
+  r.addAccount(acct('claude2'));
+  assert.equal(r.managers.length, 2, 'existing provider reuses its pool');
+  assert.equal(r.accounts.length, 3);
+});
+
+test('exportQuotaState / restoreQuotaState round-trip across pools', () => {
+  const r = new AccountRouter([
+    acct('claude1', { provider: 'anthropic', accountUuid: 'uuid-a' }),
+    acct('codex1', { provider: 'openai', accountUuid: 'uuid-c' }),
+  ], 0.9);
+  // Seed a learned weekly window on each pool's account.
+  r.managers[0].accounts[0].quota.unified7d = 0.5;
+  r.managers[0].accounts[0].quota.unified7dReset = Date.now() + 86400_000;
+  r.managers[1].accounts[0].quota.unified7d = 0.25;
+  r.managers[1].accounts[0].quota.unified7dReset = Date.now() + 86400_000;
+
+  const saved = r.exportQuotaState();
+  assert.equal(saved.length, 2, 'export spans every pool');
+
+  const r2 = new AccountRouter([
+    acct('claude1', { provider: 'anthropic', accountUuid: 'uuid-a' }),
+    acct('codex1', { provider: 'openai', accountUuid: 'uuid-c' }),
+  ], 0.9);
+  r2.restoreQuotaState(saved);
+  assert.equal(r2.managers[0].accounts[0].quota.unified7d, 0.5);
+  assert.equal(r2.managers[1].accounts[0].quota.unified7d, 0.25);
+});
+
+test('onTokenRefresh registers the callback on every pool', () => {
+  const r = new AccountRouter([
+    acct('claude1', { provider: 'anthropic' }),
+    acct('codex1', { provider: 'openai' }),
+  ], 0.9);
+  const cb = () => {};
+  r.onTokenRefresh(cb);
+  // Each manager stores the callback it was given (via its own onTokenRefresh).
+  for (const m of r.managers) assert.equal(m._onTokenRefresh, cb);
+  // And selectActiveAccount fans out without throwing.
+  r.selectActiveAccount();
+});

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { anthropic } from '../src/providers/anthropic.js';
+import { providerById, providerForHost, providerForUpstream, DEFAULT_PROVIDER_ID } from '../src/providers/index.js';
+
+test('anthropic provider exposes the expected constants', () => {
+  assert.equal(anthropic.id, 'anthropic');
+  assert.equal(anthropic.upstreamBase, 'https://api.anthropic.com');
+  assert.ok(anthropic.hosts.includes('api.anthropic.com'));
+  assert.equal(anthropic.oauth.tokenUrl, 'https://platform.claude.com/v1/oauth/token');
+  assert.equal(anthropic.oauth.clientId, '9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+  assert.match(anthropic.oauth.authorizeUrl, /claude\.ai\/oauth\/authorize$/);
+  assert.match(anthropic.oauth.profileUrl, /\/api\/oauth\/profile$/);
+  assert.match(anthropic.oauth.usageUrl, /\/api\/oauth\/usage$/);
+});
+
+test('matchHost only matches this provider\'s hosts', () => {
+  assert.equal(anthropic.matchHost('api.anthropic.com'), true);
+  assert.equal(anthropic.matchHost('chatgpt.com'), false);
+  assert.equal(anthropic.matchHost(''), false);
+});
+
+test('providerById falls back to the default for unknown ids', () => {
+  assert.equal(providerById('anthropic'), anthropic);
+  assert.equal(providerById('nope').id, DEFAULT_PROVIDER_ID);
+  assert.equal(providerById(undefined).id, DEFAULT_PROVIDER_ID);
+});
+
+test('providerForHost / providerForUpstream resolve by host', () => {
+  assert.equal(providerForHost('api.anthropic.com'), anthropic);
+  assert.equal(providerForHost('unknown.example'), null);
+  assert.equal(providerForHost(null), null);
+  assert.equal(providerForUpstream('https://api.anthropic.com'), anthropic);
+  assert.equal(providerForUpstream('not a url'), null);
+});

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -33,3 +33,60 @@ test('providerForHost / providerForUpstream resolve by host', () => {
   assert.equal(providerForUpstream('https://api.anthropic.com'), anthropic);
   assert.equal(providerForUpstream('not a url'), null);
 });
+
+test('injectAuth uses Bearer for oauth and x-api-key for api-key accounts', () => {
+  const h1 = {};
+  anthropic.injectAuth(h1, { type: 'oauth', credential: 'tok' });
+  assert.equal(h1['authorization'], 'Bearer tok');
+  assert.equal(h1['x-api-key'], undefined);
+
+  const h2 = {};
+  anthropic.injectAuth(h2, { type: 'apikey', credential: 'sk-123' });
+  assert.equal(h2['x-api-key'], 'sk-123');
+  assert.equal(h2['authorization'], undefined);
+});
+
+test('rewriteBody returns the same buffer instance when nothing applies', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-x', hi: 1 }));
+  assert.equal(anthropic.rewriteBody(body, { type: 'oauth' }), body);
+});
+
+test('rewriteBody remaps the model when the account has a modelMap', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-x' }));
+  const out = anthropic.rewriteBody(body, { modelMap: { 'claude-x': 'glm-4' } });
+  assert.notEqual(out, body);
+  assert.equal(JSON.parse(out).model, 'glm-4');
+});
+
+test('rateLimitHeaders keeps only anthropic-ratelimit-* headers', () => {
+  const headers = new Map([
+    ['anthropic-ratelimit-unified-5h-status', 'allowed'],
+    ['content-type', 'application/json'],
+    ['anthropic-ratelimit-unified-7d-status', 'rejected'],
+  ]);
+  const out = anthropic.rateLimitHeaders(headers);
+  assert.deepEqual(out, {
+    'anthropic-ratelimit-unified-5h-status': 'allowed',
+    'anthropic-ratelimit-unified-7d-status': 'rejected',
+  });
+});
+
+test('classify429 distinguishes general vs model-scoped exhaustion', () => {
+  assert.deepEqual(
+    anthropic.classify429({ 'anthropic-ratelimit-unified-5h-status': 'rejected' }),
+    { quotaExhausted: true, modelScoped: false });
+  assert.deepEqual(
+    anthropic.classify429({ 'anthropic-ratelimit-unified-7d_oi-status': 'rejected' }),
+    { quotaExhausted: true, modelScoped: true });
+  assert.deepEqual(
+    anthropic.classify429({ 'anthropic-ratelimit-unified-5h-status': 'allowed' }),
+    { quotaExhausted: false, modelScoped: false });
+});
+
+test('parseUsageEvent / parseUsageBody extract token deltas', () => {
+  assert.deepEqual(anthropic.parseUsageEvent({ type: 'message_start', message: { usage: { input_tokens: 10 } } }), { input: 10, output: 0 });
+  assert.deepEqual(anthropic.parseUsageEvent({ type: 'message_delta', usage: { output_tokens: 5 } }), { input: 0, output: 5 });
+  assert.equal(anthropic.parseUsageEvent({ type: 'ping' }), null);
+  assert.deepEqual(anthropic.parseUsageBody({ usage: { input_tokens: 3, output_tokens: 7 } }), { input: 3, output: 7 });
+  assert.equal(anthropic.parseUsageBody({ ok: true }), null);
+});


### PR DESCRIPTION
**Draft — in progress.** Foundational work to let teamclaude proxy **both** Claude and OpenAI/Codex from one instance, routing each request to its own account pool by host (MITM). This PR is **Phase 0**: the provider abstraction + account router, with zero behavior change. Codex login + relay + quota land in follow-up PRs.

### Design (agreed)
- **One proxy, both providers** — MITM intercepts `api.anthropic.com` → Claude pool and `chatgpt.com` → Codex pool (`ab.chatgpt.com` blind-tunneled).
- **Two `AccountManager`s behind a router** — each pool rotates independently; `AccountRouter` presents a flattened facade to TUI/persistence/prober/warmer and hands the request path the pool for the request's host.
- **Codex = single pool** metered by the account-wide `x-codex-primary/secondary-*` windows (no per-model buckets).
- **Codex auth**: real OpenAI OAuth (`auth.openai.com`, client_id `app_EMoamEEZ73f0CkXaXp7hrann`, PKCE) + `Authorization: Bearer` / `ChatGPT-Account-ID` injection. (All endpoints/headers verified against the open-source `openai/codex` repo.)

### Phase 0 checklist — ✅ complete
- [x] **0a — provider seam.** `src/providers/{index,anthropic}.js` as the single source of truth for Anthropic host/OAuth constants; replaced ~15 scattered literals; added `providerForHost`/`providerById` + tests.
- [x] **0b — behavioral hooks.** Anthropic request logic extracted out of `forwardRequest` into provider methods (`injectAuth`, `rewriteBody`, `rateLimitHeaders`, `classify429`, usage parsing), carried on `ctx.provider`. MITM `hostMode` rewrites any known provider host.
- [x] **0c — account router.** `src/account-router.js` (one `AccountManager` per provider) wired through startup + the request path (pool resolved by host, duck-typed for tests). Anthropic-only config → one pool → byte-identical.

**Behavior-preserving throughout.** 260 tests pass (baseline 243 + 17 new), lint clean. Verified at runtime: status endpoint, account selection, TUI render, and clean shutdown all work with the router.

### Next (separate PRs)
- **Phase 1** — `src/providers/openai.js`: OpenAI OAuth login, token refresh, `chatgpt.com` host registration + `ab.chatgpt.com` tunnel, Bearer/`ChatGPT-Account-ID` injection, rotate-on-429 replay. One Codex account proxying end-to-end.
- **Phase 2** — Codex quota-aware rotation from `x-codex-*` response headers; mixed-pool TUI/status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)