### PR TITLE
Account pinning via ANTHROPIC_BASE_URL + activity log improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Hot-reload accounts** — add or change accounts while the server is running; press **R** in the TUI, or run headless and CLI changes auto-reload via a local control endpoint
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
-- **Third-party backend accounts** — route requests to any Anthropic-compatible API (e.g. DeepSeek, GLM) as a fallback when Claude accounts are exhausted; a per-account `upstream` URL and `modelMap` translate model names transparently. Accounts with a `models` list are reserved for requests that explicitly name those models, enabling per-session backend selection without touching other sessions
+- **Third-party backend accounts** — route requests to any Anthropic-compatible API (e.g. DeepSeek, GLM) as a fallback when Claude accounts are exhausted; a per-account `upstream` URL and `modelMap` translate model names transparently. Use [model routes](#model-routes) to reserve a third-party account for sessions that explicitly name its models
 - **Model blocklist** — reject requests for unwanted models (glob patterns, e.g. `*fable*`) with a fast `400` instead of forwarding them; a model no account can serve otherwise gets rate-limited upstream and hangs the pipeline. Edit live in the TUI settings screen (`g` → Blocked models)
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
@@ -356,7 +356,7 @@ When on, teamclaude routes each **new** session to the least-loaded eligible acc
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
 | `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only |
 | `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |
-| `accounts[].models` | Array of model names this account exclusively handles. When any account declares a `models` list, requests for those models are routed only to accounts that list them — use this to reserve a third-party account for sessions that pass `--model <name>` explicitly |
+| `accounts[].models` | **Deprecated** — use a [`routes`](#model-routes) entry with `match` and `accounts` instead. Array of model names this account exclusively handles; kept for backward compatibility with pre-routes configs. |
 | `routes` | Optional list of routing rules that pin model patterns to specific accounts — see [Model routes](#model-routes) |
 
 ### Model routes
@@ -465,7 +465,13 @@ Any Anthropic-compatible API can be added as an account alongside your Claude ac
 
 - **`upstream`** — base URL of the target API. Requests are sent to `upstream + /v1/messages` (etc.) for this account only.
 - **`modelMap`** — when a Claude model name arrives in the request body, it is rewritten to the mapped name before forwarding.
-- **`models`** — model names this account exclusively handles. Once any account declares a `models` list, requests for those model names are locked to matching accounts. This lets you send a specific session to a third-party backend without touching others — use `--model` on launch or `/model` inside a session:
+- **`models`** — **Deprecated.** Use a [`routes`](#model-routes) entry instead:
+  ```json
+  { "name": "deepseek", "match": ["deepseek-*"], "accounts": ["deepseek"] }
+  ```
+  Routes are more flexible (glob matching, multiple accounts, bucket override) and are the recommended way to pin model patterns to specific accounts. The `models` field is kept for backward compatibility but may be removed in a future version.
+
+To send a specific session to a third-party backend without touching others, define a route for its model patterns and use `--model` on launch or `/model` inside a session:
 
 ```bash
 # This session routes to DeepSeek; all other sessions still use Claude accounts.

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -604,7 +604,7 @@ export class AccountManager {
   /** Whether `account` may serve `model`. A matching route with an `accounts`
    * list is exclusive (only listed accounts, by name or index). With no matching
    * route — or a route that lists no accounts — it falls back to the per-account
-   * `models` ownership claim so PR #74 configs keep working. */
+   * `models` ownership claim (deprecated — use `routes` instead). */
   _routeAllows(account, model) {
     const route = this._routeForModel(model);
     if (route && route.accounts.length) {
@@ -613,7 +613,8 @@ export class AccountManager {
     return this._accountOwnsModel(account, model);
   }
 
-  /** Returns true if no account claims model ownership, or this account does. */
+  /** @deprecated Use `routes` with an `accounts` list instead.
+   *  Returns true if no account claims model ownership, or this account does. */
   _accountOwnsModel(account, model) {
     for (const a of this.accounts) {
       if (a.models && a.models.some(m => modelMatches(m, model))) {

--- a/src/index.js
+++ b/src/index.js
@@ -665,7 +665,14 @@ async function runCommand() {
       // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
       // which the proxy accepts from localhost. Not setting ANTHROPIC_API_KEY
       // lets Claude Code stay in subscription mode (full model access).
-      env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+      // If the caller already set ANTHROPIC_BASE_URL to a /tc-acct/<pin> URL
+      // pointing at this proxy, preserve it so the account pin takes effect.
+      const existingBase = process.env.ANTHROPIC_BASE_URL || '';
+      const tcAcctPrefix = `http://localhost:${port}/tc-acct/`;
+      const tcAcctPrefix2 = `http://127.0.0.1:${port}/tc-acct/`;
+      if (!existingBase.startsWith(tcAcctPrefix) && !existingBase.startsWith(tcAcctPrefix2)) {
+        env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+      }
     }
   } else if (autoFallback) {
     console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (--auto-fallback; start it with: teamclaude server)`);

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,8 @@ async function serverCommand() {
       const acct = info.account || r?.account || '?';
       const model = info.model ? ` (${info.model})` : '';
       const sid = info.sessionId ? `${info.sessionId.slice(0, 6)} ` : '';
-      writeActivity(`${sid}${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
+      const pin = (info.pinned || r?.pinned) ? ' [pin]' : '';
+      writeActivity(`${sid}${info.method} ${info.path}${model} → ${acct}${pin} (${info.status}, ${dur}s)`);
     };
     // Tee console output to the activity log as well
     const origLog = console.log;

--- a/src/server.js
+++ b/src/server.js
@@ -252,6 +252,9 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         const token = decodeURIComponent(pin[1]);
         pinnedIndex = resolveAccountPin(accountManager, token);
         if (pinnedIndex == null) {
+          const reqId = ++counter;
+          const sessionId = req.headers['x-claude-code-session-id'] || null;
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${token}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
           return;
@@ -264,7 +267,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // /v1/messages and count_tokens). Read from headers up front so it drives
       // session-aware routing (issue #109) and colors the TUI activity stream.
       const sessionId = req.headers['x-claude-code-session-id'] || null;
-      if (!hideActivity) hooks.onRequestStart?.(reqId, { method: req.method, path: req.url, sessionId });
+      if (!hideActivity) hooks.onRequestStart?.(reqId, { method: req.method, path: req.url, sessionId, pinned: pinnedIndex != null });
 
       // Buffer request body (needed to resend on a different account after a 429).
       // Peek the top-level `model` field incrementally as chunks arrive so the
@@ -318,7 +321,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         }
       } finally {
         accountManager.endSession(sessionId);
-        if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId });
+        if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId, pinned: ctx.pinnedIndex != null });
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);

