### PR TITLE
feat(run): require a live proxy by default; --auto-fallback for direct launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,11 @@ In selection mode, use `j`/`k` or arrow keys to navigate, `Enter` to confirm, `E
 teamclaude run
 ```
 
-`run` probes the proxy first: if it's up, Claude Code is routed through it; if it's **not** running, `claude` is launched directly so nothing breaks.
+`run` probes the proxy first: if it's up, Claude Code is routed through it; if it's **not** running, `run` errors out rather than silently bypassing the proxy (which would spend your own quota with no rotation). Pass `--auto-fallback` to launch `claude` directly when the proxy is down instead:
+
+```bash
+teamclaude run --auto-fallback
+```
 
 Since **1.1.0**, `run` defaults to [MITM forward-proxy mode](#mitm-proxy-mode-default) so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) are intercepted. To keep the previous base-URL-only behavior, pass `--no-mitm`:
 
@@ -158,7 +162,7 @@ claude
 
 ### Routing plain `claude` automatically (alias)
 
-So you don't have to type `teamclaude run` every time, add a shell alias that makes plain `claude` go through the proxy (and fall back to direct when it's down):
+So you don't have to type `teamclaude run` every time, add a shell alias that makes plain `claude` go through the proxy (it errors if the proxy is down rather than silently bypassing it — add `--auto-fallback` to launch claude directly instead):
 
 ```bash
 teamclaude alias              # print the alias for your shell

--- a/src/alias.js
+++ b/src/alias.js
@@ -1,8 +1,9 @@
 // `claude` shell alias — print or install/uninstall.
 //
-// The alias simply routes plain `claude` through `teamclaude run`, which itself
-// probes the proxy and falls back to launching claude directly when it's down.
-// So the alias stays a dumb passthrough and all the smarts live in `run`.
+// The alias simply routes plain `claude` through `teamclaude run`, which probes
+// the proxy and, when it's down, errors out rather than silently bypassing the
+// proxy. All the smarts live in `run`; add `--auto-fallback` to the alias if you
+// want plain `claude` to launch directly when the proxy is down instead.
 //
 // This only affects interactive shells (aliases aren't seen by editors/scripts
 // that exec `claude` themselves). It's intentionally lighter than a PATH shim:
@@ -65,7 +66,8 @@ export function rcPathForShell(shell = detectShell()) {
 
 export function printAlias({ shell = detectShell() } = {}) {
   const line = aliasLine(shell);
-  console.log('# Route plain `claude` through the proxy (when it is running; direct otherwise).');
+  console.log('# Route plain `claude` through the proxy (errors if the proxy is down;');
+  console.log('# append --auto-fallback before `--` to launch claude directly instead).');
   console.log('# Add this to your shell config:');
   console.log('');
   console.log(`  ${line}`);

--- a/src/index.js
+++ b/src/index.js
@@ -561,13 +561,15 @@ async function runCommand() {
   const sep = rest.indexOf('--');
   const tcFlags = sep >= 0 ? rest.slice(0, sep) : rest;
   const useMitm = !tcFlags.includes('--no-mitm');
+  const autoFallback = tcFlags.includes('--auto-fallback');
   const claudeArgs = sep >= 0
     ? rest.slice(sep + 1)
-    : rest.filter(a => a !== '--mitm' && a !== '--no-mitm');
+    : rest.filter(a => a !== '--mitm' && a !== '--no-mitm' && a !== '--auto-fallback');
 
-  // Route through the proxy only when it's actually up; otherwise launch claude
-  // directly so a stopped proxy doesn't break `claude`. This is what lets the
-  // shell alias (`claude='teamclaude run --'`) be a dumb passthrough.
+  // Route through the proxy when it's up. When it's down we refuse by default —
+  // silently launching claude directly hides that requests are bypassing the
+  // proxy (no rotation, spending the user's own quota). Pass --auto-fallback to
+  // opt back into the transparent direct launch (e.g. for a dumb shell alias).
   const port = config.proxy.port;
   const env = { ...process.env };
   if (await isProxyUp(port)) {
@@ -588,8 +590,13 @@ async function runCommand() {
       // lets Claude Code stay in subscription mode (full model access).
       env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
     }
+  } else if (autoFallback) {
+    console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (--auto-fallback; start it with: teamclaude server)`);
   } else {
-    console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (start it with: teamclaude server)`);
+    console.error(`[TeamClaude] Proxy not running on port ${port}.`);
+    console.error('Start it with: teamclaude server');
+    console.error('Or pass --auto-fallback to launch claude directly (bypassing the proxy) when it is down.');
+    process.exit(1);
   }
 
   // Use spawnSync so the Node process blocks entirely — behaves like execvp.
@@ -1137,8 +1144,9 @@ Commands:
   login               OAuth login via browser
   login --api         Add an API key account
   env                 Print env vars to use with Claude
-  run [--no-mitm] [-- args...]
-                      Run Claude Code through the proxy (direct if it's down).
+  run [--no-mitm] [--auto-fallback] [-- args...]
+                      Run Claude Code through the proxy (errors if it's down,
+                      unless --auto-fallback launches claude directly instead).
                       Routes via an HTTPS forward proxy + local CA by default, so
                       even hardcoded api.anthropic.com endpoints are intercepted;
                       --no-mitm uses base-URL routing only
@@ -1172,6 +1180,8 @@ Options:
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)
   --headless          Run the server without the interactive TUI (for backgrounding)
   --no-mitm           (run) skip the forward proxy; route via ANTHROPIC_BASE_URL only
+  --auto-fallback     (run) if the proxy is down, launch claude directly instead
+                      of erroring out (bypasses the proxy: no rotation)
 
 The server always accepts both base-URL and proxy/CONNECT clients, so instances
 launched with and without --no-mitm can share one server.


### PR DESCRIPTION
## Summary

`teamclaude run` (and the plain `claude` shell alias) previously **silently** launched `claude` directly when the proxy was down. That transparent fallback hides that requests are bypassing the proxy entirely — no account rotation, spending the user's own quota against Anthropic.

This makes the fallback **opt-in**:

- **Default:** when the proxy is down, `run` prints an error and exits `1` (does not launch claude):
  ```
  [TeamClaude] Proxy not running on port 3000.
  Start it with: teamclaude server
  Or pass --auto-fallback to launch claude directly (bypassing the proxy) when it is down.
  ```
- **`--auto-fallback`:** restores the old behavior — warns and launches `claude` directly when the proxy is down.

The flag is parsed alongside `--no-mitm` and stripped before args are forwarded to `claude`.

## Changes

- `src/index.js` — `runCommand`: add `--auto-fallback`; error+exit 1 when the proxy is down unless the flag is set. Documented in `showHelp`.
- `src/alias.js` — updated the header comment and printed alias instructions. The installed alias stays `teamclaude run --` (errors by default); users can add `--auto-fallback` if they want passthrough.
- `README.md` — updated the `run` and alias sections; added an `--auto-fallback` example.

## Behavior change note

Existing alias users: after updating, plain `claude` will error when the proxy is down until they start the server (or add `--auto-fallback` to the alias).

## Testing

- `npm run lint` clean
- `npm test` — 266/266 pass
- Manually verified against a config pointing at a dead port: default errors with exit 1; `--auto-fallback` launches claude directly (exit 0), with the flag correctly stripped from claude's args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)