### PR TITLE
feat(run): TC_ACCT pins a session to one account, including MITM mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Session awareness** — tracks running Claude Code sessions (by their session id) and shows how many are active; opt into `distributeSessions` to spread concurrent sessions across accounts while keeping each one pinned for cache reuse
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
 - **Optional keep-warm** — off by default; when enabled, periodically starts idle accounts' 5h session timers with a minimal request (`teamclaude warmup`) so the next account isn't cold when rotation reaches it (spends a little quota, unlike the probe)
-- **Account pinning** — force a request onto one account via an `ANTHROPIC_BASE_URL=.../tc-acct/<name>` prefix, bypassing rotation
+- **Account pinning** — `TC_ACCT=<name>` pins a whole session to one account, bypassing rotation; works in both MITM and base-URL modes, and is stripped from the environment before claude starts
 - **MITM proxy mode (default)** — `teamclaude run` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected; pass `--no-mitm` for base-URL routing only
 - **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
@@ -431,18 +431,37 @@ In practice this rarely bites, because **TeamClaude prefers to keep you on one a
 
 > Keep-warm (above) is unrelated to this — it starts an idle account's **5h session timer**, not its prompt cache. A freshly-rotated account still takes a one-turn cache miss regardless.
 
-### Pin a request to a specific account
+### Pin a session to a specific account
 
-`ANTHROPIC_BASE_URL` with a `/tc-acct/<name-or-index>` prefix forces every request onto **one** account, bypassing rotation (and never failing over to another). This is what keep-warm uses internally, and it doubles as a manual way to exercise a specific account:
+`TC_ACCT` forces every request onto **one** account, bypassing rotation (and never failing over to another). It works in **both** modes — MITM (the default) and `--no-mitm`:
 
 ```bash
-# Route this whole claude session to the account named "work (Acme)" (index also works)
-ANTHROPIC_BASE_URL='http://127.0.0.1:3456/tc-acct/1' \
-ANTHROPIC_API_KEY='<your teamclaude proxy key>' \
-  claude -p --bare 'say hi'
+# Route this whole claude session to the account named "work (Acme)"
+TC_ACCT='work (Acme)' teamclaude run
+
+# A numeric rotation index works too
+TC_ACCT=1 teamclaude run
 ```
 
-The `<name>` matches an account's display name exactly (URL-encode spaces/parens), or a numeric rotation index. An unknown pin returns `404`. The prefix is stripped before the request is forwarded upstream.
+`TC_ACCT` is read by `teamclaude run` and **removed from the environment before claude is launched** — it never reaches the client or anything it spawns. Under `--no-mitm` teamclaude builds the pinned base URL itself; under MITM it travels as the proxy credential on each `CONNECT`, which is the only pin channel an `HTTPS_PROXY` URL can carry. Either way you don't hand-write a URL.
+
+The value matches an account's display name exactly (no escaping needed — spaces, `@` and parens are handled for you), or a numeric rotation index. An unknown account is refused up front rather than quietly served by whichever account rotation picked.
+
+<details>
+<summary>Pinning without <code>teamclaude run</code></summary>
+
+Talking to the proxy directly, the pin is a `/tc-acct/<name-or-index>` path prefix. This is what keep-warm uses internally, and it's handy for exercising one account from a script:
+
+```bash
+curl -s http://127.0.0.1:3456/tc-acct/1/v1/messages \
+  -H 'content-type: application/json' \
+  -H 'x-api-key: <your teamclaude proxy key>' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+URL-encode spaces and parens in a name here. An unknown pin returns `404`. The prefix is stripped before the request is forwarded upstream.
+
+</details>
 
 ### Third-party backend accounts
 

--- a/src/index.js
+++ b/src/index.js
@@ -664,10 +664,15 @@ async function runCommand() {
   // opt back into the transparent direct launch (e.g. for a dumb shell alias).
   const port = config.proxy.port;
   const env = { ...process.env };
-  // A caller-supplied ANTHROPIC_BASE_URL of http://<this proxy>/tc-acct/<name>
-  // pins the session to one account. Detected up front so BOTH modes can act on
-  // it: base-URL mode preserves it, MITM mode says it is ignoring it. Dropping
-  // it silently is what made the documented shell alias look broken by default.
+  // TC_ACCT pins this session to one account, in either mode. It is teamclaude's
+  // own knob, so it never reaches the child: claude has no use for it, and an
+  // account name is not something to leak into a subprocess environment that
+  // gets inherited by every tool and MCP server claude spawns.
+  const tcAcct = (process.env.TC_ACCT || '').trim();
+  delete env.TC_ACCT;
+  // Legacy: a caller-supplied ANTHROPIC_BASE_URL of http://<this proxy>/tc-acct/…
+  // also pins (shipped in 1.1.10). TC_ACCT is the supported way now — it works in
+  // MITM mode too, and keeps the pin out of the API path.
   const pinnedBase = isLocalAccountPin(process.env.ANTHROPIC_BASE_URL, port);
   if (await isProxyUp(port)) {
     if (useMitm) {
@@ -676,22 +681,37 @@ async function runCommand() {
       // real token injected. claude trusts our MITM leaf via NODE_EXTRA_CA_CERTS.
       const host = upstreamHost(config);
       const { caPath } = await ensureCerts(host);
-      const proxyUrl = `http://127.0.0.1:${port}`;
+      // The pin rides in the proxy URL's userinfo, which the client forwards as
+      // `Proxy-Authorization: Basic <acct>:<key>` on each CONNECT — the only pin
+      // channel an HTTPS_PROXY env var can express. The password slot keeps the
+      // proxy apiKey, matching the existing `--proxy http://<key>@host:port`
+      // form, so auth and pinning coexist in one URL.
+      const userinfo = tcAcct
+        ? `${encodeURIComponent(tcAcct)}:${encodeURIComponent(config.proxy?.apiKey || '')}@`
+        : '';
+      const proxyUrl = `http://${userinfo}127.0.0.1:${port}`;
       env.HTTPS_PROXY = env.HTTP_PROXY = env.https_proxy = env.http_proxy = proxyUrl;
       env.NO_PROXY = env.no_proxy = 'localhost,127.0.0.1,::1';
       env.NODE_EXTRA_CA_CERTS = caPath;
