### PR TITLE
fix(routing): stop reporting a healthy pool as fully exhausted

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -473,6 +473,49 @@ export class AccountManager {
   }
 
   /**
+   * Explain why each account is or is not requestable without exposing account
+   * identities. The server uses these mutually-exclusive counts to avoid
+   * collapsing authentication failures, quota exhaustion, transient throttles,
+   * routing exclusions, and per-request failures into one synthetic message.
+   */
+  getAvailabilitySummary(exclude = null, model = null, advisorModel = null) {
+    const counts = {
+      available: 0,
+      authentication: 0,
+      quota: 0,
+      temporary: 0,
+      disabled: 0,
+      route: 0,
+      excluded: 0,
+    };
+
+    for (const account of this.accounts) {
+      if (account.disabled) {
+        counts.disabled++;
+        continue;
+      }
+      if ((model && !this._routeAllows(account, model))
+          || (advisorModel && !this._routeAllows(account, advisorModel))) {
+        counts.route++;
+        continue;
+      }
+      if (!this._isAvailable(account, model, advisorModel)) {
+        if (account.status === 'error') counts.authentication++;
+        else if (account.status === 'exhausted' || this._isNearQuota(account, model)) counts.quota++;
+        else if (account.status === 'throttled') counts.temporary++;
+        else counts.quota++;
+        continue;
+      }
+      // Preserve persistent state evidence above. `excluded` is only for an
+      // otherwise-requestable account that failed earlier in this request.
+      if (exclude?.has(account.index)) counts.excluded++;
+      else counts.available++;
+    }
+
+    return { total: this.accounts.length, counts };
+  }
+
+  /**
    * Normalize and store the configurable routing table. A route pins a set of
    * model globs to an exclusive set of accounts (and may override the governing
    * quota bucket). Called from the constructor and on config reload.
@@ -977,10 +1020,13 @@ export class AccountManager {
     const account = this.accounts[accountIndex];
     if (!account) return;
     account.disabled = disabled;
-    if (!disabled && account.status === 'error') {
+    if (!disabled && ['error', 'throttled', 'exhausted'].includes(account.status)) {
       account.status = 'active';
       account.rateLimitedUntil = null;
-      console.log(`[TeamClaude] Account "${account.name}" re-enabled — clearing error state`);
+      account.throttledAt = null;
+      account.pausedUntil = null;
+      account.requalify = true;
+      console.log(`[TeamClaude] Account "${account.name}" re-enabled — clearing cached unavailable state`);
     }
   }
 
@@ -1009,6 +1055,14 @@ export class AccountManager {
     if (usage.sevenDayFable) {
       if (usage.sevenDayFable.utilization != null) q.unified7dFable = usage.sevenDayFable.utilization;
       if (usage.sevenDayFable.resetAt != null) q.unified7dFableReset = usage.sevenDayFable.resetAt;
+    }
+
+    // A successful usage response is live evidence. Retire the legacy hard
+    // `exhausted` state once the governing quota is below the live threshold;
+    // the quota values remain authoritative and still gate selection normally.
+    if (account.status === 'exhausted' && !this._isNearQuota(account)) {
+      account.status = 'active';
+      account.requalify = true;
     }
 
     // If we just learned this account's weekly window while probing, re-evaluate
@@ -1049,15 +1103,35 @@ export class AccountManager {
   }
 
   /**
+   * Quarantine one account after live upstream proof that its credential is
+   * rejected. Authentication state is account-local: it must never poison the
+   * rest of the pool or be collapsed into quota exhaustion.
+   */
+  markAuthenticationFailed(accountIndex) {
+    const account = this.accounts[accountIndex];
+    if (!account) return;
+    account.status = 'error';
+    account.rateLimitedUntil = null;
+    account.throttledAt = null;
+    account.pausedUntil = null;
+    account.requalify = false;
+    console.error(`[TeamClaude] Account "${account.name}" rejected authentication — isolated from rotation`);
+  }
+
+  /**
    * Ensure an OAuth account's token is fresh, refreshing if needed.
    * Pass force=true to refresh regardless of expiry (e.g. after a 401).
    * Concurrent calls for the same account coalesce into a single refresh.
    */
   async ensureTokenFresh(accountIndex, force = false) {
     const account = this.accounts[accountIndex];
-    if (!account || account.type !== 'oauth' || !account.refreshToken) return;
+    if (!account || account.type !== 'oauth' || !account.refreshToken) {
+      return { ok: true, classification: 'not-applicable' };
+    }
 
-    if (!force && !isTokenExpiringSoon(account.expiresAt)) return;
+    if (!force && !isTokenExpiringSoon(account.expiresAt)) {
+      return { ok: true, classification: 'fresh' };
+    }
 
     // Coalesce concurrent refreshes
     if (account._refreshPromise) return account._refreshPromise;
@@ -1069,8 +1143,10 @@ export class AccountManager {
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
+        if (account.status === 'error') account.status = 'active';
         console.log(`[TeamClaude] Token refreshed for account "${account.name}"`);
         this._onTokenRefresh?.(accountIndex, newTokens);
+        return { ok: true, classification: 'refreshed' };
       } catch (err) {
         console.error(`[TeamClaude] Token refresh failed for "${account.name}": ${err.message}`);
         // Reserve 'error' (which drops the account from rotation until re-login)
@@ -1083,7 +1159,9 @@ export class AccountManager {
         if (isAuthRejection) {
           account.status = 'error';
           console.error(`[TeamClaude] Account "${account.name}" needs re-login (refresh token rejected) — run: teamclaude login`);
+          return { ok: false, classification: 'authentication' };
         }
+        return { ok: false, classification: 'transient' };
       } finally {
         account._refreshPromise = null;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -215,7 +215,7 @@ async function serverCommand() {
   // POST /teamclaude/reload endpoint, and the CLI notify after add/change all
   // funnel through here. Returns the number of newly added accounts. Also picks
   // up a changed probe interval so `teamclaude probe` applies live.
-  const reloadAccounts = async () => {
+  const reloadAccounts = async (revalidateConfigIndex = null) => {
     const diskConfig = await loadConfig();
     if (!diskConfig) return 0;
     const added = await syncAccountsFromDisk(diskConfig, config, accountManager);
@@ -244,6 +244,42 @@ async function serverCommand() {
         warmer.reschedule(ms);
       }
     }
+
+    let revalidated = null;
+    if (Number.isSafeInteger(revalidateConfigIndex)) {
+      const diskAccount = diskConfig.accounts[revalidateConfigIndex];
+      const managerIndex = diskAccount
+        ? accountManager.accounts.findIndex(account => sameIdentity(account, diskAccount))
+        : -1;
+      const account = managerIndex >= 0 ? accountManager.accounts[managerIndex] : null;
+      if (!account) {
+        revalidated = { requested: true, status: 'missing' };
+      } else if (account.disabled) {
+        revalidated = { requested: true, status: 'disabled' };
+      } else if (account.type === 'oauth' && !account.refreshToken) {
+        account.status = 'error';
+        revalidated = { requested: true, status: 'authentication' };
+      } else {
+        // Consume fresh provider truth at the command boundary. A credential
+        // refresh alone cannot retire stale quota, while the zero-spend usage
+        // endpoint updates the exact fields used by selection.
+        const validation = prober
+          ? await prober.probeAccount(account)
+          : await accountManager.ensureTokenFresh(managerIndex, true);
+        revalidated = {
+          requested: true,
+          status: validation?.ok
+            ? (accountManager._isAvailable(account) ? 'active' : 'quota')
+            : (validation?.classification || 'transient'),
+        };
+      }
+    }
+
+    // Re-evaluate the active account after every config sync. Priority changes
+    // take effect immediately, while a failed validation leaves the target out
+    // of rotation and selects the next requestable account.
+    accountManager.selectActiveAccount();
+    if (revalidated) return { added, revalidated };
     return added;
   };
 
@@ -1100,7 +1136,11 @@ async function priorityCommand() {
   account.priority = priority;
   await saveConfig(config);
   console.log(`Set priority of "${account.name}" to ${priority} (lower = preferred)`);
-  await notifyRunningServer(config);
+  const reload = await notifyRunningServer(config, config.accounts.indexOf(account));
+  if (reload?.revalidated && reload.revalidated.status !== 'active') {
+    console.error(`Priority saved, but the target is not requestable (${reload.revalidated.status}). The running server selected another healthy account.`);
+    process.exitCode = 2;
+  }
 }
 
 // ── enable / disable ────────────────────────────────────────
@@ -1127,8 +1167,15 @@ async function setDisabledCommand(disabled) {
     delete account.disabled;
   }
   await saveConfig(config);
+  const reload = await notifyRunningServer(
+    config,
+    disabled ? null : config.accounts.indexOf(account),
+  );
   console.log(`${disabled ? 'Disabled' : 'Enabled'} account "${account.name}"`);
-  await notifyRunningServer(config);
+  if (!disabled && reload?.revalidated && reload.revalidated.status !== 'active') {
+    console.error(`Account enabled in config but not requestable (${reload.revalidated.status}). Credential repair is required.`);
+    process.exitCode = 2;
+  }
 }
 
 // ── help ────────────────────────────────────────────────────
@@ -1404,19 +1451,25 @@ function upstreamHost(config) {
 // connection immediately, so this is a no-op (and near-instant) when nothing is
 // running. Reload picks up new accounts, credential, priority, and enable/disable
 // changes; account removals still need a restart.
-async function notifyRunningServer(config) {
+async function notifyRunningServer(config, revalidateIndex = null) {
   const port = config?.proxy?.port;
-  if (!port) return;
+  if (!port) return null;
   try {
+    const headers = { 'x-api-key': config.proxy?.apiKey || '' };
+    if (Number.isSafeInteger(revalidateIndex) && revalidateIndex >= 0) {
+      headers['x-teamclaude-revalidate-index'] = String(revalidateIndex);
+    }
     const res = await fetch(`http://localhost:${port}/teamclaude/reload`, {
       method: 'POST',
-      headers: { 'x-api-key': config.proxy?.apiKey || '' },
+      headers,
     });
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       console.log(`Reloaded running server${data.added ? ` (+${data.added} new account)` : ''}.`);
+      return data;
     }
   } catch { /* no server running — nothing to notify */ }
+  return null;
 }
 
 // Quick liveness probe: is something listening on the local proxy port?

--- a/src/prober.js
+++ b/src/prober.js
@@ -76,12 +76,27 @@ export class Prober {
       let usage = await this._withTimeout(this.probeFn(account.credential));
       if (usage?.status === 401) {
         // Token rejected: force refresh and retry once.
-        await this.am.ensureTokenFresh(account.index, true);
+        const refresh = await this.am.ensureTokenFresh(account.index, true);
+        if (!refresh?.ok && refresh?.classification === 'authentication') {
+          const finishedAt = Date.now();
+          this._recordAccount(account, {
+            status: 'error',
+            error: 'authentication rejected',
+            startedAt,
+            finishedAt,
+            durationMs: finishedAt - startedAt,
+          });
+          return { ok: false, classification: 'authentication' };
+        }
         usage = await this._withTimeout(this.probeFn(account.credential));
       }
 
       if (!usage || usage.error) {
         const finishedAt = Date.now();
+        const classification = usage?.status === 401 ? 'authentication' : 'transient';
+        if (classification === 'authentication') {
+          this.am.markAuthenticationFailed(account.index);
+        }
         this._recordAccount(account, {
           status: usage?.error ? 'error' : 'timeout',
           error: usage?.error || 'probe timed out',
@@ -89,7 +104,7 @@ export class Prober {
           finishedAt,
           durationMs: finishedAt - startedAt,
         });
-        return;
+        return { ok: false, classification };
       }
 
       this.am.applyUsageData(account.index, usage);
@@ -101,6 +116,7 @@ export class Prober {
         finishedAt,
         durationMs: finishedAt - startedAt,
       });
+      return { ok: true, classification: 'active' };
     } catch (err) {
       const finishedAt = Date.now();
       this._recordAccount(account, {
@@ -110,6 +126,7 @@ export class Prober {
         finishedAt,
         durationMs: finishedAt - startedAt,
       });
+      return { ok: false, classification: 'transient' };
     }
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -89,9 +89,18 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
           return;
         }
         try {
-          const added = await hooks.reload();
+          const rawIndex = req.headers['x-teamclaude-revalidate-index'];
+          const parsedIndex = typeof rawIndex === 'string' && /^\d+$/.test(rawIndex)
+            ? Number(rawIndex) : null;
+          const revalidateIndex = parsedIndex != null
+            && Number.isSafeInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < 10_000
+            ? parsedIndex : null;
+          const result = await hooks.reload(revalidateIndex);
+          const payload = typeof result === 'number'
+            ? { added: result }
+            : (result && typeof result === 'object' ? result : { added: 0 });
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: true, added: added || 0 }));
+          res.end(JSON.stringify({ ok: true, ...payload, added: payload.added || 0 }));
         } catch (err) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: false, error: err.message }));
