### PR TITLE
Bump to 1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release 1.1.8 (patch bump, current master as-is).

Merging this to master triggers `publish.yml` → publishes `@karpeleslab/teamclaude@1.1.8` to npm (OIDC Trusted Publishing) and creates the `v1.1.8` GitHub release with auto-generated notes.

Notable since 1.1.7 (all merged this session):
- Session-aware routing + opt-in `distributeSessions` (#122, issue #109); running-session counts + color-coded activity log
- HTTP/1.1 connection pooling to fix concurrency serialization (#123, issue #106); `nodeToWeb` stream fix + **Node ≥20** baseline (#128)
- Model blocklist `blockedModels` (#127, issue #116)
- `eventLogging` hide/block/show for telemetry (#126)
- Transparent forwarding for non-managed hosts (#125)
- `teamclaude env` defaults to MITM (#120); terminal title shows active account (#121)
- Remote Control WebSocket relay (#110); tool-pair sanitize (#105) + hot-path gate (#118); hold-on-exhaustion (#113); `--activity-log` (#112); Nix flake (#117)

🤖 Generated with [Claude Code](https://claude.com/claude-code)