### PR TITLE
fix(proxy): only apply account logic to managed hosts; forward the rest transparently

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -74,6 +74,12 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
         return;
       }
 
+      // Forward-proxy request (HTTP_PROXY): an absolute-form URL is a tool
+      // proxying plain HTTP to some host. Account logic is only for hosts we
+      // manage (the Anthropic upstream, which is HTTPS-only and never arrives
+      // this way); forward anything else transparently instead of hijacking it.
+      if (/^https?:\/\//i.test(req.url || '')) { relayHttpForward(req, res); return; }
+
       // Status endpoint
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
         const status = accountManager.getStatus();
@@ -151,6 +157,53 @@ export function resolveAccountPin(accountManager, token) {
 
 // Paths that must reach upstream with the client's own credential (never a
 // rotated account token): the Remote Control channel and attachment transfers.
+// teamclaude applies its account logic (rotation, exhaustion, token injection)
+// ONLY to hosts it manages — the Anthropic upstream. Anything else must be
+// forwarded transparently, never hijacked into "all accounts exhausted". For
+// HTTPS this is already true (the CONNECT tunnel in mitm.js blind-relays
+// non-upstream hosts). This is the plain-HTTP counterpart: a tool honoring
+// HTTP_PROXY sends an ABSOLUTE-form request (`GET http://host/path`), which
+// otherwise gets misrouted to Anthropic. Blind-relay it to its target with the
+// client's own headers — no account selection, no token injection,
+// content-encoding passed through (a transparent forward proxy). Anthropic is
+// HTTPS-only, so in practice this only ever sees third-party hosts.
+export function relayHttpForward(req, res) {
+  let target;
+  try { target = new URL(req.url); } catch {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'Malformed forward-proxy URL' } }));
+    return;
+  }
+  const transport = target.protocol === 'http:' ? http : https;
+  const headers = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    const lk = key.toLowerCase();
+    // Drop hop-by-hop + proxy-control headers; `host` is reset from the target.
+    if (lk.startsWith(':') || HOP_BY_HOP_HEADERS.has(lk) || lk === 'proxy-connection') continue;
+    headers[key] = value;
+  }
+
+  const upstreamReq = transport.request(target, { method: req.method, headers }, (upstreamRes) => {
+    const responseHeaders = {};
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
+      if (CONNECTION_SPECIFIC_HEADERS.has(key)) continue;
+      responseHeaders[key] = value;
+    }
+    res.writeHead(upstreamRes.statusCode, responseHeaders);
+    upstreamRes.pipe(res);
+  });
+  upstreamReq.on('error', (err) => {
+    console.error(`[TeamClaude] HTTP forward to ${target.host} failed:`, err.message);
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Upstream unreachable' } }));
+    }
+  });
+  res.on('close', () => upstreamReq.destroy());
+  if (['GET', 'HEAD'].includes(req.method)) upstreamReq.end();
+  else req.pipe(upstreamReq);
+}
+
 const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/file_upload'];
 
 /**

--- a/test/http-forward-proxy.test.js
+++ b/test/http-forward-proxy.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { createProxyServer } from '../src/server.js';
+
+async function listen(server) {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return server.address().port;
+}
+
+// An accountManager that MUST NOT be consulted for a third-party host — if the
+// forward path ever routed to Anthropic, getActiveAccount would throw. This is
+// the principle under test: account logic only for hosts we manage.
+const noRouteManager = {
+  getActiveAccount() { throw new Error('third-party host must not be routed to Anthropic'); },
+  getStatus() { return {}; },
+};
+
+// Absolute-form request through the proxy (`GET http://target/…`), as sent by any
+// tool honoring HTTP_PROXY.
+function proxyRequest({ proxyPort, method = 'GET', absoluteUrl, body }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port: proxyPort, method, path: absoluteUrl }, (res) => {
+      let d = '';
+      res.on('data', (c) => { d += c; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d }));
+    });
+    req.on('error', reject);
+    if (body) req.end(body); else req.end();
+  });
+}
+
+test('forwards an absolute-form HTTP request to its target host, not to Anthropic', async () => {
+  const target = http.createServer((req, res) => {
+    res.writeHead(200, { 'x-served-by': 'target', 'content-type': 'text/plain' });
+    res.end('hello from target');
+  });
+  const targetPort = await listen(target);
+
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  const r = await proxyRequest({ proxyPort, absoluteUrl: `http://127.0.0.1:${targetPort}/hello` });
+  assert.equal(r.status, 200);
+  assert.equal(r.headers['x-served-by'], 'target');
+  assert.equal(r.body, 'hello from target');
+
+  proxy.close(); target.close();
+});
+
+test('forwards a POST body and method to the target', async () => {
+  const target = http.createServer((req, res) => {
+    let received = '';
+    req.on('data', (c) => { received += c; });
+    req.on('end', () => {
+      res.writeHead(201, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ method: req.method, echo: received }));
+    });
+  });
+  const targetPort = await listen(target);
+
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  const r = await proxyRequest({ proxyPort, method: 'POST', absoluteUrl: `http://127.0.0.1:${targetPort}/`, body: 'payload-123' });
+  assert.equal(r.status, 201);
+  assert.deepEqual(JSON.parse(r.body), { method: 'POST', echo: 'payload-123' });
+
+  proxy.close(); target.close();
+});
+
+test('returns 502 (not a hang) when the target host is unreachable', async () => {
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+
+  // Port 1 is not listening → connection refused.
+  const r = await proxyRequest({ proxyPort, absoluteUrl: 'http://127.0.0.1:1/' });
+  assert.equal(r.status, 502);
+  assert.match(r.body, /proxy_error/);
+
+  proxy.close();
+});


### PR DESCRIPTION
Implements the principle: **teamclaude's account logic (rotation, exhaustion, token injection) applies only to hosts it manages** (the Anthropic upstream). Anything else is forwarded transparently, never hijacked into "all accounts exhausted".

## Where each path stands

- **HTTPS already obeys this.** The CONNECT tunnel (`mitm.js` `hostMode`) MITMs/account-routes only the upstream host; every other host is blind-tunneled end-to-end. So all real (TLS) traffic from tools alongside teamclaude — gh, curl, npm — already forwards transparently.
- **Origin-form requests** (`/v1/messages` via `ANTHROPIC_BASE_URL`) are Anthropic by definition — the client chose us as their endpoint. Unchanged.
- **The gap: absolute-form plain HTTP.** A tool honoring `HTTP_PROXY` sends `GET http://host/path`; the base server assumed Anthropic and misrouted it — returning a bogus account-exhausted 429, or (with quota) wasting a request on a malformed URL:

  ```
  $ curl http://example.org/          # HTTP_PROXY -> teamclaude
  {"type":"error","error":{"type":"rate_limit_error","message":"All 3 accounts exhausted. Retry in 60s."}}
  ```

## Fix

Detect absolute-form requests in the base server and **blind-relay them to their target host** with the client's own headers — no account selection, no token injection, `content-encoding` passed through (a transparent forward proxy, the plain-HTTP analogue of the CONNECT tunnel). Anthropic is HTTPS-only, so this only ever sees third-party hosts. Runs after the auth gate (loopback exempt), so it isn't an open relay.

## Verification

- Integration tests (`test/http-forward-proxy.test.js`): absolute-form GET forwarded to target, POST body+method forwarded, and 502-not-hang on an unreachable target — each with an `accountManager` whose `getActiveAccount` **throws**, proving Anthropic is never consulted.
- Live-checked against a real headless instance: `curl --proxy … http://<local-target>/` now returns the target's response (`200`, target header) instead of the Anthropic 429.

Full suite green (316), lint clean.

> Note: this reinstates the previously-closed #124, now framed by the maintainer's principle — not "plain-HTTP support" but "don't hijack hosts we don't manage." Future managed domains would extend the same idea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)