-      if (pinnedBase) {
-        console.error('[TeamClaude] Account pin in ANTHROPIC_BASE_URL ignored: MITM mode intercepts api.anthropic.com directly and does not use a base URL.');
-        console.error('[TeamClaude] Re-run with --no-mitm for the pin to take effect.');
+      if (tcAcct) console.error(`[TeamClaude] Pinned to account "${tcAcct}" (TC_ACCT)`);
+      else if (pinnedBase) {
+        console.error('[TeamClaude] Account pin in ANTHROPIC_BASE_URL ignored: MITM mode does not use a base URL.');
+        console.error('[TeamClaude] Use TC_ACCT=<account> instead — it pins in both modes.');
       }
       delete env.ANTHROPIC_BASE_URL;
     } else {
       // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
       // which the proxy accepts from localhost. Not setting ANTHROPIC_API_KEY
       // lets Claude Code stay in subscription mode (full model access).
-      // If the caller already set ANTHROPIC_BASE_URL to a /tc-acct/<pin> URL
-      // pointing at this proxy, preserve it so the account pin takes effect.
-      if (!pinnedBase) env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+      // TC_ACCT wins; teamclaude builds the pinned URL itself rather than making
+      // the caller hand-write one. Otherwise an existing /tc-acct/ base URL
+      // pointing at this proxy is preserved for configs written against 1.1.10.
+      if (tcAcct) {
+        env.ANTHROPIC_BASE_URL = `http://localhost:${port}/tc-acct/${encodeURIComponent(tcAcct)}`;
+        console.error(`[TeamClaude] Pinned to account "${tcAcct}" (TC_ACCT)`);
+      } else if (!pinnedBase) {
+        env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+      }
     }
   } else if (autoFallback) {
     console.error(`[TeamClaude] Proxy not running on port ${port} — launching claude directly (--auto-fallback; start it with: teamclaude server)`);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -20,7 +20,7 @@ import tls from 'node:tls';
 import http2 from 'node:http2';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
-import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr, relayUpgrade } from './server.js';
+import { createProxyRequestListener, safeKeyEqual, isLoopbackAddr, relayUpgrade, resolveAccountPin } from './server.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -114,19 +114,28 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const holdMs = (config.holdSeconds || 0) * 1000;
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config });
 
