### PR TITLE
docs: add Compliance & Terms of Service section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,22 @@ npm package. TeamClaude is **never** distributed as a downloadable binary
 archive — be wary of soft-forks that bundle a `.zip` and tell you to extract and
 run it. See [SECURITY.md](SECURITY.md) for details and how to report issues.
 
+## Compliance & Terms of Service
+
+> This is the maintainer's good-faith understanding, **not legal advice.** Anthropic's Terms are theirs to interpret and to change; read the current [Claude Code legal terms](https://code.claude.com/docs/en/legal-and-compliance) and decide for yourself.
+
+TeamClaude is a **self-hosted local proxy**. You run it on your own machine, it holds *your own* credentials, and it forwards the requests that *your own* Claude Code CLI makes to Anthropic. It is **not** a hosted service, it does not offer "Claude.ai login" to anyone, and it never routes requests on behalf of third parties — it only moves your own traffic through accounts you control.
+
+How you use it is your responsibility. In particular:
+
+- **Use the genuine Claude Code CLI.** Pointing a third-party frontend (opencode and similar) at Pro/Max OAuth credentials is the pattern Anthropic explicitly restricts.
+- **Keep a human in the loop.** The terms expect interactive, human-present use rather than fully unattended automation. The two features that make background calls on their own — [keep-warm](#keep-warm-start-idle-accounts-5h-timers-optional-off-by-default) and the [quota probe](#quota-probe-optional-off-by-default) — are **off by default**.
+- **Only use subscriptions you legitimately purchased.**
+
+On **rotating across multiple subscriptions** — the question people ask most — note that Claude Code's own `/extra-usage` flow already offers signing into a *different* account when you hit a limit. "Switch to another account you own to get more usage" is a move the native client itself surfaces; TeamClaude automates that same switch. Anthropic hasn't explicitly blessed *automated* pooling, so weigh it against the current terms — but the idea that using more than one of your own subscriptions is inherently off-limits is hard to square with the first-party client offering to do the same thing by hand.
+
+To the best of the maintainer's knowledge, using TeamClaude as intended — the real Claude Code CLI, your own subscriptions, a human present — is consistent with Claude Code's Terms. See [#107](https://github.com/KarpelesLab/teamclaude/issues/107) for the full write-up.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=KarpelesLab%2Fteamclaude&type=date&legend=top-left">


### PR DESCRIPTION
Adds a canonical **Compliance & Terms of Service** section to the README (between Security and Star History), so the recurring ToS questions (#107, #115) have a durable, linkable home instead of being re-litigated per issue.

Content mirrors the answer posted on #107:
- TeamClaude as a self-hosted local proxy — not a hosted service, not a third-party login intermediary.
- What stays the user's responsibility: genuine Claude Code CLI, human present, own subscriptions.
- The multi-subscription question, anchored to Claude Code's own `/extra-usage` flow (which already offers switching to a different account on limit) — TeamClaude automates that same switch.
- Framed explicitly as the maintainer's good-faith understanding, **not legal advice**.

Links the two off-by-default background-call features (keep-warm, quota probe) to their existing README sections, and links #107 for the full write-up.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)