### PR TITLE
fix(upstream): pool HTTP/1.1 connections to fix concurrency serialization (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,14 @@ TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 
 After a host network drop and reconnect, Node's shared connection pool can hold dead keep-alive sockets. Because a request has no default time limit, a retry can land on a dead socket and hang forever — every account and every retry keeps hitting the same poison, so the proxy appears wedged until you restart it. teamclaude bounds each stage so a stuck request fails fast instead: the failure lets Node evict the dead socket, the client retries, and the next request connects fresh — no restart needed. Recovery is per-socket, so after a flap it can take a few failed-then-retried requests to fully drain, but it always converges.
 
+**Connection pooling under concurrency.** Upstream requests go over a pooled **HTTP/1.1** transport (`node:https`), so each concurrent request gets its own connection. Node's global `fetch` instead multiplexes every request to `api.anthropic.com` over a **single HTTP/2 connection**; under many concurrent large uploads (Claude Code POSTs ~1&nbsp;MB of context per turn) that one connection serializes on HTTP/2's shared flow-control windows, and a trivial request can wait minutes for headers ([#106](https://github.com/KarpelesLab/teamclaude/issues/106)). Independent H1 connections have no such contention — each upload fills its own socket at TCP speed, matching what N direct Claude Code processes do. `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH=1` reverts to the old single-connection global-fetch path if ever needed.
+
 | Variable | Default | Description |
 |---|---|---|
 | `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS` | `120000` | Max wait for upstream **response headers** (time-to-first-byte). Cleared the instant headers arrive, so a long streaming body is never cut. Streamed completions deliver first byte in seconds; a non-streaming (`stream:false`) request that legitimately generates for longer than this could trip it — raise it for such callers. |
 | `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS` | `120000` | Max **idle** gap between response-body chunks. Resets on every chunk, so a slow-but-healthy stream is fine; it fires only when the socket goes silent mid-stream (a drop after headers), turning a hang into a fast, retryable failure. |
+| `TEAMCLAUDE_UPSTREAM_MAX_SOCKETS` | `256` | Max concurrent upstream connections **per origin** in the pooled path. Requests beyond this queue (raise it if you run more concurrent sessions than this against one host). |
+| `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH` | _(off)_ | Set to `1` to route upstream requests through Node's global `fetch` (single HTTP/2 connection) instead of the pooled H1 transport — an escape hatch, not recommended under concurrency. |
 | `TEAMCLAUDE_REFRESH_TIMEOUT_MS` | `30000` | Max wait for an OAuth token refresh. A hung refresh is coalesced across all callers, so it would otherwise wedge every request for that account. |
 
 ### Storm control (switchover ramp-up)

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -9,9 +9,27 @@
 // `status`, `headers.get()/.entries()`, `text()`, `arrayBuffer()`, and `body`
 // (a web ReadableStream, so streamResponse()'s getReader()/cancel() is untouched).
 
+import http from 'node:http';
 import https from 'node:https';
 import { Readable } from 'node:stream';
 import { tunnelTls } from './sx.js';
+
+// Pooled keep-alive agents for the direct (non-sx) path. Node's global fetch
+// multiplexes ALL requests to an origin over a SINGLE HTTP/2 connection; under
+// many concurrent large uploads (Claude Code POSTs ~1MB of context per turn)
+// that one connection serializes on HTTP/2's shared flow-control windows —
+// api.anthropic.com advertises maxConcurrentStreams=100 (not the limit) but only
+// a 64KB initial window, so concurrent uploads queue behind WINDOW_UPDATEs and a
+// trivial request can wait minutes for headers (issue #106). Independent HTTP/1.1
+// connections have no application-layer flow control: each upload fills its own
+// socket at TCP speed, exactly like N direct Claude Code processes. keep-alive
+// reuses idle sockets (Node unrefs them, so they don't hold the process open);
+// maxSockets is per-origin and bounds the fan-out. Escape hatch:
+// TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH=1 reverts to the old global-fetch path.
+const MAX_SOCKETS = Number(process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS) || 256;
+const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
+const httpAgent = new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
+const USE_GLOBAL_FETCH = /^(1|true|yes|on)$/i.test(process.env.TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH || '');
 
 // Time to wait for RESPONSE HEADERS before treating the upstream socket as dead.
 // This is NOT a limit on the response body (SSE completions can stream for
@@ -67,13 +85,22 @@ function headersTimeoutError(ms) {
 export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
   const { headersTimeoutMs, ...fetchOpts } = opts;
   const timeoutMs = resolveHeadersTimeout(headersTimeoutMs);
-  if (!sx || !useProxy || !sx.isProvisioned()) return directFetch(url, fetchOpts, timeoutMs);
-  return proxiedFetch(url, fetchOpts, sx, timeoutMs);
+  if (sx && useProxy && sx.isProvisioned()) return proxiedFetch(url, fetchOpts, sx, timeoutMs);
+  return USE_GLOBAL_FETCH ? directFetch(url, fetchOpts, timeoutMs) : pooledFetch(url, fetchOpts, timeoutMs);
 }
 
-// Global fetch driven by our own AbortController so we can arm a headers-only
-// deadline and disarm it the moment headers arrive (letting the body stream with
-// no deadline). AbortSignal.timeout can't do this — it would also kill the body.
+// Default direct path: HTTP/1.1 over a pooled keep-alive agent, so N concurrent
+// requests use N connections instead of serializing over one h2 connection (#106).
+function pooledFetch(url, opts, timeoutMs) {
+  const u = new URL(url);
+  const isHttp = u.protocol === 'http:';
+  return nodeRequest(u, opts, timeoutMs, { transport: isHttp ? http : https, agent: isHttp ? httpAgent : httpsAgent });
+}
+
+// Legacy direct path (escape hatch): Node global fetch, driven by our own
+// AbortController so we can arm a headers-only deadline and disarm it the moment
+// headers arrive (letting the body stream with no deadline). AbortSignal.timeout
+// can't do this — it would also kill the body.
 function directFetch(url, opts, timeoutMs) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(headersTimeoutError(timeoutMs)), timeoutMs);
@@ -84,14 +111,13 @@ function directFetch(url, opts, timeoutMs) {
   );
 }
 
+// sx path: every socket is a fresh TLS connection tunneled through sx.org. The
+// agent is created per request (its createConnection closes over this call's
+// target), so keep-alive would give no reuse — it would only park the tunneled
+// socket in a soon-orphaned pool and leak an open sx.org connection per request.
 function proxiedFetch(url, opts, sx, timeoutMs) {
   const u = new URL(url);
   const proxy = sx.getProxy();
-
-  // Custom agent: every socket is a TLS connection tunneled through sx.org. This
-  // agent is created per request (its createConnection closes over this call's
-  // target), so keep-alive would give no reuse — it would only park the tunneled
-  // socket in a soon-orphaned pool and leak an open sx.org connection per request.
   const agent = new https.Agent({ keepAlive: false });
   agent.createConnection = (_options, cb) => {
     // sx.tlsOptions is undefined in production (system CAs verify api.anthropic.com);
@@ -101,14 +127,18 @@ function proxiedFetch(url, opts, sx, timeoutMs) {
       .catch((err) => cb(err));
     return undefined; // socket delivered asynchronously via cb
   };
+  return nodeRequest(u, opts, timeoutMs, { transport: https, agent });
+}
 
+// Shared node:http(s) request → the fetch-Response subset server.js uses, with
+// the headers-only deadline: it fires before headers arrive and tears the request
+// down; it is cleared the instant the response starts, so a body that streams for
+// minutes is never cut. `req` is created BEFORE the timer so a synchronous
+// throw (e.g. an invalid client header) can't leave a scheduled timer that later
+// fires against an uninitialized binding.
+function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
   return new Promise((resolve, reject) => {
-    // Headers-only deadline (same as the direct path): fires before headers
-    // arrive and tears the tunneled request down; cleared once the response
-    // starts. `req` is created BEFORE the timer so a synchronous https.request
-    // throw (e.g. an invalid client header) can't leave a scheduled timer that
-    // fires later and dereferences an uninitialized binding.
-    const req = https.request(
+    const req = transport.request(
       u,
       { method: opts.method || 'GET', headers: opts.headers || {}, agent },
       (res) => { clearTimeout(timer); resolve(makeResponse(res)); },

--- a/test/upstream-pool.test.js
+++ b/test/upstream-pool.test.js
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { upstreamFetch } from '../src/upstream-fetch.js';
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0);
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+// The #106 fix: the default direct path pools HTTP/1.1 connections, so N
+// concurrent requests use N connections and run in PARALLEL — they do not
+// serialize behind one shared connection the way Node global fetch's single
+// HTTP/2 connection does under concurrent uploads.
+test('concurrent requests each open their own connection and run in parallel', async () => {
+  let conns = 0;
+  const HEADER_DELAY = 300;
+  const { server, port } = await listen((req, res) => {
+    setTimeout(() => { res.writeHead(200); res.end('ok'); }, HEADER_DELAY);
+  });
+  server.on('connection', () => { conns += 1; });
+
+  const N = 8;
+  const started = Date.now();
+  const bodies = await Promise.all(
+    Array.from({ length: N }, () =>
+      upstreamFetch(`http://127.0.0.1:${port}/`, { headersTimeoutMs: 5000 }).then((r) => r.text())),
+  );
+  const elapsed = Date.now() - started;
+
+  assert.deepEqual(bodies, Array(N).fill('ok'));
+  assert.equal(conns, N, `expected ${N} parallel connections, saw ${conns}`);
+  // Parallel: total ≈ one request's delay, NOT N × delay (serialization).
+  assert.ok(elapsed < HEADER_DELAY * 3, `expected parallel (~${HEADER_DELAY}ms), took ${elapsed}ms`);
+
+  server.close();
+});
+
+// A large POST body (the workload that serializes on one h2 connection) streams
+// through, and the fetch-Response surface server.js relies on is intact.
+test('streams a large POST body and exposes the fetch-Response surface', async () => {
+  const bodyLen = 1_000_000;
+  const { server, port } = await listen((req, res) => {
+    let received = 0;
+    req.on('data', (c) => { received += c.length; });
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json', 'x-received': String(received) });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+
+  const res = await upstreamFetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: Buffer.alloc(bodyLen, 0x61),
+    headersTimeoutMs: 5000,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('x-received'), String(bodyLen));
+  assert.equal(res.headers.get('content-type'), 'application/json');
+  assert.deepEqual(JSON.parse(await res.text()), { ok: true });
+
+  server.close();
+});
+
+// Streaming (SSE) response is delivered incrementally through the web-stream body.
+test('streams an SSE response body incrementally', async () => {
+  const { server, port } = await listen(async (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: a\n\n');
+    await new Promise((r) => setTimeout(r, 50));
+    res.write('event: b\n\n');
+    res.end();
+  });
+
+  const res = await upstreamFetch(`http://127.0.0.1:${port}/`, { headersTimeoutMs: 5000 });
+  assert.equal(res.status, 200);
+  const reader = res.body.getReader();
+  let text = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += Buffer.from(value).toString();
+  }
+  assert.match(text, /event: a/);
+  assert.match(text, /event: b/);
+
+  server.close();
+});

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -91,46 +91,59 @@ test('does not cut a slow body once headers have arrived', async () => {
 // one chunk then goes silent; the second read must fail fast with a transient
 // TEAMCLAUDE_BODY_TIMEOUT (which server.js treats as retryable) rather than hang.
 test('body watchdog fails fast when the stream goes silent mid-body', async () => {
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode('event: ping\n\n'));
-      // never enqueue again and never close — a mid-stream network drop
-    },
-  });
-  const reader = stream.getReader();
+  // readWithIdleTimeout's watchdog is unref'd (in production the listening socket
+  // keeps the loop alive; here this test has no socket of its own), so hold a
+  // ref'd handle for the test's duration or the loop can drain before it fires.
+  const alive = setInterval(() => {}, 60_000);
+  try {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: ping\n\n'));
+        // never enqueue again and never close — a mid-stream network drop
+      },
+    });
+    const reader = stream.getReader();
 
-  // First chunk is already buffered: resolves immediately, no timeout.
-  const first = await readWithIdleTimeout(reader, 200);
-  assert.equal(first.done, false);
-  assert.equal(new TextDecoder().decode(first.value), 'event: ping\n\n');
+    // First chunk is already buffered: resolves immediately, no timeout.
+    const first = await readWithIdleTimeout(reader, 200);
+    assert.equal(first.done, false);
+    assert.equal(new TextDecoder().decode(first.value), 'event: ping\n\n');
 
-  // Second read: the stream is silent, so the watchdog fires fast.
-  const start = Date.now();
-  await assert.rejects(
-    () => readWithIdleTimeout(reader, 200),
-    (err) => err.code === 'TEAMCLAUDE_BODY_TIMEOUT',
-  );
-  const elapsed = Date.now() - start;
-  assert.ok(elapsed < 2000, `expected fast body-timeout, took ${elapsed}ms`);
+    // Second read: the stream is silent, so the watchdog fires fast.
+    const start = Date.now();
+    await assert.rejects(
+      () => readWithIdleTimeout(reader, 200),
+      (err) => err.code === 'TEAMCLAUDE_BODY_TIMEOUT',
+    );
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 2000, `expected fast body-timeout, took ${elapsed}ms`);
+  } finally {
+    clearInterval(alive);
+  }
 });
 
 // The watchdog must not fire on a healthy-but-slow stream: a chunk that arrives
 // within the window resets nothing artificially — it simply resolves.
 test('body watchdog does not fire when chunks keep arriving', async () => {
-  let pushed = false;
-  const stream = new ReadableStream({
-    pull(controller) {
-      if (pushed) { controller.close(); return; }
-      pushed = true;
-      return new Promise((resolve) => setTimeout(() => {
-        controller.enqueue(new TextEncoder().encode('event: ok\n\n'));
-        resolve();
-      }, 100));
-    },
-  });
-  const reader = stream.getReader();
+  const alive = setInterval(() => {}, 60_000); // see note above: keep the loop alive
+  try {
+    let pushed = false;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (pushed) { controller.close(); return; }
+        pushed = true;
+        return new Promise((resolve) => setTimeout(() => {
+          controller.enqueue(new TextEncoder().encode('event: ok\n\n'));
+          resolve();
+        }, 100));
+      },
+    });
+    const reader = stream.getReader();
 
