### PR TITLE
feat(tui): on-demand quota refresh (p) + account management in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Model-aware routing** — the per-model weekly cap (e.g. Fable) is tracked separately, so an account whose Fable quota is spent is skipped **only** for Fable requests and still serves Opus/Sonnet. Requests are routed by their `model` (read exactly from the request body, in both base-URL and MITM modes). Optional **[model routes](#model-routes)** pin model patterns to a specific set of accounts (config, `teamclaude route`, or the TUI settings screen → Manage routing)
 - **Auto-retry on 429** — distinguishes the two kinds of 429: a **quota rejection** (a spent 5h/weekly bucket, `unified-…-status: rejected`) switches accounts immediately; a **rate-limit 429** (the per-minute throttle) does **not** switch — it [pauses the account](#storm-control-switchover-ramp-up) so concurrent requests wait instead of flooding, retries the same account (absorbing short `retry-after`s inline), and only surfaces a 429 to the client for longer waits. Rotating on a rate-limit 429 would just move the burst to the next account and throw away the first account's cache
 - **Storm control** — when many agents fail over to a fresh account at once, requests are [paced onto it](#storm-control-switchover-ramp-up) with a short ramp-up so the herd doesn't instantly throttle it and cascade down the fleet
-- **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, and sx.org proxy live
+- **Interactive TUI** — real-time dashboard with color-coded quota bars, reset countdowns, activity log, and keyboard controls; a settings screen (`g`) edits the rotation threshold, quota-probe interval, routing, accounts (add/remove), and sx.org proxy live, and `p` refreshes every account's quota on demand
 - **OAuth token management** — automatically refreshes tokens nearing expiry and persists them to config; client token refreshes pass through untouched
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
@@ -127,13 +127,13 @@ You usually don't need to call it directly: `teamclaude login`, `import`, `enabl
 | Key | Action |
 |-----|--------|
 | `s` | Switch active account |
-| `a` | Add account (import or API key) |
-| `r` | Remove an account |
 | `d` | Enable/disable an account |
+| `p` | Refresh quota on all accounts (one-shot probe of the zero-spend usage endpoint) |
 | `R` | Reload accounts from config |
+| `g` | Settings (threshold, quota probe, routing, **add/remove accounts**, sx.org) |
 | `q` | Quit |
 
-In selection mode, use `j`/`k` or arrow keys to navigate, `Enter` to confirm, `Esc` to cancel.
+In selection mode, use `j`/`k` or arrow keys to navigate, `Enter` to confirm, `Esc` to cancel. Adding and removing accounts lives on the settings screen: `g` → **Add account** (import from Claude Code or paste an API key) / **Remove account**.
 
 ### Run Claude Code through the proxy
 

--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,9 @@ async function serverCommand() {
         if (config.routes != null) diskConfig.routes = config.routes;
       }),
       syncAccounts: reloadAccounts,
+      // `p` key: on-demand fleet-wide quota refresh. The prober is constructed
+      // after the TUI, so this is a thunk over the closure variable.
+      probeQuota: () => prober?.probeAll(),
       // ctrl-c / q from the TUI: funnel through the same idempotent shutdown as
       // POSIX signals (defined below). In raw mode ctrl-c never reaches the OS as
       // a signal, so without this the process would only tear down via keypress.

--- a/src/tui.js
+++ b/src/tui.js
@@ -154,7 +154,7 @@ function timestamp() {
 // ── TUI class ────────────────────────────────────────────────
 
 export class TUI {
-  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null }) {
+  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null }) {
     this.am = accountManager;
     this.config = config;
     this.saveConfig = saveConfig;
@@ -162,6 +162,7 @@ export class TUI {
     this.onQuit = onQuit;
     this.sx = sx;            // sx.org proxy manager (may be null)
     this.sxBalance = null;   // last fetched sx.org balance, for the settings screen
+    this.probeQuota = probeQuota; // on-demand fleet-wide quota refresh (may be null)
 
     this.log = [];           // completed activity entries
     this.active = new Map(); // in-flight requests
@@ -169,6 +170,7 @@ export class TUI {
     this.selAction = null;   // switch | remove | toggle
     this.selIdx = 0;
     this.selRoute = null;    // in switch mode: null = global default, else a getRoutes() entry to pin
+    this.selReturn = 'normal'; // mode to fall back to when select mode closes
     this.setIdx = 0;         // cursor row on the settings screen (BIOS-style nav)
     this.inputPrompt = '';
     this.inputBuf = '';
@@ -283,15 +285,12 @@ export class TUI {
   _keyNormal(k) {
     if (k === 'q') { this.stop(); this.onQuit?.(); }
     else if (k === 's' && this.am.accounts.length > 0) {
-      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = this.am.currentIndex; this.selRoute = null;
-    }
-    else if (k === 'r' && this.am.accounts.length > 0) {
-      this.mode = 'select'; this.selAction = 'remove'; this.selIdx = 0;
+      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = this.am.currentIndex; this.selRoute = null; this.selReturn = 'normal';
     }
     else if (k === 'd' && this.am.accounts.length > 0) {
-      this.mode = 'select'; this.selAction = 'toggle'; this.selIdx = this.am.currentIndex;
+      this.mode = 'select'; this.selAction = 'toggle'; this.selIdx = this.am.currentIndex; this.selReturn = 'normal';
     }
-    else if (k === 'a') { this.mode = 'add'; }
+    else if (k === 'p' && this.am.accounts.length > 0) { this._doProbe(); }
     else if (k === 'R') { this._doSync(); }
     else if (k === 'g') { this.mode = 'settings'; this.setIdx = 0; this._loadSxBalance(); }
   }
@@ -339,6 +338,27 @@ export class TUI {
       },
       enter: () => { this.mode = 'routes'; this.routeIdx = 0; },
     });
+
+    fields.push({
+      id: 'addAccount',
+      label: 'Add account',
+      hint: 'Enter to open',
+      value: () => {
+        const n = this.am.accounts.length;
+        return n ? green(`${n} account${n === 1 ? '' : 's'}`) : gray('none');
+      },
+      enter: () => { this.mode = 'add'; },
+    });
+
+    if (this.am.accounts.length > 0) {
+      fields.push({
+        id: 'removeAccount',
+        label: 'Remove account',
+        hint: 'Enter to pick',
+        value: () => dim('—'),
+        enter: () => { this.mode = 'select'; this.selAction = 'remove'; this.selIdx = 0; this.selReturn = 'settings'; },
+      });
+    }
 
     if (this.sx) {
       fields.push({
@@ -468,9 +488,9 @@ export class TUI {
       } else {
         this._doRemove(this.selIdx);
       }
-      if (this.mode === 'select') this.mode = 'normal';
+      if (this.mode === 'select') this.mode = this.selReturn;
     }
-    else if (k === 'esc' || k === 'q') { this.mode = 'normal'; }
+    else if (k === 'esc' || k === 'q') { this.mode = this.selReturn; }
   }
 
   // Apply an Enter in switch mode: with no route selected this sets the global
@@ -501,16 +521,18 @@ export class TUI {
     }
   }
 
+  // The add chooser is opened from the settings screen (g → Add account), so
+  // every exit path returns there.
   _keyAdd(k) {
-    if (k === 'i') { this._doImport(); this.mode = 'normal'; }
+    if (k === 'i') { this._doImport(); this.mode = 'settings'; }
     else if (k === 'k') {
       this.mode = 'input';
-      this.inputReturn = 'normal';
+      this.inputReturn = 'settings';
       this.inputPrompt = 'API key';
       this.inputBuf = '';
       this.inputCb = v => { if (v) this._doAddKey(v); };
     }
-    else if (k === 'esc' || k === 'q') { this.mode = 'normal'; }
+    else if (k === 'esc' || k === 'q') { this.mode = 'settings'; }
   }
 
   _keyInput(k) {
@@ -526,6 +548,26 @@ export class TUI {
   }
 
   // ── account operations ─────────────────────────────
+
+  // On-demand fleet-wide quota refresh (the `p` key): probe every OAuth
+  // account's zero-spend usage endpoint once, whether or not the periodic
+  // probe is enabled. Fire-and-forget; progress lands in the activity log.
+  async _doProbe() {
+    if (!this.probeQuota) { this._addLog('Quota probe unavailable'); return; }
+    if (this._probing) return; // one refresh at a time
+    const n = this.am.accounts.filter(a => a.type === 'oauth' && a.credential).length;
+    if (n === 0) { this._addLog('No OAuth accounts to probe'); return; }
+    this._probing = true;
+    this._addLog(`Refreshing quota on ${n} account${n === 1 ? '' : 's'}...`);
+    try {
+      await this.probeQuota();
+      this._addLog('Quota refresh complete');
+    } catch (e) {
+      this._addLog(`Quota refresh failed: ${e.message}`);
+    } finally {
+      this._probing = false;
+    }
+  }
 
   async _doSync() {
     try {
@@ -738,7 +780,12 @@ export class TUI {
     // While a prompt is open (mode 'input') keep showing the screen it was
     // launched from, so e.g. adding a route stays on the routes screen rather
     // than flashing back to the main dashboard with just the footer prompt.
-    const view = this.mode === 'input' ? this.inputReturn : this.mode;
+    // The add-account chooser is a settings flow, so it keeps the settings
+    // screen behind its footer too (select-to-remove, by contrast, needs the
+    // dashboard: the account table IS the selection UI).
+    const view = this.mode === 'input' ? this.inputReturn
+      : this.mode === 'add' ? 'settings'
+      : this.mode;
     if (view === 'settings') {
       this._renderSettings(lines);
     } else if (view === 'routes') {
@@ -747,7 +794,7 @@ export class TUI {
     // ── Accounts
     if (this.am.accounts.length === 0) {
       lines.push('');
-      lines.push(yellow('  No accounts configured. Press [a] to add one.'));
+      lines.push(yellow('  No accounts configured. Press [g] → Add account.'));
     } else {
       lines.push('');
       const showBoth = W >= 70;
@@ -952,6 +999,11 @@ export class TUI {
     lines.push(bold('  Routing') + dim('  — pin model families to specific accounts'));
     lines.push(row(byId('routes')));
     lines.push('');
+    // ── Accounts
+    lines.push(bold('  Accounts') + dim('  — add (import / API key) or remove an account'));
+    lines.push(row(byId('addAccount')));
+    if (byId('removeAccount')) lines.push(row(byId('removeAccount')));
+    lines.push('');
     // ── sx.org
     lines.push(bold('  sx.org proxy') + dim('  — route upstream via a residential IP (429 workaround)'));
     lines.push('');
@@ -1100,7 +1152,7 @@ export class TUI {
   _renderFooter() {
     switch (this.mode) {
       case 'normal':
-        return ` ${bold('s')}witch  ${bold('a')}dd  ${bold('r')}emove  ${bold('d')}isable  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
+        return ` ${bold('s')}witch  ${bold('d')}isable  ${bold('p')}robe quota  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
       case 'settings':
         return ` ${dim('↑↓')} navigate  ${dim('←→')} change  ${bold('Enter')} edit  ${bold('Esc')} back`;
       case 'routes':

--- a/test/tui-accounts.test.js
+++ b/test/tui-accounts.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TUI } from '../src/tui.js';
+
+// TUI account management (settings screen) + the on-demand quota probe (`p`).
+// Same approach as tui-routes.test.js: a minimal AccountManager stand-in and a
+// stubbed render() so these exercise the state machine, not the terminal.
+
+function makeTUI({ accounts = [{ name: 'a', index: 0, type: 'oauth', credential: 't' }], probeQuota } = {}) {
+  const calls = { added: [], removed: [], probed: 0 };
+  const am = {
+    accounts,
+    currentIndex: 0,
+    switchThreshold: 0.98,
+    getRoutes() { return []; },
+    addAccount(entry) { calls.added.push(entry); this.accounts.push({ ...entry, index: this.accounts.length }); },
+    removeAccount(idx) { calls.removed.push(this.accounts[idx]?.name); this.accounts.splice(idx, 1); },
+  };
+  const config = { proxy: { port: 1 }, accounts: accounts.map(a => ({ name: a.name, type: a.type })), routes: [] };
+  const tui = new TUI({
+    accountManager: am, config, sx: null,
+    saveConfig: async () => {},
+    syncAccounts: async () => 0,
+    onQuit: () => {},
+    probeQuota: probeQuota === undefined ? (() => { calls.probed++; }) : probeQuota,
+  });
+  tui.render = () => {}; // bypass terminal rendering
+  return { tui, am, config, calls };
+}
+
+const type = (tui, s) => { for (const ch of s) tui._key(ch); };
+const settle = () => new Promise(r => setTimeout(r, 5)); // let async handlers finish
+
+// Settings rows: threshold(0), probe(1), routes(2), addAccount(3), removeAccount(4).
+function openSettingsRow(tui, row) {
+  tui._key('g');
+  for (let i = 0; i < row; i++) tui._key('down');
+  tui._key('enter');
+}
+
+test('the a/r shortcuts are gone from normal mode', () => {
+  const { tui } = makeTUI();
+  tui._key('a');
+  assert.equal(tui.mode, 'normal'); // no add chooser
+  tui._key('r');
+  assert.equal(tui.mode, 'normal'); // no remove selector
+});
+
+test('p probes quota on all accounts and logs the result', async () => {
+  const { tui, calls } = makeTUI();
+  tui._key('p');
+  await settle();
+  assert.equal(calls.probed, 1);
+  assert.equal(tui.mode, 'normal'); // fire-and-forget, no mode change
+  assert.ok(tui.log.some(l => /Refreshing quota on 1 account/.test(l.msg)));
+  assert.ok(tui.log.some(l => /Quota refresh complete/.test(l.msg)));
+});
+
+test('p reports when there is nothing to probe (no OAuth accounts)', async () => {
+  const { tui, calls } = makeTUI({ accounts: [{ name: 'k', index: 0, type: 'apikey' }] });
+  tui._key('p');
+  await settle();
+  assert.equal(calls.probed, 0);
+  assert.ok(tui.log.some(l => /No OAuth accounts to probe/.test(l.msg)));
+});
+
+test('a probe failure is logged, and a re-press probes again', async () => {
+  let n = 0;
+  const { tui } = makeTUI({ probeQuota: () => { n++; return Promise.reject(new Error('boom')); } });
+  tui._key('p');
+  await settle();
+  assert.ok(tui.log.some(l => /Quota refresh failed: boom/.test(l.msg)));
+  tui._key('p');
+  await settle();
+  assert.equal(n, 2); // the in-flight guard was released
+});
+
+test('settings → Add account → API key adds the account and returns to settings', async () => {
+  const { tui, am, config, calls } = makeTUI();
+  openSettingsRow(tui, 3);
+  assert.equal(tui.mode, 'add');
+  tui._key('k'); // API key path
+  assert.equal(tui.mode, 'input');
+  type(tui, 'sk-test');
+  tui._key('enter');
+  await settle();
+  assert.equal(tui.mode, 'settings'); // input falls back to the launching screen
+  assert.equal(calls.added.length, 1);
+  assert.equal(am.accounts.length, 2);
+  assert.equal(config.accounts.at(-1).type, 'apikey');
+});
+
+test('Esc backs out of the add chooser to settings', () => {
+  const { tui } = makeTUI();
+  openSettingsRow(tui, 3);
+  tui._key('esc');
+  assert.equal(tui.mode, 'settings');
+});
+
+test('settings → Remove account removes the picked account and returns to settings', async () => {
+  const { tui, am, config, calls } = makeTUI({
+    accounts: [
+      { name: 'a', index: 0, type: 'oauth', credential: 't' },
+      { name: 'b', index: 1, type: 'oauth', credential: 't' },
+    ],
+  });
+  openSettingsRow(tui, 4);
+  assert.equal(tui.mode, 'select');
+  assert.equal(tui.selAction, 'remove');
+  tui._key('down'); // pick "b"
+  tui._key('enter');
+  await settle();
+  assert.deepEqual(calls.removed, ['b']);
+  assert.equal(am.accounts.length, 1);
+  assert.equal(config.accounts.length, 1);
+  assert.equal(tui.mode, 'settings'); // back where the flow started
+});
+
+test('the Remove account row is absent with no accounts, and Esc from remove-select returns to settings', () => {
+  const none = makeTUI({ accounts: [] });
+  assert.ok(!none.tui._settingsFields().some(f => f.id === 'removeAccount'));
+  assert.ok(none.tui._settingsFields().some(f => f.id === 'addAccount')); // add still offered
+
+  const { tui } = makeTUI();
+  openSettingsRow(tui, 4);
+  tui._key('esc');
+  assert.equal(tui.mode, 'settings');
+});
+
+test('select mode entered from the dashboard still returns to normal', () => {
+  const { tui } = makeTUI();
+  tui._key('d'); // enable/disable selector from normal mode
+  assert.equal(tui.mode, 'select');
+  tui._key('esc');
+  assert.equal(tui.mode, 'normal');
+});


### PR DESCRIPTION
Two TUI changes:

## `p` — refresh quota on all accounts

A new dashboard shortcut triggers a one-shot `Prober.probeAll()` — the zero-spend `/api/oauth/usage` probe — on every OAuth account, whether or not the periodic quota probe is enabled. Progress/failures go to the activity log; an in-flight guard keeps a held key from stacking probes. Wired via a `probeQuota` thunk from `index.js` (the prober is constructed after the TUI).

## Account management moves into settings

The `a`dd / `r`emove dashboard shortcuts are removed. The settings screen (`g`) gains an **Accounts** section:

- **Add account** — opens the existing chooser (import from Claude Code / paste an API key); the settings screen stays visible behind the chooser footer.
- **Remove account** — opens the account picker (the dashboard table is the selection UI). Hidden when no accounts are configured.

All flows return to the settings screen; `s`/`d` entered from the dashboard still return to the dashboard (new `selReturn` state). Footer and the no-accounts empty state now point at `g`.

## Docs & tests

README shortcut table and feature bullets updated. 257 tests pass (248 baseline + 9 new `tui-accounts` state-machine tests: shortcut removal, probe logging/failure/no-op paths, add/remove flows and their return modes). Existing `tui-routes` tests are unaffected (settings row order preserved above the new section). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)