### PR TITLE
feat(proxy): forward plain-HTTP requests to third-party hosts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -74,6 +74,12 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
         return;
       }
 
+      // Forward-proxy request (HTTP_PROXY): an absolute-form URL means a tool
+      // running alongside teamclaude (gh, curl, npm…) is proxying plain HTTP to a
+      // third-party host. Blind-relay it there — Anthropic traffic is never
+      // absolute-form here, so this only ever sees third-party hosts.
+      if (/^https?:\/\//i.test(req.url || '')) { relayHttpForward(req, res); return; }
+
       // Status endpoint
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
         const status = accountManager.getStatus();
@@ -151,6 +157,50 @@ export function resolveAccountPin(accountManager, token) {
 
 // Paths that must reach upstream with the client's own credential (never a
 // rotated account token): the Remote Control channel and attachment transfers.
+// A plain-HTTP forward-proxy request (via HTTP_PROXY) arrives in ABSOLUTE form —
+// `GET http://host/path` — whereas an Anthropic request is always origin-form
+// (`/v1/messages`, via ANTHROPIC_BASE_URL or a CONNECT tunnel). teamclaude is a
+// general forward proxy for tools running alongside it (gh, curl, npm…); the
+// HTTPS equivalent is the CONNECT tunnel in mitm.js. Blind-relay it to its target
+// with the client's own headers — no account selection, no token injection, and
+// content-encoding passed through untouched (a transparent proxy).
+export function relayHttpForward(req, res) {
+  let target;
+  try { target = new URL(req.url); } catch {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'Malformed forward-proxy URL' } }));
+    return;
+  }
+  const transport = target.protocol === 'http:' ? http : https;
+  const headers = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    const lk = key.toLowerCase();
+    // Drop hop-by-hop + proxy-control headers; `host` is reset from the target.
+    if (lk.startsWith(':') || HOP_BY_HOP_HEADERS.has(lk) || lk === 'proxy-connection') continue;
+    headers[key] = value;
+  }
+
+  const upstreamReq = transport.request(target, { method: req.method, headers }, (upstreamRes) => {
+    const responseHeaders = {};
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
+      if (CONNECTION_SPECIFIC_HEADERS.has(key)) continue;
+      responseHeaders[key] = value;
+    }
+    res.writeHead(upstreamRes.statusCode, responseHeaders);
+    upstreamRes.pipe(res);
+  });
+  upstreamReq.on('error', (err) => {
+    console.error(`[TeamClaude] HTTP forward to ${target.host} failed:`, err.message);
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Upstream unreachable' } }));
+    }
+  });
+  res.on('close', () => upstreamReq.destroy());
+  if (['GET', 'HEAD'].includes(req.method)) upstreamReq.end();
+  else req.pipe(upstreamReq);
+}
+
 const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/file_upload'];
 
 /**

--- a/test/http-forward-proxy.test.js
+++ b/test/http-forward-proxy.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { createProxyServer } from '../src/server.js';
+
+async function listen(server) {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return server.address().port;
+}
+
+// An accountManager that MUST NOT be consulted for third-party HTTP — if the
+// forward path ever routed to Anthropic, getActiveAccount would throw.
+const noRouteManager = {
+  getActiveAccount() { throw new Error('third-party HTTP must not be routed to Anthropic'); },
+  getStatus() { return {}; },
+};
+
+// Absolute-form request through the proxy (`GET http://target/…`) as sent by any
+// tool honoring HTTP_PROXY.
+function proxyRequest({ proxyPort, method = 'GET', absoluteUrl, body }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port: proxyPort, method, path: absoluteUrl }, (res) => {
+      let d = '';
+      res.on('data', (c) => { d += c; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d }));
+    });
+    req.on('error', reject);
+    if (body) req.end(body); else req.end();
+  });
+}
+
+test('forwards an absolute-form HTTP request to its target host, not to Anthropic', async () => {
+  const target = http.createServer((req, res) => {
+    res.writeHead(200, { 'x-served-by': 'target', 'content-type': 'text/plain' });
+    res.end('hello from target');
+  });
+  const targetPort = await listen(target);
+
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  const r = await proxyRequest({ proxyPort, absoluteUrl: `http://127.0.0.1:${targetPort}/hello` });
+  assert.equal(r.status, 200);
+  assert.equal(r.headers['x-served-by'], 'target');
+  assert.equal(r.body, 'hello from target');
+
+  proxy.close(); target.close();
+});
+
+test('forwards a POST body and method to the target', async () => {
+  const target = http.createServer((req, res) => {
+    let received = '';
+    req.on('data', (c) => { received += c; });
+    req.on('end', () => {
+      res.writeHead(201, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ method: req.method, echo: received }));
+    });
+  });
+  const targetPort = await listen(target);
+
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  const r = await proxyRequest({ proxyPort, method: 'POST', absoluteUrl: `http://127.0.0.1:${targetPort}/`, body: 'payload-123' });
+  assert.equal(r.status, 201);
+  assert.deepEqual(JSON.parse(r.body), { method: 'POST', echo: 'payload-123' });
+
+  proxy.close(); target.close();
+});
+
+test('returns 502 (not a hang) when the target host is unreachable', async () => {
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  // Port 1 is not listening → connection refused.
+  const r = await proxyRequest({ proxyPort, absoluteUrl: 'http://127.0.0.1:1/' });
+  assert.equal(r.status, 502);
+  assert.match(r.body, /proxy_error/);
+
+  proxy.close();
+});


### PR DESCRIPTION
## Problem

Tools running alongside teamclaude that honor `HTTP_PROXY` (gh, curl, npm, …) send a **plain-HTTP** request to the proxy in **absolute form** — `GET http://host/path`. teamclaude treated that as an origin request and routed it through account selection to Anthropic, so the call came back as a bogus account error instead of reaching its target:

```
$ curl http://example.org/          # HTTP_PROXY -> teamclaude
{"type":"error","error":{"type":"rate_limit_error","message":"All 3 accounts exhausted. Retry in 60s."}}
```

HTTPS already worked — the CONNECT tunnel (`mitm.js`) blind-relays non-Anthropic hosts end-to-end. Only the plain-HTTP forward-proxy path was missing.

## Fix

Detect an absolute-form request URL in the base server and **blind-relay it to its target host** with the client's own headers — no account selection, no token injection, `content-encoding` passed through untouched (a transparent forward proxy). It's the plain-HTTP analogue of the CONNECT tunnel.

- Anthropic traffic is never absolute-form here (it's origin-form via `ANTHROPIC_BASE_URL`, or a CONNECT tunnel), so this only ever sees third-party hosts.
- Runs **after** the existing auth gate (loopback exempt, remote needs the proxy key), so it isn't an open relay.
- Hop-by-hop and `proxy-connection` headers stripped; `502` on an unreachable target instead of a hang.

## Tests

`test/http-forward-proxy.test.js` spins up a real `createProxyServer` + a target origin server and asserts: an absolute-form GET is forwarded to the target (with an accountManager whose `getActiveAccount` throws, proving Anthropic is never consulted), a POST body+method is forwarded, and an unreachable target yields `502` rather than hanging.

Full suite green (316), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)