### PR TITLE
Serialize atomicConfigUpdate to prevent concurrent token-refresh loss

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -79,14 +79,30 @@ export async function saveConfig(config) {
   await chmod(path, 0o600).catch(() => {});
 }
 
+// Serialize config updates. atomicConfigUpdate is a read-modify-write, so two
+// concurrent callers can both read the same config and then save in turn, and
+// the later save silently drops the earlier caller's change. This bites hardest
+// on startup, when several OAuth accounts refresh their tokens at once: only the
+// last writer's rotated refresh token persists, and the other accounts keep a
+// token that was just rotated away, so they fail on the next restart with
+// invalid_grant and need a re-login. Chaining the updates keeps every write.
+let configUpdateChain = Promise.resolve();
+
 /**
  * Atomically update the config: re-reads from disk, calls updater(config),
  * then saves. Returns the updated config. This prevents overwriting changes
- * made by other processes (e.g. `teamclaude import` while the server runs).
+ * made by other processes (e.g. `teamclaude import` while the server runs), and
+ * serializes concurrent callers so simultaneous updates queue instead of
+ * clobbering one another.
  */
-export async function atomicConfigUpdate(updater) {
-  const config = await loadConfig() || createDefaultConfig();
-  await updater(config);
-  await saveConfig(config);
-  return config;
+export function atomicConfigUpdate(updater) {
+  const run = async () => {
+    const config = await loadConfig() || createDefaultConfig();
+    await updater(config);
+    await saveConfig(config);
+    return config;
+  };
+  const result = configUpdateChain.then(run, run);
+  configUpdateChain = result.then(() => {}, () => {});
+  return result;
 }


### PR DESCRIPTION
## Problem

`atomicConfigUpdate` re-reads the config, applies the updater, and writes it back, but nothing serializes concurrent callers. When several updates run at once they each read the same on-disk config and then save in turn, so the last writer silently drops the others' changes.

This bites hardest on startup. When more than one OAuth account refreshes its access token at the same time, each refresh calls `atomicConfigUpdate` to persist its new (rotated) refresh token. They race, only the last one's tokens land on disk, and the other accounts keep the refresh tokens that were just rotated away. On the next restart those stale tokens are rejected with `invalid_grant` and the accounts drop out until you `teamclaude login` again.

I hit this with three Max accounts: after a restart, two of them were locked out even though nothing was actually wrong with the accounts.

## Fix

Chain `atomicConfigUpdate` calls through a module-level promise so they run one at a time. Each update still re-reads the latest config before writing, so concurrent updates now queue instead of clobbering each other, and a failed update doesn't block the ones behind it.

No API change: the function still returns a promise of the updated config and callers still `await` it.

## Notes

- Only touches `src/config.js`; `node --check` passes.
- The serialization is process-local (a single proxy owns the file), which matches how the tokens are refreshed today.