### PR TITLE
feat(env): default `teamclaude env` to MITM mode; make it eval-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,29 @@ Since **1.1.0**, `run` defaults to [MITM forward-proxy mode](#mitm-proxy-mode-de
 teamclaude run --no-mitm
 ```
 
-Or manually set the environment:
+Or set the environment yourself with `teamclaude env`, which prints the same
+export lines `run` uses — MITM forward-proxy by default (`--no-mitm` for
+base-URL only):
 
 ```bash
-eval $(teamclaude env)
+eval "$(teamclaude env)"           # MITM: HTTPS_PROXY + NODE_EXTRA_CA_CERTS
+eval "$(teamclaude env --no-mitm)" # base-URL: ANTHROPIC_BASE_URL only
 claude
 ```
+
+Only the export lines go to stdout (so `eval` is safe); a short summary and any
+hints go to stderr. No `ANTHROPIC_API_KEY` is emitted — loopback clients are
+exempt from the proxy key gate, and setting it would drop Claude Code out of
+subscription mode. A remote (non-loopback) client must add the proxy key itself.
+
+**Using an agent multiplexer or a tool that spawns `claude` itself?** Point it at
+the proxy by exporting this env in the process that launches those `claude`
+instances — e.g. `eval "$(teamclaude env)"` in the shell you start the
+multiplexer from. That gives every spawned `claude` the same routing (and MITM
+interception of hardcoded endpoints like the Claude Design MCP) without going
+through `teamclaude run`. The trade-off: `run`'s proxy-up/down guard only applies
+when you launch via `run`, so start the server (`teamclaude server`) before the
+multiplexer.
 
 ### Routing plain `claude` automatically (alias)
 

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -1,0 +1,43 @@
+// Build the shell `export` lines that point Claude Code — or any tool that
+// spawns it, e.g. an agent multiplexer — at the proxy. This is the same
+// environment `teamclaude run` sets up, but emitted for `eval "$(teamclaude
+// env)"` instead of launching claude directly. Pure and side-effect free so it
+// can be unit-tested; the caller resolves the port, cert path, and holdSeconds.
+//
+// MITM (forward-proxy) mode is the default, matching `teamclaude run`: it routes
+// ALL of claude's traffic through the proxy — even hardcoded api.anthropic.com
+// endpoints (e.g. the design MCP) — with claude trusting our leaf via
+// NODE_EXTRA_CA_CERTS. base-URL mode only redirects the Anthropic base URL and
+// leaves other hosts alone.
+//
+// No ANTHROPIC_API_KEY is emitted: loopback clients are exempt from the proxy's
+// key gate, and setting it would drop Claude Code out of subscription mode (and
+// its full model access). Remote clients that aren't on loopback must add the
+// proxy key themselves.
+export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0 }) {
+  const lines = [];
+
+  if (useMitm) {
+    const proxyUrl = `http://127.0.0.1:${port}`;
+    lines.push(
+      `export HTTPS_PROXY=${proxyUrl}`,
+      `export HTTP_PROXY=${proxyUrl}`,
+      `export https_proxy=${proxyUrl}`,
+      `export http_proxy=${proxyUrl}`,
+      'export NO_PROXY=localhost,127.0.0.1,::1',
+      'export no_proxy=localhost,127.0.0.1,::1',
+    );
+    if (caPath) lines.push(`export NODE_EXTRA_CA_CERTS=${caPath}`);
+    // Clear any stale base-URL so the two modes don't stack in one shell.
+    lines.push('unset ANTHROPIC_BASE_URL');
+  } else {
+    lines.push(`export ANTHROPIC_BASE_URL=http://localhost:${port}`);
+  }
+
+  // Parity with `run`: if the proxy may hold the connection on exhaustion, raise
+  // the client-side timeout so it doesn't give up mid-hold.
+  const holdMs = (holdSeconds || 0) * 1000;
+  if (holdMs > 0) lines.push(`export API_TIMEOUT_MS=${holdMs + 60_000}`);
+
+  return lines;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
+import { buildClaudeEnvLines } from './claude-env.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -581,10 +582,39 @@ async function loginOAuthCommand() {
 
 // ── env ─────────────────────────────────────────────────────
 
+// `teamclaude env [--no-mitm]` — print the export lines that point Claude Code
+// at the proxy, for `eval "$(teamclaude env)"`. Mirrors `teamclaude run`'s
+// environment (MITM forward-proxy by default; --no-mitm for base-URL only) so a
+// tool that spawns claude itself — an agent multiplexer, a CI job, a manual
+// shell — gets the same routing without going through `run`. Only the export
+// lines go to stdout; all guidance goes to stderr so the output stays eval-safe.
 async function envCommand() {
-  const config = await loadOrCreateConfig();
-  console.log(`export ANTHROPIC_BASE_URL=http://localhost:${config.proxy.port}`);
-  console.log(`export ANTHROPIC_API_KEY=${config.proxy.apiKey}`);
+  // Use loadConfig (not loadOrCreateConfig): a query command must never write to
+  // stdout — creating a config prints "Created config at …", which would poison
+  // `eval "$(teamclaude env)"` — nor silently create config as a side effect.
+  const config = await loadConfig();
+  if (!config) {
+    process.stderr.write(`No config found at ${getConfigPath()}. Add an account first: teamclaude login\n`);
+    process.exit(1);
+  }
+  const port = config.proxy.port;
+  const useMitm = !args.slice(1).includes('--no-mitm');
+
+  let caPath = null;
+  if (useMitm) ({ caPath } = await ensureCerts(upstreamHost(config)));
+
+  const lines = buildClaudeEnvLines({ port, useMitm, caPath, holdSeconds: config.holdSeconds });
+  process.stdout.write(`${lines.join('\n')}\n`);
+
+  const mode = useMitm ? 'MITM forward-proxy' : 'base-URL';
+  process.stderr.write(`# TeamClaude env: ${mode} mode, localhost:${port}\n`);
+  process.stderr.write(`# apply to this shell:  eval "$(teamclaude env${useMitm ? '' : ' --no-mitm'})"\n`);
+  if (!(await isProxyUp(port))) {
+    process.stderr.write(`# note: proxy not running on port ${port} — start it with: teamclaude server\n`);
+  }
+  if (config.proxy?.apiKey) {
+    process.stderr.write(`# remote (non-loopback) clients must also present the proxy key: ANTHROPIC_API_KEY=<proxy.apiKey> (base-URL), or http://<key>@host:${port} (MITM)\n`);
+  }
 }
 
 // ── run ─────────────────────────────────────────────────────
@@ -1196,7 +1226,10 @@ Commands:
   import              Import credentials from Claude Code
   login               OAuth login via browser
   login --api         Add an API key account
-  env                 Print env vars to use with Claude
+  env [--no-mitm]     Print export lines to point Claude Code at the proxy, for
+                      'eval "$(teamclaude env)"' (MITM forward-proxy by default;
+                      --no-mitm for base-URL only). Handy for agent multiplexers
+                      that spawn claude themselves instead of via 'teamclaude run'
   run [--no-mitm] [--auto-fallback] [-- args...]
                       Run Claude Code through the proxy (errors if it's down,
                       unless --auto-fallback launches claude directly instead).

--- a/test/claude-env.test.js
+++ b/test/claude-env.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildClaudeEnvLines } from '../src/claude-env.js';
+
+test('MITM mode (default) emits proxy vars + CA cert, and clears ANTHROPIC_BASE_URL', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, caPath: '/home/u/.config/teamclaude-ca.pem' });
+  assert.deepEqual(lines, [
+    'export HTTPS_PROXY=http://127.0.0.1:3456',
+    'export HTTP_PROXY=http://127.0.0.1:3456',
+    'export https_proxy=http://127.0.0.1:3456',
+    'export http_proxy=http://127.0.0.1:3456',
+    'export NO_PROXY=localhost,127.0.0.1,::1',
+    'export no_proxy=localhost,127.0.0.1,::1',
+    'export NODE_EXTRA_CA_CERTS=/home/u/.config/teamclaude-ca.pem',
+    'unset ANTHROPIC_BASE_URL',
+  ]);
+});
+
+test('MITM mode without a caPath omits NODE_EXTRA_CA_CERTS (never emits an empty value)', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, useMitm: true, caPath: null });
+  assert.ok(!lines.some((l) => l.startsWith('export NODE_EXTRA_CA_CERTS')));
+  assert.ok(lines.includes('export HTTPS_PROXY=http://127.0.0.1:3456'));
+});
+
+test('--no-mitm (base-URL) mode emits only ANTHROPIC_BASE_URL, no proxy/cert vars', () => {
+  const lines = buildClaudeEnvLines({ port: 8080, useMitm: false });
+  assert.deepEqual(lines, ['export ANTHROPIC_BASE_URL=http://localhost:8080']);
+});
+
+test('no ANTHROPIC_API_KEY is ever emitted (loopback is auth-exempt; keeps subscription mode)', () => {
+  const mitm = buildClaudeEnvLines({ port: 3456, useMitm: true, caPath: '/x' });
+  const base = buildClaudeEnvLines({ port: 3456, useMitm: false });
+  for (const l of [...mitm, ...base]) assert.ok(!l.includes('ANTHROPIC_API_KEY'), l);
+});
+
+test('holdSeconds > 0 adds API_TIMEOUT_MS = holdSeconds + 60s, in both modes', () => {
+  const mitm = buildClaudeEnvLines({ port: 3456, caPath: '/x', holdSeconds: 3600 });
+  assert.ok(mitm.includes('export API_TIMEOUT_MS=3660000'));
+  const base = buildClaudeEnvLines({ port: 3456, useMitm: false, holdSeconds: 120 });
+  assert.ok(base.includes('export API_TIMEOUT_MS=180000'));
+});
+
+test('holdSeconds 0 / unset adds no API_TIMEOUT_MS', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, useMitm: false });
+  assert.ok(!lines.some((l) => l.startsWith('export API_TIMEOUT_MS')));
+});


