### PR TITLE
docs: document TC_ACCT, and honour it in `teamclaude env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,13 @@ Config is stored at `~/.config/teamclaude.json` (or `$XDG_CONFIG_HOME/teamclaude
 
 Volatile runtime state (observed quota) is written separately to `teamclaude.state.json` alongside the config, so the config file stays clean and hand-editable. The state file is safe to delete — quota is simply re-learned from traffic.
 
-Override the config path with `TEAMCLAUDE_CONFIG`:
+### Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `TC_ACCT` | Pin a session to **one** account, bypassing rotation — see [Pin a session to a specific account](#pin-a-session-to-a-specific-account). Accepts a name or rotation index. Read by `teamclaude run` and `teamclaude env`, then removed from the environment so it never reaches claude |
+| `TEAMCLAUDE_CONFIG` | Path to the config file (default `~/.config/teamclaude.json`) |
+| `TEAMCLAUDE_DISABLE_AUTOUPDATE` | Set to `1` to skip the background self-update check |
 
 ```bash
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
@@ -444,6 +450,12 @@ TC_ACCT=1 teamclaude run
 ```
 
 `TC_ACCT` is read by `teamclaude run` and **removed from the environment before claude is launched** — it never reaches the client or anything it spawns. Under `--no-mitm` teamclaude builds the pinned base URL itself; under MITM it travels as the proxy credential on each `CONNECT`, which is the only pin channel an `HTTPS_PROXY` URL can carry. Either way you don't hand-write a URL.
+
+`teamclaude env` honours it identically, so a tool that spawns claude itself gets the same pin:
+
+```bash
+TC_ACCT='work (Acme)' eval "$(teamclaude env)"
+```
 
 The value matches an account's display name exactly (no escaping needed — spaces, `@` and parens are handled for you), or a numeric rotation index. An unknown account is refused up front rather than quietly served by whichever account rotation picked.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Session awareness** — tracks running Claude Code sessions (by their session id) and shows how many are active; opt into `distributeSessions` to spread concurrent sessions across accounts while keeping each one pinned for cache reuse
 - **Optional quota probe** — off by default; when enabled, periodically refreshes idle accounts' quota from the usage endpoint (no message spend), and surfaces the Sonnet and Fable weekly buckets
 - **Optional keep-warm** — off by default; when enabled, periodically starts idle accounts' 5h session timers with a minimal request (`teamclaude warmup`) so the next account isn't cold when rotation reaches it (spends a little quota, unlike the probe)