-  const r = await readWithIdleTimeout(reader, 500); // 100ms chunk < 500ms window
-  assert.equal(r.done, false);
-  assert.match(new TextDecoder().decode(r.value), /ok/);
+    const r = await readWithIdleTimeout(reader, 500); // 100ms chunk < 500ms window
+    assert.equal(r.done, false);
+    assert.match(new TextDecoder().decode(r.value), /ok/);
+  } finally {
+    clearInterval(alive);
+  }
 });


### PR DESCRIPTION
Fixes #106.

## Root cause (measured, not guessed)

I connected to `api.anthropic.com` over h2 and read its SETTINGS:

```
maxConcurrentStreams = 100
initialWindowSize    = 65536   (64 KB)
```

So the serialization under concurrency is **not** stream-count exhaustion (100 ≫ the ~26 concurrent requests). It's **HTTP/2 flow control**. Node's global `fetch` multiplexes every request to the origin over **one** h2 connection; Claude Code POSTs ~1 MB of context per turn (confirmed in real request logs), and all those uploads share that connection's flow-control budget with only a 64 KB initial window — so they queue behind `WINDOW_UPDATE` round-trips. A trivial request then waits minutes for headers, the 120 s guard aborts it, the client sees `ECONNRESET`, and Claude Code's 10× retry loop re-piles load. A direct Claude Code process doesn't feel this because it has its **own** connection.

