### PR TITLE
Bump to 1.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch bump 1.1.8 → 1.1.9.

Ships the routing-screen picker UX (#130 / #131): route accounts/bucket/color are now selected rather than typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)