### PR TITLE
feat: warn on deprecated accounts[].models, honour account pins in both run modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Any Anthropic-compatible API can be added as an account alongside your Claude ac
   ```json
   { "name": "deepseek", "match": ["deepseek-*"], "accounts": ["deepseek"] }
   ```
-  Routes are more flexible (glob matching, multiple accounts, bucket override) and are the recommended way to pin model patterns to specific accounts. The `models` field is kept for backward compatibility but may be removed in a future version.
+  Routes are more flexible (glob matching, multiple accounts, bucket override) and are the recommended way to pin model patterns to specific accounts. They are also less surprising: a `models` list changes eligibility across the *whole fleet* — once any account claims a model, every account that doesn't claim it is skipped for that model. The field is kept for backward compatibility, but the server prints a deprecation notice at startup naming the route to replace it with, and it may be removed in a future version.
 
 To send a specific session to a third-party backend without touching others, define a route for its model patterns and use `--model` on launch or `/model` inside a session:
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,19 @@ async function serverCommand() {
     process.exit(1);
   }
 
+  // `accounts[].models` (#74) is superseded by the `routes` table (#86). Routes
+  // do the same job with glob matching, several accounts per rule and a bucket
+  // override — and, unlike `models`, they don't silently change eligibility
+  // fleet-wide the moment one account declares a list (see _accountOwnsModel).
+  // Behaviour is unchanged; this only tells pre-#86 configs what to migrate to
+  // before the field goes away. Read from config.accounts, not the resolved
+  // list: resolveAccounts rebuilds importFrom entries and drops the field.
+  for (const acct of config.accounts) {
+    if (!acct.models?.length) continue;
+    const route = { name: acct.name, match: acct.models, accounts: [acct.name] };
+    console.error(`[TeamClaude] Deprecated: account "${acct.name}" uses "models" — replace it with a routes entry: ${JSON.stringify(route)}`);
+  }
+
   const threshold = config.switchThreshold || 0.98;
   const accountManager = new AccountManager(accounts, threshold, { routes: config.routes, ramp: config.stormRamp, distributeSessions: config.distributeSessions });
 
@@ -650,6 +663,11 @@ async function runCommand() {
   // opt back into the transparent direct launch (e.g. for a dumb shell alias).
   const port = config.proxy.port;
   const env = { ...process.env };
+  // A caller-supplied ANTHROPIC_BASE_URL of http://<this proxy>/tc-acct/<name>
+  // pins the session to one account. Detected up front so BOTH modes can act on
+  // it: base-URL mode preserves it, MITM mode says it is ignoring it. Dropping
+  // it silently is what made the documented shell alias look broken by default.
+  const pinnedBase = isLocalAccountPin(process.env.ANTHROPIC_BASE_URL, port);
   if (await isProxyUp(port)) {
     if (useMitm) {
       // Route ALL of claude's traffic through us as an HTTPS forward proxy, so
@@ -661,6 +679,10 @@ async function runCommand() {
       env.HTTPS_PROXY = env.HTTP_PROXY = env.https_proxy = env.http_proxy = proxyUrl;
       env.NO_PROXY = env.no_proxy = 'localhost,127.0.0.1,::1';
       env.NODE_EXTRA_CA_CERTS = caPath;
+      if (pinnedBase) {
+        console.error('[TeamClaude] Account pin in ANTHROPIC_BASE_URL ignored: MITM mode intercepts api.anthropic.com directly and does not use a base URL.');
+        console.error('[TeamClaude] Re-run with --no-mitm for the pin to take effect.');
+      }
       delete env.ANTHROPIC_BASE_URL;
     } else {
       // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
@@ -668,12 +690,7 @@ async function runCommand() {
       // lets Claude Code stay in subscription mode (full model access).
       // If the caller already set ANTHROPIC_BASE_URL to a /tc-acct/<pin> URL
       // pointing at this proxy, preserve it so the account pin takes effect.
-      const existingBase = process.env.ANTHROPIC_BASE_URL || '';
-      const tcAcctPrefix = `http://localhost:${port}/tc-acct/`;
-      const tcAcctPrefix2 = `http://127.0.0.1:${port}/tc-acct/`;
-      if (!existingBase.startsWith(tcAcctPrefix) && !existingBase.startsWith(tcAcctPrefix2)) {
-        env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
-      }
+      if (!pinnedBase) env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
     }
   } else if (autoFallback) {
     console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (--auto-fallback; start it with: teamclaude server)`);
@@ -1488,6 +1505,21 @@ async function resolveAccounts(config) {
     }
   }
   return accounts;
+}
+
+// Is `url` a /tc-acct/<name> account pin aimed at OUR proxy? Parsed rather than
+// prefix-matched so every local spelling counts (localhost, 127.0.0.1, [::1]),
+// while a pin URL for a different host/port is not ours to honour.
+function isLocalAccountPin(url, port) {
+  if (!url) return false;
+  let u;
+  try { u = new URL(url); } catch { return false; }
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  const isLocal = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+  // An omitted port means the scheme default, which still matches a proxy that
+  // happens to run on 80/443.
+  const urlPort = u.port || (u.protocol === 'https:' ? '443' : '80');
+  return isLocal && urlPort === String(port) && u.pathname.startsWith('/tc-acct/');
 }
 
 function argValue(flag) {


### PR DESCRIPTION
Follow-up to #133.

## 1. `accounts[].models` deprecation is now visible at runtime

#133 marked the field deprecated in the README and in comments, but nothing told an existing user they were on the deprecated path — `models` is read once in `makeAccount()` (`account-manager.js:55`) and never validated anywhere.

The server now names each account still using it at startup and prints the `routes` entry to replace it with:

```
[TeamClaude] Deprecated: account "deepseek" uses "models" — replace it with a routes entry: {"name":"deepseek","match":["deepseek-v4-pro"],"accounts":["deepseek"]}
```

Behaviour is unchanged — `_accountOwnsModel` stays wired into `_routeAllows`, so pre-#86 configs keep working.

It reads `config.accounts` rather than the resolved list on purpose: `resolveAccounts` rebuilds `importFrom` entries as `{ name, type, ...creds }` (`index.js:1493`) and drops the field.

## 2. Account pins now behave predictably in both `run` modes

#133 preserved a `/tc-acct/<name>` `ANTHROPIC_BASE_URL` only in the `--no-mitm` branch. But MITM is the **default** for `teamclaude run`, and that branch does `delete env.ANTHROPIC_BASE_URL` — so the alias the PR documents,

```bash
ANTHROPIC_BASE_URL='http://localhost:3456/tc-acct/myaccount' claude
```

silently did nothing under `teamclaude run` unless `--no-mitm` was also passed.

Both modes now share one detector: base-URL mode preserves the pin, MITM mode reports that it is ignoring it and points at `--no-mitm`. The detector parses the URL instead of prefix-matching two hardcoded spellings, so `[::1]` and scheme-default ports are recognised too.

## Note, not fixed here

`resolveAccounts` rebuilding `importFrom` accounts drops **every** extra field — `disabled`, `priority`, `upstream`, `modelMap`, `models`. An `importFrom` account marked `disabled: true` comes back enabled. Out of scope for this PR; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)