### PR TITLE
fix(mitm): return 502/504 on CONNECT failures instead of a silent drop

### DIFF
--- a/src/mitm.js
+++ b/src/mitm.js
@@ -158,17 +158,39 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     const mode = hostMode(host, config);
 
     if (mode === 'tunnel') {
+      // Until the upstream connects we still owe the client a CONNECT status
+      // line. If we tore the socket down on an upstream failure without one,
+      // the client reports "Proxy connection ended before receiving CONNECT
+      // response" — so before the tunnel is live, surface failures as a real
+      // proxy error status instead of a silent drop.
+      let established = false, closed = false;
+      // Tear down BOTH sockets when either errors or closes, so a one-sided
+      // failure can't leave the paired socket lingering (FD leak). The `closed`
+      // guard makes it idempotent (error+close both fire) and ensures we write
+      // at most one status line.
+      const teardown = (statusLine) => {
+        if (closed) return;
+        closed = true;
+        if (!established && statusLine) {
+          try { clientSocket.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`); } catch { /* client already gone */ }
+        }
+        up.destroy(); clientSocket.destroy();
+      };
       const up = net.connect(port, host, () => {
+        established = true;
         reply200Raw(clientSocket);
         if (head && head.length) up.write(head);
         up.pipe(clientSocket); clientSocket.pipe(up);
       });
-      // Tear down BOTH sockets when either errors or closes, so a one-sided
-      // failure can't leave the paired socket lingering (FD leak).
-      const teardown = () => { up.destroy(); clientSocket.destroy(); };
-      up.on('error', teardown); up.on('close', teardown);
-      clientSocket.on('close', teardown);
-      up.setTimeout(30_000, teardown); // bound a stalled connect/idle tunnel
+      up.on('error', (err) => {
+        if (!established) log(`[TeamClaude] tunnel ${host}:${port} failed: ${err.message}`);
+        teardown('502 Bad Gateway');
+      });
+      // A FIN before the tunnel is live (no preceding 'error') is still a failed
+      // dial from the client's view — surface a 502 rather than a silent drop.
+      up.on('close', () => teardown('502 Bad Gateway'));
+      clientSocket.on('close', () => teardown()); // client gone: nothing to write
+      up.setTimeout(30_000, () => teardown('504 Gateway Timeout')); // bound a stalled connect/idle tunnel
       return;
     }
 
@@ -177,18 +199,21 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
       ensureLeaf().then(({ key, cert }) => {
         reply200Raw(clientSocket);
         serveTest(termClaude(clientSocket, head, key, cert, ['http/1.1']));
-      }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
+      }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); reply502Raw(clientSocket); clientSocket.destroy(); });
       return;
     }
 
     // rewrite: terminate the tunnel and forward each request with buffering +
     // retry. Reply 200, hand the raw socket (ClientHello and all) to the h2/h1
-    // server, which does TLS + protocol negotiation itself.
+    // server, which does TLS + protocol negotiation itself. If the terminating
+    // server can't be minted (cert/disk/TLS-init failure) we haven't replied yet
+    // — send a 502 so the client sees a real proxy error instead of "Proxy
+    // connection ended before receiving CONNECT response".
     getServer().then((srv) => {
       reply200Raw(clientSocket);
       if (head && head.length) clientSocket.unshift(head);
       srv.emit('connection', clientSocket);
-    }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); clientSocket.destroy(); });
+    }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); reply502Raw(clientSocket); clientSocket.destroy(); });
   };
 }
 
@@ -213,6 +238,7 @@ export function connectAuthorized(req, socket, proxyApiKey) {
 }
 
 function reply200Raw(sock) { sock.write('HTTP/1.1 200 Connection Established\r\n\r\n'); }
+function reply502Raw(sock) { try { sock.write('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n'); } catch { /* client already gone */ } }
 
 function termClaude(clientSocket, head, key, cert, alpn) {
   if (head && head.length) clientSocket.unshift(head);

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -289,3 +289,33 @@ test('MITM logs proxied requests when a log dir is set', T, async () => {
     rmSync(logDir, { recursive: true, force: true });
   }
 });
+
+// Regression: a tunnel-mode CONNECT whose upstream connect FAILS must return a
+// proper proxy error status line, not a silent socket drop. Dropping it made
+// the client report "Proxy connection ended before receiving CONNECT response".
+test('tunnel: upstream connect failure returns 502, not a silent drop', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  // Grab a port, then free it so a connect there is refused deterministically.
+  const dead = http.createServer();
+  const deadPort = await listen(dead);
+  await new Promise((r) => dead.close(r));
+
+  // config.upstream host is 127.0.0.1, so `CONNECT localhost:<port>` is tunnel mode.
+  const am = new AccountManager([oauthAccount('acct@x', 'T')], 0.98);
+  const proxy = makeProxy(am, 65500, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const status = await new Promise((resolve, reject) => {
+      const raw = net.connect(proxyPort, '127.0.0.1');
+      raw.once('error', reject);
+      raw.once('connect', () => raw.write(`CONNECT localhost:${deadPort} HTTP/1.1\r\nHost: localhost:${deadPort}\r\n\r\n`));
+      let buf = '';
+      raw.on('data', (d) => { buf += d.toString('latin1'); if (buf.includes('\r\n\r\n')) resolve(buf.split('\r\n')[0]); });
+      raw.on('close', () => { if (!buf) reject(new Error('socket closed with no CONNECT response')); });
+    });
+    assert.match(status, /^HTTP\/1\.1 502/, `expected a 502 status line, got: ${status}`);
+  } finally {
+    closeHard(proxy);
+  }
+});


### PR DESCRIPTION
## Problem

Claude Code (and other clients) intermittently saw:

```
Proxy connection ended before receiving CONNECT response
```

when fetching non-Anthropic hosts (e.g. `https://docs.dflow.net`) through the MITM proxy.

## Root cause

Those hosts take the blind-**tunnel** branch in `src/mitm.js`. The `HTTP/1.1 200 Connection Established` status line was written **only inside** the `net.connect` success callback. On any upstream connect failure — DNS blip, connection refused, reset, or the 30 s connect/idle timeout — `teardown` destroyed the client socket **without ever writing a status line**, so the client reported a silent drop instead of a retryable proxy error. It's not corruption — it's transient upstream reachability being mis-surfaced.

## Fix

Always return a real proxy status line before the tunnel is live:

- **tunnel**: `502 Bad Gateway` on connect error or a FIN-before-connect; `504 Gateway Timeout` on the 30 s timeout. A `closed` guard makes teardown idempotent (error+close both fire) so at most one status line is written; the FD-leak-safe dual-destroy is preserved.
- **rewrite** (`api.anthropic.com`): `502` before destroy if the terminating TLS server can't be minted (cert/disk/TLS-init failure) — the equivalent silent-drop edge for the Anthropic host itself.
- **test** host: same `502`-before-destroy treatment.
- Added a `[TeamClaude] tunnel <host>:<port> failed: <msg>` log line so intermittent egress failures are diagnosable instead of invisible.

This makes failures legible and retryable; it does not itself make an unreachable host reachable — the new log line shows whether it's DNS or network egress from the proxy host.

## Testing

- New regression test: a tunnel CONNECT to a dead port now returns `HTTP/1.1 502` rather than closing with no response.
- Full suite: **267 pass, 0 fail**. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)