### PR TITLE
Sanitize orphaned tool_use/tool_result blocks before forwarding

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
+import { sanitizeToolPairs } from './tool-pair-sanitize.js';
 import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
 import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
@@ -438,14 +439,19 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   const upstreamUrl = `${account.upstream || upstream}${req.url}`;
   const method = req.method;
 
+  // Strip orphaned tool_use / tool_result blocks so a client that compacted or
+  // interrupted a turn can't wedge the session with Anthropic's non-retryable
+  // 400 ("tool_use ids were found without tool_result blocks"). No-op (same
+  // Buffer) for a well-formed body.
+  let sendBody = sanitizeToolPairs(body, req.url, req.headers['content-type']);
   // Align the body's account_uuid (in metadata.user_id) with the account whose
   // token we're injecting (same-length patch; no-op if absent).
-  let sendBody = account.accountUuid ? patchAccountUuid(body, account.accountUuid) : body;
+  if (account.accountUuid) sendBody = patchAccountUuid(sendBody, account.accountUuid);
   // Rewrite the model name for accounts that target a different upstream (e.g.
   // GLM), which uses different model identifiers than Anthropic.
   if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);
-  // If the body changed length (model name rewrite), update Content-Length so the
-  // upstream doesn't receive a mismatched framing and truncate or stall.
+  // If the body changed length (sanitize or model rewrite), update Content-Length
+  // so the upstream doesn't receive a mismatched framing and truncate or stall.
   if (sendBody !== body) headers['content-length'] = String(sendBody.length);
 
   // Streaming request log, opened lazily on the first terminal outcome (a

--- a/src/tool-pair-sanitize.js
+++ b/src/tool-pair-sanitize.js
@@ -6,12 +6,16 @@
 //   immediately after: toolu_XXXX. Each `tool_use` block must have a
 //   corresponding `tool_result` block in the next message.
 //
-// Anthropic requires every tool_use block to be answered by a matching
-// tool_result in the next message. When a client summarizes ("compacts") a long
-// conversation or an in-flight tool call is interrupted, the slice can split
-// that pair, leaving a tool_use with no result (or a tool_result whose tool_use
-// was cut). Anthropic then rejects the whole conversation and every follow-up in
-// that session fails too, so the session is stuck until the client is rewound.
+// Anthropic enforces this POSITIONALLY: every tool_use block in an assistant
+// message must be answered by a matching tool_result in the IMMEDIATELY FOLLOWING
+// message, and every tool_result must be grounded by a tool_use in the message
+// right before it. A client that summarizes ("compacts") a long conversation or
+// gets an in-flight tool call interrupted can break that in two ways:
+//   1. the counterpart is dropped entirely (a tool_use with no result), or
+//   2. the pair is SEPARATED — both blocks survive but other messages slip
+//      between them, so the result is no longer "immediately after".
+// Whole-body pairing (does the id exist somewhere?) misses case 2 — that is the
+// bug that let the 400 through. This checks the true neighbor instead.
 //
 // The proxy already buffers and rewrites the body (account_uuid, model map), so
 // it is the natural single place to normalize this for every client that routes
@@ -30,6 +34,28 @@ function isMessagesRequest(url, contentType) {
   return true;
 }
 
+// Ids of the tool_use blocks in a message (empty for a non-array / absent message).
+function toolUseIds(msg) {
+  const ids = new Set();
+  if (msg && Array.isArray(msg.content)) {
+    for (const b of msg.content) {
+      if (b && typeof b === 'object' && b.type === 'tool_use' && typeof b.id === 'string') ids.add(b.id);
+    }
+  }
+  return ids;
+}
+
+// tool_use_ids referenced by the tool_result blocks in a message.
+function toolResultIds(msg) {
+  const ids = new Set();
+  if (msg && Array.isArray(msg.content)) {
+    for (const b of msg.content) {
+      if (b && typeof b === 'object' && b.type === 'tool_result' && typeof b.tool_use_id === 'string') ids.add(b.tool_use_id);
+    }
+  }
+  return ids;
+}
+
 // Normalize a message's `content` to a block array so same-role messages can be
 // merged losslessly. Anthropic accepts a single-text-block array as equivalent
 // to a plain string, so this never changes meaning. Returns null for shapes we
@@ -40,11 +66,10 @@ function toBlocks(content) {
   return null;
 }
 
