### PR TITLE
fix(server): don't hand the client a 403 meant for the proxy's own account

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -608,14 +608,26 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // account needs attention, not a retry — so say so plainly rather than
     // reporting a rate limit. Not a 403 either: the client's own credential is
     // fine, and a 403 would make it drop its login over someone else's problem.
-    if (ctx.credentialRejected) {
+    //
+    // Only when the refusals are the WHOLE story, though. If some accounts were
+    // refused and others are merely out of quota, a reset will still serve this
+    // request — so fall through to the retry-after/hold path below rather than
+    // failing fast on the strength of one bad credential. Reporting 502 there
+    // would turn a recoverable exhaustion into a hard error, and silently skip
+    // the holdSeconds wait an unattended run depends on.
+    const rejected = ctx.credentialRejected;
+    const allRefused = rejected?.size > 0 && (ctx.pinnedIndex != null
+      ? rejected.has(accountManager.accounts[ctx.pinnedIndex]?.name)
+      : rejected.size === accountManager.accounts.length);
+    if (allRefused) {
+      const names = [...rejected].map(n => `"${n}"`).join(', ');
       ctx.status = 502;
-      ctx.account = `(${ctx.credentialRejected} refused)`;
+      ctx.account = `(${[...rejected].join(', ')} refused)`;
       if (!res.headersSent) {
         res.writeHead(502, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           type: 'error',
-          error: { type: 'proxy_error', message: `Upstream refused the credential for account "${ctx.credentialRejected}" (403). Check the account, then re-add it with: teamclaude login` },
+          error: { type: 'proxy_error', message: `Upstream refused the credential for account ${names} (403). Check the account, then re-add it with: teamclaude login` },
         }));
       }
       return;
@@ -890,7 +902,10 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // account left, the no-account branch reports a proxy error instead.
     if (upstreamRes.status === 403 && !res.headersSent) {
       await upstreamRes.body?.cancel();
-      ctx.credentialRejected = account.name;
+      // A set, not a name: the no-account branch needs to tell "every account was
+      // refused" (fail fast, nothing to wait for) from "this one was, others are
+      // just out of quota" (still worth holding for a reset).
+      (ctx.credentialRejected ??= new Set()).add(account.name);
       ctx.tried.add(account.index);
       console.error(`[TeamClaude] 403 on "${account.name}" — upstream refused the account credential`);
       return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);