-  // One terminating h2/h1 server, minted lazily on the first intercepted CONNECT.
+  // One terminating h2/h1 server per pin, minted lazily on the first intercepted
+  // CONNECT that needs it (key '' = unpinned, the common case).
   // TLS uses our leaf; ALPN negotiates h2 or http/1.1 (allowHTTP1) with whatever
   // the client offers. It emits 'request' for BOTH protocols, so `forward` — the
   // shared buffering/retrying proxy listener — handles them identically. Each
   // CONNECT feeds it the raw tunnel socket; the client keeps the tunnel open and
   // multiplexes many requests over it, each independently account-selected.
-  let serverPromise = null;
-  const getServer = () => (serverPromise ||= (async () => {
+  //
+  // Keying by pin is what carries a TC_ACCT pin from the CONNECT to the requests
+  // inside the tunnel. The alternative — tagging the raw socket and reading it
+  // back from the request — means digging through a TLSSocket and, under h2, a
+  // Proxy over the session socket. A listener bound to the account is the same
+  // information with none of that. The map is bounded by the account count.
+  const serverPromises = new Map();
+  const getServer = (pin = '') => {
+    let p = serverPromises.get(pin);
+    if (p) return p;
+    p = (async () => {
     const { key, cert } = await ensureLeaf();
     const srv = http2.createSecureServer({ key, cert, allowHTTP1: true });
-    srv.on('request', forward);
+    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null }));
     // Remote Control's real-time channel is a WebSocket (Upgrade handshake),
     // which never fires 'request' — only 'upgrade', with a raw socket instead
     // of a response object (h1-only; falls back to blind h2 passthrough is not
@@ -135,13 +144,16 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     srv.on('sessionError', (e) => log(`[TeamClaude] MITM session error: ${e.message}`));
     srv.on('clientError', (e, sock) => { try { sock.destroy(); } catch { /* already gone */ } });
     return srv;
-  })().catch((err) => {
-    // Don't let a transient cert/disk failure poison the memo forever: reset it
-    // so the next intercepted CONNECT retries instead of re-awaiting a cached
-    // rejection (which would leave the MITM path dead until a restart).
-    serverPromise = null;
-    throw err;
-  }));
+    })().catch((err) => {
+      // Don't let a transient cert/disk failure poison the memo forever: drop it
+      // so the next intercepted CONNECT retries instead of re-awaiting a cached
+      // rejection (which would leave the MITM path dead until a restart).
+      serverPromises.delete(pin);
+      throw err;
+    });
+    serverPromises.set(pin, p);
+    return p;
+  };
 
   return (req, clientSocket, head) => {
     clientSocket.on('error', () => {});
@@ -215,12 +227,64 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     // server can't be minted (cert/disk/TLS-init failure) we haven't replied yet
     // — send a 502 so the client sees a real proxy error instead of "Proxy
     // connection ended before receiving CONNECT response".
-    getServer().then((srv) => {
+    // Pin resolution is deliberately confined to `rewrite`. Clients send
+    // Proxy-Authorization on EVERY CONNECT, including blind-tunneled third-party
+    // hosts, where an account pin is meaningless — rejecting there would take
+    // down unrelated traffic over a typo meant for Anthropic.
+    const { pin, error } = resolveConnectPin(req, accountManager, proxyApiKey);
+    if (error) {
+      log(`[TeamClaude] CONNECT ${host}: ${error}`);
+      try {
+        clientSocket.write(`HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="teamclaude"\r\nConnection: close\r\n\r\n`);
+      } catch { /* client already gone */ }
+      clientSocket.destroy();
+      return;
+    }
+
+    getServer(pin || '').then((srv) => {
       reply200Raw(clientSocket);
       if (head && head.length) clientSocket.unshift(head);
       srv.emit('connection', clientSocket);
     }).catch((err) => { log(`[TeamClaude] MITM ${host}: ${err.message}`); reply502Raw(clientSocket); clientSocket.destroy(); });
   };
+}
+
+// The Basic username from a CONNECT's `Proxy-Authorization`, or null. This is
+// the only pin channel expressible in an HTTPS_PROXY URL, which is what
+// `teamclaude run` has to work with in MITM mode (there is no request path to
+// carry a `/tc-acct/` prefix — inside the tunnel the path is the real upstream
+// one). Clients send this preemptively on every CONNECT.
+export function connectPinToken(req) {
+  const m = /^\s*basic\s+(.+?)\s*$/i.exec(req?.headers?.['proxy-authorization'] || '');
+  if (!m) return null;
+  const dec = Buffer.from(m[1], 'base64').toString('utf8'); // "user:pass"
+  const i = dec.indexOf(':');
+  const user = i >= 0 ? dec.slice(0, i) : dec;
+  return user || null;
+}
+
+/**
+ * Resolve the account pin on a CONNECT, or a rejection reason.
+ *
+ * The username slot is overloaded: the documented remote form is
+ * `--proxy http://<key>@host:port`, where it holds the proxy apiKey, not an
+ * account. So the key wins over any account of the same name — an operator who
+ * names an account after their proxy key gets auth, not a surprise pin.
+ *
+ * An unrecognized username is an ERROR rather than a silently ignored pin: a
+ * typo'd account name that quietly served from the wrong account is exactly the
+ * failure mode this feature exists to remove.
+ *
+ * @returns {{pin: string|null, error: string|null}}
+ */
+export function resolveConnectPin(req, accountManager, proxyApiKey) {
+  const token = connectPinToken(req);
+  if (!token) return { pin: null, error: null };
+  if (proxyApiKey && safeKeyEqual(token, proxyApiKey)) return { pin: null, error: null };
+  if (resolveAccountPin(accountManager, token) == null) {
+    return { pin: null, error: `Unknown account pin "${token}"` };
+  }
+  return { pin: token, error: null };
 }
 
 // Authorize a CONNECT: no key configured → open (matches the HTTP path); a

--- a/src/server.js
+++ b/src/server.js
@@ -213,7 +213,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/f
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
-export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {} }) {
+export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null }) {
   let counter = 0;
   return async (req, res) => {
     try {
@@ -260,6 +260,24 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           return;
         }
         req.url = pin[2];
+      }
+
+      // MITM-mode pin. A CONNECT carrying `Proxy-Authorization: Basic <acct>:…`
+      // has no URL to hang a `/tc-acct/` prefix on — the path inside the tunnel
+      // is the real Anthropic one — so the pin arrives as a listener bound to
+      // that account (see createConnectHandler). Resolved per request rather
+      // than at CONNECT time: a hot reload can renumber accounts while a tunnel
+      // is open, and a name outliving an index is the safer half of that race.
+      if (pinnedIndex == null && forcedPin != null) {
+        pinnedIndex = resolveAccountPin(accountManager, forcedPin);
+        if (pinnedIndex == null) {
+          const reqId = ++counter;
+          const sessionId = req.headers['x-claude-code-session-id'] || null;
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${forcedPin}")`, status: 404, model: null, sessionId, pinned: false });
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${forcedPin}" (from TC_ACCT)` } }));
+          return;
+        }
       }
 
       const reqId = ++counter;

--- a/test/mitm-pin.test.js
+++ b/test/mitm-pin.test.js
@@ -1,0 +1,243 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http2 from 'node:http2';
+import http from 'node:http';
+import net from 'node:net';
+import tls from 'node:tls';
+import { once } from 'node:events';
+import { generateCertChain } from '../src/x509.js';
+import { createConnectHandler, resolveConnectPin, connectPinToken } from '../src/mitm.js';
+import { AccountManager } from '../src/account-manager.js';
+
+// MITM-mode account pinning (TC_ACCT). Inside a CONNECT tunnel the request path
+// is the real upstream one, so there is nowhere to hang a `/tc-acct/` prefix —
+// the pin rides in the proxy URL's userinfo and arrives as the Basic *username*
+// of `Proxy-Authorization` on the CONNECT. Verified against Claude Code 2.1.220,
+// which sends that header preemptively on every CONNECT.
+
+function listen(server) { return new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port))); }
+const T = { timeout: 30000 };
+
+function closeHard(server) {
+  if (!server) return;
+  server.closeAllConnections?.();
+  try { server.close(); } catch { /* already closing */ }
+}
+
+const basic = (s) => 'Basic ' + Buffer.from(s).toString('base64');
+
+// CONNECT (optionally with Proxy-Authorization), then TLS over the tunnel.
+// Resolves the TLS socket, or rejects with the proxy's status line if refused.
+function connectThroughProxy(proxyPort, target, caCertPem, alpn, proxyAuth = null) {
+  return new Promise((resolve, reject) => {
+    const raw = net.connect(proxyPort, '127.0.0.1');
+    raw.once('error', reject);
+    raw.once('connect', () => raw.write(
+      `CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n` +
+      (proxyAuth ? `Proxy-Authorization: ${proxyAuth}\r\n` : '') + '\r\n',
+    ));
+    let buf = Buffer.alloc(0);
+    const onData = (d) => {
+      buf = Buffer.concat([buf, d]);
+      if (!buf.includes('\r\n\r\n')) return;
+      raw.removeListener('data', onData);
+      const status = buf.toString('utf8').split('\r\n')[0];
+      if (!/ 200 /.test(status)) { raw.destroy(); reject(new Error(status)); return; }
+      const sock = tls.connect({ socket: raw, servername: 'localhost', ca: [caCertPem], ALPNProtocols: alpn }, () => resolve(sock));
+      sock.once('error', reject);
+    };
+    raw.on('data', onData);
+  });
+}
+
+function makeUpstream(handler) {
+  return http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const out = handler(req, Buffer.concat(chunks).toString('utf8')) || {};
+      res.writeHead(out.status || 200, out.headers || {});
+      res.end(out.body ?? '');
+    });
+  });
+}
+
+function makeProxy(am, upPort, { leafCertPem, leafKeyPem }, config = {}) {
+  const proxy = http.createServer();
+  proxy.on('connect', createConnectHandler({
+    config: { upstream: `http://127.0.0.1:${upPort}`, ...config },
+    accountManager: am,
+    ensureLeaf: async () => ({ key: leafKeyPem, cert: leafCertPem }),
+    log: () => {},
+  }));
+  return proxy;
+}
+
+const oauthAccount = (name, token) =>
+  ({ name, type: 'oauth', accessToken: token, refreshToken: 'r', expiresAt: Date.now() + 3600_000 });
+
+// Send one POST over the tunnel and resolve the response headers.
+async function postOverTunnel(tlsSock) {
+  const client = http2.connect('https://localhost', { createConnection: () => tlsSock });
+  const req = client.request({ ':method': 'POST', ':path': '/v1/messages', 'content-type': 'application/json' });
+  let resp;
+  req.on('response', (h) => { resp = h; });
+  req.resume(); req.end('{"model":"x"}');
+  await once(req, 'close');
+  client.close();
+  return resp;
+}
+
+// ── the resolver ──────────────────────────────────────────────────────────────
+
+test('the Basic username selects the account', () => {
+  const am = { accounts: [{ name: 'work' }, { name: 'personal' }] };
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('work:k') } }, am, 'k'), { pin: 'work', error: null });
+  // No key configured — username alone still pins.
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('personal:') } }, am, null), { pin: 'personal', error: null });
+  // Numeric index, same as the /tc-acct/ form accepts.
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('1:') } }, am, null), { pin: '1', error: null });
+});
+
+// The documented remote form is `--proxy http://<key>@host:port`, which puts the
+// API KEY in the username slot. That must stay auth, never be read as a pin.
+test('a username equal to the proxy key is auth, not a pin', () => {
+  const am = { accounts: [{ name: 'work' }] };
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('secret:') } }, am, 'secret'), { pin: null, error: null });
+  // Even when an account is (unwisely) named after the key, auth wins.
+  const clash = { accounts: [{ name: 'secret' }] };
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('secret:') } }, clash, 'secret'), { pin: null, error: null });
+});
+
+// A typo'd pin that silently served from the wrong account is the failure this
+// feature exists to remove, so an unknown username is an error, not a shrug.
+test('an unknown username is an error rather than an ignored pin', () => {
+  const am = { accounts: [{ name: 'work' }] };
+  const { pin, error } = resolveConnectPin({ headers: { 'proxy-authorization': basic('typo:') } }, am, 'secret');
+  assert.equal(pin, null);
+  assert.match(error, /Unknown account pin "typo"/);
+});
+
+test('no header, or a Bearer key, yields no pin', () => {
+  const am = { accounts: [{ name: 'work' }] };
+  assert.deepEqual(resolveConnectPin({ headers: {} }, am, 'secret'), { pin: null, error: null });
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': 'Bearer secret' } }, am, 'secret'), { pin: null, error: null });
+  assert.equal(connectPinToken({ headers: {} }), null);
+});
+
+// ── end to end through a real tunnel ──────────────────────────────────────────
+
+test('a pinned CONNECT serves every request in the tunnel from that account', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = makeUpstream((req) => ({
+    status: 200,
+    headers: { 'x-saw-auth': req.headers['authorization'] || 'none' },
+  }));
+  const upPort = await listen(upstream);
+
+  // 'first' is what rotation would pick; the pin must override that.
+  const am = new AccountManager([oauthAccount('first', 'TOKEN-A'), oauthAccount('second', 'TOKEN-B')], 0.98);
+  const proxy = makeProxy(am, upPort, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2'], basic('second:'));
+  try {
+    const resp = await postOverTunnel(tlsSock);
+    assert.equal(resp['x-saw-auth'], 'Bearer TOKEN-B');   // the pinned account, not the rotation pick
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});
+
+test('an unpinned CONNECT still rotates normally', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = makeUpstream((req) => ({
+    status: 200,
+    headers: { 'x-saw-auth': req.headers['authorization'] || 'none' },
+  }));
+  const upPort = await listen(upstream);
+
+  const am = new AccountManager([oauthAccount('first', 'TOKEN-A'), oauthAccount('second', 'TOKEN-B')], 0.98);
+  const proxy = makeProxy(am, upPort, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  const tlsSock = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2']);
+  try {
+    const resp = await postOverTunnel(tlsSock);
+    assert.equal(resp['x-saw-auth'], 'Bearer TOKEN-A');   // ordinary selection
+  } finally {
+    tlsSock.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});
+
+// Two pins on one proxy must not bleed into each other — each tunnel gets the
+// listener bound to its own account.
+test('concurrent tunnels with different pins stay separate', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = makeUpstream((req) => ({
+    status: 200,
+    headers: { 'x-saw-auth': req.headers['authorization'] || 'none' },
+  }));
+  const upPort = await listen(upstream);
+
+  const am = new AccountManager([oauthAccount('first', 'TOKEN-A'), oauthAccount('second', 'TOKEN-B')], 0.98);
+  const proxy = makeProxy(am, upPort, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  const a = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2'], basic('first:'));
+  const b = await connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2'], basic('second:'));
+  try {
+    const [ra, rb] = await Promise.all([postOverTunnel(a), postOverTunnel(b)]);
+    assert.equal(ra['x-saw-auth'], 'Bearer TOKEN-A');
+    assert.equal(rb['x-saw-auth'], 'Bearer TOKEN-B');
+  } finally {
+    a.destroy(); b.destroy(); closeHard(proxy); closeHard(upstream);
+  }
+});
+
+test('an unknown pin is refused at CONNECT', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const upstream = makeUpstream(() => ({ status: 200 }));
+  const upPort = await listen(upstream);
+
+  const am = new AccountManager([oauthAccount('first', 'TOKEN-A')], 0.98);
+  const proxy = makeProxy(am, upPort, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  try {
+    await assert.rejects(
+      connectThroughProxy(proxyPort, `127.0.0.1:${upPort}`, caCertPem, ['h2'], basic('nosuch:')),
+      /407/,
+    );
+  } finally {
+    closeHard(proxy); closeHard(upstream);
+  }
+});
+
+// Clients send Proxy-Authorization on EVERY CONNECT, including blind-tunneled
+// third-party hosts where a pin is meaningless. A pin meant for Anthropic must
+// not take down unrelated traffic.
+test('a pin on a blind-tunneled host is ignored, not refused', T, async () => {
+  const { caCertPem, leafCertPem, leafKeyPem } = generateCertChain('localhost');
+  const target = http.createServer((_req, res) => { res.writeHead(200); res.end('ok'); });
+  const targetPort = await listen(target);
+  const upstream = makeUpstream(() => ({ status: 200 }));
+  const upPort = await listen(upstream);
+
+  const am = new AccountManager([oauthAccount('first', 'TOKEN-A')], 0.98);
+  const proxy = makeProxy(am, upPort, { caCertPem, leafCertPem, leafKeyPem });
+  const proxyPort = await listen(proxy);
+
+  // A garbage pin that WOULD 407 in rewrite mode. hostMode compares the HOST
+  // only, so the tunnel target must differ by name, not just port: the upstream
+  // is 127.0.0.1, so `localhost` is a different host and takes the tunnel path.
+  const raw = net.connect(proxyPort, '127.0.0.1');
+  try {
+    await once(raw, 'connect');
+    raw.write(`CONNECT localhost:${targetPort} HTTP/1.1\r\nHost: localhost:${targetPort}\r\nProxy-Authorization: ${basic('typo:')}\r\n\r\n`);
+    const [chunk] = await once(raw, 'data');
+    assert.match(chunk.toString('utf8').split('\r\n')[0], / 200 /);
+  } finally {
+    raw.destroy(); closeHard(proxy); closeHard(target); closeHard(upstream);
+  }
+});


### PR DESCRIPTION
Account pinning only worked under `--no-mitm`. The pin lived in the request path (`/tc-acct/<name>`), but MITM is the **default** for `teamclaude run` — and inside a CONNECT tunnel the path is the real upstream one, so there is nowhere to hang a prefix. `teamclaude run` deleted `ANTHROPIC_BASE_URL` outright in that mode.

## `TC_ACCT`

A dedicated env var instead of an override of the API path:

```bash
TC_ACCT='work (Acme)' teamclaude run
TC_ACCT=1 teamclaude run          # rotation index also works
```

- **`--no-mitm`** — teamclaude builds the pinned base URL itself; the caller never hand-writes one.
- **MITM** — the pin rides in the proxy URL's userinfo, which the client sends as `Proxy-Authorization: Basic <acct>:<key>` on each CONNECT. That is the only pin channel an `HTTPS_PROXY` env var can express. The apiKey keeps the password slot, matching the existing `--proxy http://<key>@host:port` form, so auth and pinning coexist in one URL.

`TC_ACCT` is **deleted from the child environment** before claude launches — it's teamclaude's knob, and it would otherwise be inherited by every tool and MCP server claude spawns.

## How the pin reaches the request

The CONNECT's pin selects a **per-pin** terminating h2/h1 server whose request listener is bound to that account (new `forcedPin` option on `createProxyRequestListener`). Keying the memo by pin is what carries the pin into the tunnel; the alternative — tagging the raw socket and reading it back — means digging through a TLSSocket and, under h2, a Proxy over the session socket. The map is bounded by the account count.

The pin is resolved **per request, by name**, so a hot reload that renumbers accounts can't misroute a live tunnel.

## Safety properties

- A username equal to the proxy apiKey is **auth, not a pin** — the documented remote form keeps working, and an account unwisely named after the key doesn't hijack it.
- An unrecognized username is an **error**, not an ignored pin. Quietly serving from whichever account rotation picked is exactly the failure this removes.
- Pin validation is confined to `rewrite` mode. Clients send `Proxy-Authorization` on *every* CONNECT including blind-tunneled third-party hosts, where a pin is meaningless — validating there would take down unrelated traffic over a typo meant for Anthropic. (CONNECT headers are consumed by the proxy and never forwarded, so nothing leaks upstream either.)

## Verified against the real client

Claude Code 2.1.220, captured with a logging CONNECT proxy:

- it sends `Proxy-Authorization` **preemptively on every CONNECT**, h1 and h2, keep-alive and `close`;
- it **percent-decodes** URL userinfo before base64, so `user%40example.com%20%28Org%29` arrives as `user@example.com (Org)` — email-style account names with `@`, spaces and parens survive intact.

The whole design rested on the first point, so it was measured rather than assumed.

## Compatibility

The 1.1.10 behaviour — a caller-supplied `/tc-acct/` `ANTHROPIC_BASE_URL` being preserved under `--no-mitm` — still works. `TC_ACCT` takes precedence, and the docs now point only at `TC_ACCT`. The `/tc-acct/` path prefix remains the way to pin when talking to the proxy directly (keep-warm uses it internally); that's now documented under a fold.

## Tests

`test/mitm-pin.test.js` — resolver unit tests (username selects account, key-as-username stays auth, unknown username errors, no-header/Bearer yield no pin) plus end-to-end through real CONNECT + TLS tunnels: a pinned tunnel serves from that account rather than the rotation pick, an unpinned one rotates normally, two concurrent tunnels with different pins stay separate, an unknown pin is refused at CONNECT, and a pin on a blind-tunneled host is ignored rather than refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)