### PR TITLE
perf(sanitize): fast-path tool-pair check; review follow-up to #105/#110

### DIFF
--- a/src/tool-pair-sanitize.js
+++ b/src/tool-pair-sanitize.js
@@ -26,6 +26,15 @@
 
 const MESSAGES_PATH = '/v1/messages';
 
+// A tool_use / tool_result block type can only appear in the body as one of
+// these exact JSON substrings. If NEITHER is present there is nothing this pass
+// could ever prune, so we can skip the (potentially multi-hundred-KB) JSON.parse
+// and tree walk entirely — a cheap Buffer scan on the hot path instead. A false
+// positive (the literal text appearing inside some string content) only costs an
+// unnecessary parse that still returns the same Buffer, so it stays correct.
+const TOOL_USE_MARKER = Buffer.from('"tool_use"');
+const TOOL_RESULT_MARKER = Buffer.from('"tool_result"');
+
 // Is this a JSON /v1/messages (or /v1/messages/count_tokens) request we can
 // reason about? Everything else (token refreshes, GETs, non-JSON) is left alone.
 function isMessagesRequest(url, contentType) {
@@ -162,6 +171,8 @@ function pruneOrphans(messages) {
 export function sanitizeToolPairs(body, url, contentType) {
   if (!Buffer.isBuffer(body) || body.length === 0) return body;
   if (!isMessagesRequest(url, contentType)) return body;
+  // Fast path: no tool block markers at all → nothing to prune, skip the parse.
+  if (!body.includes(TOOL_USE_MARKER) && !body.includes(TOOL_RESULT_MARKER)) return body;
 
   let payload;
   try {

--- a/test/tool-pair-sanitize.test.js
+++ b/test/tool-pair-sanitize.test.js
@@ -54,6 +54,17 @@ test('strips a tail tool_use that has no tool_result and drops the emptied turn'
   assert.equal(body.messages[0].role, 'user');
 });
 
+test('a tool-free body is a same-Buffer no-op via the fast path (never parsed)', () => {
+  const original = buf({
+    model: 'claude',
+    messages: [
+      { role: 'user', content: 'just a plain question' },
+      { role: 'assistant', content: [{ type: 'text', text: 'a plain answer' }] },
+    ],
+  });
+  assert.equal(sanitizeToolPairs(original, MESSAGES, JSON_CT), original);
+});
+
 test('well-formed body is returned as the same Buffer instance (no reserialize)', () => {
   const original = buf({
     model: 'claude',


### PR DESCRIPTION
Follow-up after merging #105 (tool-pair sanitize) and #110 (Remote Control WebSocket relay), addressing the one actionable issue from reviewing both.

## Change

`sanitizeToolPairs` (#105) ran a full `JSON.parse` + tree walk on **every** `/v1/messages` body, including the overwhelmingly common well-formed case. On large contexts (multi-hundred-KB conversations) that's real per-request CPU on the hot path — the #105 note that it was "zero cost" held only for the content-length realignment, not the parse.

An orphaned block can only exist if the body contains a `tool_use` or `tool_result` block, so this gates the parse behind a cheap `Buffer.includes` scan for those two markers and returns the **same Buffer instance** (a genuine no-op) when neither is present. A false positive (the literal substring inside some string content) merely triggers an unnecessary parse that still returns the same Buffer — correctness is preserved either way.

Added a test asserting a tool-free body is a same-Buffer no-op. Full suite green (280/280, incl. the formerly-flaky `server-listen-error.test.js`); lint clean.

## On the other items from review

- **#110 "content-encoding" concern — withdrawn, not a bug.** On a closer read of the *merged* source, `relayStream` already strips `accept-encoding` from the forwarded request (`server.js:265`, pre-existing context the PR diff elided), so upstream never returns a compressed body and stripping `content-encoding` on the response is harmless. No change needed.
- **#105 leading-role edge** (a dropped leading orphan-only user turn could leave the conversation starting with `assistant`): left as-is. It can only occur on a body that was already going to 400, real Claude Code conversations never open with an orphan-only turn, and a guard risked overreach without a repro. Documented here as a known, accepted limitation.
- **#110 relayUpgrade path allowlist**: deliberately not added — the permissive relay is the safer default over the unknown WS surface, and it forwards the client's own credential (never a rotated account token), so a too-strict allowlist could break a future path for no security gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)