@@ -380,23 +389,40 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ctx.account = '(none available)';
     const status = accountManager.getStatus();
     const retryAfter = computeRetryAfter(status.accounts);
+    const availability = accountManager.getAvailabilitySummary(ctx.tried, ctx.model, ctx.advisorModel);
+    const counts = availability.counts;
+    const quotaOnly = counts.quota > 0
+      && counts.authentication === 0 && counts.temporary === 0 && counts.excluded === 0;
+    const temporaryOnly = counts.temporary > 0
+      && counts.authentication === 0 && counts.quota === 0 && counts.excluded === 0;
     const exhaustedRetries = ctx.exhaustedRetries || 0;
-    if (exhaustedRetries < 1 && retryAfter <= INLINE_RETRY_AFTER_MAX_SECONDS) {
+    if ((quotaOnly || temporaryOnly)
+        && exhaustedRetries < 1 && retryAfter <= INLINE_RETRY_AFTER_MAX_SECONDS) {
       ctx.exhaustedRetries = exhaustedRetries + 1;
-      console.log(`[TeamClaude] All accounts exhausted — waiting ${retryAfter}s before retry`);
+      console.log(`[TeamClaude] Pool unavailable (${quotaOnly ? 'quota' : 'temporary'}) — waiting ${retryAfter}s before retry`);
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
       if (res.destroyed) return;
       return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
     }
-    res.writeHead(429, {
+    const responseStatus = quotaOnly || temporaryOnly ? 429 : 503;
+    const code = quotaOnly ? 'all_quota_exhausted'
+      : temporaryOnly ? 'temporary_rate_limited' : 'mixed_pool_unavailable';
+    const message = quotaOnly
+      ? `All ${counts.quota} eligible accounts are at usage limits. Retry in ${retryAfter}s.`
+      : temporaryOnly
+        ? `All ${counts.temporary} eligible accounts are temporarily rate limited. Retry in ${retryAfter}s.`
+        : `TeamClaude pool unavailable: ${counts.authentication} authentication-invalid, ${counts.quota} quota-limited, ${counts.temporary} temporarily-limited, ${counts.excluded} failed-this-request.`;
+    ctx.status = responseStatus;
+    res.writeHead(responseStatus, {
       'Content-Type': 'application/json',
       'retry-after': String(retryAfter),
     });
     res.end(JSON.stringify({
       type: 'error',
       error: {
-        type: 'rate_limit_error',
-        message: `All ${accountManager.accounts.length} accounts exhausted. Retry in ${retryAfter}s.`,
+        type: responseStatus === 429 ? 'rate_limit_error' : 'service_unavailable_error',
+        code,
+        message,
       },
     }));
     return;
@@ -497,6 +523,38 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // this is what lets a revalidation probe (a throttled account selected by
     // _selectProbe) clear its own hold and return the fleet to service.
     if (upstreamRes.status !== 429) accountManager.clearRateLimited(account.index);
+
+    // A live 401 is account-local authentication evidence, never a fleet-wide
+    // quota state. OAuth gets one forced refresh per account per request; a
+    // second 401 after refreshed credentials (or an API-key 401) quarantines
+    // only that account and fails over within the existing bounded retry walk.
+    if (upstreamRes.status === 401) {
+      await upstreamRes.body?.cancel();
+      ctx.authRefreshTried ||= new Set();
+      let validation = null;
+      if (account.type === 'oauth' && account.refreshToken
+          && !ctx.authRefreshTried.has(account.index)) {
+        ctx.authRefreshTried.add(account.index);
+        validation = await accountManager.ensureTokenFresh(account.index, true);
+        if (validation?.ok && retryCount < maxRetries) {
+          console.log(`[TeamClaude] Authentication rejected for "${account.name}" — retrying once with refreshed credentials`);
+          if (res.destroyed) return;
+          return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
+        }
+      }
+
+      // A transient refresh transport failure is not proof the refresh token is
+      // bad. Exclude the account only for this request; all definitive cases are
+      // quarantined until a credential update or explicit re-enable revalidates.
+      if (validation?.classification !== 'transient') {
+        accountManager.markAuthenticationFailed(account.index);
+      }
+      ctx.tried.add(account.index);
+      if (retryCount < maxRetries) {
+        if (res.destroyed) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+      }
+    }
 
     // Two kinds of 429 are handled differently below: a quota rejection rotates
     // to another account; a transient rate-limit throttle pauses + retries the

--- a/test/quota-routing-availability.test.js
+++ b/test/quota-routing-availability.test.js
@@ -1,0 +1,570 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+import { Prober } from '../src/prober.js';
+
+// White-box guards below read the CLI wiring straight from source so a future
+// refactor cannot silently drop the enable/priority/reload revalidation path.
+const INDEX_SOURCE_PATH = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+function manager(accounts, options = {}) {
+  return new AccountManager(accounts, 0.98, {
+    ramp: { enabled: false },
+    ...options,
+  });
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  return server.address().port;
+}
+
+async function close(server) {
+  await new Promise(resolve => server.close(resolve));
+}
+
+async function postJson(port, path = '/v1/messages') {
+  const body = JSON.stringify({ model: 'claude-opus-4-8', max_tokens: 1, messages: [{ role: 'user', content: 'x' }] });
+  return await new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1', port, path, method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
+    }, res => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    req.once('error', reject);
+    req.end(body);
+  });
+}
+
+test('mixed auth and quota failures never claim fleet-wide quota exhaustion', async () => {
+  const rejected = Object.assign(new Error('invalid grant'), { status: 400 });
+  const am = manager([
+    { name: 'target', type: 'oauth', accessToken: 'old-a', refreshToken: 'bad-a', expiresAt: 1, priority: -10 },
+    { name: 'quota', type: 'apikey', apiKey: 'quota-key', priority: 0 },
+    { name: 'auth2', type: 'oauth', accessToken: 'old-c', refreshToken: 'bad-c', expiresAt: 1, priority: 1 },
+  ], { refreshFn: async () => { throw rejected; } });
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(429, {
+      'content-type': 'application/json',
+      'retry-after': '120',
+      'anthropic-ratelimit-unified-5h-status': 'rejected',
+      'anthropic-ratelimit-unified-5h-utilization': '1',
+    });
+    res.end('{"type":"error"}');
+  });
+  const upstreamPort = await listen(upstream);
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const port = await listen(proxy);
+  try {
+    const response = await postJson(port);
+    assert.equal(response.status, 503);
+    assert.match(response.body, /2 authentication-invalid, 1 quota-limited/);
+    assert.doesNotMatch(response.body, /All 3 accounts exhausted/);
+  } finally {
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('only a genuinely all-quota fleet emits a quota-exhausted response', async () => {
+  const am = manager([
+    { name: 'quota1', type: 'apikey', apiKey: 'a' },
+    { name: 'quota2', type: 'apikey', apiKey: 'b' },
+  ]);
+  for (const account of am.accounts) account.quota.unified5h = 1;
+  am._nextProbeAt = Infinity;
+  const proxy = createProxyServer(am, { upstream: 'http://127.0.0.1:1', proxy: {} });
+  const port = await listen(proxy);
+  try {
+    const response = await postJson(port);
+    assert.equal(response.status, 429);
+    assert.match(response.body, /all_quota_exhausted/);
+    assert.match(response.body, /usage limits/);
+  } finally { await close(proxy); }
+});
+
+test('transient server 429 without an alternative keeps same-account backoff semantics', async () => {
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(429, { 'content-type': 'application/json', 'retry-after': '120' });
+    res.end('{"type":"error"}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = manager([{ name: 'only', type: 'apikey', apiKey: 'only' }]);
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const response = await postJson(proxyPort);
+    assert.equal(response.status, 429);
+    assert.match(response.body, /Rate limited/);
+    assert.equal(response.headers['retry-after'], '120');
+  } finally {
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('lower numeric priority preempts a healthy current account', () => {
+  const am = manager([
+    { name: 'current', type: 'apikey', apiKey: 'a', priority: 0 },
+    { name: 'preferred', type: 'apikey', apiKey: 'b', priority: -10 },
+  ]);
+  assert.equal(am.getActiveAccount().name, 'preferred');
+});
+
+test('an authentication-error priority target falls back to a healthy account', () => {
+  const am = manager([
+    { name: 'fallback', type: 'apikey', apiKey: 'a', priority: 0 },
+    { name: 'preferred', type: 'apikey', apiKey: 'b', priority: -10 },
+  ]);
+  am.accounts[1].status = 'error';
+  assert.equal(am.getActiveAccount().name, 'fallback');
+});
+
+test('explicit enable clears cached error, throttle, and legacy exhausted states', () => {
+  for (const staleState of ['error', 'throttled', 'exhausted']) {
+    const am = manager([{ name: staleState, type: 'apikey', apiKey: 'a' }]);
+    am.accounts[0].disabled = true;
+    am.accounts[0].status = staleState;
+    am.accounts[0].rateLimitedUntil = Date.now() + 60_000;
+    am.setDisabled(0, false);
+    assert.equal(am.accounts[0].status, 'active');
+    assert.equal(am.accounts[0].rateLimitedUntil, null);
+  }
+});
+
+test('forced credential revalidation reports rejected refresh and marks auth error', async () => {
+  const rejected = Object.assign(new Error('invalid grant'), { status: 400 });
+  const am = manager([{
+    name: 'oauth', type: 'oauth', accessToken: 'old', refreshToken: 'bad', expiresAt: Date.now() + 60_000,
+  }], { refreshFn: async () => { throw rejected; } });
+  const result = await am.ensureTokenFresh(0, true);
+  assert.deepEqual(result, { ok: false, classification: 'authentication' });
+  assert.equal(am.accounts[0].status, 'error');
+});
+
+test('fresh credentials clear an authentication error without clearing quota evidence', () => {
+  const am = manager([{ name: 'oauth', type: 'oauth', accessToken: 'old', refreshToken: 'old-r', expiresAt: 1 }]);
+  am.accounts[0].status = 'error';
+  am.accounts[0].quota.unified7d = 0.7;
+  am.updateAccountTokens(0, { accessToken: 'new', refreshToken: 'new-r', expiresAt: Date.now() + 60_000 });
+  assert.equal(am.accounts[0].status, 'active');
+  assert.equal(am.accounts[0].quota.unified7d, 0.7);
+});
+
+test('live under-threshold usage evidence clears a legacy exhausted state', () => {
+  const am = manager([{ name: 'quota', type: 'apikey', apiKey: 'a' }]);
+  am.accounts[0].status = 'exhausted';
+  am.accounts[0].quota.unified5h = 1;
+  am.applyUsageData(0, {
+    fiveHour: { utilization: 0.2, resetAt: Date.now() + 60_000 },
+    sevenDay: { utilization: 0.3, resetAt: Date.now() + 60_000 },
+  });
+  assert.equal(am.accounts[0].status, 'active');
+});
+
+test('availability summary separates requestable, auth, quota, throttle, disabled, and excluded', () => {
+  const am = manager([
+    { name: 'available', type: 'apikey', apiKey: 'a' },
+    { name: 'auth', type: 'apikey', apiKey: 'b' },
+    { name: 'quota', type: 'apikey', apiKey: 'c' },
+    { name: 'throttle', type: 'apikey', apiKey: 'd' },
+    { name: 'disabled', type: 'apikey', apiKey: 'e', disabled: true },
+    { name: 'excluded', type: 'apikey', apiKey: 'f' },
+  ]);
+  am.accounts[1].status = 'error';
+  am.accounts[2].quota.unified5h = 1;
+  am.accounts[3].status = 'throttled';
+  am.accounts[3].rateLimitedUntil = Date.now() + 60_000;
+  const summary = am.getAvailabilitySummary(new Set([5]), 'claude-opus-4-8');
+  assert.deepEqual(summary.counts, {
+    available: 1, authentication: 1, quota: 1, temporary: 1,
+    disabled: 1, route: 0, excluded: 1,
+  });
+
+  const routed = manager([
+    { name: 'general', type: 'apikey', apiKey: 'g' },
+    { name: 'fable-only', type: 'apikey', apiKey: 'f' },
+  ], { routes: [{ name: 'fable', match: ['claude-fable-5'], accounts: ['fable-only'] }] });
+  const routedSummary = routed.getAvailabilitySummary(null, 'claude-fable-5');
+  assert.equal(routedSummary.counts.available, 1);
+  assert.equal(routedSummary.counts.route, 1);
+});
+
+test('reload control forwards a bounded revalidation index and returns safe state', async () => {
+  const am = manager([{ name: 'one', type: 'apikey', apiKey: 'a' }]);
+  let observed = null;
+  const proxy = createProxyServer(am, { upstream: 'http://127.0.0.1:1', proxy: {} }, {
+    reload: async index => {
+      observed = index;
+      return { added: 0, revalidated: { requested: true, status: 'active' } };
+    },
+  });
+  const port = await listen(proxy);
+  try {
+    const response = await new Promise((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1', port, path: '/teamclaude/reload', method: 'POST',
+        headers: { 'x-teamclaude-revalidate-index': '0' },
+      }, res => {
+        const chunks = [];
+        res.on('data', chunk => chunks.push(chunk));
+        res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString('utf8') }));
+      });
+      req.once('error', reject);
+      req.end();
+    });
+    assert.equal(response.status, 200);
+    assert.equal(observed, 0);
+    assert.deepEqual(JSON.parse(response.body).revalidated, { requested: true, status: 'active' });
+  } finally { await close(proxy); }
+
+  const indexSource = await readFile(INDEX_SOURCE_PATH, 'utf8');
+  assert.match(indexSource, /x-teamclaude-revalidate-index/);
+  assert.match(indexSource, /sameIdentity\(account, diskAccount\)/);
+});
+
+test('a live upstream 401 is isolated and the request fails over to a healthy account', async () => {
+  const calls = [];
+  const emitted = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => emitted.push(args.join(' '));
+  console.error = (...args) => emitted.push(args.join(' '));
+  const upstream = http.createServer((req, res) => {
+    const key = req.headers['x-api-key'];
+    calls.push(key);
+    if (key === 'secret-rejected-credential') {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end('{"type":"error","error":{"type":"authentication_error"}}');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{"ok":true,"sentinel":"ASCII_OK"}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = manager([
+    { name: 'account-a', type: 'apikey', apiKey: 'secret-rejected-credential', priority: -10 },
+    { name: 'account-b', type: 'apikey', apiKey: 'secret-healthy-credential', priority: 0 },
+  ]);
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const response = await postJson(proxyPort);
+    assert.equal(response.status, 200);
+    assert.deepEqual(calls, ['secret-rejected-credential', 'secret-healthy-credential']);
+    assert.equal(am.accounts[0].status, 'error');
+    assert.deepEqual(am.getAvailabilitySummary().counts, {
+      available: 1, authentication: 1, quota: 0, temporary: 0,
+      disabled: 0, route: 0, excluded: 0,
+    });
+    assert.doesNotMatch(emitted.join('\n'), /secret-(rejected|healthy)-credential/);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('one healthy account remains selectable beside two exhausted accounts', () => {
+  const am = manager([
+    { name: 'spent-a', type: 'apikey', apiKey: 'a', priority: -20 },
+    { name: 'healthy', type: 'apikey', apiKey: 'b', priority: 0 },
+    { name: 'spent-b', type: 'apikey', apiKey: 'c', priority: -10 },
+  ]);
+  am.accounts[0].quota.unified5h = 1;
+  am.accounts[2].quota.unified7d = 1;
+  assert.equal(am.getActiveAccount().name, 'healthy');
+});
+
+test('healthy selection survives one authentication failure and one exhausted account', () => {
+  const am = manager([
+    { name: 'auth', type: 'apikey', apiKey: 'a', priority: -20 },
+    { name: 'quota', type: 'apikey', apiKey: 'b', priority: -10 },
+    { name: 'healthy', type: 'apikey', apiKey: 'c', priority: 0 },
+  ]);
+  am.markAuthenticationFailed(0);
+  am.accounts[1].quota.unified5h = 1;
+  assert.equal(am.getActiveAccount().name, 'healthy');
+});
+
+test('a real usage rejection fails over and preserves quota classification', async () => {
+  const calls = [];
+  const upstream = http.createServer((req, res) => {
+    const key = req.headers['x-api-key'];
+    calls.push(key);
+    if (key === 'spent') {
+      res.writeHead(429, {
+        'content-type': 'application/json',
+        'retry-after': '120',
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'anthropic-ratelimit-unified-5h-utilization': '1',
+        'anthropic-ratelimit-unified-5h-reset': String(Math.floor((Date.now() + 120_000) / 1000)),
+      });
+      res.end('{"type":"error"}');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{"ok":true}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = manager([
+    { name: 'spent', type: 'apikey', apiKey: 'spent', priority: -10 },
+    { name: 'healthy', type: 'apikey', apiKey: 'healthy', priority: 0 },
+  ]);
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const response = await postJson(proxyPort);
+    assert.equal(response.status, 200);
+    assert.deepEqual(calls, ['spent', 'healthy']);
+    assert.equal(am.getAvailabilitySummary().counts.quota, 1);
+  } finally {
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('an all-quota pool returns explicit quota code and reset timing', async () => {
+  const resetAt = Date.now() + 120_000;
+  const am = manager([
+    { name: 'spent-a', type: 'apikey', apiKey: 'a' },
+    { name: 'spent-b', type: 'apikey', apiKey: 'b' },
+  ]);
+  for (const account of am.accounts) {
+    account.quota.unified5h = 1;
+    account.quota.unified5hReset = resetAt;
+  }
+  am._nextProbeAt = Infinity;
+  const proxy = createProxyServer(am, { upstream: 'http://127.0.0.1:1', proxy: {} });
+  const port = await listen(proxy);
+  try {
+    const response = await postJson(port);
+    const payload = JSON.parse(response.body);
+    assert.equal(response.status, 429);
+    assert.equal(payload.error.code, 'all_quota_exhausted');
+    assert.ok(Number(response.headers['retry-after']) > 0);
+  } finally { await close(proxy); }
+});
+
+test('an all-temporary pool is not reported as quota exhausted', async () => {
+  const am = manager([
+    { name: 'temp-a', type: 'apikey', apiKey: 'a' },
+    { name: 'temp-b', type: 'apikey', apiKey: 'b' },
+  ]);
+  for (const account of am.accounts) {
+    account.status = 'throttled';
+    account.rateLimitedUntil = Date.now() + 120_000;
+    account.throttledAt = Date.now();
+  }
+  am._nextProbeAt = Infinity;
+  const proxy = createProxyServer(am, { upstream: 'http://127.0.0.1:1', proxy: {} });
+  const port = await listen(proxy);
+  try {
+    const response = await postJson(port);
+    const payload = JSON.parse(response.body);
+    assert.equal(response.status, 429);
+    assert.equal(payload.error.code, 'temporary_rate_limited');
+    assert.doesNotMatch(response.body, /quota|exhausted/i);
+  } finally { await close(proxy); }
+});
+
+test('concurrent admission serializes a live lease without poisoning availability', async () => {
+  const am = manager([{ name: 'healthy', type: 'apikey', apiKey: 'a' }], {
+    ramp: { enabled: true, startConc: 1, stepConc: 1, stepMs: 10_000, windowMs: 30_000, pollMs: 1 },
+  });
+  am._beginRamp(am.accounts[0]);
+  assert.equal(await am.admit(0), true);
+  let secondAdmitted = false;
+  const second = am.admit(0).then(value => { secondAdmitted = value; return value; });
+  await new Promise(resolve => setTimeout(resolve, 10));
+  assert.equal(secondAdmitted, false);
+  assert.equal(am.getAvailabilitySummary().counts.available, 1);
+  am.release(0);
+  assert.equal(await second, true);
+  am.release(0);
+  assert.equal(am.accounts[0].inFlight, 0);
+});
+
+test('OAuth 401 refreshes once, then isolates and fails over without credential logs', async () => {
+  const calls = [];
+  const emitted = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => emitted.push(args.join(' '));
+  console.error = (...args) => emitted.push(args.join(' '));
+  const upstream = http.createServer((req, res) => {
+    calls.push(req.headers.authorization || req.headers['x-api-key']);
+    if (req.headers.authorization) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end('{"type":"error"}');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{"ok":true}');
+  });
+  const upstreamPort = await listen(upstream);
+  let refreshes = 0;
+  const am = manager([
+    {
+      name: 'oauth-a', type: 'oauth', accessToken: 'secret-old-token',
+      refreshToken: 'secret-refresh-token', expiresAt: Date.now() + 3_600_000, priority: -10,
+    },
+    { name: 'fallback', type: 'apikey', apiKey: 'secret-fallback-key', priority: 0 },
+  ], {
+    refreshFn: async () => {
+      refreshes++;
+      return {
+        accessToken: 'secret-new-token', refreshToken: 'secret-new-refresh',
+        expiresAt: Date.now() + 3_600_000,
+      };
+    },
+  });
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const response = await postJson(proxyPort);
+    assert.equal(response.status, 200);
+    assert.equal(refreshes, 1);
+    assert.equal(calls.length, 3);
+    assert.equal(am.accounts[0].status, 'error');
+    assert.doesNotMatch(emitted.join('\n'), /secret-(old|new|refresh|fallback)/);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('all authentication failures terminate as mixed pool unavailable, not a leaked 401', async () => {
+  let calls = 0;
+  const upstream = http.createServer((req, res) => {
+    calls++;
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end('{"type":"error"}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = manager([
+    { name: 'a', type: 'apikey', apiKey: 'a' },
+    { name: 'b', type: 'apikey', apiKey: 'b' },
+    { name: 'c', type: 'apikey', apiKey: 'c' },
+  ]);
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const response = await postJson(proxyPort);
+    assert.equal(calls, 3);
+    assert.equal(response.status, 503);
+    assert.equal(JSON.parse(response.body).error.code, 'mixed_pool_unavailable');
+  } finally {
+    await close(proxy);
+    await close(upstream);
+  }
+});
+
+test('enable plus live revalidation retires stale quota before priority selection', async () => {
+  const am = manager([
+    { name: 'fallback', type: 'apikey', apiKey: 'fallback', priority: 0 },
+    {
+      name: 'target', type: 'oauth', accessToken: 'target-token', refreshToken: 'target-refresh',
+      expiresAt: Date.now() + 3_600_000, priority: -100, disabled: true,
+    },
+  ]);
+  am.accounts[1].status = 'exhausted';
+  am.accounts[1].quota.unified5h = 1;
+  am.setDisabled(1, false);
+  assert.equal(am.getActiveAccount().name, 'fallback');
+
+  const prober = new Prober(am, {
+    probeFn: async () => ({
+      fiveHour: { utilization: 0.1, resetAt: Date.now() + 60_000 },
+      sevenDay: { utilization: 0.2, resetAt: Date.now() + 60_000 },
+    }),
+  });
+  const validation = await prober.probeAccount(am.accounts[1]);
+  assert.deepEqual(validation, { ok: true, classification: 'active' });
+  assert.equal(am.selectActiveAccount().name, 'target');
+
+  const indexSource = await readFile(INDEX_SOURCE_PATH, 'utf8');
+  assert.match(indexSource, /await prober\.probeAccount\(account\)/);
+  assert.match(indexSource, /accountManager\._isAvailable\(account\) \? 'active' : 'quota'/);
+});
+
+test('usage revalidation retries one 401 then quarantines the account', async () => {
+  let probes = 0;
+  let refreshes = 0;
+  const am = manager([{
+    name: 'oauth', type: 'oauth', accessToken: 'old', refreshToken: 'refresh',
+    expiresAt: Date.now() + 3_600_000,
+  }], {
+    refreshFn: async () => {
+      refreshes++;
+      return { accessToken: 'new', refreshToken: 'new-refresh', expiresAt: Date.now() + 3_600_000 };
+    },
+  });
+  const prober = new Prober(am, {
+    probeFn: async () => {
+      probes++;
+      return { error: 'HTTP 401', status: 401 };
+    },
+  });
+  const result = await prober.probeAccount(am.accounts[0]);
+  assert.deepEqual(result, { ok: false, classification: 'authentication' });
+  assert.equal(probes, 2);
+  assert.equal(refreshes, 1);
+  assert.equal(am.accounts[0].status, 'error');
+});
+
+test('concurrent 401 recovery coalesces refresh and releases every lease', async () => {
+  let refreshes = 0;
+  const upstream = http.createServer((req, res) => {
+    if (req.headers.authorization === 'Bearer refreshed-token') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true}');
+      return;
+    }
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end('{"type":"error"}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = manager([{
+    name: 'oauth', type: 'oauth', accessToken: 'stale-token', refreshToken: 'refresh-token',
+    expiresAt: Date.now() + 3_600_000,
+  }], {
+    refreshFn: async () => {
+      refreshes++;
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return {
+        accessToken: 'refreshed-token', refreshToken: 'next-refresh-token',
+        expiresAt: Date.now() + 3_600_000,
+      };
+    },
+  });
+  const proxy = createProxyServer(am, { upstream: `http://127.0.0.1:${upstreamPort}`, proxy: {} });
+  const proxyPort = await listen(proxy);
+  try {
+    const responses = await Promise.all([postJson(proxyPort), postJson(proxyPort)]);
+    assert.deepEqual(responses.map(response => response.status), [200, 200]);
+    assert.equal(refreshes, 1);
+    assert.equal(am.accounts[0].status, 'active');
+    assert.equal(am.accounts[0].inFlight, 0);
+  } finally {
+    await close(proxy);
+    await close(upstream);
+  }
+});


### PR DESCRIPTION
## Summary

TeamClaude could return `All N accounts exhausted` (HTTP 429) even when a healthy
account was available, and it forwarded a live upstream `401` straight to the
client. This PR keeps authentication failure, quota exhaustion, transient
throttling, route exclusion, and per-request failure as **separate** states, so
the proxy selects a requestable account whenever one exists and only reports the
condition that is actually true.

Reproduced on current `master` (not just an installed copy) before fixing.

## The bug, concretely

Given a pool of `[healthy, auth-rejected, quota-exhausted]`:

- **Before:** the request often ended in the terminal "no account" branch, which
  had a single message and always returned `429 rate_limit_error` with
  `All 3 accounts exhausted` -- even though one account was perfectly usable, and
  even when the real blocker was an expired credential or a transient per-minute
  429, not usage limits.
- A live `401` from upstream was passed back to the caller instead of isolating
  the one rejected account and retrying on a healthy one.
- After `enable` / `priority` / `reload`, config and credentials were synced but
  fresh usage was never consumed, so a stale `exhausted` flag could outlive a
  repaired account until the next natural probe.

## Root causes (all confirmed on current master)

1. The terminal no-account branch in `server.js` collapsed authentication, quota,
   temporary-throttle, and request-local exclusion into one synthetic
   `All N accounts exhausted` 429.
2. A live upstream `401` was neither quarantined to the rejected account nor
   failed over to a healthy one.
3. `enable` / `priority` / `reload` did not revalidate against the zero-spend
   usage endpoint, so a stale hard `exhausted` state was not retired even after
   the account became healthy again.

## What changed

**`src/account-manager.js`**
- `getAvailabilitySummary(exclude, model, advisorModel)` -- new; returns
  mutually-exclusive counts:
  `available / authentication / quota / temporary / disabled / route / excluded`.
- `markAuthenticationFailed(index)` -- account-local auth quarantine (never
  poisons the rest of the pool, never collapses into quota).
- `applyUsageData(...)` retires a stale `exhausted` state once a live usage
  response is under the quota threshold (the quota numbers still gate selection
  normally).
- Re-enabling an account clears a cached `error` / `throttled` / `exhausted`
  state (previously only `error`).
- `ensureTokenFresh(...)` now returns a structured `{ ok, classification }`
  (`not-applicable | fresh | refreshed | authentication | transient`).

**`src/server.js`**
- The terminal branch now emits an accurate response:
  `429 all_quota_exhausted`, `429 temporary_rate_limited`, or
  `503 mixed_pool_unavailable`, with a message that names the real counts.
- A live `401` gets one coalesced OAuth refresh + single retry; if it still fails
  (or it is an API-key 401), only that account is quarantined and the request
  fails over within the **existing** bounded retry walk.
- `POST /teamclaude/reload` accepts an optional `x-teamclaude-revalidate-index`
  header to revalidate exactly one account against live usage.
- The transient rate-limit `429` behavior (#84: pause + retry the same account,
  never rotate the burst) is deliberately **unchanged**.

**`src/prober.js`**
- `probeAccount(...)` returns `{ ok, classification }` and quarantines a repeated
  provider `401` without logging any credential.

**`src/index.js`**
- `enable` / `priority` / `reload` revalidate the target against live provider
  usage before re-selecting, and surface a non-requestable target (non-zero exit).

## Tests

Adds `test/quota-routing-availability.test.js` (23 tests, `node --test`):

- one healthy account is selectable beside two exhausted accounts;
- healthy selection survives a mix of one auth failure + one exhausted account;
- lower numeric priority preempts, and an auth-error priority target falls back;
- a stale `exhausted` state is cleared by live under-threshold usage, then the
  target is re-selected after `enable`;
- a real usage rejection rotates and preserves quota classification;
- an all-quota pool returns `all_quota_exhausted`; an all-temporary pool returns
  `temporary_rate_limited` (never mislabeled as quota);
- a mixed auth+quota pool returns `mixed_pool_unavailable`, never a fleet-wide
  quota claim;
- concurrent admission serializes a live lease without poisoning availability;
- a live `401` is isolated and the request fails over to a healthy account, with
  the healthy pool count preserved;
- concurrent `401` recovery coalesces to a single OAuth refresh and releases
  every lease;
- credential sentinels never appear in logs.

`npm test` (full suite) and `npm run lint` both pass locally.

## Compatibility

- `POST /teamclaude/reload` still accepts and returns the old numeric `added`
  form; the new response fields are additive.
- New `AccountManager` methods are additive; no existing signature changed in a
  breaking way (`ensureTokenFresh` previously returned `undefined`; callers that
  ignore the return value are unaffected).
- No config-schema or CLI-flag changes.
- One behavior change worth calling out: `enable` / `priority` now set a non-zero
  exit code when the running server reports the target is still not requestable
  (previously it exited 0 silently). This surfaces a real failure; a script that
  assumed exit 0 on every enable/priority should be aware.

## Risk / non-goals

- No second selector and no new router -- the fix stays inside the existing
  selection and retry paths.
- Bounded everywhere: one forced OAuth refresh per account per request; failover
  bounded by the existing account-count retry walk. No infinite retry, no
  fail-open (a fully-unavailable pool returns a structured 5xx/429, never a
  known-bad account), no account starvation, no priority lock, no 401
  propagation.
