### PR TITLE
fix: Remote Control fails — no WebSocket upgrade handler

### DIFF
--- a/src/mitm.js
+++ b/src/mitm.js
@@ -20,7 +20,7 @@ import tls from 'node:tls';
 import http2 from 'node:http2';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
-import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr } from './server.js';
+import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr, relayUpgrade } from './server.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -126,6 +126,11 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     const { key, cert } = await ensureLeaf();
     const srv = http2.createSecureServer({ key, cert, allowHTTP1: true });
     srv.on('request', forward);
+    // Remote Control's real-time channel is a WebSocket (Upgrade handshake),
+    // which never fires 'request' — only 'upgrade', with a raw socket instead
+    // of a response object (h1-only; falls back to blind h2 passthrough is not
+    // needed since WS clients negotiate h1 for the handshake).
+    srv.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, upstream, sx));
     srv.on('sessionError', (e) => log(`[TeamClaude] MITM session error: ${e.message}`));
     srv.on('clientError', (e, sock) => { try { sock.destroy(); } catch { /* already gone */ } });
     return srv;

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import https from 'node:https';
 import { timingSafeEqual } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
@@ -9,6 +10,7 @@ import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
 import { TopLevelFieldFinder } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
+import { tunnelTls } from './sx.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -123,6 +125,11 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
   server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx }));
+  // Remote Control's real-time channel is a WebSocket, not a request/response
+  // call — Node fires 'upgrade' for that handshake, never 'request', so it
+  // needs its own listener (base-URL routing path; the MITM path wires the
+  // same relayUpgrade onto its own terminating server in mitm.js).
+  server.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, upstream, sx));
 
   return server;
 }
@@ -226,17 +233,31 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
   };
 }
 