--- a/src/tui.js
+++ b/src/tui.js
@@ -274,7 +274,8 @@ export class TUI {
     const acct = info.account || r?.account || '?';
     const model = info.model ? ` (${info.model})` : ''; // shown when the request named a model
     const sid = info.sessionId || r?.sessionId || null;
-    this._addLog(`${sessionTag(sid)} ${info.method} ${info.path}${model} → ${acct} (${info.status}, ${dur}s)`);
+    const pin = (info.pinned || r?.pinned) ? dim(' [pin]') : '';
+    this._addLog(`${sessionTag(sid)} ${info.method} ${info.path}${model} → ${acct}${pin} (${info.status}, ${dur}s)`);
   }
 
   _addLog(msg) {
@@ -918,7 +919,8 @@ export class TUI {
       const el = ((now - r.started) / 1000).toFixed(1);
       const sp = cyan(SPINNER[this.frame]);
       const m = r.model ? dim(` (${r.model})`) : ''; // filled in as soon as the model is peeked from the stream
-      const a = r.account ? ` → ${r.account}` : '';
+      const pin = r.pinned ? dim(' [pin]') : '';
+      const a = r.account ? ` → ${r.account}${pin}` : '';
       lines.push(` ${sp} ${gray(r.t)}  ${sessionTag(r.sessionId)} ${r.method} ${r.path}${m}${a} ${dim(`(${el}s...)`)}`);
     }
 


### PR DESCRIPTION
## Problem

teamclaude run unconditionally overwrites ANTHROPIC_BASE_URL with the bare proxy URL (http://localhost:<port>), so any /tc-acct/<name> pin prefix set by the caller was silently discarded. Requests ended up in normal rotation instead of the intended account, with no indication of why.

## Changes

### Commit 1 — feat(run): preserve /tc-acct/ pin prefix in ANTHROPIC_BASE_URL

When ANTHROPIC_BASE_URL is already set to a /tc-acct/<name> URL pointing at this proxy, teamclaude run --no-mitm now preserves it. This makes account pinning work from the shell alias:

ANTHROPIC_BASE_URL='http://localhost:3456/tc-acct/myaccount' claude

The check is host+port-aware: URLs pointing at a different server are still overwritten as before. MITM mode is unaffected (it doesn't use ANTHROPIC_BASE_URL).

Also marks accounts[].models as deprecated in code and docs in favor of the routes table (introduced in #86), which covers the same use case with glob matching, multiple accounts, and bucket overrides. The field is kept for backward compatibility.

### Commit 2 — feat(tui): show [pin] marker in activity log for pinned requests

Pinned requests now show a dim [pin] tag in both the TUI activity stream and the --activity-log file, on both in-flight and completed rows:

2380e1 POST /v1/messages (claude-sonnet-4-6) → cc5@test.com [pin] (200, 3.1s)

Unknown pin names (account not found) now emit an activity log entry instead of failing silently:

2380e1 POST /tc-acct/cc5@tset.com/v1/messages → (unknown pin: "cc5@test.com") (404, ?s)