### PR TITLE
feat(server): record a fatal error to a crash log before exiting

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,15 @@ export function getStatePath() {
   return cfg.endsWith('.json') ? cfg.replace(/\.json$/, '.state.json') : cfg + '.state';
 }
 
+/**
+ * Path to the crash log (a sibling of the config), where a fatal error is
+ * recorded before the process exits.
+ */
+export function getCrashLogPath() {
+  const cfg = getConfigPath();
+  return cfg.endsWith('.json') ? cfg.replace(/\.json$/, '-crash.log') : cfg + '-crash.log';
+}
+
 export async function loadState() {
   try {
     return JSON.parse(await readFile(getStatePath(), 'utf-8'));

--- a/src/crash-log.js
+++ b/src/crash-log.js
@@ -1,0 +1,27 @@
+import { appendFileSync } from 'node:fs';
+
+/**
+ * Write a fatal error to `path` before the process dies.
+ *
+ * Node prints an uncaught exception to stderr and exits, which is invisible in
+ * practice: the server runs under a full-screen TUI that repaints over the
+ * stack, and stderr usually goes nowhere anyone kept. The one artifact that
+ * explains a sudden exit has to outlive the process, so write it to a file.
+ *
+ * Handling these events replaces Node's own behaviour, so this must do what
+ * Node would: report and exit non-zero. Continuing after an uncaught exception
+ * would leave the proxy running on unknown state.
+ */
+export function installCrashHandlers(path, { exit = process.exit, log = process.stderr } = {}) {
+  const report = (kind) => (err) => {
+    const stack = err?.stack || String(err);
+    const entry = `\n=== ${new Date().toISOString()} ${kind} ===\n${stack}\n`;
+    // 0600: a stack can carry request context. A write failure (read-only home,
+    // full disk) must not mask the crash itself — stderr still gets the entry.
+    try { appendFileSync(path, entry, { mode: 0o600 }); } catch { /* report to stderr regardless */ }
+    log.write(entry);
+    exit(1);
+  };
+  process.on('uncaughtException', report('uncaughtException'));
+  process.on('unhandledRejection', report('unhandledRejection'));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { createWriteStream } from 'node:fs';
 import net from 'node:net';
-import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, loadState, saveState } from './config.js';
+import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, getCrashLogPath, loadState, saveState } from './config.js';
+import { installCrashHandlers } from './crash-log.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
@@ -117,6 +118,13 @@ switch (command) {
 // ── server ──────────────────────────────────────────────────
 
 async function serverCommand() {
+  // Installed first: the server is the long-lived process, it runs under a TUI
+  // that repaints over anything Node prints on the way out, and a crash here
+  // takes every routed session with it. Without this, a proxy that vanished
+  // overnight leaves nothing behind to explain why.
+  const crashLog = getCrashLogPath();
+  installCrashHandlers(crashLog);
+
   const config = await loadOrCreateConfig();
 
   // --log-to <dir>
@@ -1364,6 +1372,7 @@ on the next launch). Disable with TEAMCLAUDE_DISABLE_AUTOUPDATE=1 or
 "autoUpdate": false in the config.
 
 Config: ${getConfigPath()}
+Crash log: ${getCrashLogPath()} (server; written when the process dies unexpectedly)
 `);
 }
 

--- a/test/crash-log.test.js
+++ b/test/crash-log.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getCrashLogPath } from '../src/config.js';
+
+const CRASH_LOG = fileURLToPath(new URL('../src/crash-log.js', import.meta.url));
+
+// The handlers end the process, so they can only be exercised from a child.
+// Returns { code, stderr, logged } — the last being what survived on disk.
+function crashIn(dir, source) {
+  const path = join(dir, 'crash.log');
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ['--input-type=module', '--eval',
+        `import { installCrashHandlers } from ${JSON.stringify(CRASH_LOG)};
+         installCrashHandlers(${JSON.stringify(path)});
+         ${source}`],
+      async (err, _stdout, stderr) => {
+        const logged = await readFile(path, 'utf-8').catch(() => '');
+        resolve({ code: err?.code ?? 0, stderr, logged });
+      },
+    );
+  });
+}
+
+test('an uncaught exception is recorded before the process dies', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-crash-'));
+  try {
+    const { code, stderr, logged } = await crashIn(dir, 'setTimeout(() => { throw new Error("boom"); }, 0);');
+    assert.equal(code, 1);                       // still exits like Node would
+    assert.match(logged, /uncaughtException/);
+    assert.match(logged, /Error: boom/);
+    assert.match(logged, /at /);                 // the stack, not just the message
+    assert.match(stderr, /Error: boom/);         // and stderr keeps working
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// A rejected promise nobody handles kills the process the same way an uncaught
+// exception does, and is just as invisible under the TUI.
+test('an unhandled rejection is recorded too', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-crash-'));
+  try {
+    const { code, logged } = await crashIn(dir, 'Promise.reject(new Error("nope"));');
+    assert.equal(code, 1);
+    assert.match(logged, /unhandledRejection/);
+    assert.match(logged, /Error: nope/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Successive crashes must accumulate: the interesting one is often the first,
+// and a restart loop would otherwise overwrite it.
+test('crashes append rather than overwrite', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-crash-'));
+  try {
+    await crashIn(dir, 'throw new Error("first");');
+    const { logged } = await crashIn(dir, 'throw new Error("second");');
+    assert.match(logged, /Error: first/);
+    assert.match(logged, /Error: second/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the crash log sits next to the config', () => {
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = '/tmp/somewhere/teamclaude.json';
+  try {
+    assert.equal(getCrashLogPath(), '/tmp/somewhere/teamclaude-crash.log');
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+  }
+});


### PR DESCRIPTION
When the server dies unexpectedly there is nothing left to explain it. Node prints the stack to stderr and exits, but the server runs under a full-screen TUI that repaints over it, and stderr is rarely redirected anywhere that outlives the process — so a proxy that vanished mid-session gives the operator nothing to go on.

Write the stack — and unhandled rejections, which end the process the same way — to a crash log beside the config, then exit non-zero as Node would. Entries append, so a restart loop keeps the first and usually most informative failure. `--help` prints the path.