Notably this means the large-POST workload is exactly what makes a single h2 connection the wrong choice here — independent H1 connections have **no** application-layer flow control, so each upload fills its own socket at TCP speed.

## Fix

Route the default (non-sx) upstream path over a **pooled keep-alive HTTP/1.1 transport** (`node:https`/`node:http`), so N concurrent requests use N connections. This:

- generalizes the sx `proxiedFetch` path, which already runs `https.request` → the same `makeResponse` machinery in production (both now share one `nodeRequest` helper);
- is safe on the response side because `forwardRequest` already strips `accept-encoding` upstream (responses are identity — nothing to decompress, unlike the trap in the #110 relay);
- keeps the existing headers-timeout guard, which still handles stale pooled sockets;
- zero new dependencies.

Escape hatch: `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH=1` reverts to the old single-connection global-fetch path. `TEAMCLAUDE_UPSTREAM_MAX_SOCKETS` (default 256) bounds per-origin fan-out.

## Why H1, not an H2 session pool

Even a pool of h2 sessions can't escape this: upload flow-control windows are advertised by **Anthropic**, not us, so to match H1's upload throughput you'd need ~one session per concurrent upload — i.e. reinvent H1-per-request with more code and h2 overhead for no gain on this workload.

## Tests

- `test/upstream-pool.test.js` — **N concurrent requests open N connections and run in parallel** (the fix, asserted via connection count + wall-clock), a 1 MB POST body round-trips, and SSE streams incrementally.
- `test/upstream-timeout.test.js` — the existing fast-fail / socket-eviction / slow-body tests now exercise the pooled path (they pass unchanged); the two `readWithIdleTimeout` body-watchdog tests now hold a ref'd handle, since they had been leaning on global fetch's incidental one that the pooled path correctly drops.

Full suite green (316), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)