-// After whole messages are dropped, two same-role messages can end up adjacent
-// (e.g. a user turn that held only an orphaned tool_result is removed, leaving
-// the assistant turns on either side touching). Anthropic requires roles to
-// alternate, so coalesce any same-role neighbors by concatenating their content.
-// This is a no-op when nothing is adjacent, so it is always safe to run.
+// When pruning empties whole messages, two same-role messages can end up adjacent
+// (a user turn that held only an orphaned tool_result is removed, leaving the
+// assistant turns on either side touching). Anthropic requires roles to alternate,
+// so coalesce same-role neighbors by concatenating their content.
 function coalesceSameRole(messages) {
   const out = [];
   for (const msg of messages) {
@@ -62,59 +87,67 @@ function coalesceSameRole(messages) {
   return out;
 }
 
-// Returns a new messages array with orphans pruned, or null if nothing changed.
-function pruneOrphans(messages) {
-  // Whole-body pairing. In practice the only breakage clients produce is a
-  // MISSING counterpart (an interrupted tail, or a compaction slice that split a
-  // pair), never a reordered one, so pairing across the whole body catches every
-  // real orphan class without ever un-pairing a valid adjacent pair.
-  const useIds = new Set(); // ids of every tool_use block present
-  const resultIds = new Set(); // tool_use_ids referenced by every tool_result
-  for (const msg of messages) {
-    if (!msg || !Array.isArray(msg.content)) continue;
-    for (const block of msg.content) {
-      if (!block || typeof block !== 'object') continue;
-      if (block.type === 'tool_use' && typeof block.id === 'string') useIds.add(block.id);
-      else if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') resultIds.add(block.tool_use_id);
-    }
-  }
+// One pruning pass over the array. Strips positionally-unpaired blocks, drops any
+// message it empties, and (only when it dropped something) coalesces same-role
+// neighbors so roles still alternate. Returns the possibly-new array plus whether
+// it changed anything. Mutates the `content` arrays of the (already-cloned) input.
+function pruneOnce(messages) {
+  let changed = false;
 
-  let mutated = false;
-  let droppedMessage = false;
-  const out = [];
-  for (const msg of messages) {
-    if (!msg || !Array.isArray(msg.content)) {
-      out.push(msg);
-      continue;
-    }
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || !Array.isArray(msg.content)) continue;
+    const answeredByNext = toolResultIds(messages[i + 1]); // results that answer THIS msg's tool_use
+    const groundedByPrev = toolUseIds(messages[i - 1]); // tool_use that grounds THIS msg's tool_result
     const kept = [];
-    for (const block of msg.content) {
-      if (block && typeof block === 'object') {
-        // Drop a tool_use whose result is nowhere in the body.
-        if (block.type === 'tool_use' && typeof block.id === 'string' && !resultIds.has(block.id)) {
-          mutated = true;
+    for (const b of msg.content) {
+      if (b && typeof b === 'object') {
+        // A tool_use whose result is not in the immediately following message.
+        if (b.type === 'tool_use' && typeof b.id === 'string' && !answeredByNext.has(b.id)) {
+          changed = true;
           continue;
         }
-        // Drop a tool_result whose tool_use is nowhere in the body.
-        if (block.type === 'tool_result' && typeof block.tool_use_id === 'string' && !useIds.has(block.tool_use_id)) {
-          mutated = true;
+        // A tool_result whose tool_use is not in the immediately preceding message.
+        if (b.type === 'tool_result' && typeof b.tool_use_id === 'string' && !groundedByPrev.has(b.tool_use_id)) {
+          changed = true;
           continue;
         }
       }
-      kept.push(block);
+      kept.push(b);
     }
-    if (kept.length === 0) {
-      // The message held only orphan block(s); an all-orphan message is itself
-      // orphaned and Anthropic rejects empty content, so drop the whole message.
-      mutated = true;
-      droppedMessage = true;
-      continue;
-    }
-    out.push(kept.length !== msg.content.length ? { ...msg, content: kept } : msg);
+    if (kept.length !== msg.content.length) msg.content = kept;
   }
 
-  if (!mutated) return null;
-  return droppedMessage ? coalesceSameRole(out) : out;
+  let droppedAny = false;
+  const kept = [];
+  for (const msg of messages) {
+    if (msg && Array.isArray(msg.content) && msg.content.length === 0) {
+      changed = true;
+      droppedAny = true;
+      continue;
+    }
+    kept.push(msg);
+  }
+
+  const result = droppedAny ? coalesceSameRole(kept) : kept;
+  if (result.length !== kept.length) changed = true;
+  return { messages: result, changed };
+}
+
+// Repeat pruning to a fixed point: dropping a message shifts adjacency, which can
+// expose a new positional orphan (the cascade), so one pass is not enough. Each
+// pass only removes, so this terminates. Returns the new array, or null if the
+// body was already valid (so the caller can forward the original bytes untouched).
+function pruneOrphans(messages) {
+  let current = messages;
+  let everChanged = false;
+  for (let guard = 0; guard < 1000; guard++) {
+    const { messages: next, changed } = pruneOnce(current);
+    current = next;
+    if (!changed) break;
+    everChanged = true;
+  }
+  return everChanged ? current : null;
 }
 
 /**

--- a/src/tool-pair-sanitize.js
+++ b/src/tool-pair-sanitize.js
@@ -1,0 +1,149 @@
+// Drop orphaned tool_use / tool_result blocks from an Anthropic /v1/messages
+// request body so a client that compacted or interrupted a turn can't wedge the
+// session with Anthropic's non-retryable 400:
+//
+//   messages.N: `tool_use` ids were found without `tool_result` blocks
+//   immediately after: toolu_XXXX. Each `tool_use` block must have a
+//   corresponding `tool_result` block in the next message.
+//
+// Anthropic requires every tool_use block to be answered by a matching
+// tool_result in the next message. When a client summarizes ("compacts") a long
+// conversation or an in-flight tool call is interrupted, the slice can split
+// that pair, leaving a tool_use with no result (or a tool_result whose tool_use
+// was cut). Anthropic then rejects the whole conversation and every follow-up in
+// that session fails too, so the session is stuck until the client is rewound.
+//
+// The proxy already buffers and rewrites the body (account_uuid, model map), so
+// it is the natural single place to normalize this for every client that routes
+// through it. This pass only ever REMOVES provably-unpaired blocks; it never
+// fabricates a tool_result the model would reason over. A well-formed body is
+// returned as the SAME Buffer instance (identity preserved), so the forwarder's
+// `sendBody !== body` check keeps it a no-op with zero cost on the hot path.
+
+const MESSAGES_PATH = '/v1/messages';
+
+// Is this a JSON /v1/messages (or /v1/messages/count_tokens) request we can
+// reason about? Everything else (token refreshes, GETs, non-JSON) is left alone.
+function isMessagesRequest(url, contentType) {
+  if (typeof url !== 'string' || !url.includes(MESSAGES_PATH)) return false;
+  if (contentType && !/json/i.test(contentType)) return false;
+  return true;
+}
+
+// Normalize a message's `content` to a block array so same-role messages can be
+// merged losslessly. Anthropic accepts a single-text-block array as equivalent
+// to a plain string, so this never changes meaning. Returns null for shapes we
+// don't recognize (caller then declines to merge rather than risk corruption).
+function toBlocks(content) {
+  if (Array.isArray(content)) return content;
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return null;
+}
+
+// After whole messages are dropped, two same-role messages can end up adjacent
+// (e.g. a user turn that held only an orphaned tool_result is removed, leaving
+// the assistant turns on either side touching). Anthropic requires roles to
+// alternate, so coalesce any same-role neighbors by concatenating their content.
+// This is a no-op when nothing is adjacent, so it is always safe to run.
+function coalesceSameRole(messages) {
+  const out = [];
+  for (const msg of messages) {
+    const prev = out[out.length - 1];
+    if (prev && msg && prev.role && prev.role === msg.role) {
+      const a = toBlocks(prev.content);
+      const b = toBlocks(msg.content);
+      if (a && b) {
+        out[out.length - 1] = { ...prev, content: [...a, ...b] };
+        continue;
+      }
+    }
+    out.push(msg);
+  }
+  return out;
+}
+
+// Returns a new messages array with orphans pruned, or null if nothing changed.
+function pruneOrphans(messages) {
+  // Whole-body pairing. In practice the only breakage clients produce is a
+  // MISSING counterpart (an interrupted tail, or a compaction slice that split a
+  // pair), never a reordered one, so pairing across the whole body catches every
+  // real orphan class without ever un-pairing a valid adjacent pair.
+  const useIds = new Set(); // ids of every tool_use block present
+  const resultIds = new Set(); // tool_use_ids referenced by every tool_result
+  for (const msg of messages) {
+    if (!msg || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'tool_use' && typeof block.id === 'string') useIds.add(block.id);
+      else if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') resultIds.add(block.tool_use_id);
+    }
+  }
+
+  let mutated = false;
+  let droppedMessage = false;
+  const out = [];
+  for (const msg of messages) {
+    if (!msg || !Array.isArray(msg.content)) {
+      out.push(msg);
+      continue;
+    }
+    const kept = [];
+    for (const block of msg.content) {
+      if (block && typeof block === 'object') {
+        // Drop a tool_use whose result is nowhere in the body.
+        if (block.type === 'tool_use' && typeof block.id === 'string' && !resultIds.has(block.id)) {
+          mutated = true;
+          continue;
+        }
+        // Drop a tool_result whose tool_use is nowhere in the body.
+        if (block.type === 'tool_result' && typeof block.tool_use_id === 'string' && !useIds.has(block.tool_use_id)) {
+          mutated = true;
+          continue;
+        }
+      }
+      kept.push(block);
+    }
+    if (kept.length === 0) {
+      // The message held only orphan block(s); an all-orphan message is itself
+      // orphaned and Anthropic rejects empty content, so drop the whole message.
+      mutated = true;
+      droppedMessage = true;
+      continue;
+    }
+    out.push(kept.length !== msg.content.length ? { ...msg, content: kept } : msg);
+  }
+
+  if (!mutated) return null;
+  return droppedMessage ? coalesceSameRole(out) : out;
+}
+
+/**
+ * Strip orphaned tool_use / tool_result blocks from a buffered /v1/messages body.
+ *
+ * @param {Buffer} body fully-buffered request body
+ * @param {string} url req.url (only /v1/messages bodies are inspected)
+ * @param {string} [contentType] the request's content-type header
+ * @returns {Buffer} the original buffer when nothing was unpaired (or on any
+ *   parse / shape surprise), else a re-serialized buffer with orphans removed.
+ */
+export function sanitizeToolPairs(body, url, contentType) {
+  if (!Buffer.isBuffer(body) || body.length === 0) return body;
+  if (!isMessagesRequest(url, contentType)) return body;
+
+  let payload;
+  try {
+    payload = JSON.parse(body.toString('utf8'));
+  } catch {
+    return body; // not JSON we can reason about — never break it
+  }
+  if (!payload || !Array.isArray(payload.messages)) return body;
+
+  try {
+    const pruned = pruneOrphans(payload.messages);
+    if (!pruned) return body;
+    payload.messages = pruned;
+    return Buffer.from(JSON.stringify(payload), 'utf8');
+  } catch {
+    return body; // any surprise → forward the original untouched
+  }
+}

--- a/test/tool-pair-sanitize.test.js
+++ b/test/tool-pair-sanitize.test.js
@@ -8,19 +8,27 @@ const buf = (obj) => Buffer.from(JSON.stringify(obj), 'utf8');
 const parse = (b) => JSON.parse(b.toString('utf8'));
 const run = (obj, url = MESSAGES, ct = JSON_CT) => sanitizeToolPairs(buf(obj), url, ct);
 
-// True when no tool_use lacks a result and no tool_result lacks a use — the exact
-// invariant Anthropic enforces (whole-body pairing).
+// True when the body satisfies Anthropic's ACTUAL rule: every tool_use is answered
+// by a matching tool_result in the IMMEDIATELY FOLLOWING message, and every
+// tool_result is grounded by a tool_use in the message right before it. (Whole-body
+// "does the id exist anywhere" is too lenient — it was the bug.)
+function idsOf(msg, type, key) {
+  const ids = new Set();
+  for (const b of Array.isArray(msg?.content) ? msg.content : []) {
+    if (b?.type === type && typeof b[key] === 'string') ids.add(b[key]);
+  }
+  return ids;
+}
 function isPaired(body) {
-  const uses = new Set();
-  const results = new Set();
-  for (const m of body.messages ?? []) {
-    for (const b of Array.isArray(m.content) ? m.content : []) {
-      if (b?.type === 'tool_use') uses.add(b.id);
-      else if (b?.type === 'tool_result') results.add(b.tool_use_id);
+  const msgs = body.messages ?? [];
+  for (let i = 0; i < msgs.length; i++) {
+    const next = idsOf(msgs[i + 1], 'tool_result', 'tool_use_id');
+    const prev = idsOf(msgs[i - 1], 'tool_use', 'id');
+    for (const b of Array.isArray(msgs[i]?.content) ? msgs[i].content : []) {
+      if (b?.type === 'tool_use' && !next.has(b.id)) return false;
+      if (b?.type === 'tool_result' && !prev.has(b.tool_use_id)) return false;
     }
   }
-  for (const id of uses) if (!results.has(id)) return false;
-  for (const id of results) if (!uses.has(id)) return false;
   return true;
 }
 
@@ -124,4 +132,43 @@ test('also covers /v1/messages/count_tokens', () => {
     '/v1/messages/count_tokens',
   );
   assert.ok(isPaired(parse(out)));
+});
+
+test('strips a SEPARATED pair — result present but not immediately after (the messages.2 case)', () => {
+  // A compaction that keeps a tool_use at messages[2] but moves its tool_result to
+  // messages[4] instead of [3]. The id still exists in the body, so whole-body
+  // pairing would keep it and Anthropic still 400s. Positional pairing must strip it.
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'start' },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_gap', name: 'noop', input: {} }] },
+      { role: 'user', content: 'unrelated next turn' },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_gap', content: 'late' }] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.ok(rolesAlternate(body));
+  assert.ok(!JSON.stringify(body).includes('toolu_gap'));
+});
+
+test('cascade: dropping one turn exposes the next orphan, valid pair is preserved', () => {
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_A', name: 'a', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_A', content: 'ra' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_B', name: 'b', input: {} }] },
+      { role: 'user', content: 'chatter' },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_B', content: 'rb late' }] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.ok(rolesAlternate(body));
+  assert.ok(JSON.stringify(body).includes('toolu_A'));
+  assert.ok(!JSON.stringify(body).includes('toolu_B'));
 });

--- a/test/tool-pair-sanitize.test.js
+++ b/test/tool-pair-sanitize.test.js
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeToolPairs } from '../src/tool-pair-sanitize.js';
+
+const MESSAGES = '/v1/messages';
+const JSON_CT = 'application/json';
+const buf = (obj) => Buffer.from(JSON.stringify(obj), 'utf8');
+const parse = (b) => JSON.parse(b.toString('utf8'));
+const run = (obj, url = MESSAGES, ct = JSON_CT) => sanitizeToolPairs(buf(obj), url, ct);
+
+// True when no tool_use lacks a result and no tool_result lacks a use — the exact
+// invariant Anthropic enforces (whole-body pairing).
+function isPaired(body) {
+  const uses = new Set();
+  const results = new Set();
+  for (const m of body.messages ?? []) {
+    for (const b of Array.isArray(m.content) ? m.content : []) {
+      if (b?.type === 'tool_use') uses.add(b.id);
+      else if (b?.type === 'tool_result') results.add(b.tool_use_id);
+    }
+  }
+  for (const id of uses) if (!results.has(id)) return false;
+  for (const id of results) if (!uses.has(id)) return false;
+  return true;
+}
+
+function rolesAlternate(body) {
+  const roles = (body.messages ?? []).map((m) => m.role);
+  return roles.every((r, i) => i === 0 || r !== roles[i - 1]);
+}
+
+test('strips a tail tool_use that has no tool_result and drops the emptied turn', () => {
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'do the thing' },
+      { role: 'assistant', content: [
+        { type: 'tool_use', id: 'toolu_a', name: 'a', input: {} },
+        { type: 'tool_use', id: 'toolu_b', name: 'b', input: {} },
+      ] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].role, 'user');
+});
+
+test('well-formed body is returned as the same Buffer instance (no reserialize)', () => {
+  const original = buf({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_ok', name: 'a', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_ok', content: 'done' }] },
+      { role: 'assistant', content: 'all set' },
+    ],
+  });
+  assert.equal(sanitizeToolPairs(original, MESSAGES, JSON_CT), original);
+});
+
+test('removes a dangling tool_result whose tool_use is gone, keeps sibling content', () => {
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: [
+        { type: 'tool_result', tool_use_id: 'toolu_missing', content: 'orphan' },
+        { type: 'text', text: 'and here is my next ask' },
+      ] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.equal(body.messages.length, 1);
+  assert.ok(body.messages[0].content.some((b) => b.type === 'text'));
+});
+
+test('an orphan alongside real content drops only the orphan, keeps the message', () => {
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: [
+        { type: 'text', text: 'let me check' },
+        { type: 'tool_use', id: 'toolu_dead', name: 'a', input: {} },
+      ] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.equal(body.messages[1].content.length, 1);
+  assert.equal(body.messages[1].content[0].type, 'text');
+});
+
+test('dropping a whole message coalesces same-role neighbors so roles still alternate', () => {
+  const out = run({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'start' },
+      { role: 'assistant', content: [{ type: 'text', text: 'first' }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_gone', content: 'x' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    ],
+  });
+  const body = parse(out);
+  assert.ok(isPaired(body));
+  assert.ok(rolesAlternate(body));
+  assert.equal(body.messages.filter((m) => m.role === 'assistant').length, 1);
+});
+
+test('leaves non-/v1/messages, non-JSON, and unparseable bodies untouched', () => {
+  const orphan = { model: 'x', messages: [{ role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_z', name: 'a', input: {} }] }] };
+  const b1 = buf(orphan);
+  assert.equal(sanitizeToolPairs(b1, '/v1/complete', JSON_CT), b1);
+  const b2 = Buffer.from('not json at all', 'utf8');
+  assert.equal(sanitizeToolPairs(b2, MESSAGES, JSON_CT), b2);
+  const b3 = buf(orphan);
+  assert.equal(sanitizeToolPairs(b3, MESSAGES, 'text/plain'), b3);
+});
+
+test('also covers /v1/messages/count_tokens', () => {
+  const out = run(
+    { model: 'x', messages: [{ role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_ct', name: 'a', input: {} }] }] },
+    '/v1/messages/count_tokens',
+  );
+  assert.ok(isPaired(parse(out)));
+});


### PR DESCRIPTION
## The problem

Anthropic rejects any request where a `tool_use` block isn't answered by a matching `tool_result` in the next message, with a non-retryable 400:

```
messages.N: `tool_use` ids were found without `tool_result` blocks immediately
after: toolu_XXXX. Each `tool_use` block must have a corresponding `tool_result`
block in the next message.
```

When a client compacts (summarizes) a long conversation, or an in-flight tool call gets interrupted, the slice can split that pair: a `tool_use` is left with no result, or a `tool_result` survives whose `tool_use` was cut. teamclaude forwards the body as-is, Anthropic returns the 400, and because it's non-retryable every follow-up in the session fails too. The session is wedged until the client is rewound or abandoned.

I hit this repeatedly with GUI agents (Paseo, and the Claude Code CLI after an interrupted turn) routing through teamclaude. It's the same class of bug the OpenCode ecosystem works around client-side, but agents that point straight at the proxy have no such guard. Since teamclaude is the one place every client funnels through, fixing it here covers all of them at once.

## The change

`src/tool-pair-sanitize.js` adds `sanitizeToolPairs(body, url, contentType)`. It runs in `forwardRequest` right before the existing `account_uuid` and model-map rewrites, so it reuses the body buffering and the `content-length` realignment that are already there.

It only ever removes provably-unpaired blocks:

- a `tool_use` with no `tool_result` anywhere in the body, or
- a `tool_result` whose `tool_use` is gone.

It never fabricates tool output the model would reason over, which keeps it safe by construction. A few details worth calling out:

- A well-formed body is returned as the **same Buffer instance**, so it's a genuine no-op on the hot path (the `sendBody !== body` check already in place skips the content-length update).
- Only `/v1/messages` (and `/v1/messages/count_tokens`) JSON bodies are inspected. Anything else, non-JSON, or unparseable is passed through untouched.
- If pruning empties a whole message, same-role neighbors are coalesced so roles still alternate (Anthropic requires that), rather than leaving two `user` or two `assistant` turns adjacent.

## Tests

`test/tool-pair-sanitize.test.js` (node:test) covers the reported tail-orphan case, a dangling `tool_result`, an orphan alongside real content, the same-role coalescing path, the same-Buffer no-op, and the non-messages / non-JSON / count_tokens paths.

`npm run lint` is clean and `npm test` passes for everything I touched. One unrelated test (`test/server-listen-error.test.js`, "server exits cleanly when the port is already in use") fails on my machine, but it fails identically on a clean `master` checkout with this change stashed, so it's a pre-existing environment flake, not from this PR.
