### PR TITLE
feat(tui): ←→ cycle the pin target in the account picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ teamclaude route rm fable
 
 **Inline markers (TUI).** Instead of a separate list, each route surfaces on the account rows as a colored `►`: next to the **`F7`/`S7`** bar for a Fable/Sonnet route, or at the **start of the row** for a general route (one fixed column per route so its position is stable). The marker is bold on the account a route is pinned to, dim when that account is currently ineligible. `teamclaude status` (the CLI text dump) still prints the routes as a list, now colored and annotated with any pin.
 
-**Manual per-route switching (TUI).** Press **`s`** to switch accounts, then **`Tab`** to choose *what* you're switching: the global **default** account, or a specific **route**. Pick an account with `↑/↓` and **`Enter`** to pin that route to it; `Enter` again on the current pin clears it. Pins are a **runtime preference** — not saved to config — and routing **falls back** to normal best-available selection whenever the pinned account is throttled or over quota, so a pin never stalls requests.
+**Manual per-route switching (TUI).** Press **`s`** to switch accounts, then **`←`/`→`** (or **`Tab`**) to choose *what* you're switching: the global **default** account, or a specific **route**. Pick an account with `↑/↓` and **`Enter`** to pin that route to it; `Enter` again on the current pin clears it. Pins are a **runtime preference** — not saved to config — and routing **falls back** to normal best-available selection whenever the pinned account is throttled or over quota, so a pin never stalls requests.
 
 ### Quota probe (optional, off by default)
 

--- a/src/tui.js
+++ b/src/tui.js
@@ -534,14 +534,11 @@ export class TUI {
     const len = this.am.accounts.length;
     if (k === 'up' || k === 'k') this.selIdx = Math.max(0, this.selIdx - 1);
     else if (k === 'down' || k === 'j') this.selIdx = Math.min(len - 1, this.selIdx + 1);
-    // Tab (switch only): cycle which route the pick applies to. null = the global
-    // default account; each getRoutes() entry = a per-route manual pin.
-    else if (k === 'tab' && this.selAction === 'switch') {
-      const routes = this.am.getRoutes();
-      const cycle = [null, ...routes];
-      const at = this.selRoute ? routes.findIndex(r => r.name === this.selRoute.name) + 1 : 0;
-      this.selRoute = cycle[(at + 1) % cycle.length];
-    }
+    // Tab / ←→ (switch only): cycle which route the pick applies to. null = the
+    // global default account; each getRoutes() entry = a per-route manual pin.
+    // ↑↓ move within the account list, so ←→ are free to move across targets.
+    else if ((k === 'tab' || k === 'right') && this.selAction === 'switch') this._cycleSelRoute(+1);
+    else if (k === 'left' && this.selAction === 'switch') this._cycleSelRoute(-1);
     else if (k === 'enter') {
       if (this.selAction === 'switch') {
         this._doSwitchSelection();
@@ -553,6 +550,18 @@ export class TUI {
       if (this.mode === 'select') this.mode = this.selReturn;
     }
     else if (k === 'esc' || k === 'q') { this.mode = this.selReturn; }
+  }
+
+  // Step the switch-mode pin target by `dir` through [default, ...routes],
+  // wrapping at both ends. A route that vanished between renders (an autocreated
+  // family route whose quota expired) leaves us at the default rather than
+  // stranding the cursor.
+  _cycleSelRoute(dir) {
+    const routes = this.am.getRoutes();
+    const cycle = [null, ...routes];
+    const at = this.selRoute ? routes.findIndex(r => r.name === this.selRoute.name) + 1 : 0;
+    const from = at < 1 ? 0 : at; // findIndex -1 → 0 → treat as the default entry
+    this.selRoute = cycle[(from + dir + cycle.length) % cycle.length];
   }
 
   // Apply an Enter in switch mode: with no route selected this sets the global
@@ -1413,7 +1422,7 @@ export class TUI {
           const target = this.selRoute
             ? routeColorFn(this.selRoute.color)(`route ${this.selRoute.name}`)
             : 'default';
-          return ` ${dim('↑↓')} select  ${bold('Tab')} target: ${target}  ${bold('Enter')} pin  ${bold('Esc')} cancel`;
+          return ` ${dim('↑↓')} select  ${dim('←→')} target: ${target}  ${bold('Enter')} pin  ${bold('Esc')} cancel`;
         }
         const act = this.selAction === 'toggle' ? 'enable/disable' : 'remove';
         return ` ${dim('↑↓')} select  ${bold('Enter')} ${act}  ${bold('Esc')} cancel`;

--- a/test/tui-routes.test.js
+++ b/test/tui-routes.test.js
@@ -170,6 +170,37 @@ test('TUI switch mode: Tab is inert for remove/toggle actions', () => {
   assert.equal(tui.selRoute, null);    // unchanged — Tab only cycles in switch mode
 });
 
+test('TUI switch mode: ←→ cycle the pin target both ways and wrap', () => {
+  const mk = n => ({
+    name: n, match: [`*${n}*`], color: 'red', autocreated: true, pinned: null,
+    accounts: [{ name: 'a', eligible: true }, { name: 'b', eligible: true }],
+  });
+  const { tui } = makeTUI({ routes: [mk('fable'), mk('sonnet')] });
+
+  tui._key('s');
+  assert.equal(tui.selRoute, null);     // default
+  tui._key('right');
+  assert.equal(tui.selRoute?.name, 'fable');
+  tui._key('right');
+  assert.equal(tui.selRoute?.name, 'sonnet');
+  tui._key('right');
+  assert.equal(tui.selRoute, null);     // wraps forward to the default
+  tui._key('left');
+  assert.equal(tui.selRoute?.name, 'sonnet'); // wraps backward to the last route
+  tui._key('left');
+  assert.equal(tui.selRoute?.name, 'fable');
+  tui._key('left');
+  assert.equal(tui.selRoute, null);
+});
+
+test('TUI switch mode: ←→ are inert for remove/toggle actions', () => {
+  const routes = [{ name: 'fable', match: ['*fable*'], accounts: [{ name: 'a', eligible: true }] }];
+  const { tui } = makeTUI({ routes });
+  tui._key('d');                       // toggle action
+  tui._key('right'); tui._key('left');
+  assert.equal(tui.selRoute, null);
+});
+
 test('TUI: the F7 (Fable) marker sits on exactly one account — the routing target', () => {
   const future = Date.now() + 7 * 24 * 3600_000;
   const oauth = n => ({ name: n, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: future });


### PR DESCRIPTION
In the account picker (`s`), `Tab` was the only key that moved between the global **default** and a per-route pin. `←`/`→` — which *do* work on the settings screen — were unbound in select mode, so reaching for them did nothing.

- `→` steps the pin target forward, `←` steps back; `Tab` stays as an alias. `↑↓` already move within the account list, so the horizontal axis was free.
- Cycling wraps in both directions, and falls back to the default when the targeted route no longer exists (an autocreated `fable`/`sonnet` route whose quota data expired) instead of stranding the cursor.
- Footer hint updated to `↑↓ select  ←→ target: <route>  Enter pin  Esc cancel`; README updated to match.
- Both keys stay inert for the remove/disable actions.

Tests: bidirectional cycling with wrap-around, and inertness in toggle mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)