### PR DESCRIPTION
## What

`teamclaude env` now mirrors `teamclaude run`'s environment so a tool that spawns `claude` itself — an agent multiplexer, a CI job, a manual shell — gets the same routing without going through `run` (issue #108).

**Before:** `env` emitted only base-URL mode plus `ANTHROPIC_API_KEY`:
```
export ANTHROPIC_BASE_URL=http://localhost:3456
export ANTHROPIC_API_KEY=<proxy key>
```
That didn't match `run` (MITM forward-proxy by default, so hardcoded `api.anthropic.com` endpoints like the Claude Design MCP are intercepted), and the key was both unnecessary for loopback clients (exempt from the proxy key gate) and could drop Claude Code out of subscription mode.

**Now:**
- **MITM forward-proxy by default** (`HTTPS_PROXY`/`HTTP_PROXY` + `NODE_EXTRA_CA_CERTS`, clears `ANTHROPIC_BASE_URL`); `--no-mitm` for base-URL only.
- `API_TIMEOUT_MS` raised when `holdSeconds` is set (parity with `run`).
- **No `ANTHROPIC_API_KEY`** emitted (loopback is auth-exempt; a stderr hint tells remote clients how to add it).

## Eval-safety

Only export lines go to **stdout**, so `eval "$(teamclaude env)"` is clean. The mode summary and hints go to **stderr**. A missing config now errors to stderr and exits 1 rather than calling `loadOrCreateConfig` (which prints `Created config at …` to stdout and would poison the eval).

```
$ teamclaude env
export HTTPS_PROXY=http://127.0.0.1:3456
export HTTP_PROXY=http://127.0.0.1:3456
export https_proxy=http://127.0.0.1:3456
export http_proxy=http://127.0.0.1:3456
export NO_PROXY=localhost,127.0.0.1,::1
export no_proxy=localhost,127.0.0.1,::1
export NODE_EXTRA_CA_CERTS=/home/u/.config/teamclaude-ca.pem
unset ANTHROPIC_BASE_URL
# (stderr) TeamClaude env: MITM forward-proxy mode, localhost:3456
```

## Tests

Line-building is extracted to a pure `src/claude-env.js`; `test/claude-env.test.js` covers both modes, the no-cert case, `holdSeconds` → `API_TIMEOUT_MS`, and that no API key is ever emitted. Full suite green (286), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)