### PR TITLE
feat: hold HTTP connection on exhaustion to keep long-running tasks alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
+- **Hold on exhaustion** — when all accounts are spent, `holdSeconds` keeps the HTTP connection open and polls silently until quota resets, so long-running Claude Code tasks continue automatically instead of aborting with a 429
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
 - **Optional keep-warm** — off by default; when enabled, periodically starts idle accounts' 5h session timers with a minimal request (`teamclaude warmup`) so the next account isn't cold when rotation reaches it (spends a little quota, unlike the probe)
 - **Account pinning** — force a request onto one account via an `ANTHROPIC_BASE_URL=.../tc-acct/<name>` prefix, bypassing rotation
@@ -257,6 +258,20 @@ On by default. Tune or disable via `stormRamp` in the config:
 
 The same gate handles **rate-limit 429s** (the per-minute throttle, not quota exhaustion): teamclaude pauses the account for the `retry-after` window so new queries wait instead of piling on, then releases the held queries through a fresh ramp (staggered, not all at once). It **never rotates** on a rate-limit 429 — that would just move the burst to the next account and drop the first account's cache. Short waits are absorbed inline on the same account (default ≤ 60s, `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`); longer ones return a 429 + `retry-after` so the client backs off. Only a **quota rejection** (`unified-…-status: rejected`) rotates.
 
