### PR TITLE
feat(server): set terminal title to the active account

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
 import { buildClaudeEnvLines } from './claude-env.js';
+import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -409,6 +410,10 @@ async function serverCommand() {
     }
   });
 
+  // Reflect the active account in the terminal title so a backgrounded/tabbed
+  // server is glanceable. Works in both TUI and headless modes.
+  const stopTitle = startTerminalTitleUpdater(accountManager);
+
   // Persist quota every minute; unref so it never keeps the process alive.
   quotaSaveInterval = setInterval(persistQuotaState, 60_000);
   quotaSaveInterval.unref?.();
@@ -443,6 +448,7 @@ async function serverCommand() {
     if (shuttingDown) process.exit(0); // second ctrl-c: stop waiting, just go
     shuttingDown = true;
     try { tui?.stop(); } catch { /* terminal already restored */ }
+    stopTitle();
     if (!tui) console.log('\n[TeamClaude] Shutting down...');
     prober?.stop();
     warmer?.stop();
@@ -1484,6 +1490,41 @@ function argValue(flag) {
 function upstreamHost(config) {
   try { return new URL(config.upstream || 'https://api.anthropic.com').hostname; }
   catch { return 'api.anthropic.com'; }
+}
+
+// Keep the terminal title in sync with the active account (e.g. "teamclaude 2/4
+// work") so a backgrounded or tabbed `teamclaude server` is glanceable. TTY-only
+// — never emit escapes into a pipe, a `--log-to` redirect, or a systemd journal;
+// opt out entirely with TEAMCLAUDE_NO_TITLE. Polls (rather than hooking every
+// currentIndex mutation) and writes only when the title actually changes.
+// Returns an idempotent stop() that restores the shell's previous title.
+function startTerminalTitleUpdater(accountManager) {
+  const out = process.stdout;
+  if (!out.isTTY || process.env.TEAMCLAUDE_NO_TITLE) return () => {};
+
+  let last = null;
+  const render = () => {
+    const total = accountManager.accounts.length;
+    const index = Math.min(accountManager.currentIndex || 0, Math.max(0, total - 1));
+    const name = accountManager.accounts[index]?.name || null;
+    const title = formatTerminalTitle({ index, total, name });
+    if (title !== last) { last = title; out.write(titleSequence(title)); }
+  };
+
+  out.write(TITLE_STACK_PUSH); // save whatever title the shell had
+  render();
+  const timer = setInterval(render, 2000);
+  timer.unref?.();
+
+  let stopped = false;
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    try { out.write(TITLE_STACK_POP); } catch { /* terminal gone */ }
+  };
+  process.on('exit', stop); // backstop for exits that bypass shutdown()
+  return stop;
 }
 
 // Best-effort: tell a running server (if any) to re-sync accounts from config so

--- a/src/terminal-title.js
+++ b/src/terminal-title.js
@@ -1,0 +1,31 @@
+// Reflect the active account in the terminal title (e.g. "teamclaude 2/4 work"),
+// so a backgrounded or tabbed `teamclaude server` is glanceable without
+// switching to it. Pure/side-effect-free here so it can be unit-tested; the
+// caller owns the TTY gate and the interval.
+
+const OSC_TITLE = '\x1b]0;'; // OSC 0 — set icon name + window title
+const BEL = '\x07';
+
+// xterm title stack: save the shell's current title on start and restore it on
+// exit. No-op on terminals that don't implement it.
+export const TITLE_STACK_PUSH = '\x1b[22;2t';
+export const TITLE_STACK_POP = '\x1b[23;2t';
+
+function truncate(s, max) {
+  s = String(s);
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+// Short, glanceable title: "teamclaude <pos>/<total> <name>". `index` is 0-based.
+export function formatTerminalTitle({ index = 0, total = 0, name = null } = {}) {
+  const pos = total > 0 ? `${index + 1}/${total}` : '0/0';
+  const who = name ? ` ${truncate(name, 24)}` : '';
+  return `teamclaude ${pos}${who}`;
+}
+
+// Wrap a title string in the OSC set-title sequence, stripping control chars so a
+// crafted account name can't break out of the escape or move the cursor.
+export function titleSequence(title) {
+  const safe = String(title).replace(/[\x00-\x1f\x7f]/g, ' ').trimEnd();
+  return `${OSC_TITLE}${safe}${BEL}`;
+}

--- a/test/terminal-title.test.js
+++ b/test/terminal-title.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from '../src/terminal-title.js';
+
+test('formats a 0-based index as a 1-based position out of the total, with the name', () => {
+  assert.equal(formatTerminalTitle({ index: 0, total: 4, name: 'work' }), 'teamclaude 1/4 work');
+  assert.equal(formatTerminalTitle({ index: 3, total: 4, name: 'personal' }), 'teamclaude 4/4 personal');
+});
+
+test('omits the name when absent', () => {
+  assert.equal(formatTerminalTitle({ index: 1, total: 2 }), 'teamclaude 2/2');
+});
+
+test('handles the no-accounts edge without going negative', () => {
+  assert.equal(formatTerminalTitle({ index: 0, total: 0 }), 'teamclaude 0/0');
+  assert.equal(formatTerminalTitle({}), 'teamclaude 0/0');
+});
+
+test('truncates a long account name so the title stays short', () => {
+  const out = formatTerminalTitle({ index: 0, total: 1, name: 'user@example.com (Some Very Long Org Name)' });
+  assert.ok(out.length <= 'teamclaude 1/1 '.length + 24, out);
+  assert.ok(out.endsWith('…'), out);
+});
+
+test('titleSequence wraps in OSC 0 ... BEL', () => {
+  assert.equal(titleSequence('teamclaude 1/4 work'), '\x1b]0;teamclaude 1/4 work\x07');
+});
+
+test('titleSequence strips control chars so a crafted name cannot break the escape', () => {
+  const seq = titleSequence('evil\x07\x1b]0;pwned\x1b[31m');
+  // Exactly one OSC opener and one BEL terminator — no injected sequences survive.
+  assert.equal(seq.match(/\x1b\]0;/g).length, 1);
+  assert.equal(seq.match(/\x07/g).length, 1);
+  assert.ok(!seq.includes('\x1b[31m'));
+});
+
+test('title stack push/pop are the xterm sequences', () => {
+  assert.equal(TITLE_STACK_PUSH, '\x1b[22;2t');
+  assert.equal(TITLE_STACK_POP, '\x1b[23;2t');
+});


### PR DESCRIPTION
## What

In server mode, keep the terminal title in sync with the active account — e.g. **`teamclaude 2/4 work`** — so a backgrounded or tabbed `teamclaude server` tells you at a glance which account (out of how many) is currently serving traffic. Works in both TUI and headless modes.

Under a PTY:
```
\x1b]0;teamclaude 1/2 work\x07
```

## Safety / behavior

- **TTY-only.** Gated on `process.stdout.isTTY`, so title escapes never leak into a pipe, a `--log-to` redirect, or a systemd journal. Verified: a headless run with stdout piped emits **zero** escape bytes; the same run under a PTY emits the title.
- **Opt out** with `TEAMCLAUDE_NO_TITLE`.
- Polls `accountManager` (every 2s, `unref`'d) and writes **only when the title changes**, rather than threading a callback through every `currentIndex` mutation site.
- Saves the shell's prior title on the **xterm title stack** (`\e[22;2t`) and restores it on shutdown (`\e[23;2t`), via the existing `shutdown()` funnel plus a `process.on('exit')` backstop.
- Account names are truncated to keep the title short, and control chars are stripped so a crafted account name can't break out of the OSC sequence.

## Tests

Formatting/escaping is a pure `src/terminal-title.js` with `test/terminal-title.test.js` (position/count formatting, name truncation, the no-accounts edge, OSC wrapping, and the control-char injection guard). Full suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)