### PR TITLE
fix: mark the single account each secondary quota (Fable/Sonnet) routes to

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -265,6 +265,30 @@ export class AccountManager {
     return account;
   }
 
+  /**
+   * Read-only: the index of the account a request for `model` would be served by
+   * right now — the same decision getActiveAccount makes (manual pin → the global
+   * current account if it can serve the model → best-available), but WITHOUT
+   * mutating currentIndex and without the exhausted-fleet probe fallback. Returns
+   * null when nothing can serve `model` at the moment. The TUI uses this to mark
+   * the single account each secondary bucket (Fable/Sonnet) currently routes to —
+   * the F7/S7 analogue of the ► that marks the default route's current account.
+   */
+  previewRouteIndex(model) {
+    const pinned = this._pinnedAccountForModel(model);
+    if (pinned && this._isAvailable(pinned, model)) return pinned.index;
+    const current = this.accounts[this.currentIndex];
+    if (current && this._isAvailable(current, model)) {
+      // Mirror getActiveAccount's priority preemption: a strictly higher-priority
+      // available account wins over a healthy current one; same tier stays put.
+      const better = this.accounts.some(a =>
+        this._isAvailable(a, model) && (a.priority || 0) < (current.priority || 0));
+      if (!better) return current.index;
+    }
+    const best = this._pickBestAvailable(null, model);
+    return best ? best.index : null;
+  }
+
   _isProbeable(account) {
     if (!account) return false;
     // Never probe an account the operator has taken out of rotation or one

--- a/src/tui.js
+++ b/src/tui.js
@@ -759,8 +759,17 @@ export class TUI {
       // column each at the row start so the marker's position identifies the route.
       const routes = this.am.getRoutes();
       const genRoutes = routes.filter(r => routeFamily(r) === null);
+      // The single account each secondary bucket currently routes to (null = none
+      // can serve it right now). Marked next to that account's F7/S7 bar — the
+      // secondary-quota analogue of ► marking the default route's current account.
+      const anyFable = this.am.accounts.some(a => a.quota.unified7dFable != null);
+      const anySonnet = this.am.accounts.some(a => a.quota.unified7dSonnet != null);
+      const familyTarget = {
+        fable: anyFable ? this.am.previewRouteIndex('claude-fable-5') : null,
+        sonnet: anySonnet ? this.am.previewRouteIndex('claude-sonnet-4-6') : null,
+      };
       for (let i = 0; i < this.am.accounts.length; i++) {
-        lines.push(this._renderAcct(i, bw, showBoth, routes, genRoutes));
+        lines.push(this._renderAcct(i, bw, showBoth, routes, genRoutes, familyTarget));
       }
     }
 
@@ -810,7 +819,7 @@ export class TUI {
     process.stdout.write(buf);
   }
 
-  _renderAcct(idx, bw, showBoth, routes = this.am.getRoutes(), genRoutes = routes.filter(r => routeFamily(r) === null)) {
+  _renderAcct(idx, bw, showBoth, routes = this.am.getRoutes(), genRoutes = routes.filter(r => routeFamily(r) === null), familyTarget = {}) {
     const a = this.am.accounts[idx];
     const isCur = idx === this.am.currentIndex;
     const isSel = this.mode === 'select' && idx === this.selIdx;
@@ -830,12 +839,17 @@ export class TUI {
     });
     const startSlot = genRoutes.length ? `${startCells.join('')} ` : '';
 
-    // Family-route markers for this account's F7/S7 bars.
+    // Family (Fable/Sonnet) marker for this account's F7/S7 bar: a single ► on the
+    // one account that bucket currently routes to — the secondary-quota analogue of
+    // the default route's ►, not one marker per eligible account. Every account
+    // meters the bucket, so "membership" is meaningless here; only the live routing
+    // target matters. Bold when that target is the route's manual pin; the route's
+    // configured color is honored, else cyan.
     const familyMark = (fam) => {
-      const r = routes.find(x => routeFamily(x) === fam && memberOf(x));
-      if (!r) return ' ';
-      const m = memberOf(r);
-      return routeGlyph(routeColorFn(r.color), m.eligible, r.pinned === a.name);
+      if (familyTarget[fam] !== idx) return ' ';
+      const r = routes.find(x => routeFamily(x) === fam);
+      const pinned = r ? r.pinned === a.name : false;
+      return routeGlyph(routeColorFn(r?.color), true, pinned);
     };
 
     // Name (bold if selected)

--- a/test/per-model-routing.test.js
+++ b/test/per-model-routing.test.js
@@ -166,6 +166,54 @@ test('routes with no account list fall back to the legacy per-account models cla
   assert.equal(am._isAvailable(am.accounts[1], FABLE), true, 'b owns Fable');
 });
 
+// ── read-only route preview (drives the single F7/S7 marker) ──
+
+test('previewRouteIndex names the ONE account a model routes to, matching getActiveAccount', () => {
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  const future = Date.now() + 3600_000;
+  for (const acc of am.accounts) {
+    acc.quota.unified5h = 0.1; acc.quota.unified5hReset = future;
+    acc.quota.unified7d = 0.1; acc.quota.unified7dReset = future;
+    acc.quota.unified7dFable = 0.2; acc.quota.unified7dFableReset = future; // all meter Fable
+  }
+  // Every account is Fable-eligible, yet the marker must resolve to exactly one.
+  const target = am.previewRouteIndex(FABLE);
+  assert.equal(typeof target, 'number');
+  assert.equal(am.accounts[target].name, am.getActiveAccount(null, FABLE).name,
+    'preview matches the account a real request would be served by');
+});
+
+test('previewRouteIndex is read-only — it never moves currentIndex', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const future = Date.now() + 3600_000;
+  // a is Fable-spent, so a Fable request routes to b — but previewing it must not
+  // shift the global current account away from a (that thrash is the bug we fix).
+  am.accounts[0].quota.unified5h = 0.1; am.accounts[0].quota.unified7d = 0.1;
+  am.accounts[0].quota.unified7dFable = 1.0; am.accounts[0].quota.unified7dFableReset = future;
+  am.accounts[1].quota.unified5h = 0.1; am.accounts[1].quota.unified7d = 0.1;
+  am.accounts[1].quota.unified7dFable = 0.2; am.accounts[1].quota.unified7dFableReset = future;
+  assert.equal(am.currentIndex, 0);
+  assert.equal(am.accounts[am.previewRouteIndex(FABLE)].name, 'b'); // Fable falls to b
+  assert.equal(am.currentIndex, 0, 'currentIndex unchanged by the preview');
+});
+
+test('previewRouteIndex honors a pin, and falls back when the pin is ineligible', () => {
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  const future = Date.now() + 3600_000;
+  for (const acc of am.accounts) { acc.quota.unified7dFable = 0.2; acc.quota.unified7dFableReset = future; }
+  am.setRoutePin('fable', 2);                                   // pin c
+  assert.equal(am.accounts[am.previewRouteIndex(FABLE)].name, 'c');
+  am.accounts[2].quota.unified7dFable = 1.0;                    // c's Fable now spent
+  assert.notEqual(am.accounts[am.previewRouteIndex(FABLE)].name, 'c', 'pin ineligible → fallback');
+});
+
+test('previewRouteIndex returns null when no account can serve the model', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.accounts[0].quota.unified5h = 0.999;                       // shared 5h spent → nothing routes
+  am.accounts[0].quota.unified5hReset = Date.now() + 3600_000;
+  assert.equal(am.previewRouteIndex(FABLE), null);
+});
+
 test('setRoutes normalizes shapes and is re-appliable on reload', () => {
   const am = new AccountManager([oauth('a')], 0.98);
   assert.deepEqual(am.routes, []);

--- a/test/tui-routes.test.js
+++ b/test/tui-routes.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { TUI } from '../src/tui.js';
+import { AccountManager } from '../src/account-manager.js';
+
+const stripAnsi = s => s.replace(/\x1b\[[0-9;]*m/g, '');
 
 // Minimal AccountManager stand-in for the routes editor: it only needs the
 // surface the editor touches (accounts, setRoutes). render() is stubbed out so
@@ -146,6 +149,32 @@ test('TUI switch mode: Tab is inert for remove/toggle actions', () => {
   tui._key('r');                       // remove action
   tui._key('tab');
   assert.equal(tui.selRoute, null);    // unchanged — Tab only cycles in switch mode
+});
+
+test('TUI: the F7 (Fable) marker sits on exactly one account — the routing target', () => {
+  const future = Date.now() + 7 * 24 * 3600_000;
+  const oauth = n => ({ name: n, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: future });
+  const am = new AccountManager([oauth('a'), oauth('b'), oauth('c')], 0.98);
+  for (const acc of am.accounts) {
+    acc.quota.unified5h = 0.1; acc.quota.unified5hReset = future;
+    acc.quota.unified7d = 0.1; acc.quota.unified7dReset = future;
+    acc.quota.unified7dFable = 0.2; acc.quota.unified7dFableReset = future; // all meter Fable → F7 bar shows
+  }
+  // a's Fable weekly is spent → Fable routes elsewhere, but a stays the default current.
+  am.accounts[0].quota.unified7dFable = 1.0;
+
+  const tui = Object.create(TUI.prototype);
+  tui.am = am; tui.mode = 'normal'; tui.selIdx = -1;
+  const routes = am.getRoutes();
+  const familyTarget = { fable: am.previewRouteIndex('claude-fable-5'), sonnet: null };
+
+  const rows = am.accounts.map((_, i) =>
+    stripAnsi(tui._renderAcct(i, 8, true, routes, [], familyTarget)));
+  const marked = rows.filter(r => /►\s*F7/.test(r));
+  assert.equal(marked.length, 1, 'exactly one F7 marker across all accounts');
+  // ...and it is NOT the Fable-spent account a (which instead shows the ⊘ tag).
+  assert.ok(!/►\s*F7/.test(rows[0]), 'the Fable-spent account carries no F7 marker');
+  assert.match(rows[0], /⊘ Fable/, 'the Fable-spent account is tagged blocked');
 });
 
 test('TUI routes editor: delete removes the selected route', async () => {


### PR DESCRIPTION
## Problem

The inline routing markers added in #94 drew a `►` next to the **F7/S7** bar on *every* account that was a "member" of the Fable/Sonnet route — i.e. every account eligible to serve that model. Since every Max account meters its own Fable/Sonnet weekly bucket, they're all eligible, so the marker showed up on **every row** and no longer told you where requests actually go.

The "family / member list" framing is the wrong abstraction for a secondary quota: it's present on every account, so "membership" is meaningless. At any instant a Fable (or Sonnet) request routes to exactly **one** account — the F7/S7 analogue of the green `►` that marks the single default-route account.

## Fix

- **`AccountManager.previewRouteIndex(model)`** — a read-only resolver that mirrors `getActiveAccount`'s real decision (manual pin → global current if it can serve the model → best-available), but **without mutating `currentIndex`** and without the exhausted-fleet probe fallback. Returns the one account index that serves `model` right now, or `null` if none can.
- **TUI** resolves the Fable/Sonnet target once per render and marks that single account (bold when it's the route's manual pin, route color else cyan). No marker when nothing can serve the model — the existing `⊘ Fable/Sonnet` tag already conveys that.

Behaviorally the routing itself is unchanged; this only corrects what the TUI displays.

### Before / after

With three accounts all metering Fable and account `A`'s Fable bucket spent:

```
► A-pref   oauth  active  Ses .. Wk .. F7 ..   ⊘ Fable
  B        oauth  active  Ses .. Wk .. ►F7 ..
  C        oauth  active  Ses .. Wk .. F7 ..
```

One green `►` on the default-route account (A), one `►` on the single Fable target (B). Previously B **and** C both carried an F7 arrow.

## Tests

- `previewRouteIndex`: matches what `getActiveAccount` actually serves; never moves `currentIndex`; honors a pin and falls back when the pin is ineligible; returns `null` when nothing can serve the model.
- A TUI render test asserts exactly one `F7` marker across accounts, and that the Fable-spent account carries `⊘ Fable` instead.

248 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)