### PR TITLE
Bump to 1.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch release covering everything merged since 1.1.9.

### Fixes

- **#136** — a 401 is no longer surfaced to the client. An OAuth access token can be revoked well before its clock expiry, and `ensureTokenFresh` only compares the clock, so the proxy served a dead token until it aged out. A 401 now forces one refresh and retries; if the refresh token is dead too the account is errored and the request fails over.
- **#139** — a burst of 401s no longer rotates the refresh-token family once per request. Refresh coalescing only merges refreshes that overlap in time, but the 401s from requests already in flight arrive staggered, so each forced its own refresh. Forced refreshes are now suppressed for 10s after a successful one.
- **#140** — `importFrom` accounts no longer lose their config fields at startup. They were rebuilt as `{ name, type, ...creds }`, discarding `disabled`, `priority`, `upstream`, `modelMap`, `models` and `orgUuid` — so an account disabled on disk quietly rejoined rotation on every restart, and a third-party backend account reverted to talking to Anthropic.

### Features

- **#133** — account pinning works from the shell: a `/tc-acct/<name>` prefix in `ANTHROPIC_BASE_URL` is preserved by `teamclaude run` instead of being overwritten. Pinned requests are tagged `[pin]` in the TUI activity log, and unknown pins are now visible there too.
- **#138** — `accounts[].models` is deprecated in favour of the `routes` table. Behaviour is unchanged, but the server now names each account still using it at startup and prints the `routes` entry to replace it with. Also, MITM mode (the default for `teamclaude run`) now reports that it is ignoring an account pin rather than dropping it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)