### PR TITLE
fix(server): re-auth and retry on a 401 instead of surfacing it

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -302,7 +302,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         return;
       }
 
-      const ctx = { account: null, status: null, tried: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId };
+      const ctx = { account: null, status: null, tried: new Set(), reauthed: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId };
       // Hold the session "in flight" across the WHOLE request (incl. retries and
       // a multi-minute streaming completion) so it stays counted as active and
       // never expires mid-request.
@@ -784,6 +784,28 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
         res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: `Rate limited; retry in ${retryAfter}s.` } }));
       }
       return;
+    }
+
+    // A 401 means the credential we injected was rejected. For an OAuth account
+    // that usually means the access token was revoked BEFORE its clock expiry —
+    // something else refreshed the same token family, so upstream reports it
+    // revoked while it still looks fresh locally. ensureTokenFresh's expiry
+    // check cannot see that (it only compares the clock), so the account would
+    // otherwise keep serving a dead token until the token aged out, and every
+    // request in between would surface a 401 to the client with no recovery.
+    // Force one refresh and retry. If the refresh is itself rejected the refresh
+    // token is dead too: ensureTokenFresh marks the account errored, and the
+    // retry's status check rotates to another account. Bounded to one re-auth
+    // per account per request, so a genuinely dead credential surfaces the 401
+    // instead of looping.
+    if (upstreamRes.status === 401 && account.type === 'oauth' && account.refreshToken
+        && retryCount < maxRetries && !ctx.reauthed.has(account.index)) {
+      ctx.reauthed.add(account.index);
+      await upstreamRes.body?.cancel();
+      console.log(`[TeamClaude] 401 on "${account.name}" — token rejected; forcing refresh and retrying`);
+      await accountManager.ensureTokenFresh(account.index, true);
+      if (res.destroyed) return;
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
     }
 
     // Log the request head (once) followed by the response headers, streaming

