### PR TITLE
Bump to 1.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Patch release covering everything merged since 1.1.10.

### Account pinning

- **`TC_ACCT`** pins a whole session to one account, bypassing rotation, and works in **both** modes (#142). Pinning previously only worked under `--no-mitm`, because the pin lived in the request path — and inside a CONNECT tunnel the path is the real upstream one, so MITM (the default) had nowhere to put it. Under MITM the pin now rides in the proxy URL's userinfo and arrives as the CONNECT's `Proxy-Authorization` username; under `--no-mitm` teamclaude builds the pinned base URL itself.

  ```bash
  TC_ACCT=me@example.com teamclaude run
  ```

  `TC_ACCT` is removed from the environment before claude launches, so it never reaches the client or anything it spawns. `teamclaude env` honours it identically (#143).

- **Pins resolve by stable identity** (#143): `accountUuid`, `orgUuid`, or `accountUuid/orgUuid`, falling back to the display name or bare email. `teamclaude accounts` now prints the ID.

  The rotation index is no longer accepted. It was array position, so deleting an account silently repointed every later pin at a *different* account. The warmer, which was its only real user, now pins by `accountUuid`.

- **`/tc-acct/` is deprecated** in favour of `TC_ACCT` — it cannot work in MITM mode, so it only ever covered half the product. Still supported for keep-warm and direct API callers.

### Notes

Verified against Claude Code 2.1.220: it sends `Proxy-Authorization` preemptively on every CONNECT, and percent-decodes URL userinfo before base64, so email-style account names with `@`, spaces and parens survive intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)