### PR TITLE
fix(auth): don't rotate the token family once per 401 in a burst

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -6,6 +6,12 @@ import { SessionTracker } from './session-tracker.js';
 // Re-exported for callers that import these model helpers from here.
 export { isFableModel, parseRequestModel, parseAdvisorModel } from './model.js';
 
+// How long after a successful token refresh a forced (post-401) refresh is
+// suppressed. Long enough to cover the 401s from requests already in flight
+// when the token turned over, short enough that a genuinely bad new token
+// recovers on the next request rather than staying stuck.
+const FORCED_REFRESH_FLOOR_MS = 10_000;
+
 // Quota fields that survive a restart: utilization levels and their reset
 // windows, learned passively from upstream responses. Transient/derived state
 // (probing, requalify, rateLimitedUntil) is intentionally excluded.
@@ -78,6 +84,10 @@ function makeAccount(acct, index) {
     // retry-after. Distinct from `throttled`/rateLimitedUntil: it does NOT
     // make the account unavailable, so selection never rotates away from it.
     pausedUntil: null,
+    // When this account's token was last successfully refreshed. Gates forced
+    // (post-401) refreshes so a burst of stale in-flight requests can't rotate
+    // the refresh-token family once per request — see ensureTokenFresh.
+    _lastRefreshAt: null,
   };
 }
 
@@ -90,7 +100,9 @@ function modelMatches(declared, model) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
+    // How long a just-minted token is trusted against a forced refresh.
+    this._forcedRefreshFloorMs = forcedRefreshFloorMs;
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
@@ -1153,6 +1165,21 @@ export class AccountManager {
 
     if (!force && !isTokenExpiringSoon(account.expiresAt)) return;
 
+    // A forced refresh answers a 401, but 401s arrive in bursts: every request
+    // already in flight when the token went bad comes back rejected, and each
+    // one would force its own refresh. Coalescing only covers refreshes that
+    // OVERLAP — these arrive staggered, so they would rotate the refresh-token
+    // family once per request and make the proxy the very "other holder
+    // rotating the family" that causes this failure in the first place. A 401
+    // for a token minted moments ago is stale news from a request sent before
+    // the refresh landed, so trust the new token and let the caller retry with
+    // it. Only an expiry-driven refresh (force=false) bypasses this — it isn't
+    // reacting to a response and can't stampede.
+    if (force && account._lastRefreshAt !== null
+        && Date.now() - account._lastRefreshAt < this._forcedRefreshFloorMs) {
+      return;
+    }
+
     // Coalesce concurrent refreshes
     if (account._refreshPromise) return account._refreshPromise;
 
@@ -1163,6 +1190,7 @@ export class AccountManager {
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
+        account._lastRefreshAt = Date.now();
         console.log(`[TeamClaude] Token refreshed for account "${account.name}"`);
         this._onTokenRefresh?.(accountIndex, newTokens);
       } catch (err) {

--- a/src/server.js
+++ b/src/server.js
@@ -526,6 +526,10 @@ function formatHeaders(headers) {
 
 export async function forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, useSx) {
   const maxRetries = accountManager.accounts.length;
+  // This function is exported, so a caller may hand us a ctx built elsewhere.
+  // The 401 path reads ctx.reauthed on every response; default it here rather
+  // than trusting every construction site to include it.
+  ctx.reauthed ??= new Set();
   // Whether THIS attempt dials via sx.org. Undefined on the first call → derive
   // from the default policy ('always' routes; 'off'/'429' start direct).
   const route = useSx === undefined ? !!(sx?.useByDefault()) : useSx;

--- a/test/server-401.test.js
+++ b/test/server-401.test.js
@@ -146,3 +146,79 @@ test('401 on an api-key account is not retried', async () => {
     upstream.close();
   }
 });
+
+// The refresh-storm guard. Every request already in flight when a token turns
+// over comes back 401, staggered — so they miss the concurrent-refresh
+// coalescing and would each force their own refresh, rotating the refresh-token
+// family once per request. A 401 for a just-minted token is stale news; the
+// forced refresh must be suppressed for a short window after a successful one.
+test('a forced refresh is suppressed right after a successful refresh', async () => {
+  let refreshes = 0;
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't0', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    {
+      forcedRefreshFloorMs: 10_000,
+      refreshFn: async () => { refreshes++; return { accessToken: `t${refreshes}`, refreshToken: 'r', expiresAt: Date.now() + HOUR }; },
+    },
+  );
+
+  await am.ensureTokenFresh(0, true);
+  assert.equal(refreshes, 1);
+  assert.equal(am.accounts[0].credential, 't1');
+
+  // Two more stale 401s land immediately — neither may rotate the family again.
+  await am.ensureTokenFresh(0, true);
+  await am.ensureTokenFresh(0, true);
+  assert.equal(refreshes, 1);
+  assert.equal(am.accounts[0].credential, 't1');       // the good token survives
+});
+
+// The suppression must expire, or a token that really is bad stays stuck.
+test('a forced refresh is allowed again once the floor elapses', async () => {
+  let refreshes = 0;
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't0', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    {
+      forcedRefreshFloorMs: 30,
+      refreshFn: async () => { refreshes++; return { accessToken: `t${refreshes}`, refreshToken: 'r', expiresAt: Date.now() + HOUR }; },
+    },
+  );
+
+  await am.ensureTokenFresh(0, true);
+  await am.ensureTokenFresh(0, true);
+  assert.equal(refreshes, 1);                          // second one suppressed
+  await new Promise(r => setTimeout(r, 50));
+  await am.ensureTokenFresh(0, true);
+  assert.equal(refreshes, 2);                          // floor elapsed, allowed
+});
+
+// End to end: a second request arriving inside the floor must not trigger a
+// second rotation, even though it too gets a 401 (this upstream accepts
+// nothing). Without the guard, refreshes would climb with every request.
+test('back-to-back 401 requests rotate the token family once', async () => {
+  const { server: upstream } = revokingUpstream(new Set());
+  const upstreamPort = await listen(upstream);
+
+  let refreshes = 0;
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't0', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    {
+      forcedRefreshFloorMs: 10_000,
+      refreshFn: async () => { refreshes++; return { accessToken: `t${refreshes}`, refreshToken: 'r', expiresAt: Date.now() + HOUR }; },
+    },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    assert.equal(await post(proxyPort), 401);
+    assert.equal(await post(proxyPort), 401);
+    assert.equal(refreshes, 1);                        // not once per request
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});


