### PR TITLE
Bump to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch release: #99 (advisor-model routing, fixes #98) and #100 (TUI on-demand quota refresh + account management in settings).

Merging this triggers publish.yml: npm publish (Trusted Publishing), git tag v1.1.7, and the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)