### PR TITLE
feat: session-aware routing to distribute concurrent sessions (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Useful for overnight or unattended runs: rather than waking up to a stopped task
 
 ### Session-aware routing (distributeSessions, off by default)
 
-teamclaude always tracks running Claude Code sessions by their `x-claude-code-session-id` header — the TUI header and `teamclaude status` show how many are **active** (a request in the last ~2 min) and **known** (seen in the last hour; sessions are forgotten after an hour idle, the maximum prompt-cache extension window). This is passive: it observes, it doesn't change routing.
+teamclaude always tracks running Claude Code sessions by their `x-claude-code-session-id` header — the TUI header and `teamclaude status` show how many are **active** (a request in flight right now, or seen in the last ~2 min) and **known** (seen in the last hour; sessions are forgotten after an hour idle, the maximum prompt-cache extension window). A long streaming request keeps its session active and non-expirable for its whole duration, so a multi-minute completion still counts as load. This is passive: it observes, it doesn't change routing.
 
 Default rotation is purely quota-driven, so many parallel sessions all pile onto the *current* account while equal-priority siblings sit idle — one account queues behind its upstream concurrency ceiling while others do nothing ([#109](https://github.com/KarpelesLab/teamclaude/issues/109)). Enable `distributeSessions` to fix that:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
 - **Quota persistence** — observed quota survives restarts (saved to a sibling state file), so rotation state isn't lost on restart; stale windows are discarded automatically
 - **Hold on exhaustion** — when all accounts are spent, `holdSeconds` keeps the HTTP connection open and polls silently until quota resets, so long-running Claude Code tasks continue automatically instead of aborting with a 429
+- **Session awareness** — tracks running Claude Code sessions (by their session id) and shows how many are active; opt into `distributeSessions` to spread concurrent sessions across accounts while keeping each one pinned for cache reuse
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
 - **Optional keep-warm** — off by default; when enabled, periodically starts idle accounts' 5h session timers with a minimal request (`teamclaude warmup`) so the next account isn't cold when rotation reaches it (spends a little quota, unlike the probe)
 - **Account pinning** — force a request onto one account via an `ANTHROPIC_BASE_URL=.../tc-acct/<name>` prefix, bypassing rotation
@@ -289,6 +290,18 @@ Set it in the config file (`~/.config/teamclaude.json`):
 
 Useful for overnight or unattended runs: rather than waking up to a stopped task, the session resumes silently once a quota window opens.
 
+### Session-aware routing (distributeSessions, off by default)
+
+teamclaude always tracks running Claude Code sessions by their `x-claude-code-session-id` header — the TUI header and `teamclaude status` show how many are **active** (a request in the last ~2 min) and **known** (seen in the last hour; sessions are forgotten after an hour idle, the maximum prompt-cache extension window). This is passive: it observes, it doesn't change routing.
+
+Default rotation is purely quota-driven, so many parallel sessions all pile onto the *current* account while equal-priority siblings sit idle — one account queues behind its upstream concurrency ceiling while others do nothing ([#109](https://github.com/KarpelesLab/teamclaude/issues/109)). Enable `distributeSessions` to fix that:
+
+```json
+"distributeSessions": true
+```
+
+When on, teamclaude routes each **new** session to the least-loaded eligible account (fewest active sessions, then fewest in-flight) and **pins** it there, so a session keeps hitting the same account and preserves its prompt cache — while different sessions spread across accounts instead of funnelling onto one. Account **priority still wins** (a higher-priority account is never skipped to balance load), and a session whose account becomes exhausted re-routes automatically. Off by default; single-session use is unaffected either way.
+
 ### Config format
 
 ```json
@@ -326,6 +339,7 @@ Useful for overnight or unattended runs: rather than waking up to a stopped task
 | `quotaProbeSeconds` | Background quota-probe interval in seconds (`0` = off, the default; CLI `probe` or TUI `g` → `p`) |
 | `warmupSeconds` | Keep-warm interval in seconds (`0` = off, the default; CLI `warmup`). Spawns a minimal `claude` per idle account to start its 5h timer — **spends a little quota**, unlike the probe |
 | `holdSeconds` | Maximum seconds to hold the connection when all accounts are exhausted, polling silently until one recovers (`0` = return 429 immediately, the default). `teamclaude run` raises `API_TIMEOUT_MS` automatically to match |
+| `distributeSessions` | Spread concurrent Claude Code sessions across equal-priority accounts, each session pinned to one account for cache reuse (`false` = quota-driven rotation only, the default). Session tracking/readout is always on regardless — see [Session-aware routing](#session-aware-routing-distributesessions-off-by-default) |
 | `stormRamp` | Optional storm-control tuning (on by default) — see [Storm control](#storm-control-switchover-ramp-up). Object: `{ enabled, startConc, stepConc, stepMs, windowMs }` |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -353,6 +353,17 @@ export class AccountManager {
     if (sessionId) this.sessionTracker.touch(sessionId, accountIndex);
   }
 
+  /** Mark a session request as in flight / finished. Paired around the whole
+   * client request (including retries) so a long streaming completion keeps the
+   * session counted as active for its full duration. */
+  beginSession(sessionId) {
+    if (sessionId) this.sessionTracker.beginRequest(sessionId);
+  }
+
+  endSession(sessionId) {
+    if (sessionId) this.sessionTracker.endRequest(sessionId);
+  }
+
   /** { known, active, perAccount } session counts for status/TUI. */
   sessionStats() {
     return this.sessionTracker.stats();

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,6 +1,7 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches } from './model.js';
+import { SessionTracker } from './session-tracker.js';
 
 // Re-exported for callers that import these model helpers from here.
 export { isFableModel, parseRequestModel, parseAdvisorModel } from './model.js';
@@ -89,12 +90,19 @@ function modelMatches(declared, model) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes, ramp } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
     this.accounts = accounts.map((acct, index) => makeAccount(acct, index));
     this.currentIndex = 0;
+    // Session awareness (issue #109). The tracker is always on (passive — it just
+    // observes the x-claude-code-session-id header for the status readout).
+    // `distributeSessions` gates the behavioural change: keep each session on its
+    // account for cache reuse, but spread NEW sessions across equal-priority
+    // accounts by load instead of funnelling them all onto the current one.
+    this.sessionTracker = sessionTracker || new SessionTracker();
+    this.distributeSessions = !!distributeSessions;
     // Ephemeral per-route manual pins (routeName → account index). Not persisted:
     // like the global manual switch (currentIndex) these are runtime overrides that
     // bias selection for a route's models and reset on restart. A pinned account
@@ -213,11 +221,20 @@ export class AccountManager {
    * satisfies both, selection degrades to executor-only routing so the main
    * request keeps flowing (upstream then fails just the advisor call).
    */
-  getActiveAccount(exclude = null, model = null, advisorModel = null) {
+  getActiveAccount(exclude = null, model = null, advisorModel = null, sessionId = null) {
     // Clear expired quotas across all accounts and switch proactively if a
     // session reset made a sooner-expiring account the better choice. This runs
     // on every request so the behaviour holds without the TUI render loop.
     this.refreshExpiredQuotas();
+    // Session-affinity distribution (opt-in): keep a session on its pinned
+    // account for cache reuse, and route a new session to the least-loaded
+    // account. Only when enabled, only for a real session, and only outside a
+    // manual route pin (which must still win). Falls through to the normal walk
+    // if nothing session-eligible is found (e.g. the whole tier is exhausted).
+    if (this.distributeSessions && sessionId && !this._pinnedAccountForModel(model, advisorModel)) {
+      const acc = this._selectForSession(sessionId, exclude, model, advisorModel);
+      if (acc) return acc;
+    }
     if (advisorModel) {
       const account = this._select(exclude, model, advisorModel, false);
       if (account) return account;
@@ -276,6 +293,71 @@ export class AccountManager {
     return allowProbe ? this._selectProbe(exclude, model) : null;
   }
 
+  /** Session-affinity selection (opt-in, issue #109). Honor a known session's
+   * pin when that account is still eligible and not preempted by a
+   * higher-priority one; otherwise route the session to the least-loaded
+   * eligible account. Returns null if nothing is eligible, so the caller falls
+   * back to the normal quota-driven walk. Does NOT record the pin — that happens
+   * on the actual route (recordSession), so retries/failover re-pin naturally. */
+  _selectForSession(sessionId, exclude, model, advisorModel) {
+    const pinIdx = this.sessionTracker.pinnedAccount(sessionId);
+    if (pinIdx != null) {
+      const pinned = this.accounts[pinIdx];
+      if (pinned && this._isAvailable(pinned, model, advisorModel) && !exclude?.has(pinIdx)) {
+        // Mirror _select's priority preemption so an operator's priority order
+        // still wins over a session's stickiness.
+        const betterExists = this.accounts.some(a =>
+          this._isAvailable(a, model, advisorModel) && !exclude?.has(a.index) && (a.priority || 0) < (pinned.priority || 0));
+        if (!betterExists) return pinned;
+      }
+    }
+    return this._pickLeastLoaded(exclude, model, advisorModel);
+  }
+
+  /** Best-available biased toward the fewest active sessions, so new sessions
+   * spread across equal-priority accounts instead of funnelling onto one. Order:
+   * priority → fewest active sessions → fewest in-flight → soonest weekly reset
+   * (the existing tiebreak). */
+  _pickLeastLoaded(exclude = null, model = null, advisorModel = null) {
+    const now = Date.now();
+    let best = null;
+    let bestPriority = Infinity;
+    let bestSessions = Infinity;
+    let bestInFlight = Infinity;
+    let bestReset = Infinity;
+    for (const account of this.accounts) {
+      if (exclude?.has(account.index)) continue;
+      if (!this._isAvailable(account, model, advisorModel)) continue;
+      const priority = account.priority || 0;
+      const sessions = this.sessionTracker.activeCountFor(account.index, now);
+      const inFlight = account.inFlight || 0;
+      const reset = this._governingWeeklyReset(account, model) || -Infinity;
+      if (priority < bestPriority
+        || (priority === bestPriority && sessions < bestSessions)
+        || (priority === bestPriority && sessions === bestSessions && inFlight < bestInFlight)
+        || (priority === bestPriority && sessions === bestSessions && inFlight === bestInFlight && reset < bestReset)) {
+        best = account;
+        bestPriority = priority;
+        bestSessions = sessions;
+        bestInFlight = inFlight;
+        bestReset = reset;
+      }
+    }
+    return best;
+  }
+
+  /** Record that a session's request was served by an account (always on, even
+   * when distribution is off — the readout is passive). This is what pins a
+   * session for future affinity. */
+  recordSession(sessionId, accountIndex) {
+    if (sessionId) this.sessionTracker.touch(sessionId, accountIndex);
+  }
+
+  /** { known, active, perAccount } session counts for status/TUI. */
+  sessionStats() {
+    return this.sessionTracker.stats();
+  }
+
   /**
    * Like getActiveAccount, but if the selected account's OAuth token has ALREADY
    * expired it blocks on a refresh before returning — so a caller that injects
@@ -283,8 +365,8 @@ export class AccountManager {
    * 401. A token that is merely expiring soon (still valid) is left to the
    * caller's opportunistic background refresh; only a hard-expired one blocks.
    */
-  async getActiveAccountFresh(exclude = null, model = null, advisorModel = null) {
-    const account = this.getActiveAccount(exclude, model, advisorModel);
+  async getActiveAccountFresh(exclude = null, model = null, advisorModel = null, sessionId = null) {
+    const account = this.getActiveAccount(exclude, model, advisorModel, sessionId);
     if (account && account.type === 'oauth' && account.refreshToken
         && isTokenExpired(account.expiresAt)) {
       await this.ensureTokenFresh(account.index); // coalesces with any in-flight refresh
@@ -1181,10 +1263,12 @@ export class AccountManager {
    * Return a status summary of all accounts (safe to expose, no credentials).
    */
   getStatus() {
+    const sessions = this.sessionTracker.stats();
     return {
       currentAccount: this.accounts[this.currentIndex]?.name,
       switchThreshold: this.switchThreshold,
       routes: this.getRoutes(),
+      sessions: { ...sessions, distribute: this.distributeSessions },
       accounts: this.accounts.map(a => ({
         name: a.name,
         type: a.type,
@@ -1192,6 +1276,7 @@ export class AccountManager {
         priority: a.priority || 0,
         disabled: a.disabled || false,
         status: a.status,
+        sessions: sessions.perAccount[a.index] || 0,
         quota: { ...a.quota },
         usage: { ...a.usage },
         rateLimitedUntil: a.rateLimitedUntil

--- a/src/config.js
+++ b/src/config.js
@@ -47,6 +47,7 @@ export function createDefaultConfig() {
     upstream: 'https://api.anthropic.com',
     switchThreshold: 0.98,
     holdSeconds: 0,
+    distributeSessions: false,
     accounts: [],
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ async function serverCommand() {
   }
 
   const threshold = config.switchThreshold || 0.98;
-  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes, ramp: config.stormRamp });
+  const accountManager = new AccountManager(accounts, threshold, { routes: config.routes, ramp: config.stormRamp, distributeSessions: config.distributeSessions });
 
   // Restore quota observed in a previous run so a restart doesn't lose rotation
   // state (passive — we never call the API to re-learn it). Stale windows are

--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,8 @@ async function serverCommand() {
       const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
       const acct = info.account || r?.account || '?';
       const model = info.model ? ` (${info.model})` : '';
-      writeActivity(`${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
+      const sid = info.sessionId ? `${info.sessionId.slice(0, 6)} ` : '';
+      writeActivity(`${sid}${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
     };
     // Tee console output to the activity log as well
     const origLog = console.log;

--- a/src/server.js
+++ b/src/server.js
@@ -216,7 +216,11 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).
       const advisorModel = parseAdvisorModel(body);
-      const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs };
+      // Claude Code tags each session's requests with this header (present on
+      // /v1/messages and count_tokens). Drives session-aware routing + the
+      // running-sessions readout (issue #109).
+      const sessionId = req.headers['x-claude-code-session-id'] || null;
+      const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId };
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -444,7 +448,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // and the caller gets the exhausted response rather than leaking to another.
   const account = ctx.pinnedIndex != null
     ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
-    : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel);
+    : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId);
   if (!account) {
     // A pinned request concerns exactly one account: don't compute a fleet-wide
     // retry-after or sleep on other accounts' windows — return immediately.
@@ -505,6 +509,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
 
   // Track which account handles this request
   ctx.account = account.name;
+  // Pin this session to the serving account (for affinity) and keep it "active"
+  // in the running-sessions readout. Passive when distribution is off.
+  accountManager.recordSession(ctx.sessionId, account.index);
   hooks.onRequestRouted?.(reqId, { account: account.name });
 
   // Refresh OAuth token if needed

--- a/src/server.js
+++ b/src/server.js
@@ -221,6 +221,10 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // running-sessions readout (issue #109).
       const sessionId = req.headers['x-claude-code-session-id'] || null;
       const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId };
+      // Hold the session "in flight" across the WHOLE request (incl. retries and
+      // a multi-minute streaming completion) so it stays counted as active and
+      // never expires mid-request.
+      accountManager.beginSession(sessionId);
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -231,6 +235,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
         }
       } finally {
+        accountManager.endSession(sessionId);
         hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model });
       }
     } catch (err) {

--- a/src/server.js
+++ b/src/server.js
@@ -194,7 +194,11 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       }
 
       const reqId = ++counter;
-      hooks.onRequestStart?.(reqId, { method: req.method, path: req.url });
+      // Claude Code tags each session's requests with this header (present on
+      // /v1/messages and count_tokens). Read from headers up front so it drives
+      // session-aware routing (issue #109) and colors the TUI activity stream.
+      const sessionId = req.headers['x-claude-code-session-id'] || null;
+      hooks.onRequestStart?.(reqId, { method: req.method, path: req.url, sessionId });
 
       // Buffer request body (needed to resend on a different account after a 429).
       // Peek the top-level `model` field incrementally as chunks arrive so the
@@ -216,10 +220,6 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).
       const advisorModel = parseAdvisorModel(body);
-      // Claude Code tags each session's requests with this header (present on
-      // /v1/messages and count_tokens). Drives session-aware routing + the
-      // running-sessions readout (issue #109).
-      const sessionId = req.headers['x-claude-code-session-id'] || null;
       const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId };
       // Hold the session "in flight" across the WHOLE request (incl. retries and
       // a multi-minute streaming completion) so it stays counted as active and
@@ -236,7 +236,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         }
       } finally {
         accountManager.endSession(sessionId);
-        hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model });
+        hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId });
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -17,7 +17,7 @@ const SWEEP_INTERVAL_MS = 60 * 1000; // bound growth without an external timer
 
 export class SessionTracker {
   constructor({ knownTtlMs, activeTtlMs, now } = {}) {
-    // id -> { accountIndex, firstSeen, lastSeen, count }
+    // id -> { accountIndex, firstSeen, lastSeen, count, inFlight }
     this.sessions = new Map();
     this.knownTtlMs = knownTtlMs ?? SESSION_KNOWN_TTL_MS;
     this.activeTtlMs = activeTtlMs ?? SESSION_ACTIVE_TTL_MS;
@@ -31,11 +31,7 @@ export class SessionTracker {
   // even in a headless server that never renders status.
   touch(sessionId, accountIndex = null, now = this._now()) {
     if (!sessionId) return null;
-    let s = this.sessions.get(sessionId);
-    if (!s) {
-      s = { accountIndex, firstSeen: now, lastSeen: now, count: 0 };
-      this.sessions.set(sessionId, s);
-    }
+    const s = this._ensure(sessionId, now);
     s.lastSeen = now;
     s.count += 1;
     if (accountIndex != null) s.accountIndex = accountIndex;
@@ -43,12 +39,52 @@ export class SessionTracker {
     return s;
   }
 
+  // Mark a request for this session as started. A session with any request in
+  // flight counts as active (and non-expirable) for the whole request, however
+  // long it streams — a 5-minute completion must not drop out of "active" or the
+  // load balancer would under-count that account. Paired with endRequest.
+  beginRequest(sessionId, now = this._now()) {
+    if (!sessionId) return null;
+    const s = this._ensure(sessionId, now);
+    s.inFlight += 1;
+    s.lastSeen = now;
+    return s;
+  }
+
+  // Mark a request as finished (refreshes recency; releases the in-flight hold).
+  endRequest(sessionId, now = this._now()) {
+    const s = sessionId && this.sessions.get(sessionId);
+    if (!s) return;
+    s.inFlight = Math.max(0, s.inFlight - 1);
+    s.lastSeen = now;
+  }
+
+  _ensure(sessionId, now) {
+    let s = this.sessions.get(sessionId);
+    if (!s) {
+      s = { accountIndex: null, firstSeen: now, lastSeen: now, count: 0, inFlight: 0 };
+      this.sessions.set(sessionId, s);
+    }
+    return s;
+  }
+
+  // Active = a request in flight now, or one seen within the active window.
+  _isActive(s, now) {
+    return s.inFlight > 0 || now - s.lastSeen <= this.activeTtlMs;
+  }
+
+  // Expired = idle past the known window AND nothing in flight (a long-running
+  // request keeps the session alive no matter how old lastSeen is).
+  _isExpired(s, now) {
+    return s.inFlight === 0 && now - s.lastSeen > this.knownTtlMs;
+  }
+
   // The account a known (non-expired) session is pinned to, or null if the
   // session is unknown/forgotten. Expired-on-read entries are dropped.
   pinnedAccount(sessionId, now = this._now()) {
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return null;
-    if (now - s.lastSeen > this.knownTtlMs) {
+    if (this._isExpired(s, now)) {
       this.sessions.delete(sessionId);
       return null;
     }
@@ -56,20 +92,21 @@ export class SessionTracker {
   }
 
   // Active sessions currently pinned to `accountIndex` — the load metric used to
-  // spread new sessions across accounts.
+  // spread new sessions across accounts. Counts in-flight sessions regardless of
+  // how long their request has been streaming.
   activeCountFor(accountIndex, now = this._now()) {
     let n = 0;
     for (const s of this.sessions.values()) {
-      if (s.accountIndex === accountIndex && now - s.lastSeen <= this.activeTtlMs) n += 1;
+      if (s.accountIndex === accountIndex && this._isActive(s, now)) n += 1;
     }
     return n;
   }
 
-  // Drop sessions idle longer than the known window.
+  // Drop sessions idle longer than the known window (but never one still in flight).
   sweep(now = this._now()) {
     this._lastSweep = now;
     for (const [id, s] of this.sessions) {
-      if (now - s.lastSeen > this.knownTtlMs) this.sessions.delete(id);
+      if (this._isExpired(s, now)) this.sessions.delete(id);
     }
   }
 
@@ -81,13 +118,12 @@ export class SessionTracker {
     let active = 0;
     const perAccount = {};
     for (const [id, s] of this.sessions) {
-      const idle = now - s.lastSeen;
-      if (idle > this.knownTtlMs) {
+      if (this._isExpired(s, now)) {
         this.sessions.delete(id);
         continue;
       }
       known += 1;
-      if (idle <= this.activeTtlMs) {
+      if (this._isActive(s, now)) {
         active += 1;
         if (s.accountIndex != null) perAccount[s.accountIndex] = (perAccount[s.accountIndex] || 0) + 1;
       }

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -1,0 +1,97 @@
+// Tracks Claude Code sessions by their `x-claude-code-session-id` header so
+// teamclaude can (a) report how many sessions are running and (b) optionally
+// keep each session pinned to one account while spreading NEW sessions across
+// accounts (the opt-in fix for concurrency funnelling — issue #109).
+//
+// Two windows:
+//   - KNOWN: a session is remembered until it goes idle for this long, then
+//     forgotten. 1h matches the maximum prompt-cache extension window — past
+//     that there is no cache left to preserve, so the pin has no value.
+//   - ACTIVE: a session counts as "active" (and toward per-account load) if it
+//     made a request this recently. Short, so load-balancing reacts to what is
+//     actually running now rather than to sessions merely lingering in the hour.
+export const SESSION_KNOWN_TTL_MS = 60 * 60 * 1000; // 1h idle → forgotten
+export const SESSION_ACTIVE_TTL_MS = 2 * 60 * 1000; // 2min idle → no longer "active"
+
+const SWEEP_INTERVAL_MS = 60 * 1000; // bound growth without an external timer
+
+export class SessionTracker {
+  constructor({ knownTtlMs, activeTtlMs, now } = {}) {
+    // id -> { accountIndex, firstSeen, lastSeen, count }
+    this.sessions = new Map();
+    this.knownTtlMs = knownTtlMs ?? SESSION_KNOWN_TTL_MS;
+    this.activeTtlMs = activeTtlMs ?? SESSION_ACTIVE_TTL_MS;
+    this._now = now || (() => Date.now());
+    this._lastSweep = 0;
+  }
+
+  // Record that `sessionId` made a request served by `accountIndex`. Refreshes
+  // lastSeen (keeping the session "active"/"known") and, when an account is
+  // given, (re)pins the session to it. Throttled sweep keeps the map bounded
+  // even in a headless server that never renders status.
+  touch(sessionId, accountIndex = null, now = this._now()) {
+    if (!sessionId) return null;
+    let s = this.sessions.get(sessionId);
+    if (!s) {
+      s = { accountIndex, firstSeen: now, lastSeen: now, count: 0 };
+      this.sessions.set(sessionId, s);
+    }
+    s.lastSeen = now;
+    s.count += 1;
+    if (accountIndex != null) s.accountIndex = accountIndex;
+    if (now - this._lastSweep > SWEEP_INTERVAL_MS) this.sweep(now);
+    return s;
+  }
+
+  // The account a known (non-expired) session is pinned to, or null if the
+  // session is unknown/forgotten. Expired-on-read entries are dropped.
+  pinnedAccount(sessionId, now = this._now()) {
+    const s = sessionId && this.sessions.get(sessionId);
+    if (!s) return null;
+    if (now - s.lastSeen > this.knownTtlMs) {
+      this.sessions.delete(sessionId);
+      return null;
+    }
+    return s.accountIndex ?? null;
+  }
+
+  // Active sessions currently pinned to `accountIndex` — the load metric used to
+  // spread new sessions across accounts.
+  activeCountFor(accountIndex, now = this._now()) {
+    let n = 0;
+    for (const s of this.sessions.values()) {
+      if (s.accountIndex === accountIndex && now - s.lastSeen <= this.activeTtlMs) n += 1;
+    }
+    return n;
+  }
+
+  // Drop sessions idle longer than the known window.
+  sweep(now = this._now()) {
+    this._lastSweep = now;
+    for (const [id, s] of this.sessions) {
+      if (now - s.lastSeen > this.knownTtlMs) this.sessions.delete(id);
+    }
+  }
+
+  // { known, active, perAccount: { [index]: activeCount } } — for status/TUI.
+  // Sweeps as it goes so a long-lived headless server stays bounded.
+  stats(now = this._now()) {
+    this._lastSweep = now;
+    let known = 0;
+    let active = 0;
+    const perAccount = {};
+    for (const [id, s] of this.sessions) {
+      const idle = now - s.lastSeen;
+      if (idle > this.knownTtlMs) {
+        this.sessions.delete(id);
+        continue;
+      }
+      known += 1;
+      if (idle <= this.activeTtlMs) {
+        active += 1;
+        if (s.accountIndex != null) perAccount[s.accountIndex] = (perAccount[s.accountIndex] || 0) + 1;
+      }
+    }
+    return { known, active, perAccount };
+  }
+}

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -11,6 +11,9 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   lines.push(paint.bold('TeamClaude status'));
   lines.push(`${paint.dim('Active'.padEnd(12))} ${paint.cyan(status.currentAccount || 'none')}`);
   lines.push(`${paint.dim('Switch at'.padEnd(12))} ${formatPercent(status.switchThreshold)}`);
+  if (status.sessions) {
+    lines.push(`${paint.dim('Sessions'.padEnd(12))} ${formatSessions(status.sessions, paint)}`);
+  }
   lines.push(`${paint.dim('Probe'.padEnd(12))} ${formatProbeSummary(probe, now, paint)}`);
   if (warm.enabled) {
     lines.push(`${paint.dim('Keep-warm'.padEnd(12))} ${formatProbeSummary(warm, now, paint)}`);
@@ -87,7 +90,16 @@ function renderAccountHeader(account, currentAccount, paint, now) {
   const name = current ? paint.bold(account.name) : account.name;
   const status = formatAccountStatus(account, now, paint);
   const org = account.orgName ? ` ${paint.dim(account.orgName)}` : '';
-  return `${marker} ${name} ${paint.dim(`(${account.type}, prio ${account.priority || 0})`)} ${status}${org}`;
+  const sess = account.sessions ? ` ${paint.dim(`${account.sessions} sess`)}` : '';
+  return `${marker} ${name} ${paint.dim(`(${account.type}, prio ${account.priority || 0})`)} ${status}${org}${sess}`;
+}
+
+// "2 active / 3 known · distributing" — the running-sessions readout.
+function formatSessions(sessions, paint) {
+  const active = sessions.active || 0;
+  const known = sessions.known || 0;
+  const mode = sessions.distribute ? paint.green('distributing') : paint.dim('single-account');
+  return `${active} active / ${known} known ${paint.dim('·')} ${mode}`;
 }
 
 function formatAccountStatus(account, now, paint) {

--- a/src/tui.js
+++ b/src/tui.js
@@ -786,7 +786,11 @@ export class TUI {
     // ── Header
     const left = bold(' TeamClaude');
     const port = this.config.proxy?.port || 3456;
-    const right = `Port ${port} ${green('▲')} `;
+    const sess = this.am.sessionStats();
+    const sessStr = (sess.active || sess.known)
+      ? `${sess.active} sess${this.am.distributeSessions ? green(' dist') : ''}  `
+      : '';
+    const right = `${sessStr}Port ${port} ${green('▲')} `;
     lines.push(left + ' '.repeat(Math.max(1, W - vw(left) - vw(right))) + right);
     lines.push(' ' + dim('─'.repeat(W - 2)));
 

--- a/src/tui.js
+++ b/src/tui.js
@@ -36,6 +36,21 @@ const routeColorFn = name => {
   return code ? (s => fg(code, s)) : cyan;
 };
 
+// Per-session coloring for the activity log: a stable color derived from the
+// session id lets you tell concurrent sessions apart at a glance. Palette avoids
+// red (error) and gray (timestamps); includes bright variants for separation.
+const SESSION_FG = [36, 35, 34, 33, 94, 95, 96, 93, 92];
+const SESSION_ID_LEN = 6; // first 6 hex chars — plenty to distinguish a handful
+function sessionColorCode(sid) {
+  let h = 0;
+  for (let i = 0; i < sid.length; i++) h = (h * 31 + sid.charCodeAt(i)) >>> 0;
+  return SESSION_FG[h % SESSION_FG.length];
+}
+// Fixed-width colored short id (blank-padded when there's no session, e.g. a
+// telemetry request), so the activity column stays aligned.
+const sessionTag = sid =>
+  sid ? fg(sessionColorCode(sid), sid.slice(0, SESSION_ID_LEN)) : ' '.repeat(SESSION_ID_LEN);
+
 // Which quota-family bar (F7/S7) a route binds to, or null for a general route.
 // Auto routes are named 'fable'/'sonnet'; a configured route is classified by its
 // globs so e.g. `*fable*` sits next to the F7 bar.
@@ -255,7 +270,8 @@ export class TUI {
     const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
     const acct = info.account || r?.account || '?';
     const model = info.model ? ` (${info.model})` : ''; // shown when the request named a model
-    this._addLog(`${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
+    const sid = info.sessionId || r?.sessionId || null;
+    this._addLog(`${sessionTag(sid)} ${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
   }
 
   _addLog(msg) {
@@ -856,7 +872,7 @@ export class TUI {
       const sp = cyan(SPINNER[this.frame]);
       const m = r.model ? dim(` (${r.model})`) : ''; // filled in as soon as the model is peeked from the stream
       const a = r.account ? ` → ${r.account}` : '';
-      lines.push(` ${sp} ${gray(r.t)}  ${r.method} ${r.path}${m}${a} ${dim(`(${el}s...)`)}`);
+      lines.push(` ${sp} ${gray(r.t)}  ${sessionTag(r.sessionId)} ${r.method} ${r.path}${m}${a} ${dim(`(${el}s...)`)}`);
     }
 
     // Completed log

--- a/test/session-distribution.test.js
+++ b/test/session-distribution.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+function mgr(names, opts = {}) {
+  return new AccountManager(names.map((n) => oauth(n)), 0.98, opts);
+}
+
+test('distribution off: session id does not change quota-driven selection', () => {
+  const am = mgr(['a', 'b']); // distributeSessions defaults false
+  // Two different sessions both land on the current account (index 0), as before.
+  const s1 = am.getActiveAccount(null, null, null, 'sess-1');
+  const s2 = am.getActiveAccount(null, null, null, 'sess-2');
+  assert.equal(s1.name, 'a');
+  assert.equal(s2.name, 'a');
+});
+
+test('distribution on: a new session goes to the least-loaded account', () => {
+  const am = mgr(['a', 'b'], { distributeSessions: true });
+  // Session 1 routes and is recorded on 'a'.
+  const s1 = am.getActiveAccount(null, null, null, 'sess-1');
+  am.recordSession('sess-1', s1.index);
+  assert.equal(s1.name, 'a');
+  // Session 2, now that 'a' carries an active session, should spill to 'b'.
+  const s2 = am.getActiveAccount(null, null, null, 'sess-2');
+  assert.equal(s2.name, 'b');
+});
+
+test('distribution on: an existing session stays pinned to its account (cache affinity)', () => {
+  const am = mgr(['a', 'b'], { distributeSessions: true });
+  const first = am.getActiveAccount(null, null, null, 'sess-1');
+  am.recordSession('sess-1', first.index);
+  // Load up 'b' with two other sessions so it is now the busier account.
+  am.recordSession('sess-x', 1);
+  am.recordSession('sess-y', 1);
+  // sess-1 must still return its original account, not the (now) less-loaded one.
+  const again = am.getActiveAccount(null, null, null, 'sess-1');
+  assert.equal(again.index, first.index);
+});
+
+test('distribution on: three sessions spread across three accounts', () => {
+  const am = mgr(['a', 'b', 'c'], { distributeSessions: true });
+  const seen = new Set();
+  for (const sid of ['s1', 's2', 's3']) {
+    const acc = am.getActiveAccount(null, null, null, sid);
+    am.recordSession(sid, acc.index);
+    seen.add(acc.name);
+  }
+  assert.deepEqual([...seen].sort(), ['a', 'b', 'c']);
+});
+
+test('distribution on: priority still wins over session load-balancing', () => {
+  const am = new AccountManager([
+    oauth('a', { priority: 0 }),
+    oauth('b', { priority: 1 }), // less preferred
+  ], 0.98, { distributeSessions: true });
+  // Even as 'a' accrues sessions, new sessions stay on the higher-priority 'a'
+  // (its whole tier is just one account) rather than spilling to lower-priority 'b'.
+  for (const sid of ['s1', 's2', 's3']) {
+    const acc = am.getActiveAccount(null, null, null, sid);
+    am.recordSession(sid, acc.index);
+    assert.equal(acc.name, 'a');
+  }
+});
+
+test('distribution on: a pinned session whose account is exhausted re-routes', () => {
+  const am = mgr(['a', 'b'], { distributeSessions: true });
+  am.recordSession('sess-1', 0);
+  am.accounts[0].status = 'exhausted'; // 'a' no longer available
+  const acc = am.getActiveAccount(null, null, null, 'sess-1');
+  assert.equal(acc.name, 'b');
+});
+
+test('getStatus exposes session counts (known/active/perAccount) and the mode flag', () => {
+  const am = mgr(['a', 'b'], { distributeSessions: true });
+  am.recordSession('s1', 0);
+  am.recordSession('s2', 1);
+  const status = am.getStatus();
+  assert.equal(status.sessions.known, 2);
+  assert.equal(status.sessions.active, 2);
+  assert.equal(status.sessions.distribute, true);
+  assert.equal(status.accounts[0].sessions, 1);
+  assert.equal(status.accounts[1].sessions, 1);
+});

--- a/test/session-tracker.test.js
+++ b/test/session-tracker.test.js
@@ -50,6 +50,51 @@ test('a session stays known but goes inactive past the active window', () => {
   assert.equal(st.activeCountFor(1, clock.t), 0);
 });
 
+test('an in-flight request keeps a session active well past the active window', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t);
+  st.touch('s1', 1, clock.t); // routed to account 1
+  // A 5-minute completion — far longer than the 2-min active window.
+  clock.t += SESSION_ACTIVE_TTL_MS * 3;
+  assert.equal(st.stats(clock.t).active, 1, 'still active while in flight');
+  assert.equal(st.activeCountFor(1, clock.t), 1, 'still counts as load on its account');
+  // Request finishes; recency now governs and it stays active a bit longer.
+  st.endRequest('s1', clock.t);
+  assert.equal(st.stats(clock.t).active, 1);
+  // Then idles out of the active window.
+  clock.t += SESSION_ACTIVE_TTL_MS + 1;
+  assert.equal(st.stats(clock.t).active, 0);
+});
+
+test('an in-flight session is never expired, even past the 1h known window', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t);
+  st.touch('s1', 0, clock.t);
+  clock.t += SESSION_KNOWN_TTL_MS * 2; // a 2h+ stream
+  assert.equal(st.pinnedAccount('s1', clock.t), 0, 'pin survives while in flight');
+  assert.equal(st.stats(clock.t).known, 1);
+  // Only after it finishes and idles out does it get forgotten.
+  st.endRequest('s1', clock.t);
+  clock.t += SESSION_KNOWN_TTL_MS + 1;
+  assert.equal(st.pinnedAccount('s1', clock.t), null);
+});
+
+test('concurrent requests on one session balance in/out via inFlight', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t);
+  st.beginRequest('s1', clock.t);
+  st.touch('s1', 2, clock.t);
+  clock.t += SESSION_ACTIVE_TTL_MS + 1;
+  st.endRequest('s1', clock.t); // one still in flight
+  assert.equal(st.activeCountFor(2, clock.t), 1);
+  st.endRequest('s1', clock.t); // now idle
+  clock.t += SESSION_ACTIVE_TTL_MS + 1;
+  assert.equal(st.activeCountFor(2, clock.t), 0);
+});
+
 test('activeCountFor counts only recently-active sessions on that account', () => {
   const { clock, now } = fixedClock();
   const st = new SessionTracker({ now });

--- a/test/session-tracker.test.js
+++ b/test/session-tracker.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SessionTracker, SESSION_KNOWN_TTL_MS, SESSION_ACTIVE_TTL_MS } from '../src/session-tracker.js';
+
+// A tracker whose clock we drive by hand.
+function fixedClock(start = 1_000_000) {
+  const c = { t: start };
+  return { clock: c, now: () => c.t };
+}
+
+test('touch records a session and pins it to the serving account', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('s1', 2, clock.t);
+  assert.equal(st.pinnedAccount('s1', clock.t), 2);
+  assert.equal(st.pinnedAccount('unknown', clock.t), null);
+});
+
+test('a later touch re-pins the session (failover moves it)', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('s1', 0, clock.t);
+  st.touch('s1', 3, clock.t);
+  assert.equal(st.pinnedAccount('s1', clock.t), 3);
+});
+
+test('touch with no session id is a no-op', () => {
+  const st = new SessionTracker();
+  assert.equal(st.touch(null, 1), null);
+  assert.equal(st.touch(undefined, 1), null);
+});
+
+test('a session is forgotten after the known (1h) idle window', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('s1', 1, clock.t);
+  clock.t += SESSION_KNOWN_TTL_MS + 1;
+  assert.equal(st.pinnedAccount('s1', clock.t), null);
+  assert.equal(st.stats(clock.t).known, 0);
+});
+
+test('a session stays known but goes inactive past the active window', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('s1', 1, clock.t);
+  clock.t += SESSION_ACTIVE_TTL_MS + 1;
+  const stats = st.stats(clock.t);
+  assert.equal(stats.known, 1);
+  assert.equal(stats.active, 0);
+  assert.equal(st.activeCountFor(1, clock.t), 0);
+});
+
+test('activeCountFor counts only recently-active sessions on that account', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('a', 0, clock.t);
+  st.touch('b', 0, clock.t);
+  st.touch('c', 1, clock.t);
+  assert.equal(st.activeCountFor(0, clock.t), 2);
+  assert.equal(st.activeCountFor(1, clock.t), 1);
+  assert.equal(st.activeCountFor(2, clock.t), 0);
+});
+
+test('stats reports known, active, and per-account active distribution', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('a', 0, clock.t);
+  st.touch('b', 0, clock.t);
+  st.touch('c', 1, clock.t);
+  const stats = st.stats(clock.t);
+  assert.equal(stats.known, 3);
+  assert.equal(stats.active, 3);
+  assert.deepEqual(stats.perAccount, { 0: 2, 1: 1 });
+});
+
+test('stats sweeps forgotten sessions out of the map', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('old', 0, clock.t);
+  clock.t += SESSION_KNOWN_TTL_MS + 1;
+  st.touch('new', 1, clock.t);
+  st.stats(clock.t);
+  assert.equal(st.sessions.has('old'), false);
+  assert.equal(st.sessions.has('new'), true);
+});

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -35,6 +35,20 @@ test('renderStatus prints core status', () => {
   assert.match(output, /2 req, 1.5k tok/);
 });
 
+test('renderStatus shows the sessions line and per-account session count when present', () => {
+  const status = sampleStatus();
+  status.sessions = { known: 3, active: 2, perAccount: { 0: 2 }, distribute: true };
+  status.accounts[0].sessions = 2;
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /Sessions\s+2 active \/ 3 known · distributing/);
+  assert.match(output, /a \(oauth, prio 0\).*2 sess/);
+});
+
+test('renderStatus omits the sessions line when the status has no sessions field', () => {
+  const output = renderStatus(sampleStatus(), { color: false, now });
+  assert.doesNotMatch(output, /Sessions\s/);
+});
+
 test('renderStatus colors active accounts and bars', () => {
   const output = renderStatus(sampleStatus(), { color: true, now });
 


### PR DESCRIPTION
Fixes #109.

## Problem

Rotation is purely quota-driven: an account stays "current" until it nears `switchThreshold`, so a fleet of parallel Claude Code sessions all funnel onto **one** account while equal-priority siblings sit idle. That one account queues behind its upstream concurrency ceiling (the 240s timeouts in #109) while the others do nothing. `inFlight` was already tracked but never consulted for balancing, and the commenter's caveat stands: you must keep a session on the same account or you lose cache-read savings.

## Approach — session awareness via `x-claude-code-session-id`

Confirmed against real request logs: Claude Code stamps every `/v1/messages` (and `count_tokens`) request with `x-claude-code-session-id: <uuid>`; telemetry endpoints don't. Concurrent sessions interleave exactly as #109 describes.

**Tracking is always on and passive.** A `SessionTracker` observes the header and reports counts — the TUI header and `teamclaude status` now show **active** (a request in the last ~2 min) and **known** (seen within the last hour) sessions. Sessions are forgotten after 1h idle, the maximum prompt-cache extension window (past which the pin has no value). No behaviour change from tracking alone.

**Distribution is opt-in** (`distributeSessions`, default `false`). When enabled:
- a **new** session is routed to the least-loaded eligible account — fewest active sessions → fewest in-flight → existing soonest-weekly-reset tiebreak — and **pinned** there;
- an **existing** session keeps returning to its account, preserving its prompt cache;
- **priority still wins** (a higher-priority account is never skipped to balance load);
- a session whose pinned account becomes exhausted (or is tried/excluded on failover) **re-routes** automatically;
- a manual route pin still overrides everything.

Default single-account behaviour is unchanged either way.

## `teamclaude status` readout

```
Active       work
Switch at    98%
Sessions     2 active / 3 known · distributing

> work (oauth, prio 0) active 1 sess
  backup (oauth, prio 0) active 1 sess
```

## Changes

- `src/session-tracker.js` — `SessionTracker` (known/active windows, per-account load, throttled self-sweep).
- `AccountManager` — `sessionTracker`, `distributeSessions`, session-aware selection (`_selectForSession` / `_pickLeastLoaded`), `recordSession`, and session stats in `getStatus` (top-level + per-account).
- `server.js` — extract the header into `ctx.sessionId`, thread it into `getActiveAccount`, record the session on route.
- `status-renderer` + TUI header — running-session counts.
- Config default `distributeSessions: false`; README feature bullet, a dedicated section, and the config-table row.

## Tests

`session-tracker` (8), `session-distribution` behaviour (7 — off = unchanged, new-session spread, sticky affinity, priority precedence, exhausted re-route, status shape), and `status-renderer` sessions line (2). Full suite green (310), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)