### PR DESCRIPTION
Follow-up to #136.

## The problem

#136 forces a token refresh on a 401 and retries — correct for the *first* 401. But 401s don't arrive alone.

When a token turns over, every request already in flight comes back rejected. Those responses are **staggered**, so they slip past the coalescing in `ensureTokenFresh`:

```js
// Coalesce concurrent refreshes
if (account._refreshPromise) return account._refreshPromise;
```

That only merges refreshes that *overlap in time*. Request A 401s and refreshes (token → T1); request B's 401 — from a request sent before A's refresh landed — arrives after A finished, sees no in-flight promise, and forces its own refresh (T1 → T2). And so on.

Anthropic rotates the refresh token on use, so N stale 401s rotate the family N times. The proxy becomes exactly the *"something else refreshed the same token family"* holder that #136's own description identifies as the cause of the bug it fixes.

## The fix

A 401 for a token minted moments ago is stale news from a request sent before the refresh landed — not evidence the new token is bad. So:

- stamp `_lastRefreshAt` on every successful refresh;
- suppress a **forced** refresh for `FORCED_REFRESH_FLOOR_MS` (10s) after one.

The caller still retries, now with the good token. Expiry-driven refreshes (`force=false`) are untouched — they don't react to a response and can't stampede. A failed refresh doesn't stamp, so a genuinely dead credential isn't suppressed. The floor is injectable (`forcedRefreshFloorMs`) so tests don't sleep 10s.

Three tests: suppression inside the window, expiry of the window, and an end-to-end pair of back-to-back 401 requests that must rotate the family exactly once.

## Also

`ctx.reauthed ??= new Set()` in `forwardRequest`. It's exported and reads `ctx.reauthed` on every response, so a caller building its own ctx would get a `TypeError` instead of the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)