### PR TITLE
fix(tui): draw the event-logging and blocked-models settings rows

### DIFF
--- a/src/tui.js
+++ b/src/tui.js
@@ -1087,9 +1087,14 @@ export class TUI {
     lines.push(bold('  Quota probe') + dim('  — refresh idle accounts from the usage endpoint'));
     lines.push(row(byId('probe')));
     lines.push('');
+    // ── Activity log
+    lines.push(bold('  Activity log') + dim('  — what to do with Claude Code\'s telemetry'));
+    lines.push(row(byId('eventlog')));
+    lines.push('');
     // ── Routing
-    lines.push(bold('  Routing') + dim('  — pin model families to specific accounts'));
+    lines.push(bold('  Routing') + dim('  — pin model families to specific accounts, or block them outright'));
     lines.push(row(byId('routes')));
+    lines.push(row(byId('blocklist')));
     lines.push('');
     // ── Accounts
     lines.push(bold('  Accounts') + dim('  — add (import / API key) or remove an account'));

--- a/test/tui-settings.test.js
+++ b/test/tui-settings.test.js
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TUI } from '../src/tui.js';
+
+// The settings screen keeps two lists in step: _settingsFields() drives the
+// cursor (↑↓ walk it, ←→/Enter act on the current entry) and _renderSettings()
+// draws the rows. A field present in the first but missing from the second is
+// invisible yet reachable: the cursor lands on nothing and ←→ silently change a
+// setting the operator can't see.
+
+const stripAnsi = s => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+function makeTUI({ sx = null } = {}) {
+  const am = {
+    accounts: [{ name: 'a', index: 0, type: 'oauth', credential: 't' }],
+    currentIndex: 0,
+    switchThreshold: 0.98,
+    getRoutes() { return []; },
+  };
+  const config = { proxy: { port: 1 }, accounts: [{ name: 'a', type: 'oauth' }], routes: [], blockedModels: [] };
+  const tui = new TUI({
+    accountManager: am, config, sx,
+    saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {},
+  });
+  tui.render = () => {};
+  return tui;
+}
+
+function renderWithCursorAt(tui, idx) {
+  tui.setIdx = idx;
+  const lines = [];
+  tui._renderSettings(lines);
+  return lines.map(stripAnsi).join('\n');
+}
+
+test('settings: every navigable row is drawn, and the cursor stays visible on it', () => {
+  const tui = makeTUI();
+  const fields = tui._settingsFields();
+  assert.ok(fields.length > 0);
+
+  for (let i = 0; i < fields.length; i++) {
+    const text = renderWithCursorAt(tui, i);
+    assert.ok(text.includes(fields[i].label),
+      `"${fields[i].label}" is reachable with the cursor but never drawn`);
+    assert.ok(text.includes('▸'),
+      `the cursor vanishes while "${fields[i].label}" is selected`);
+  }
+});
+
+test('settings: sx.org rows are drawn once an sx client exists', () => {
+  const sx = {
+    getMode: () => 'always',
+    getProxy: () => ({ host: '203.0.113.7', port: 8080 }),
+    isProvisioned: () => true,
+  };
+  const tui = makeTUI({ sx });
+  tui.config.sx = { apiKey: 'sx-abcd1234' };
+  const fields = tui._settingsFields();
+
+  for (let i = 0; i < fields.length; i++) {
+    const text = renderWithCursorAt(tui, i);
+    assert.ok(text.includes(fields[i].label),
+      `"${fields[i].label}" is reachable with the cursor but never drawn`);
+  }
+});


### PR DESCRIPTION
`_settingsFields()` has entries for `eventlog` and `blocklist`, so the cursor walks onto them and ←/→ act on them, but `_renderSettings()` never drew a row for either. Two positions on the settings screen show no highlight bar at all: press ↓ twice from Switch threshold and the cursor is gone, and ←/→ there cycle event logging blind.

Event logging now gets its own section after the quota probe, blocked models sits under Routing next to the route editor. Both in the order the cursor already visits them.

The test walks the cursor over every field and asserts the row is drawn and keeps the highlight, so the next field added to one list and not the other fails instead of going invisible.

Found while checking the docs against the code. The README told people to press `k` for the sx.org key and `t` for the threshold, which stopped being true when the screen became a list, and looking for those keys is what surfaced the missing rows.