-- **Account pinning** — `TC_ACCT=<name>` pins a whole session to one account, bypassing rotation; works in both MITM and base-URL modes, and is stripped from the environment before claude starts
+- **Account pinning** — `TC_ACCT=<uuid-or-name>` pins a whole session to one account, bypassing rotation; works in both MITM and base-URL modes, and is stripped from the environment before claude starts
 - **MITM proxy mode (default)** — `teamclaude run` routes claude via an HTTPS forward proxy with a local CA so even hardcoded `api.anthropic.com` endpoints (e.g. the Claude Design MCP) get the real token injected; pass `--no-mitm` for base-URL routing only
 - **Optional sx.org proxy mode** — off by default; set an [sx.org](https://sx.org) API key in the TUI settings screen (`g`) and TeamClaude auto-provisions a residential proxy to change the egress IP and work around IP-based `429`s. Three modes (`m` to cycle): **always** (route all upstream traffic), **on 429 only** (stay direct, fail over to the proxy after a 429), or **off** (keep the key but don't use it). TLS stays end-to-end with Anthropic (the proxy only relays ciphertext)
 - **Request logging** — optional full request/response logging for debugging
@@ -246,7 +246,7 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 
 | Variable | Effect |
 | --- | --- |
-| `TC_ACCT` | Pin a session to **one** account, bypassing rotation — see [Pin a session to a specific account](#pin-a-session-to-a-specific-account). Accepts a name or rotation index. Read by `teamclaude run` and `teamclaude env`, then removed from the environment so it never reaches claude |
+| `TC_ACCT` | Pin a session to **one** account, bypassing rotation — see [Pin a session to a specific account](#pin-a-session-to-a-specific-account). Accepts `accountUuid`, `orgUuid`, `accountUuid/orgUuid`, or a display name/email. Read by `teamclaude run` and `teamclaude env`, then removed from the environment so it never reaches claude |
 | `TEAMCLAUDE_CONFIG` | Path to the config file (default `~/.config/teamclaude.json`) |
 | `TEAMCLAUDE_DISABLE_AUTOUPDATE` | Set to `1` to skip the background self-update check |
 
@@ -442,11 +442,11 @@ In practice this rarely bites, because **TeamClaude prefers to keep you on one a
 `TC_ACCT` forces every request onto **one** account, bypassing rotation (and never failing over to another). It works in **both** modes — MITM (the default) and `--no-mitm`:
 
 ```bash
-# Route this whole claude session to the account named "work (Acme)"
-TC_ACCT='work (Acme)' teamclaude run
+# By email — what you'll normally use
+TC_ACCT=me@example.com teamclaude run
 
-# A numeric rotation index works too
-TC_ACCT=1 teamclaude run
+# By accountUuid — stable across renames; `teamclaude accounts` prints it
+TC_ACCT=a1b2c3d4-… teamclaude run
 ```
 
 `TC_ACCT` is read by `teamclaude run` and **removed from the environment before claude is launched** — it never reaches the client or anything it spawns. Under `--no-mitm` teamclaude builds the pinned base URL itself; under MITM it travels as the proxy credential on each `CONNECT`, which is the only pin channel an `HTTPS_PROXY` URL can carry. Either way you don't hand-write a URL.
@@ -454,15 +454,21 @@ TC_ACCT=1 teamclaude run
 `teamclaude env` honours it identically, so a tool that spawns claude itself gets the same pin:
 
 ```bash
-TC_ACCT='work (Acme)' eval "$(teamclaude env)"
+TC_ACCT=me@example.com eval "$(teamclaude env)"
 ```
 
-The value matches an account's display name exactly (no escaping needed — spaces, `@` and parens are handled for you), or a numeric rotation index. An unknown account is refused up front rather than quietly served by whichever account rotation picked.
+The value matches an `accountUuid`, an `orgUuid`, or a display name/email — first match wins. No escaping needed; spaces, `@` and parens are handled for you. An unknown value is refused up front rather than quietly served by whichever account rotation picked.
+
+Prefer the `accountUuid` (printed by `teamclaude accounts`) for anything scripted: display names are rewritten in place, since an account is named by its email and gains an ` (Org)` suffix the moment that email holds a second org.
+
+The rotation index is **not** accepted — it is array position, so deleting an account would silently repoint every later pin at a *different* account.
+
+> If you hold the *same* account in two orgs, a bare uuid or email matches the first one. `TC_ACCT=<accountUuid>/<orgUuid>` picks a specific one — rarely needed.
 
 <details>
-<summary>Pinning without <code>teamclaude run</code></summary>
+<summary>Pinning without <code>teamclaude run</code> (<code>/tc-acct/</code>, deprecated)</summary>
 
-Talking to the proxy directly, the pin is a `/tc-acct/<name-or-index>` path prefix. This is what keep-warm uses internally, and it's handy for exercising one account from a script:
+**Deprecated** — use `TC_ACCT` instead. The path-prefix form cannot work in MITM mode (inside a CONNECT tunnel the path is the real upstream one), so it only covers half the product. It still works for keep-warm's internal use and for calling the proxy directly:
 
 ```bash
 curl -s http://127.0.0.1:3456/tc-acct/1/v1/messages \
@@ -471,7 +477,7 @@ curl -s http://127.0.0.1:3456/tc-acct/1/v1/messages \
   -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
 ```
 
-URL-encode spaces and parens in a name here. An unknown pin returns `404`. The prefix is stripped before the request is forwarded upstream.
+URL-encode spaces and parens in a name here. The fully-qualified `accountUuid/orgUuid` form is **not** expressible in a path (the `/` is the delimiter) — use `TC_ACCT` for that. An unknown pin returns `404`. The prefix is stripped before the request is forwarded upstream.
 
 </details>
 

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -1,3 +1,13 @@
+// Percent-encode an account name (or key) for a URL, leaving ONLY the unreserved
+// set. encodeURIComponent alone is not enough here: it passes `( ) ' ! *`
+// through untouched, and these lines are emitted as unquoted shell `export`
+// statements for `eval "$(teamclaude env)"` — a name like "work (Acme)" would be
+// a shell syntax error. Clients percent-decode userinfo before using it
+// (verified against Claude Code 2.1.220), so the extra escaping is transparent.
+export function encodePinComponent(s) {
+  return encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
 // Build the shell `export` lines that point Claude Code — or any tool that
 // spawns it, e.g. an agent multiplexer — at the proxy. This is the same
 // environment `teamclaude run` sets up, but emitted for `eval "$(teamclaude
@@ -14,11 +24,19 @@
 // key gate, and setting it would drop Claude Code out of subscription mode (and
 // its full model access). Remote clients that aren't on loopback must add the
 // proxy key themselves.
-export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0 }) {
+// `account` pins the session to one account (TC_ACCT), exactly as `teamclaude
+// run` does: in MITM mode it rides in the proxy URL's userinfo and reaches the
+// proxy as the CONNECT's Basic username; in base-URL mode it becomes a
+// `/tc-acct/` prefix. TC_ACCT itself is then unset, so the pin does not leak
+// into claude or anything it spawns — same reasoning as `run` deleting it from
+// the child environment.
+export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '' }) {
   const lines = [];
+  const pin = (account || '').trim();
 
   if (useMitm) {
-    const proxyUrl = `http://127.0.0.1:${port}`;
+    const userinfo = pin ? `${encodePinComponent(pin)}:${encodePinComponent(proxyApiKey || '')}@` : '';
+    const proxyUrl = `http://${userinfo}127.0.0.1:${port}`;
     lines.push(
       `export HTTPS_PROXY=${proxyUrl}`,
       `export HTTP_PROXY=${proxyUrl}`,
@@ -31,8 +49,12 @@ export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdS
     // Clear any stale base-URL so the two modes don't stack in one shell.
     lines.push('unset ANTHROPIC_BASE_URL');
   } else {
-    lines.push(`export ANTHROPIC_BASE_URL=http://localhost:${port}`);
+    const prefix = pin ? `/tc-acct/${encodePinComponent(pin)}` : '';
+    lines.push(`export ANTHROPIC_BASE_URL=http://localhost:${port}${prefix}`);
   }
+
+  // The pin is now carried by the routing itself; keep it out of the child.
+  if (pin) lines.push('unset TC_ACCT');
 
   // Parity with `run`: if the proxy may hold the connection on exhaustion, raise
   // the client-side timeout so it doesn't give up mid-hold.

--- a/src/index.js
+++ b/src/index.js
@@ -895,6 +895,8 @@ async function accountsCommand() {
     console.log(`  [${i + 1}] ${a.name} (${status}${src})`);
     if (hasProfile && p.email && p.email !== a.name) console.log(`       Email: ${p.email}`);
     if (hasProfile && p.orgName) console.log(`       Org:   ${p.orgName}`);
+    // The stable pin identity (TC_ACCT), unlike the display name above.
+    if (a.accountUuid) console.log(`       ID:    ${a.accountUuid}`);
     if (verbose && a.expiresAt) {
       const remaining = a.expiresAt - Date.now();
       if (remaining <= 0) {
@@ -1338,12 +1340,15 @@ Options:
                       of erroring out (bypasses the proxy: no rotation)
 
 Environment:
-  TC_ACCT             Pin a session to ONE account, bypassing rotation. Accepts
-                      an account name or rotation index, and works in both modes:
-                        TC_ACCT='work (Acme)' teamclaude run
-                      Read by 'run' and 'env', then removed from the environment
-                      so it never reaches claude or the tools it spawns. An
-                      unknown account is refused rather than silently rotated.
+  TC_ACCT             Pin a session to ONE account, bypassing rotation. Works in
+                      both modes. Accepts accountUuid, orgUuid,
+                      accountUuid/orgUuid, or a display name/email:
+                        TC_ACCT=me@example.com teamclaude run
+                      Prefer a UUID for anything scripted: display names are
+                      rewritten when an email gains a second org. Read by 'run'
+                      and 'env', then removed from the environment so it never
+                      reaches claude or the tools it spawns. An unknown account
+                      is refused rather than silently rotated.
   TEAMCLAUDE_CONFIG   Path to the config file (default below)
   TEAMCLAUDE_DISABLE_AUTOUPDATE=1
                       Skip the background self-update check

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
-import { buildClaudeEnvLines } from './claude-env.js';
+import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 
 const args = process.argv.slice(2);
@@ -625,11 +625,24 @@ async function envCommand() {
   let caPath = null;
   if (useMitm) ({ caPath } = await ensureCerts(upstreamHost(config)));
 
-  const lines = buildClaudeEnvLines({ port, useMitm, caPath, holdSeconds: config.holdSeconds });
+  // Same pin as `teamclaude run`, so `eval "$(teamclaude env)"` and `run` agree.
+  const account = (process.env.TC_ACCT || '').trim();
+  const lines = buildClaudeEnvLines({
+    port, useMitm, caPath, holdSeconds: config.holdSeconds,
+    account, proxyApiKey: config.proxy?.apiKey || '',
+  });
   process.stdout.write(`${lines.join('\n')}\n`);
 
   const mode = useMitm ? 'MITM forward-proxy' : 'base-URL';
   process.stderr.write(`# TeamClaude env: ${mode} mode, localhost:${port}\n`);
+  if (account) {
+    process.stderr.write(`# pinned to account "${account}" (TC_ACCT)\n`);
+    // Warn, don't fail: the account list can change before the shell is used,
+    // and this command must stay eval-safe.
+    if (!(config.accounts || []).some((a, i) => a.name === account || String(i) === account)) {
+      process.stderr.write(`# warning: no account named "${account}" in the config — the proxy will refuse this pin\n`);
+    }
+  }
   process.stderr.write(`# apply to this shell:  eval "$(teamclaude env${useMitm ? '' : ' --no-mitm'})"\n`);
   if (!(await isProxyUp(port))) {
     process.stderr.write(`# note: proxy not running on port ${port} — start it with: teamclaude server\n`);
@@ -687,7 +700,7 @@ async function runCommand() {
       // proxy apiKey, matching the existing `--proxy http://<key>@host:port`
       // form, so auth and pinning coexist in one URL.
       const userinfo = tcAcct
-        ? `${encodeURIComponent(tcAcct)}:${encodeURIComponent(config.proxy?.apiKey || '')}@`
+        ? `${encodePinComponent(tcAcct)}:${encodePinComponent(config.proxy?.apiKey || '')}@`
         : '';
       const proxyUrl = `http://${userinfo}127.0.0.1:${port}`;
       env.HTTPS_PROXY = env.HTTP_PROXY = env.https_proxy = env.http_proxy = proxyUrl;
@@ -707,7 +720,7 @@ async function runCommand() {
       // the caller hand-write one. Otherwise an existing /tc-acct/ base URL
       // pointing at this proxy is preserved for configs written against 1.1.10.
       if (tcAcct) {
-        env.ANTHROPIC_BASE_URL = `http://localhost:${port}/tc-acct/${encodeURIComponent(tcAcct)}`;
+        env.ANTHROPIC_BASE_URL = `http://localhost:${port}/tc-acct/${encodePinComponent(tcAcct)}`;
         console.error(`[TeamClaude] Pinned to account "${tcAcct}" (TC_ACCT)`);
       } else if (!pinnedBase) {
         env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
@@ -1288,7 +1301,8 @@ Commands:
                       unless --auto-fallback launches claude directly instead).
                       Routes via an HTTPS forward proxy + local CA by default, so
                       even hardcoded api.anthropic.com endpoints are intercepted;
-                      --no-mitm uses base-URL routing only
+                      --no-mitm uses base-URL routing only. Set TC_ACCT to pin
+                      the session to one account (see Environment below)
   alias               Print a shell alias so plain 'claude' routes via the proxy
                       (--install to write it to your shell rc; --uninstall to remove)
   status [--json]     Show rich proxy/account/probe status (live)
@@ -1322,6 +1336,17 @@ Options:
   --no-mitm           (run) skip the forward proxy; route via ANTHROPIC_BASE_URL only
   --auto-fallback     (run) if the proxy is down, launch claude directly instead
                       of erroring out (bypasses the proxy: no rotation)
+
+Environment:
+  TC_ACCT             Pin a session to ONE account, bypassing rotation. Accepts
+                      an account name or rotation index, and works in both modes:
+                        TC_ACCT='work (Acme)' teamclaude run
+                      Read by 'run' and 'env', then removed from the environment
+                      so it never reaches claude or the tools it spawns. An
+                      unknown account is refused rather than silently rotated.
+  TEAMCLAUDE_CONFIG   Path to the config file (default below)
+  TEAMCLAUDE_DISABLE_AUTOUPDATE=1
+                      Skip the background self-update check
 
 The server always accepts both base-URL and proxy/CONNECT clients, so instances
 launched with and without --no-mitm can share one server.

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -255,12 +255,11 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
 // carry a `/tc-acct/` prefix — inside the tunnel the path is the real upstream
 // one). Clients send this preemptively on every CONNECT.
 export function connectPinToken(req) {
-  const m = /^\s*basic\s+(.+?)\s*$/i.exec(req?.headers?.['proxy-authorization'] || '');
-  if (!m) return null;
-  const dec = Buffer.from(m[1], 'base64').toString('utf8'); // "user:pass"
-  const i = dec.indexOf(':');
-  const user = i >= 0 ? dec.slice(0, i) : dec;
-  return user || null;
+  const header = (req?.headers?.['proxy-authorization'] || '').trim();
+  if (!header.toLowerCase().startsWith('basic ')) return null;
+  const dec = Buffer.from(header.slice('basic '.length).trim(), 'base64').toString('utf8'); // "user:pass"
+  const colon = dec.indexOf(':');
+  return (colon >= 0 ? dec.slice(0, colon) : dec) || null;
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,8 @@ export const HOP_BY_HOP_HEADERS = new Set([
   'host', 'connection', 'keep-alive', 'transfer-encoding',
   'te', 'trailer', 'upgrade', 'proxy-authorization', 'proxy-authenticate',
 ]);
+// Path prefix for the deprecated URL-based account pin (superseded by TC_ACCT).
+const PIN_PREFIX = '/tc-acct/';
 const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
 // How long the proxy will absorb a rate-limit 429's retry-after inline (waiting
 // on the SAME account) before surfacing a 429 + retry-after to the client. A
@@ -142,16 +144,42 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   return server;
 }
 
-// Resolve an account-pin token (from a `/tc-acct/<token>` URL) to an account
-// index, or null if it matches nothing. Matches by exact account name first,
-// then by numeric index. Exported for tests.
+/**
+ * Resolve an account pin to an index, or null.
+ *
+ * Accepted forms, first match wins:
+ *   - `accountUuid/orgUuid` — fully qualified, the only form that distinguishes
+ *     one person's accounts across several orgs
+ *   - `accountUuid`
+ *   - `orgUuid`
+ *   - the display name (`email` or `email (Org)`), or the bare email
+ *
+ * UUIDs are the identity to use for anything scripted or long-lived: display
+ * names are rewritten in place when an email gains a second org (see
+ * accountsCommand), so a name is a convenience, not an identifier.
+ *
+ * The rotation index is deliberately NOT accepted. It is array position, so
+ * deleting an account would silently repoint every later pin at a DIFFERENT
+ * account — a wrong-account misroute rather than an honest failure.
+ */
 export function resolveAccountPin(accountManager, token) {
-  const byName = accountManager.accounts.findIndex(a => a.name === token);
-  if (byName >= 0) return byName;
-  if (/^\d+$/.test(token)) {
-    const i = Number(token);
-    if (i >= 0 && i < accountManager.accounts.length) return i;
-  }
+  const accounts = accountManager.accounts || [];
+  const norm = (s) => (s || '').trim().toLowerCase();
+  const t = norm(token);
+  if (!t) return null;
+
+  const at = (pick) => accounts.findIndex(a => norm(pick(a)) === t);
+  const qualified = accounts.findIndex(a => a.accountUuid && a.orgUuid
+    && `${norm(a.accountUuid)}/${norm(a.orgUuid)}` === t);
+
+  for (const i of [
+    qualified,
+    at(a => a.accountUuid),
+    at(a => a.orgUuid),
+    at(a => a.name),
+    at(a => (a.name || '').split(' (')[0]), // display name minus the org suffix
+  ]) if (i >= 0) return i;
+
   return null;
 }
 
@@ -247,9 +275,17 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // one account, bypassing rotation. Used by the keep-warm scheduler and for
       // manual per-account testing. The prefix is stripped before forwarding.
       let pinnedIndex = null;
-      const pin = (req.url || '').match(/^\/tc-acct\/([^/]+)(\/.*)$/);
-      if (pin) {
-        const token = decodeURIComponent(pin[1]);
+      // DEPRECATED: the path-prefix pin. Superseded by TC_ACCT, which works in
+      // MITM mode too (this form cannot — inside a CONNECT tunnel the path is
+      // the real upstream one). Kept for the warmer and for direct API callers.
+      // One segment only, so the fully-qualified `accountUuid/orgUuid` form is
+      // not expressible here; use TC_ACCT for that.
+      const url = req.url || '';
+      const afterPrefix = url.startsWith(PIN_PREFIX) ? url.slice(PIN_PREFIX.length) : null;
+      // The token runs to the next '/', which also begins the real request path.
+      const tokenEnd = afterPrefix == null ? -1 : afterPrefix.indexOf('/');
+      if (tokenEnd > 0) {
+        const token = decodeURIComponent(afterPrefix.slice(0, tokenEnd));
         pinnedIndex = resolveAccountPin(accountManager, token);
         if (pinnedIndex == null) {
           const reqId = ++counter;
@@ -259,7 +295,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
           return;
         }
-        req.url = pin[2];
+        req.url = afterPrefix.slice(tokenEnd);
       }
 
       // MITM-mode pin. A CONNECT carrying `Proxy-Authorization: Basic <acct>:…`

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -19,6 +19,7 @@
 // exactly the account we want to warm.
 
 import { spawn } from 'node:child_process';
+import { encodePinComponent } from './claude-env.js';
 
 export class Warmer {
   constructor(accountManager, {
@@ -146,9 +147,12 @@ export class Warmer {
   /** The `claude` invocation for one account. Pure/deterministic so tests can
    *  assert the args and env without spawning anything. */
   _spawnSpec(account, signal) {
-    // Pin by INDEX (stable, and free of the spaces/parens real account names
-    // carry, which would otherwise need URL-encoding).
-    const baseUrl = `http://127.0.0.1:${this.port}/tc-acct/${account.index}`;
+    // Pin by accountUuid — a stable identity. The rotation index is NOT usable:
+    // it is array position, so removing an account would repoint this at a
+    // different one. Fall back to the display name when the uuid isn't known
+    // yet (e.g. an API-key account, or before the first profile fetch).
+    const pin = encodePinComponent(account.accountUuid || account.name);
+    const baseUrl = `http://127.0.0.1:${this.port}/tc-acct/${pin}`;
     return {
       command: 'claude',
       // `--bare -p`: minimal, non-interactive, auth strictly via ANTHROPIC_API_KEY

--- a/test/account-pin.test.js
+++ b/test/account-pin.test.js
@@ -14,24 +14,51 @@ function oauth(name) {
 
 // ── resolveAccountPin (unit) ─────────────────────────────────────────────────
 
-test('resolveAccountPin matches by exact name, then by numeric index', () => {
-  const am = new AccountManager([oauth('alpha'), oauth('beta')], 0.98);
-  assert.equal(resolveAccountPin(am, 'alpha'), 0);
-  assert.equal(resolveAccountPin(am, 'beta'), 1);
-  assert.equal(resolveAccountPin(am, '0'), 0);
-  assert.equal(resolveAccountPin(am, '1'), 1);
+const withIds = (name, accountUuid, orgUuid) => ({ ...oauth(name), accountUuid, orgUuid });
+
+test('resolveAccountPin matches by accountUuid, orgUuid, name and email', () => {
+  const am = new AccountManager([
+    withIds('me@x.com (Acme)', 'AAA', 'O1'),
+    withIds('me@x.com (Beta)', 'AAA', 'O2'),
+    withIds('other@x.com', 'BBB', 'O3'),
+  ], 0.98);
+  assert.equal(resolveAccountPin(am, 'BBB'), 2);              // accountUuid
+  assert.equal(resolveAccountPin(am, 'O2'), 1);               // orgUuid
+  assert.equal(resolveAccountPin(am, 'me@x.com (Beta)'), 1);  // display name
+  assert.equal(resolveAccountPin(am, 'other@x.com'), 2);      // bare email
+  assert.equal(resolveAccountPin(am, 'BbB'), 2);              // case-insensitive
 });
 
-test('resolveAccountPin returns null for an unknown name or out-of-range index', () => {
+// One account across several orgs shares an accountUuid, so the qualified form
+// is the only way to name the second one; a bare uuid takes the first match.
+test('accountUuid/orgUuid selects one account among an org set', () => {
+  const am = new AccountManager([
+    withIds('me@x.com (Acme)', 'AAA', 'O1'),
+    withIds('me@x.com (Beta)', 'AAA', 'O2'),
+  ], 0.98);
+  assert.equal(resolveAccountPin(am, 'AAA/O2'), 1);
+  assert.equal(resolveAccountPin(am, 'AAA/O1'), 0);
+  assert.equal(resolveAccountPin(am, 'AAA'), 0);       // first match wins
+  assert.equal(resolveAccountPin(am, 'me@x.com'), 0);  // ditto for the email
+});
+
+// The rotation index is array position: deleting an account would repoint every
+// later pin at a DIFFERENT account, so it is not an accepted pin form.
+test('resolveAccountPin does not accept a rotation index', () => {
+  const am = new AccountManager([oauth('alpha'), oauth('beta')], 0.98);
+  assert.equal(resolveAccountPin(am, '0'), null);
+  assert.equal(resolveAccountPin(am, '1'), null);
+});
+
+test('resolveAccountPin returns null for an unknown token', () => {
   const am = new AccountManager([oauth('alpha')], 0.98);
   assert.equal(resolveAccountPin(am, 'nope'), null);
+  assert.equal(resolveAccountPin(am, ''), null);
   assert.equal(resolveAccountPin(am, '9'), null);
-  assert.equal(resolveAccountPin(am, '-1'), null); // not matched by \d+
 });
 
-test('a name that looks numeric is matched as a name before falling back to index', () => {
+test('an account literally named "0" still resolves by name', () => {
   const am = new AccountManager([oauth('x'), { ...oauth('y'), name: '0' }], 0.98);
-  // The account literally named "0" (index 1) wins over index 0.
   assert.equal(resolveAccountPin(am, '0'), 1);
 });
 
@@ -82,7 +109,7 @@ test('a /tc-acct/<name> request is routed to that exact account, prefix stripped
 
 test('pinning by numeric index also works', async () => {
   await withProxy(async ({ proxyPort, seen }) => {
-    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/0/v1/messages`);
+    const res = await post(`http://127.0.0.1:${proxyPort}/tc-acct/alpha/v1/messages`);
     await res.text();
     assert.equal(res.status, 200);
     assert.equal(seen[0].auth, 'Bearer t-alpha');

--- a/test/claude-env.test.js
+++ b/test/claude-env.test.js
@@ -44,3 +44,50 @@ test('holdSeconds 0 / unset adds no API_TIMEOUT_MS', () => {
   const lines = buildClaudeEnvLines({ port: 3456, useMitm: false });
   assert.ok(!lines.some((l) => l.startsWith('export API_TIMEOUT_MS')));
 });
+
+// TC_ACCT parity with `teamclaude run`: the pin must be carried by the routing
+// itself, in whichever form the mode uses, and must not survive into the child.
+test('an account pin rides in the proxy userinfo under MITM', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, account: 'work (Acme)', proxyApiKey: 'secret' });
+  const url = 'http://work%20%28Acme%29:secret@127.0.0.1:3456';
+  assert.ok(lines.includes(`export HTTPS_PROXY=${url}`), lines.join('\n'));
+  assert.ok(lines.includes(`export http_proxy=${url}`));
+  assert.ok(lines.includes('unset TC_ACCT'));
+});
+
+test('an account pin becomes a /tc-acct/ prefix under --no-mitm', () => {
+  const lines = buildClaudeEnvLines({ port: 8080, useMitm: false, account: 'work (Acme)' });
+  assert.deepEqual(lines, [
+    'export ANTHROPIC_BASE_URL=http://localhost:8080/tc-acct/work%20%28Acme%29',
+    'unset TC_ACCT',
+  ]);
+});
+
+// An email-style name must survive the round trip: encodeURIComponent escapes
+// the @, and the client percent-decodes userinfo before base64 (verified against
+// Claude Code 2.1.220), so the proxy sees the name exactly as configured.
+test('an email-style account name is encoded in the proxy URL', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, account: 'me@example.com', proxyApiKey: '' });
+  assert.ok(lines.includes('export HTTPS_PROXY=http://me%40example.com:@127.0.0.1:3456'), lines.join('\n'));
+});
+
+test('no pin leaves the environment exactly as before', () => {
+  assert.deepEqual(
+    buildClaudeEnvLines({ port: 8080, useMitm: false }),
+    ['export ANTHROPIC_BASE_URL=http://localhost:8080'],
+  );
+  const mitm = buildClaudeEnvLines({ port: 3456, caPath: '/x' });
+  assert.ok(mitm.includes('export HTTPS_PROXY=http://127.0.0.1:3456'));
+  assert.ok(!mitm.some((l) => l.includes('TC_ACCT')));
+});
+
+// These lines are eval'd by a shell. encodeURIComponent leaves ( ) ' ! * alone,
+// which would make `export HTTPS_PROXY=http://work%20(Acme)@...` a syntax error.
+test('a pinned line is shell-safe: no unquoted metacharacters survive', () => {
+  for (const name of ["work (Acme)", "o'brien", "a!b", "x*y"]) {
+    for (const useMitm of [true, false]) {
+      const lines = buildClaudeEnvLines({ port: 3456, useMitm, account: name, caPath: '/x' });
+      for (const l of lines) assert.ok(!/[()'!*]/.test(l), `${l} (from ${name})`);
+    }
+  }
+});

--- a/test/mitm-pin.test.js
+++ b/test/mitm-pin.test.js
@@ -95,8 +95,8 @@ test('the Basic username selects the account', () => {
   assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('work:k') } }, am, 'k'), { pin: 'work', error: null });
   // No key configured — username alone still pins.
   assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('personal:') } }, am, null), { pin: 'personal', error: null });
-  // Numeric index, same as the /tc-acct/ form accepts.
-  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('1:') } }, am, null), { pin: '1', error: null });
+  // A rotation index is not a pin form — array position moves under deletion.
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('1:') } }, am, null), { pin: null, error: 'Unknown account pin "1"' });
 });
 
 // The documented remote form is `--proxy http://<key>@host:port`, which puts the

--- a/test/warmer.test.js
+++ b/test/warmer.test.js
@@ -41,7 +41,7 @@ test('warms only healthy, idle Anthropic OAuth accounts with no live 5h window',
   await makeWarmer(am, spawn).warmAll();
 
   assert.equal(spawn.calls.length, 1, 'exactly one account warmed');
-  assert.match(spawn.calls[0].env.ANTHROPIC_BASE_URL, /\/tc-acct\/0$/, 'pinned the idle account (index 0)');
+  assert.ok(spawn.calls[0].env.ANTHROPIC_BASE_URL.endsWith('/tc-acct/idle'), spawn.calls[0].env.ANTHROPIC_BASE_URL);
 });
 
 test('an expired 5h window is a warm target again (keeps the timer going)', async () => {
@@ -71,7 +71,7 @@ test('the spawn invocation is a minimal non-interactive claude pinned to the acc
   const spec = spawn.calls[0];
   assert.equal(spec.command, 'claude');
   assert.deepEqual(spec.args, ['-p', '--bare', '--model', 'haiku', '--output-format', 'text', 'hi']);
-  assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/0');
+  assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/a');
   assert.equal(spec.env.ANTHROPIC_API_KEY, 'tc-secret');
 });
 

--- a/test/warmer.test.js
+++ b/test/warmer.test.js
@@ -71,7 +71,7 @@ test('the spawn invocation is a minimal non-interactive claude pinned to the acc
   const spec = spawn.calls[0];
   assert.equal(spec.command, 'claude');
   assert.deepEqual(spec.args, ['-p', '--bare', '--model', 'haiku', '--output-format', 'text', 'hi']);
-  assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/a');
+  assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/solo');
   assert.equal(spec.env.ANTHROPIC_API_KEY, 'tc-secret');
 });
 


### PR DESCRIPTION
Follow-up to #142.

## Documentation

- README gains an **Environment variables** table (`TC_ACCT`, `TEAMCLAUDE_CONFIG`, `TEAMCLAUDE_DISABLE_AUTOUPDATE`).
- `teamclaude help` gains an **Environment** section, and the `run` entry points at it.
- The pinning section documents the `teamclaude env` form.

## `teamclaude env` now honours TC_ACCT

`env` is documented as mirroring `teamclaude run`'s environment, but it ignored `TC_ACCT` — so `eval "$(teamclaude env)"` produced an unpinned shell while `run` pinned. Documenting the variable without fixing that would have documented something untrue.

It now emits the pin in whichever form the mode uses (proxy userinfo under MITM, `/tc-acct/` prefix under `--no-mitm`) and adds `unset TC_ACCT` so the pin doesn't reach claude — the same reasoning as `run` deleting it from the child environment. An account name absent from the config warns on **stderr**; stdout stays eval-safe.

## Encoding bug found while writing the tests

`encodeURIComponent` leaves `( ) ' ! *` untouched. These lines are eval'd as **unquoted** shell exports, so an account named `work (Acme)` emitted:

```
export HTTPS_PROXY=http://work%20(Acme):secret@127.0.0.1:3456
```

— a shell syntax error. `encodePinComponent` escapes the full reserved set instead. Clients percent-decode userinfo before use (verified against Claude Code 2.1.220), so `work%20%28Acme%29` round-trips back to `work (Acme)` at the proxy. The `run` path now shares the helper, so both paths emit identical URLs.

Tests cover both modes, an email-style name, the no-pin case being byte-identical to before, and a shell-safety check asserting no `( ) ' ! *` survives into any emitted line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)