+### Hold on quota exhaustion (holdSeconds, off by default)
+
+By default, when all accounts are exhausted teamclaude returns a `429` immediately, which causes Claude Code to abort the current task. With `holdSeconds` set, the proxy **holds the HTTP connection open** instead and polls silently every ~60 seconds; the instant any account's quota resets, the request is forwarded and Claude Code resumes — the interruption never happens.
+
+Set it in the config file (`~/.config/teamclaude.json`):
+
+```json
+"holdSeconds": 3600
+```
+
+`teamclaude run` automatically raises `API_TIMEOUT_MS` on the spawned Claude Code process to `holdSeconds + 60` seconds so the client-side timeout covers the full hold window — no manual configuration of Claude Code is needed.
+
+Useful for overnight or unattended runs: rather than waking up to a stopped task, the session resumes silently once a quota window opens.
+
 ### Config format
 
 ```json
@@ -293,6 +308,7 @@ The same gate handles **rate-limit 429s** (the per-minute throttle, not quota ex
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts (TUI: `g` → `t`) |
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |
 | `warmupSeconds` | Keep-warm interval in seconds (`0` = off, the default; CLI `warmup`). Spawns a minimal `claude` per idle account to start its 5h timer — **spends a little quota**, unlike the probe |
+| `holdSeconds` | Maximum seconds to hold the connection when all accounts are exhausted, polling silently until one recovers (`0` = return 429 immediately, the default). `teamclaude run` raises `API_TIMEOUT_MS` automatically to match |
 | `stormRamp` | Optional storm-control tuning (on by default) — see [Storm control](#storm-control-switchover-ramp-up). Object: `{ enabled, startConc, stepConc, stepMs, windowMs }` |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
@@ -483,7 +499,7 @@ TLS is established **end-to-end with `api.anthropic.com` over the tunnel**, so t
 5. When usage reaches the threshold, the proxy switches to the next available account via round-robin
 6. On 429 responses, the proxy waits the `retry-after` duration and retries; on persistent errors, it switches accounts
 7. Transient network errors (connection reset, timeout) drop the connection so the client can retry
-8. If all accounts are exhausted, returns 429 with the soonest reset time
+8. If all accounts are exhausted, returns 429 with the soonest reset time — or, with `holdSeconds` set, holds the connection open and retries silently until an account recovers
 9. Client token refresh requests (`/v1/oauth/token`) are relayed to upstream untouched — the proxy and client manage their own token lifecycles independently
 
 ## Security

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ export function createDefaultConfig() {
     },
     upstream: 'https://api.anthropic.com',
     switchThreshold: 0.98,
+    holdSeconds: 0,
     accounts: [],
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -599,6 +599,19 @@ async function runCommand() {
     process.exit(1);
   }
 
+  // If holdSeconds is set, ensure API_TIMEOUT_MS on the Claude Code side is
+  // large enough for the hold to complete. Add 60s padding (one extra poll
+  // cycle) so the client doesn't time out while we're still waiting.
+  // Claude Code defaults API_TIMEOUT_MS to 600000ms (10 min) when unset, so
+  // use that as the baseline to avoid accidentally lowering the timeout.
+  const holdMs = (config.holdSeconds || 0) * 1000;
+  if (holdMs > 0) {
+    const needed = holdMs + 60_000;
+    const API_TIMEOUT_DEFAULT_MS = 600_000;
+    const current = parseInt(env.API_TIMEOUT_MS || '0', 10) || API_TIMEOUT_DEFAULT_MS;
+    if (current < needed) env.API_TIMEOUT_MS = String(needed);
+  }
+
   // Use spawnSync so the Node process blocks entirely — behaves like execvp.
   const result = spawnSync('claude', claudeArgs, {
     stdio: 'inherit',

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -113,7 +113,8 @@ export function hostMode(host, config) {
 export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx });
+  const holdMs = (config.holdSeconds || 0) * 1000;
+  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs });
 
   // One terminating h2/h1 server, minted lazily on the first intercepted CONNECT.
   // TLS uses our leaf; ALPN negotiates h2 or http/1.1 (allowHTTP1) with whatever

--- a/src/server.js
+++ b/src/server.js
@@ -51,6 +51,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const logDir = config.logDir || null;
+  const holdMs = (config.holdSeconds || 0) * 1000;
 
   if (logDir) {
     mkdir(logDir, { recursive: true }).catch(() => {});
@@ -105,7 +106,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
     }
   };
 
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx });
+  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs });
   const server = http.createServer(requestHandler);
 
   // Forward-proxy support (always on, so multiple claude instances can use
@@ -151,7 +152,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/f
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
-export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null }) {
+export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0 }) {
   let counter = 0;
   return async (req, res) => {
     try {
@@ -207,7 +208,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).
       const advisorModel = parseAdvisorModel(body);
-      const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex };
+      const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -380,6 +381,23 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ctx.account = '(none available)';
     const status = accountManager.getStatus();
     const retryAfter = computeRetryAfter(status.accounts);
+
+    // Long-hold mode: hold the HTTP connection and poll until an account
+    // recovers or the budget (holdSeconds) runs out. Claude Code waits for
+    // the first response byte, so this is transparent to the client as long
+    // as API_TIMEOUT_MS on the Claude Code side is large enough.
+    if (ctx.holdBudgetMs > 0) {
+      // Cap the per-poll sleep to 60s so a newly-available account (e.g. one
+      // manually enabled or whose quota reset early) is picked up within a
+      // minute instead of sleeping the full retryAfter (often 3600s).
+      const waitMs = Math.min(retryAfter * 1000, ctx.holdBudgetMs, 60_000);
+      ctx.holdBudgetMs -= waitMs;
+      console.log(`[TeamClaude] All accounts exhausted — holding connection, retry in ${Math.ceil(waitMs / 1000)}s (${Math.ceil(ctx.holdBudgetMs / 1000)}s budget left)`);
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+      if (res.destroyed) return;
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
+    }
+
     const exhaustedRetries = ctx.exhaustedRetries || 0;
     if (exhaustedRetries < 1 && retryAfter <= INLINE_RETRY_AFTER_MAX_SECONDS) {
       ctx.exhaustedRetries = exhaustedRetries + 1;


### PR DESCRIPTION
When all accounts are quota-exhausted, teamclaude normally returns a 429 immediately, causing Claude Code to abort the current task. With holdSeconds set, the proxy holds the HTTP connection open instead and polls silently (every ~60s) until an account's quota resets — the request is then forwarded transparently and Claude Code continues from where it left off.

teamclaude run automatically sets API_TIMEOUT_MS = holdSeconds + 60s on the spawned Claude Code process so the client-side timeout covers the full hold window. Default holdSeconds=0 preserves existing behavior unchanged.

This is useful when we want the claude code to do a long-term task whole night, we don't want it to be interupted when all accounts are exhausted, we want the claude code to continue the work when some accounts reset the quota. Although the claude code can make some extra tries when exausted, but it only try 10 times and after that it will stop.

Not fully tested, I've run this for a few days it seems working well.