--- a/src/server.js
+++ b/src/server.js
@@ -604,6 +604,22 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
     : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId);
   if (!account) {
+    // Every candidate was refused by upstream (403). Waiting will not help — the
+    // account needs attention, not a retry — so say so plainly rather than
+    // reporting a rate limit. Not a 403 either: the client's own credential is
+    // fine, and a 403 would make it drop its login over someone else's problem.
+    if (ctx.credentialRejected) {
+      ctx.status = 502;
+      ctx.account = `(${ctx.credentialRejected} refused)`;
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          type: 'error',
+          error: { type: 'proxy_error', message: `Upstream refused the credential for account "${ctx.credentialRejected}" (403). Check the account, then re-add it with: teamclaude login` },
+        }));
+      }
+      return;
+    }
     // A pinned request concerns exactly one account: don't compute a fleet-wide
     // retry-after or sleep on other accounts' windows — return immediately.
     if (ctx.pinnedIndex != null) {
@@ -865,6 +881,21 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // retry's status check rotates to another account. Bounded to one re-auth
     // per account per request, so a genuinely dead credential surfaces the 401
     // instead of looping.
+    // A 403 ("Request not allowed") is upstream refusing THIS account outright —
+    // not a stale token a refresh could fix, and not anything the client sent.
+    // The client never sees the credential we inject, so it cannot act on the
+    // rejection; Claude Code reads a 403 as "your session is dead", drops its
+    // own login and asks for a re-login over an account problem it has no part
+    // in. Skip the account for the rest of this request and fail over. With no
+    // account left, the no-account branch reports a proxy error instead.
+    if (upstreamRes.status === 403 && !res.headersSent) {
+      await upstreamRes.body?.cancel();
+      ctx.credentialRejected = account.name;
+      ctx.tried.add(account.index);
+      console.error(`[TeamClaude] 403 on "${account.name}" — upstream refused the account credential`);
+      return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+    }
+
     if (upstreamRes.status === 401 && account.type === 'oauth' && account.refreshToken
         && retryCount < maxRetries && !ctx.reauthed.has(account.index)) {
       ctx.reauthed.add(account.index);

--- a/test/server-403.test.js
+++ b/test/server-403.test.js
@@ -94,3 +94,74 @@ test('a 403 fails over to another account', async () => {
     upstream.close();
   }
 });
+
+// Two dead credentials and nothing else: there is genuinely nothing to wait for,
+// so fail fast and name both rather than inventing a retry-after.
+test('with every account refused the error names all of them', async () => {
+  const { server: upstream } = forbiddingUpstream(new Set());
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [
+      { name: 'a', type: 'oauth', accessToken: 'ta', refreshToken: 'ra', expiresAt: Date.now() + HOUR },
+      { name: 'b', type: 'oauth', accessToken: 'tb', refreshToken: 'rb', expiresAt: Date.now() + HOUR },
+    ],
+    0.98,
+    { refreshFn: async () => { throw new Error('must not refresh on a 403'); } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const { status, body } = await post(proxyPort);
+    assert.equal(status, 502);
+    assert.match(body, /\\"a\\"/);                     // quotes are JSON-escaped in the body
+    assert.match(body, /\\"b\\"/);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// The mixed fleet: one credential is refused, the other account is merely out of
+// quota. A reset will still serve this request, so the refusal must not short —
+// circuit the exhaustion path — otherwise one bad credential turns every
+// recoverable exhaustion into a hard 502 and skips the holdSeconds wait that an
+// unattended run depends on.
+test('a refusal alongside a merely-exhausted account still reports exhaustion', async () => {
+  const upstream = http.createServer((req, res) => {
+    if (req.headers.authorization === 'Bearer ta') {
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'permission_error', message: 'Request not allowed' } }));
+      return;
+    }
+    // Durable quota rejection, far enough out that no inline retry absorbs it.
+    res.writeHead(429, {
+      'retry-after': '300',
+      'anthropic-ratelimit-unified-5h-status': 'rejected',
+      'content-type': 'application/json',
+    });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [
+      { name: 'a', type: 'oauth', accessToken: 'ta', refreshToken: 'ra', expiresAt: Date.now() + HOUR },
+      { name: 'b', type: 'oauth', accessToken: 'tb', refreshToken: 'rb', expiresAt: Date.now() + HOUR },
+    ],
+    0.98,
+    { refreshFn: async () => { throw new Error('must not refresh on a 403'); } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const { status, body } = await post(proxyPort);
+    assert.equal(status, 429, 'quota exhaustion, not a hard credential error');
+    assert.match(body, /rate_limit_error/);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});

--- a/test/server-403.test.js
+++ b/test/server-403.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const HOUR = 3600_000;
+
+// Upstream answers 403 "Request not allowed" to every token outside `live` —
+// how Anthropic rejects a credential it will not serve at all (as opposed to a
+// 401, which says the token merely needs refreshing). Records each bearer so a
+// test can prove which account was tried.
+function forbiddingUpstream(live) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    const token = (req.headers.authorization || '').replace(/^Bearer /, '');
+    seen.push(token);
+    if (!live.has(token)) {
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'permission_error', message: 'Request not allowed' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  return { server, seen };
+}
+
+async function post(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'x', messages: [] }),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+// The client never sees the credential the proxy injects, so a 403 about that
+// credential is not something the client can act on — but Claude Code reads a
+// 403 as "your session is dead", drops its own login and asks for a re-login.
+// Report it as a proxy error instead: the account needs attention, the client's
+// own credential is untouched.
+test('a 403 on the injected credential reaches the client as a proxy error, not a 403', async () => {
+  const { server: upstream, seen } = forbiddingUpstream(new Set());   // nothing is accepted
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + HOUR }],
+    0.98,
+    { refreshFn: async () => { throw new Error('must not refresh on a 403'); } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const { status, body } = await post(proxyPort);
+    assert.equal(status, 502);
+    assert.match(body, /proxy_error/);
+    assert.match(body, /account \\"a\\"/);             // names the account that was rejected
+    assert.equal(seen.length, 1);                      // no other account to try
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A 403 is about one account's credential, so the request itself is still
+// serveable — fail over the way the 401 path does rather than giving up.
+test('a 403 fails over to another account', async () => {
+  const { server: upstream, seen } = forbiddingUpstream(new Set(['b-token']));
+  const upstreamPort = await listen(upstream);
+
+  const am = new AccountManager(
+    [
+      { name: 'a', type: 'oauth', accessToken: 'a-token', refreshToken: 'ra', expiresAt: Date.now() + HOUR },
+      { name: 'b', type: 'oauth', accessToken: 'b-token', refreshToken: 'rb', expiresAt: Date.now() + HOUR },
+    ],
+    0.98,
+    { refreshFn: async () => { throw new Error('must not refresh on a 403'); } },
+  );
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200);
+    assert.deepEqual(seen, ['a-token', 'b-token']);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});


### PR DESCRIPTION
Upstream answers 403 "Request not allowed" when it refuses the account whose credential the proxy injected. The client never sees that credential, so it cannot act on the rejection — but Claude Code reads a 403 as a dead session: it drops its own login and asks the user to re-authenticate over an account problem it has no part in. A flapping connection is enough to trigger it, and the user is logged out of a working session.

```text
Please run /login · API Error: 403 Request not allowed
```

Skip the refused account for the rest of the request and fail over, the way the 401 path already does. With no account left, report a proxy error naming the account rather than a rate limit that suggests waiting will help.
