### PR TITLE
fix(accounts): stop discarding config fields on importFrom accounts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
+import { resolveAccounts } from './resolve-accounts.js';
 import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
@@ -145,8 +146,8 @@ async function serverCommand() {
   // override — and, unlike `models`, they don't silently change eligibility
   // fleet-wide the moment one account declares a list (see _accountOwnsModel).
   // Behaviour is unchanged; this only tells pre-#86 configs what to migrate to
-  // before the field goes away. Read from config.accounts, not the resolved
-  // list: resolveAccounts rebuilds importFrom entries and drops the field.
+  // before the field goes away. Reported against config.accounts so the notice
+  // names what is actually written on disk, whatever resolution does with it.
   for (const acct of config.accounts) {
     if (!acct.models?.length) continue;
     const route = { name: acct.name, match: acct.models, accounts: [acct.name] };
@@ -1482,30 +1483,6 @@ async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
 }
 
 // ── helpers ─────────────────────────────────────────────────
-
-async function resolveAccounts(config) {
-  const accounts = [];
-  for (const acct of config.accounts) {
-    if (acct.type === 'oauth') {
-      if (acct.importFrom) {
-        try {
-          const creds = await importCredentials(acct.importFrom);
-          accounts.push({ name: acct.name, type: 'oauth', ...creds });
-          console.log(`Imported "${acct.name}" from ${acct.importFrom}`);
-        } catch (err) {
-          console.error(`Failed to import "${acct.name}": ${err.message}`);
-        }
-      } else if (acct.accessToken) {
-        accounts.push(acct);
-      } else {
-        console.error(`No token for "${acct.name}", skipping`);
-      }
-    } else if (acct.type === 'apikey' && acct.apiKey) {
-      accounts.push(acct);
-    }
-  }
-  return accounts;
-}
 
 // Is `url` a /tc-acct/<name> account pin aimed at OUR proxy? Parsed rather than
 // prefix-matched so every local spelling counts (localhost, 127.0.0.1, [::1]),

--- a/src/resolve-accounts.js
+++ b/src/resolve-accounts.js
@@ -1,0 +1,43 @@
+import { importCredentials } from './oauth.js';
+
+/**
+ * Turn configured accounts into the objects the AccountManager is built from:
+ * `importFrom` entries have their credentials read from disk, and entries with
+ * no usable credential are dropped with a message.
+ *
+ * Config fields are carried through verbatim — the import supplies ONLY the
+ * credential fields. Rebuilding an imported account as `{ name, type, ...creds }`
+ * used to discard everything else on it (`disabled`, `priority`, `upstream`,
+ * `modelMap`, `models`), so an account disabled on disk silently rejoined
+ * rotation on every restart and a third-party backend lost its upstream.
+ */
+export async function resolveAccounts(config) {
+  const accounts = [];
+  for (const acct of config.accounts) {
+    if (acct.type === 'oauth') {
+      if (acct.importFrom) {
+        try {
+          const creds = await importCredentials(acct.importFrom);
+          // A readable file with no token is as unusable as a missing one; the
+          // non-import branch below already refuses that case, and pushing it
+          // anyway would send `Bearer undefined` upstream on every request.
+          if (!creds.accessToken) {
+            console.error(`No token in ${acct.importFrom} for "${acct.name}", skipping`);
+            continue;
+          }
+          accounts.push({ ...acct, ...creds });
+          console.log(`Imported "${acct.name}" from ${acct.importFrom}`);
+        } catch (err) {
+          console.error(`Failed to import "${acct.name}": ${err.message}`);
+        }
+      } else if (acct.accessToken) {
+        accounts.push(acct);
+      } else {
+        console.error(`No token for "${acct.name}", skipping`);
+      }
+    } else if (acct.type === 'apikey' && acct.apiKey) {
+      accounts.push(acct);
+    }
+  }
+  return accounts;
+}

--- a/test/resolve-accounts.test.js
+++ b/test/resolve-accounts.test.js
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveAccounts } from '../src/resolve-accounts.js';
+
+const HOUR = 3600_000;
+
+// Write a Claude Code credentials file and return its path.
+async function credsFile(dir, name, data) {
+  const path = join(dir, name);
+  await writeFile(path, JSON.stringify({ claudeAiOauth: data }));
+  return path;
+}
+
+async function withTmp(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-resolve-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// The regression. An importFrom account used to be rebuilt from scratch as
+// { name, type, ...creds }, so every other field configured on it was dropped
+// on the floor at startup — most damagingly `disabled`, which meant an account
+// switched off on disk quietly rejoined rotation on the next restart.
+test('importFrom preserves the account fields that are not credentials', async () => {
+  await withTmp(async dir => {
+    const path = await credsFile(dir, 'creds.json', {
+      accessToken: 'tok', refreshToken: 'ref', expiresAt: Date.now() + HOUR,
+    });
+
+    const [acct] = await resolveAccounts({
+      accounts: [{
+        name: 'work',
+        type: 'oauth',
+        importFrom: path,
+        disabled: true,
+        priority: 3,
+        upstream: 'https://api.deepseek.com/anthropic',
+        modelMap: { 'claude-sonnet-4-6': 'deepseek-v4-pro' },
+        models: ['deepseek-v4-pro'],
+        orgUuid: 'org-1',
+      }],
+    });
+
+    // Credentials come from the file...
+    assert.equal(acct.accessToken, 'tok');
+    assert.equal(acct.refreshToken, 'ref');
+    // ...everything else comes from the config and must survive.
+    assert.equal(acct.name, 'work');
+    assert.equal(acct.type, 'oauth');
+    assert.equal(acct.disabled, true);
+    assert.equal(acct.priority, 3);
+    assert.equal(acct.upstream, 'https://api.deepseek.com/anthropic');
+    assert.deepEqual(acct.modelMap, { 'claude-sonnet-4-6': 'deepseek-v4-pro' });
+    assert.deepEqual(acct.models, ['deepseek-v4-pro']);
+    assert.equal(acct.orgUuid, 'org-1');
+  });
+});
+
+// The file is the source of truth for credentials: a stale accessToken left in
+// the config must not win over the freshly imported one.
+test('imported credentials override stale ones in the config', async () => {
+  await withTmp(async dir => {
+    const path = await credsFile(dir, 'creds.json', {
+      accessToken: 'new', refreshToken: 'new-ref', expiresAt: 2,
+    });
+
+    const [acct] = await resolveAccounts({
+      accounts: [{ name: 'a', type: 'oauth', importFrom: path, accessToken: 'old', refreshToken: 'old-ref', expiresAt: 1 }],
+    });
+
+    assert.equal(acct.accessToken, 'new');
+    assert.equal(acct.refreshToken, 'new-ref');
+    assert.equal(acct.expiresAt, 2);
+  });
+});
+
+// A readable file with no token is as unusable as a missing one — pushing it
+// would send `Bearer undefined` upstream on every request.
+test('a credentials file with no token is skipped', async () => {
+  await withTmp(async dir => {
+    const path = await credsFile(dir, 'empty.json', { refreshToken: 'r' });
+
+    const accounts = await resolveAccounts({
+      accounts: [
+        { name: 'broken', type: 'oauth', importFrom: path },
+        { name: 'fine', type: 'apikey', apiKey: 'sk-1' },
+      ],
+    });
+
+    assert.deepEqual(accounts.map(a => a.name), ['fine']);
+  });
+});
+
+// An unreadable importFrom must drop that account only, not abort the rest.
+test('a failed import skips the account and keeps the others', async () => {
+  const accounts = await resolveAccounts({
+    accounts: [
+      { name: 'gone', type: 'oauth', importFrom: '/nonexistent/creds.json' },
+      { name: 'direct', type: 'oauth', accessToken: 'tok' },
+    ],
+  });
+
+  assert.deepEqual(accounts.map(a => a.name), ['direct']);
+});
+
+// Non-import accounts were always passed through untouched; keep it that way.
+test('non-import accounts pass through with every field intact', async () => {
+  const accounts = await resolveAccounts({
+    accounts: [
+      { name: 'oauth', type: 'oauth', accessToken: 'tok', disabled: true, priority: 2 },
+      { name: 'key', type: 'apikey', apiKey: 'sk-1', models: ['glm-4'] },
+      { name: 'no-token', type: 'oauth' },
+      { name: 'no-key', type: 'apikey' },
+    ],
+  });
+
+  assert.deepEqual(accounts.map(a => a.name), ['oauth', 'key']);
+  assert.equal(accounts[0].disabled, true);
+  assert.equal(accounts[0].priority, 2);
+  assert.deepEqual(accounts[1].models, ['glm-4']);
+});


### PR DESCRIPTION
Found while reviewing #133/#138.

## The bug

`resolveAccounts` rebuilt an `importFrom` account from scratch:

```js
const creds = await importCredentials(acct.importFrom);
accounts.push({ name: acct.name, type: 'oauth', ...creds });
```

Only `name` and `type` survived. Everything else configured on that account was discarded at startup: `disabled`, `priority`, `upstream`, `modelMap`, `models`, `orgUuid`.

The damaging one is **`disabled`** — an account switched off on disk quietly rejoined rotation on the next restart, so a deliberately parked account started serving and spending again with nothing said. `upstream`/`modelMap` are nearly as bad: a third-party backend account silently reverted to talking to Anthropic while still presenting a third-party credential.

Only `importFrom` accounts were affected; direct-credential and API-key accounts were already passed through untouched. The hot-reload path is fine too — it extracts credentials into `freshCred` and syncs `name`/`priority`/`disabled` separately (`index.js:1449-1460`) rather than rebuilding.

## The fix

Carry the config entry through and let the import supply only the credential fields:

```js
accounts.push({ ...acct, ...creds });
```

Also skip an `importFrom` whose file parses but contains no `accessToken` — the non-import branch already refuses that case, and pushing it anyway sends `Bearer undefined` upstream on every request.

## Why it moved file

`index.js` dispatches on `process.argv` at module top level (line 26), so importing it from a test runs the CLI. `resolveAccounts` is now `src/resolve-accounts.js`, which makes the regression testable — five tests covering field preservation, credential precedence, the empty-token file, a failed import not taking down other accounts, and non-import passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)