-/**
- * Stream a request through to upstream with the client's OWN headers intact
- * (including its authorization) and stream the response back — used for Remote
- * Control (/v1/code/*), whose event stream must keep the paired credential and
- * cannot be buffered.
- */
-async function relayStream(req, res, upstream, sx) {
-  const bodyChunks = [];
-  for await (const chunk of req) bodyChunks.push(chunk);
-  const body = Buffer.concat(bodyChunks);
+// Per-request https.Agent tunneled through sx.org — one-shot (no keep-alive
+// reuse, matching upstream-fetch.js's proxiedFetch), so a fresh sx tunnel is
+// dialed for this connection only.
+function sxAgent(sx, targetHost) {
+  const proxy = sx.getProxy();
+  const agent = new https.Agent({ keepAlive: false });
+  agent.createConnection = (_options, cb) => {
+    tunnelTls({ proxy, targetHost, targetPort: 443, tlsOptions: sx.tlsOptions || {} })
+      .then((sock) => cb(null, sock))
+      .catch((err) => cb(err));
+    return undefined;
+  };
+  return agent;
+}
 
+/**
+ * Relay a request to upstream with the client's OWN headers intact (including
+ * its authorization) — used for Remote Control (/v1/code/*), whose event
+ * stream is a long-poll: the client keeps the request open indefinitely and
+ * the upstream may withhold response headers for minutes between events. No
+ * buffering, no timeout, no reconstruction — just pipe bytes both ways as they
+ * arrive, exactly like a transparent proxy would.
+ */
+function relayStream(req, res, upstream, sx) {
+  const target = new URL(`${upstream}${req.url}`);
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -244,28 +265,89 @@ async function relayStream(req, res, upstream, sx) {
     headers[key] = value;
   }
 
-  try {
-    const upstreamRes = await upstreamFetch(`${upstream}${req.url}`, {
-      method: req.method, headers,
-      body: ['GET', 'HEAD'].includes(req.method) ? undefined : (body.length ? body : undefined),
-      redirect: 'manual',
-    }, sx, sx?.useByDefault());
+  const useProxy = !!(sx?.useByDefault() && sx.isProvisioned());
+  const agent = useProxy ? sxAgent(sx, target.hostname) : undefined;
+  const transport = target.protocol === 'http:' ? http : https;
 
+  const upstreamReq = transport.request(target, { method: req.method, headers, agent }, (upstreamRes) => {
     const responseHeaders = {};
-    for (const [key, value] of upstreamRes.headers.entries()) {
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
       if (CONNECTION_SPECIFIC_HEADERS.has(key) || key === 'content-encoding' || key === 'content-length') continue;
       responseHeaders[key] = value;
     }
-    res.writeHead(upstreamRes.status, responseHeaders);
-    if (upstreamRes.body) { for await (const chunk of upstreamRes.body) res.write(chunk); }
-    res.end();
-  } catch (err) {
+    res.writeHead(upstreamRes.statusCode, responseHeaders);
+    upstreamRes.pipe(res);
+  });
+
+  upstreamReq.on('error', (err) => {
     console.error('[TeamClaude] Remote Control relay error:', err.message);
     if (!res.headersSent) {
       res.writeHead(502, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Upstream unreachable' } }));
     }
+  });
+  // Client disconnected (e.g. Claude Code closed the channel): tear down the
+  // upstream side too instead of leaking an open connection.
+  res.on('close', () => upstreamReq.destroy());
+
+  if (['GET', 'HEAD'].includes(req.method)) upstreamReq.end();
+  else req.pipe(upstreamReq);
+}
+
+/**
+ * Relay a WebSocket upgrade (e.g. Remote Control's real-time
+ * `/v1/session_ingress/ws/*` channel) to upstream with the client's own
+ * headers intact. An HTTP server never emits 'request' for an Upgrade
+ * handshake — only 'upgrade', with a raw socket instead of a response object —
+ * so this needs its own relay rather than going through relayStream/res.
+ * Reuses Node's http(s) client, which already knows how to speak the Upgrade
+ * handshake (emits its own 'upgrade' event on a 101); once that fires it's
+ * just two raw sockets spliced together.
+ */
+export function relayUpgrade(req, socket, head, upstream, sx) {
+  const target = new URL(`${upstream}${req.url}`);
+  const headers = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    const lk = key.toLowerCase();
+    // Unlike relayStream, do NOT strip 'upgrade'/'connection' here — they ARE
+    // the handshake. Only 'host' (the client transport reconstructs it from
+    // `target`) and h2 pseudo-headers are dropped.
+    if (lk.startsWith(':') || lk === 'host') continue;
+    headers[key] = value;
   }
+
+  const useProxy = !!(sx?.useByDefault() && sx.isProvisioned());
+  const agent = useProxy ? sxAgent(sx, target.hostname) : undefined;
+  const transport = target.protocol === 'http:' ? http : https;
+
+  const upstreamReq = transport.request(target, { method: req.method, headers, agent });
+
+  upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
+    const headerLines = Object.entries(upstreamRes.headers)
+      .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`).join('\r\n');
+    socket.write(`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}\r\n${headerLines}\r\n\r\n`);
+    if (upstreamHead?.length) socket.write(upstreamHead);
+    if (head?.length) upstreamSocket.write(head);
+    socket.pipe(upstreamSocket);
+    upstreamSocket.pipe(socket);
+    // An upgraded socket defaults to half-open: the peer's FIN only ends the
+    // READABLE side ('end'), it does NOT destroy the socket or fire 'close' —
+    // so without this, one side hanging up (dropped wifi, killed CLI) leaves
+    // the other socket open forever. destroy() is idempotent, so reacting to
+    // both 'end' and 'close' on each side is a safe, redundant backstop.
+    socket.on('end', () => upstreamSocket.destroy());
+    upstreamSocket.on('end', () => socket.destroy());
+    socket.on('close', () => upstreamSocket.destroy());
+    upstreamSocket.on('close', () => socket.destroy());
+  });
+
+  upstreamReq.on('error', (err) => {
+    console.error('[TeamClaude] Remote Control WebSocket relay error:', err.message);
+    socket.destroy();
+  });
+  socket.on('error', () => upstreamReq.destroy());
+
+  upstreamReq.end();
 }
 
 /**

--- a/test/remote-control-relay.test.js
+++ b/test/remote-control-relay.test.js
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { once } from 'node:events';
+import { createProxyRequestListener, relayUpgrade } from '../src/server.js';
+
+// Bring up an HTTP server on an ephemeral port and hand back {server, port}.
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0);
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+async function requestThrough(listener, { method = 'GET', path, headers = {}, body } = {}) {
+  const { server: proxy, port } = await listen(listener);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, { method, headers, body });
+    return { status: res.status, text: await res.text(), headers: res.headers };
+  } finally {
+    proxy.close();
+  }
+}
+
+// Remote Control (/v1/code/*) must reach upstream with the client's OWN
+// authorization header untouched, never a rotated account token — a fake
+// accountManager whose getActiveAccount would throw proves relayStream never
+// even consults it for this path.
+test('a GET to /v1/code/* forwards the client credential and streams the response back untouched', async () => {
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => {
+    assert.equal(req.headers.authorization, 'Bearer client-own-token');
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: ping\n\n');
+    res.end();
+  });
+
+  const accountManager = { getActiveAccount() { throw new Error('must not rotate Remote Control'); } };
+  const listener = createProxyRequestListener({
+    accountManager, upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+
+  const { status, text } = await requestThrough(listener, {
+    path: '/v1/code/sessions/abc/worker/events/stream',
+    headers: { authorization: 'Bearer client-own-token' },
+  });
+
+  assert.equal(status, 200);
+  assert.match(text, /event: ping/);
+  upstream.close();
+});
+
+// The whole point of the rewrite: relayStream must not wait for the request (or
+// the response) to fully materialize before starting to move bytes — a
+// long-poll upstream that waits before sending headers must not be treated as
+// a dead request the way a normal bounded /v1/messages call would be.
+test('does not wait for the request to end before the response can start streaming', async () => {
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: hello\n\n');
+    // Deliberately never end() — mirrors a held-open worker/events/stream.
+  });
+
+  const accountManager = { getActiveAccount() { throw new Error('must not rotate'); } };
+  const listener = createProxyRequestListener({
+    accountManager, upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const { server: proxy, port } = await listen(listener);
+
+  const controller = new AbortController();
+  const res = await fetch(`http://127.0.0.1:${port}/v1/code/sessions/abc/worker/events/stream`, {
+    signal: controller.signal,
+  });
+  const reader = res.body.getReader();
+  const { value } = await reader.read();
+  assert.match(Buffer.from(value).toString(), /event: hello/);
+
+  controller.abort();
+  proxy.close();
+  upstream.close();
+});
+
+// Remote Control's real-time channel is a WebSocket
+// (wss://api.anthropic.com/v1/session_ingress/ws/{session_id}), which is an
+// HTTP Upgrade handshake — Node fires 'upgrade' for this, never 'request', so
+// relayStream (built on req/res) never even sees it. relayUpgrade is the
+// dedicated handler for that event; this proves the handshake and the
+// bidirectional byte stream both survive the relay with the client's own
+// Authorization header intact (never rewritten to a rotated account token).
+test('relays a WebSocket Upgrade handshake and echoes bytes both ways', async () => {
+  const { server: upstream, port: upstreamPort } = await listen(() => {});
+  upstream.on('upgrade', (req, socket) => {
+    assert.equal(req.headers.authorization, 'Bearer client-own-token');
+    assert.equal(req.headers.upgrade, 'websocket');
+    socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n');
+    socket.on('data', (chunk) => socket.write(chunk)); // echo whatever the client sends
+  });
+
+  const proxy = http.createServer();
+  proxy.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, `http://127.0.0.1:${upstreamPort}`, null));
+  proxy.listen(0);
+  await once(proxy, 'listening');
+  const port = proxy.address().port;
+
+  const client = net.connect(port, '127.0.0.1');
+  await once(client, 'connect');
+  client.write(
+    'GET /v1/session_ingress/ws/abc HTTP/1.1\r\n' +
+    'Host: 127.0.0.1\r\n' +
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    'authorization: Bearer client-own-token\r\n' +
+    '\r\n',
+  );
+
+  const [handshake] = await once(client, 'data');
+  assert.match(handshake.toString(), /101 Switching Protocols/);
+
+  client.write('ping');
+  const [echoed] = await once(client, 'data');
+  assert.equal(echoed.toString(), 'ping');
+
+  client.destroy();
+  proxy.close();
+  upstream.close();
+});