--- a/test/server-401.test.js
+++ b/test/server-401.test.js
@@ -1,0 +1,148 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const HOUR = 3600_000;
+
+// An upstream that accepts only the tokens in `live` and 401s everything else —
+// exactly how Anthropic answers an access token that was revoked before its
+// clock expiry (something else refreshed the same token family). Records the
+// bearer token presented on every hit so a test can prove WHICH credential was
+// retried.
+function revokingUpstream(live) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    const token = (req.headers.authorization || '').replace(/^Bearer /, '');
+    seen.push(token);
+    if (!live.has(token)) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'OAuth access token has been revoked' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  return { server, seen };
+}
+
+async function post(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'x', messages: [] }),
+  });
+  await res.text();
+  return res.status;
+}
+
+// The core recovery: a token that upstream considers revoked is indistinguishable
+// from a valid one by expiry alone, so only the 401 itself can trigger a refresh.
+test('401 forces a token refresh and retries the same account', async () => {
+  const { server: upstream, seen } = revokingUpstream(new Set(['fresh']));
+  const upstreamPort = await listen(upstream);
+
+  let refreshes = 0;
+  const am = new AccountManager(
+    // expiresAt is an hour out: the clock says this token is fine, upstream says otherwise.
+    [{ name: 'a', type: 'oauth', accessToken: 'revoked', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    { refreshFn: async () => { refreshes++; return { accessToken: 'fresh', refreshToken: 'r2', expiresAt: Date.now() + HOUR }; } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    assert.equal(await post(proxyPort), 200);          // client never sees the 401
+    assert.equal(refreshes, 1);                        // forced despite a future expiresAt
+    assert.deepEqual(seen, ['revoked', 'fresh']);      // retried with the NEW token
+    assert.equal(am.accounts[0].status, 'active');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// When the refresh token is dead too (the whole family was revoked), there is
+// nothing to recover on this account — it must drop out of rotation and the
+// request must be served by another account rather than failing.
+test('401 with a rejected refresh errors the account and fails over', async () => {
+  const { server: upstream, seen } = revokingUpstream(new Set(['b-token']));
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [
+      { name: 'a', type: 'oauth', accessToken: 'revoked', refreshToken: 'dead', expiresAt: Date.now() + HOUR },
+      { name: 'b', type: 'oauth', accessToken: 'b-token', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+    ],
+    0.98,
+    {
+      refreshFn: async () => {
+        const err = new Error('Token refresh failed (400): invalid_grant');
+        err.status = 400;                              // a genuine auth rejection, not a blip
+        throw err;
+      },
+    },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    assert.equal(await post(proxyPort), 200);          // served by the healthy account
+    assert.deepEqual(seen, ['revoked', 'b-token']);
+    assert.equal(am.accounts[0].status, 'error');      // dropped from rotation until re-login
+    assert.equal(am.accounts[1].status, 'active');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// Regression: the retry must be bounded. An upstream that 401s even a
+// freshly-minted token must surface the 401, not loop refreshing forever.
+test('persistent 401 terminates instead of looping', async () => {
+  const { server: upstream, seen } = revokingUpstream(new Set());   // nothing is ever accepted
+  const upstreamPort = await listen(upstream);
+
+  let refreshes = 0;
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    { refreshFn: async () => { refreshes++; return { accessToken: `t${refreshes}`, refreshToken: 'r', expiresAt: Date.now() + HOUR }; } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    assert.equal(await post(proxyPort), 401);          // surfaced, not hung
+    assert.equal(refreshes, 1);                        // one re-auth per account per request
+    assert.equal(seen.length, 2);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// An API-key account has no refresh token, so a 401 is a bad key — retrying it
+// would just burn a round trip. It must pass straight through.
+test('401 on an api-key account is not retried', async () => {
+  const { server: upstream, seen } = revokingUpstream(new Set());
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager([{ name: 'k', type: 'api_key', apiKey: 'sk-bad' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    assert.equal(await post(proxyPort), 401);
+    assert.equal(seen.length, 1);                      // no retry
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});


### PR DESCRIPTION
## The problem

`ensureTokenFresh` refreshes on the clock only — it compares `expiresAt` and returns early while a token still *looks* fresh:

```js
if (!force && !isTokenExpiringSoon(account.expiresAt)) return;
```

But an OAuth access token can be revoked well before it expires. Anything else that refreshes the same token family rotates it — a second holder of an imported credential, a parallel login — and upstream then answers:

```
401 {"type":"error","error":{"type":"authentication_error",
     "message":"OAuth access token has been revoked"}}
```

…for a token the proxy believes is good for hours yet.

Nothing on the serving path notices. `forwardRequest` handles 429 in detail (quota rejection vs. transient throttle, sx failover, inline absorb) but has **no 401 branch**, so the 401 is relayed straight to the client with no refresh, no retry and no failover. And because the stale token stays selected, every subsequent request fails identically until it finally ages out.

`account-manager.js` already documents the remedy —

```js
/** Pass force=true to refresh regardless of expiry (e.g. after a 401). */
async ensureTokenFresh(accountIndex, force = false) {
```

— but no caller on the request path ever passes it. Only `prober.js` does, and only for the usage endpoint, so client traffic never benefits.

### How I hit it

A long-lived Claude Code session started returning `401 OAuth access token has been revoked` and never recovered, while a newly-started session against the same proxy worked fine. The account's `expiresAt` was hours in the future throughout, so the proxy never attempted a refresh. The same account's refresh token had also been rotated out from under the proxy (it was added with `source: "import"`, sharing a lineage with the CLI's own credentials), so it sat in rotation serving a dead token with no way back.

## The fix

On a 401 for an OAuth account, force one refresh and retry:

- **refresh succeeds** → the retry carries the new token; the client never sees the 401.
- **refresh rejected** → the refresh token is dead too. `ensureTokenFresh` already marks the account `error`, and the retry's existing `account.status === 'error'` check rotates to another account.

Bounded to one re-auth per account per request via `ctx.reauthed`, so an upstream that rejects even a freshly-minted token surfaces the 401 rather than looping. API-key accounts are skipped — with no refresh token a 401 means a bad key, and retrying only burns a round trip.

The change reuses the existing retry/rotation machinery rather than adding a parallel path; ~12 lines plus the `ctx` field.

## Tests

New `test/server-401.test.js`, following `server-429.test.js` conventions — a fake upstream that accepts only a named set of tokens and 401s the rest, recording the bearer presented on each hit so the tests can assert *which* credential was retried:

1. `401 forces a token refresh and retries the same account` — `expiresAt` an hour out, so this fails without the fix (the clock check refuses to refresh). Asserts the client gets 200 and the retry carried the new token.
2. `401 with a rejected refresh errors the account and fails over` — served by the second account; the first is marked `error`.
3. `persistent 401 terminates instead of looping` — surfaces 401, exactly one refresh, two upstream hits.
4. `401 on an api-key account is not retried` — single upstream hit.

```
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

Full suite: **333 pass, 1 fail** — `server-listen-error.test.js` ("server exits cleanly when configured port is already in use"), which fails identically on a clean checkout of `master` on this machine (macOS 15, Node 24.16.0) and is unrelated to this change. `npx eslint` is clean.