### PR TITLE
feat: --activity-log flag to persist the activity stream to a file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
+import { createWriteStream } from 'node:fs';
 import net from 'node:net';
 import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, loadState, saveState } from './config.js';
 import { AccountManager } from './account-manager.js';
@@ -118,6 +119,9 @@ async function serverCommand() {
   // --log-to <dir>
   const logTo = argValue('--log-to');
   if (logTo) config.logDir = logTo;
+
+  // --activity-log <file>
+  const activityLogPath = argValue('--activity-log') || null;
 
   if (config.accounts.length === 0) {
     console.error('No accounts configured.\n');
@@ -252,7 +256,7 @@ async function serverCommand() {
 
   if (useTUI) {
     tui = new TUI({
-      accountManager, config, sx,
+      accountManager, config, sx, activityLogPath,
       saveConfig: () => atomicConfigUpdate(async diskConfig => {
         // Write in-memory accounts as the authoritative state, preserving
         // extra disk-only fields (e.g. importFrom) where the account still exists.
@@ -292,6 +296,42 @@ async function serverCommand() {
       onRequestRouted: (id, info) => tui.onRequestRouted(id, info),
       onRequestEnd: (id, info) => tui.onRequestEnd(id, info),
     };
+  }
+
+  // In headless mode, wire activity-log writes directly via hooks + console.
+  if (!tui && activityLogPath) {
+    const aStream = createWriteStream(activityLogPath, { flags: 'a' });
+    aStream.on('error', err => process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`));
+    const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
+    const writeActivity = msg => {
+      // Strip [TeamClaude] prefix to match TUI behaviour
+      aStream.write(`${ts()}  ${msg.replace(/^\[TeamClaude\]\s*/, '')}\n`);
+    };
+    // Capture request completions via the hook
+    const inFlight = new Map();
+    hooks.onRequestStart = (id, info) => inFlight.set(id, { ...info, started: Date.now() });
+    hooks.onRequestModel = (id, info) => {
+      const r = inFlight.get(id);
+      if (r && info.model) r.model = info.model;
+    };
+    hooks.onRequestRouted = (id, info) => {
+      const r = inFlight.get(id);
+      if (r) r.account = info.account;
+    };
+    hooks.onRequestEnd = (id, info) => {
+      const r = inFlight.get(id);
+      inFlight.delete(id);
+      const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
+      const acct = info.account || r?.account || '?';
+      const model = info.model ? ` (${info.model})` : '';
+      writeActivity(`${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
+    };
+    // Tee console output to the activity log as well
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = (...a) => { const m = a.join(' '); origLog(m); writeActivity(m); };
+    console.error = (...a) => { const m = a.join(' '); origErr(m); writeActivity(m); };
+    process.on('exit', () => aStream.end());
   }
 
   // Expose reload to the proxy's control endpoint (works with or without TUI).
@@ -1178,6 +1218,7 @@ Options:
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)
+  --activity-log FILE Append TUI activity lines to FILE (server; works in headless mode too)
   --headless          Run the server without the interactive TUI (for backgrounding)
   --no-mitm           (run) skip the forward proxy; route via ANTHROPIC_BASE_URL only
   --auto-fallback     (run) if the proxy is down, launch claude directly instead

--- a/src/tui.js
+++ b/src/tui.js
@@ -1,3 +1,4 @@
+import { createWriteStream } from 'node:fs';
 import { importCredentials, fetchProfile } from './oauth.js';
 import { sameIdentity } from './identity.js';
 
@@ -154,7 +155,7 @@ function timestamp() {
 // ── TUI class ────────────────────────────────────────────────
 
 export class TUI {
-  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null }) {
+  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null, activityLogPath = null }) {
     this.am = accountManager;
     this.config = config;
     this.saveConfig = saveConfig;
@@ -163,6 +164,8 @@ export class TUI {
     this.sx = sx;            // sx.org proxy manager (may be null)
     this.sxBalance = null;   // last fetched sx.org balance, for the settings screen
     this.probeQuota = probeQuota; // on-demand fleet-wide quota refresh (may be null)
+    this.activityLogPath = activityLogPath;
+    this._activityStream = null;
 
     this.log = [];           // completed activity entries
     this.active = new Map(); // in-flight requests
@@ -187,6 +190,14 @@ export class TUI {
 
   start() {
     this.running = true;
+    if (this.activityLogPath) {
+      this._activityStream = createWriteStream(this.activityLogPath, { flags: 'a' });
+      this._activityStream.on('error', err => {
+        // Swallow write errors — can't log them to the TUI without recursion
+        this._activityStream = null;
+        process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`);
+      });
+    }
     process.stdout.write(`${ESC}?1049h${ESC}?25l`);
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -213,6 +224,7 @@ export class TUI {
     this.running = false;
     if (this.timer) { clearInterval(this.timer); this.timer = null; }
     if (this._origLog) { console.log = this._origLog; console.error = this._origErr; }
+    if (this._activityStream) { this._activityStream.end(); this._activityStream = null; }
     process.stdin.removeListener('data', this._dataHandler);
     process.stdout.removeListener('resize', this._resizeHandler);
     process.stdout.write(`${ESC}?25h${ESC}?1049l`);
@@ -248,8 +260,10 @@ export class TUI {
 
   _addLog(msg) {
     msg = msg.replace(/^\[TeamClaude\]\s*/, '');
-    this.log.unshift({ t: timestamp(), msg });
+    const t = timestamp();
+    this.log.unshift({ t, msg });
     if (this.log.length > 200) this.log.length = 200;
+    if (this._activityStream) this._activityStream.write(`${t}  ${strip(msg)}\n`);
     if (this.running) this.render();
   }
 


### PR DESCRIPTION
Add --activity-log <file> to teamclaude server. Activity lines — request completions (method, path, model, account, status, duration), account switches, quota resets, and rate-limit events — are appended to the file in addition to normal TUI or console output.

Works in both modes:
- TUI mode: TUI._addLog() writes each entry to the file as it renders
- Headless mode: request lifecycle hooks capture completions; console.log and console.error are teed to the file for system messages