### PR DESCRIPTION
## Issue

`/remote-control` doesn't work through teamclaude. Root cause: Remote Control's real-time channel is a WebSocket (`wss://api.anthropic.com/v1/session_ingress/ws/{session_id}`, confirmed against public docs of the protocol). A WebSocket handshake fires Node's `upgrade` event, never `request`. Neither the base HTTP server (`createProxyServer`) nor the MITM terminating server (`mitm.js`) had any `upgrade` listener — the connection never reached any proxy logic at all, so the client just saw a generic failure with nothing in teamclaude's own logs.

Separately, `relayStream` (the non-WebSocket `/v1/code/*` HTTP path) fully buffered the request body before forwarding via `upstreamFetch`. That path is long-lived too, so buffer-then-fetch was the wrong shape even where it technically worked.

## Fixes

- Add `relayUpgrade()` (`src/server.js`): relays a WebSocket Upgrade handshake to upstream using Node's http(s) client (which natively supports the Upgrade handshake), forwarding the client's own headers untouched — including `Authorization`, never a rotated account token, matching how `/v1/code/*` already behaves. Once the 101 response arrives, splices the two raw sockets together.
- Wire `relayUpgrade` into both servers: `server.on('upgrade', ...)` in `createProxyServer` (base-URL routing) and `srv.on('upgrade', ...)` in the MITM terminating server (`mitm.js`).
- Fix a socket leak found while testing this: an upgraded socket is half-open by default — a peer's FIN only closes the readable side (`end`), it does not fire `close` or destroy the socket. Without explicit cleanup, one side hanging up (dropped wifi, killed CLI) would leak an open connection to upstream forever. Now both sides destroy each other on `end` or `close`.
- Rewrite `relayStream` to a true streaming pipe (`req.pipe(upstreamReq)`, `upstreamRes.pipe(res)`) instead of buffer-then-`upstreamFetch`, since the same channel's non-upgrade requests are long-lived too.

## Testing

Added `test/remote-control-relay.test.js`:
- `/v1/code/*` GET forwards the client's own credential and streams the response back untouched (fake `accountManager.getActiveAccount` throws, proving rotation is never consulted for this path)
- Response streaming starts without waiting for the request to end (long-poll shape)
- Full WebSocket Upgrade handshake + bidirectional byte echo through `relayUpgrade`

Full suite passes (`npm test`) except one pre-existing, unrelated failure (`test/server-listen-error.test.js`, confirmed via `git stash` to fail identically on master — caused by a local port conflict in this environment, not by this change).

Verified live: `/remote-control` now connects and works end-to-end through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)