### PR TITLE
feat(server): opt-in egress pin holds requests when the exit IP changes

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -38,5 +38,11 @@
       "accounts": ["primary-max"],
       "color": "magenta"
     }
-  ]
+  ],
+  "egress": {
+    "pin": "auto",
+    "checkUrl": "https://api.ipify.org",
+    "ttlSeconds": 30,
+    "holdSeconds": 120
+  }
 }

--- a/src/egress-guard.js
+++ b/src/egress-guard.js
@@ -1,0 +1,132 @@
+// Egress pinning — refuse to spend an account from the wrong exit IP.
+//
+// When a VPN drops mid-session, traffic silently continues from the machine's
+// own address. Anthropic answers a request from an unexpected region with 403
+// "Request not allowed", and Claude Code reads that 403 as a dead session and
+// asks for a re-login — over a network event, with the token still valid. The
+// account has already been used from the new address by then.
+//
+// So the check belongs BEFORE the request: if the exit IP is not the pinned
+// one, hold the request until the tunnel is back rather than sending it. A held
+// request looks like a slow response; a sent one can cost a re-login.
+//
+// Opt-in: without `egress.pin` in the config this is inert and nothing here runs.
+
+const DEFAULT_CHECK_URL = 'https://api.ipify.org';
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_HOLD_MS = 120_000;
+const POLL_MS = 3_000;
+
+export class EgressGuard {
+  /**
+   * @param {object} opts
+   * @param {string|string[]} opts.pin  'auto' (pin whatever is seen first), or one or more allowed IPs
+   */
+  constructor({ pin, checkUrl = DEFAULT_CHECK_URL, ttlMs = DEFAULT_TTL_MS, holdMs = DEFAULT_HOLD_MS,
+    fetchImpl = fetch, pollMs = POLL_MS, log = () => {} } = {}) {
+    this.pin = pin || null;
+    this.checkUrl = checkUrl;
+    this.ttlMs = ttlMs;
+    this.holdMs = holdMs;
+    this.pollMs = pollMs;
+    this._fetch = fetchImpl;
+    this.log = log;
+    this._ip = null;         // last observed exit IP
+    this._checkedAt = 0;     // when it was observed
+    this._auto = null;       // the address 'auto' latched onto
+    this._inFlight = null;   // coalesces concurrent probes
+  }
+
+  enabled() { return !!this.pin; }
+
+  /** The addresses considered correct, once known. */
+  allowed() {
+    if (this.pin === 'auto') return this._auto ? [this._auto] : [];
+    return Array.isArray(this.pin) ? this.pin : [this.pin];
+  }
+
+  /**
+   * Current exit IP, cached for ttlMs. Returns null when the probe fails — the
+   * caller treats that as "unknown", never as "wrong": a probe that cannot
+   * complete is usually the same outage that is about to fail the request
+   * anyway, and blocking on it would turn a third-party hiccup into an outage
+   * of our own.
+   */
+  async currentIp({ force = false } = {}) {
+    if (!force && this._ip && Date.now() - this._checkedAt < this.ttlMs) return this._ip;
+    if (this._inFlight) return this._inFlight;
+
+    this._inFlight = (async () => {
+      try {
+        const res = await this._fetch(this.checkUrl, { signal: AbortSignal.timeout(5_000) });
+        const ip = (await res.text()).trim();
+        if (!ip) return null;
+        this._ip = ip;
+        this._checkedAt = Date.now();
+        // 'auto' pins the first address it sees. The server starts with the
+        // tunnel up in the normal case, so that address is the one to hold for.
+        if (this.pin === 'auto' && !this._auto) {
+          this._auto = ip;
+          this.log(`[TeamClaude] Egress pinned to ${ip}`);
+        }
+        return ip;
+      } catch {
+        return null;
+      } finally {
+        this._inFlight = null;
+      }
+    })();
+
+    return this._inFlight;
+  }
+
+  /** Is `ip` one of the pinned addresses? Unknown (null) counts as allowed. */
+  matches(ip) {
+    if (!ip) return true;
+    const allowed = this.allowed();
+    return allowed.length === 0 || allowed.includes(ip);
+  }
+
+  /** One check against the pin: { ok, ip, expected }. */
+  async check(opts) {
+    const ip = await this.currentIp(opts);
+    return { ok: this.matches(ip), ip, expected: this.allowed() };
+  }
+
+  /**
+   * Block until the exit IP is the pinned one again, or the hold budget runs
+   * out. Returns { ok, ip, expected, waitedMs } — ok:false means the caller
+   * should refuse the request rather than send it from the wrong address.
+   */
+  async waitUntilPinned({ isAborted = () => false } = {}) {
+    const started = Date.now();
+    let state = await this.check();
+    if (state.ok) return { ...state, waitedMs: 0 };
+
+    this.log(`[TeamClaude] Egress is ${state.ip}, not the pinned ${state.expected.join(', ')} — holding requests`);
+    while (Date.now() - started < this.holdMs) {
+      if (isAborted()) return { ...state, waitedMs: Date.now() - started };
+      await new Promise(resolve => setTimeout(resolve, this.pollMs));
+      state = await this.check({ force: true });
+      if (state.ok) {
+        const waitedMs = Date.now() - started;
+        this.log(`[TeamClaude] Egress back on ${state.ip} after ${Math.round(waitedMs / 1000)}s`);
+        return { ...state, waitedMs };
+      }
+    }
+    return { ...state, waitedMs: Date.now() - started };
+  }
+}
+
+/** Build a guard from config, or null when the feature is not configured. */
+export function createEgressGuard(config, log) {
+  const cfg = config?.egress;
+  if (!cfg?.pin) return null;
+  return new EgressGuard({
+    pin: cfg.pin,
+    checkUrl: cfg.checkUrl,
+    ttlMs: cfg.ttlSeconds != null ? cfg.ttlSeconds * 1000 : undefined,
+    holdMs: cfg.holdSeconds != null ? cfg.holdSeconds * 1000 : undefined,
+    log,
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1359,6 +1359,14 @@ launched with and without --no-mitm can share one server.
 A running server re-syncs accounts from config on POST /teamclaude/reload
 (local only). add/login/enable/disable/priority trigger it automatically.
 
+Egress pin (opt-in, off unless configured). Set "egress": { "pin": "auto" } to
+hold requests whenever the exit IP is not the pinned one — a VPN that dropped
+mid-session otherwise sends the request from an unexpected region, and upstream
+answers 403, which Claude Code reports as a dead session and demands a re-login.
+"auto" pins whatever address the server sees first; an explicit IP (or a list of
+them) pins those. Held requests wait up to holdSeconds (default 120), then get a
+503. See config.example.json.
+
 A global npm install self-updates in the background (checked once/day, applied
 on the next launch). Disable with TEAMCLAUDE_DISABLE_AUTOUPDATE=1 or
 "autoUpdate": false in the config.

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -110,7 +110,7 @@ export function hostMode(host, config) {
  * the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const proxyApiKey = config.proxy?.apiKey;
   const holdMs = (config.holdSeconds || 0) * 1000;
@@ -135,7 +135,7 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     p = (async () => {
     const { key, cert } = await ensureLeaf();
     const srv = http2.createSecureServer({ key, cert, allowHTTP1: true });
-    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null }));
+    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null, egress }));
     // Remote Control's real-time channel is a WebSocket (Upgrade handshake),
     // which never fires 'request' — only 'upgrade', with a raw socket instead
     // of a response object (h1-only; falls back to blind h2 passthrough is not

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
+import { createEgressGuard } from './egress-guard.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -117,7 +118,10 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
     }
   };
 
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config });
+  // Opt-in egress pin: null unless config.egress.pin is set, and then shared by
+  // the base listener and the MITM one so both honour the same hold.
+  const egress = createEgressGuard(config, console.error);
+  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, egress });
   const server = http.createServer(requestHandler);
 
   // Forward-proxy support (always on, so multiple claude instances can use
@@ -134,7 +138,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx, egress }));
   // Remote Control's real-time channel is a WebSocket, not a request/response
   // call — Node fires 'upgrade' for that handshake, never 'request', so it
   // needs its own listener (base-URL routing path; the MITM path wires the
@@ -241,7 +245,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/f
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
-export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null }) {
+export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null }) {
   let counter = 0;
   return async (req, res) => {
     try {
@@ -258,6 +262,27 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         return;
       }
       const hideActivity = isEventLog && eventLogging !== 'show';
+      // Egress pin (opt-in): with the exit IP off the pinned one — a VPN that
+      // dropped — hold rather than send. Upstream answers a request from an
+      // unexpected region with a 403 that Claude Code reports as a dead session,
+      // so sending it costs a re-login while waiting costs latency. Checked here
+      // rather than per-account: it is a property of the connection, and this is
+      // the one path every request takes, MITM included.
+      if (egress?.enabled()) {
+        const state = await egress.waitUntilPinned({ isAborted: () => res.destroyed });
+        if (res.destroyed) return;
+        if (!state.ok) {
+          res.writeHead(503, { 'Content-Type': 'application/json', 'retry-after': '30' });
+          res.end(JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'proxy_error',
+              message: `Egress is ${state.ip || 'unknown'}, not the pinned ${state.expected.join(', ')} — not sending this request. Check the VPN.`,
+            },
+          }));
+          return;
+        }
+      }
       // Client token refresh: pass through untouched (the proxy manages its own
       // tokens via ensureTokenFresh; rewriting client refreshes would conflict).
       if (req.method === 'POST' && req.url === '/v1/oauth/token') { await relayRaw(req, res, upstream, sx); return; }

--- a/test/egress-guard.test.js
+++ b/test/egress-guard.test.js
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EgressGuard, createEgressGuard } from '../src/egress-guard.js';
+
+// A probe whose answer the test controls, and which counts how often it ran.
+function fakeProbe(ips) {
+  const state = { calls: 0 };
+  const fetchImpl = async () => {
+    const ip = Array.isArray(ips) ? (ips[Math.min(state.calls, ips.length - 1)]) : ips;
+    state.calls++;
+    if (ip instanceof Error) throw ip;
+    return { text: async () => `${ip}\n` };
+  };
+  return { fetchImpl, state };
+}
+
+test('with no pin configured the guard is not built at all', () => {
+  assert.equal(createEgressGuard({}, () => {}), null);
+  assert.equal(createEgressGuard({ egress: {} }, () => {}), null);
+  assert.equal(createEgressGuard({ egress: { pin: 'auto' } }, () => {})?.enabled(), true);
+});
+
+test('an explicit pin allows only that address', async () => {
+  const { fetchImpl } = fakeProbe('203.0.113.7');
+  const guard = new EgressGuard({ pin: '203.0.113.7', fetchImpl });
+  assert.deepEqual(await guard.check(), { ok: true, ip: '203.0.113.7', expected: ['203.0.113.7'] });
+
+  const other = new EgressGuard({ pin: '198.51.100.9', fetchImpl });
+  const state = await other.check();
+  assert.equal(state.ok, false);
+  assert.equal(state.ip, '203.0.113.7');
+});
+
+test('several pinned addresses are all accepted', async () => {
+  const { fetchImpl } = fakeProbe('198.51.100.9');
+  const guard = new EgressGuard({ pin: ['203.0.113.7', '198.51.100.9'], fetchImpl });
+  assert.equal((await guard.check()).ok, true);
+});
+
+// 'auto' exists so the common case needs no configuration: the server starts
+// with the tunnel up, so whatever it sees first is the address to hold for.
+test('auto latches onto the first address it sees and holds it', async () => {
+  const { fetchImpl } = fakeProbe(['203.0.113.7', '192.0.2.55']);
+  const guard = new EgressGuard({ pin: 'auto', ttlMs: 0, fetchImpl });
+
+  assert.equal((await guard.check()).ok, true);          // pins 203.0.113.7
+  const after = await guard.check({ force: true });      // VPN dropped
+  assert.equal(after.ok, false);
+  assert.equal(after.ip, '192.0.2.55');
+  assert.deepEqual(after.expected, ['203.0.113.7']);
+});
+
+// A probe that cannot answer must not become an outage of our own: the point is
+// to block a KNOWN-wrong address, not to require the check service to be up.
+test('a failed probe is treated as unknown, not as wrong', async () => {
+  const { fetchImpl } = fakeProbe(new Error('getaddrinfo ENOTFOUND'));
+  const guard = new EgressGuard({ pin: '203.0.113.7', fetchImpl });
+  const state = await guard.check();
+  assert.equal(state.ip, null);
+  assert.equal(state.ok, true);
+});
+
+test('the observed address is cached for its ttl', async () => {
+  const { fetchImpl, state } = fakeProbe('203.0.113.7');
+  const guard = new EgressGuard({ pin: '203.0.113.7', ttlMs: 60_000, fetchImpl });
+  await guard.check();
+  await guard.check();
+  await guard.check();
+  assert.equal(state.calls, 1);
+  await guard.check({ force: true });
+  assert.equal(state.calls, 2);
+});
+
+test('concurrent checks share one probe', async () => {
+  const { fetchImpl, state } = fakeProbe('203.0.113.7');
+  const guard = new EgressGuard({ pin: '203.0.113.7', ttlMs: 0, fetchImpl });
+  await Promise.all([guard.check(), guard.check(), guard.check()]);
+  assert.equal(state.calls, 1);
+});
+
+// The whole point: a request must wait out a flap instead of going out from the
+// wrong address.
+test('waiting returns as soon as the pinned address is back', async () => {
+  const { fetchImpl } = fakeProbe(['192.0.2.55', '192.0.2.55', '203.0.113.7']);
+  const guard = new EgressGuard({ pin: '203.0.113.7', ttlMs: 0, holdMs: 5_000, pollMs: 5, fetchImpl });
+  const state = await guard.waitUntilPinned();
+  assert.equal(state.ok, true);
+  assert.equal(state.ip, '203.0.113.7');
+});
+
+test('waiting gives up when the hold budget runs out', async () => {
+  const { fetchImpl } = fakeProbe('192.0.2.55');
+  const guard = new EgressGuard({ pin: '203.0.113.7', ttlMs: 0, holdMs: 30, pollMs: 5, fetchImpl });
+  const state = await guard.waitUntilPinned();
+  assert.equal(state.ok, false);
+  assert.equal(state.ip, '192.0.2.55');
+});
+
+test('a client that hangs up stops the wait', async () => {
+  const { fetchImpl } = fakeProbe('192.0.2.55');
+  const guard = new EgressGuard({ pin: '203.0.113.7', ttlMs: 0, holdMs: 60_000, pollMs: 5, fetchImpl });
+  let gone = false;
+  setTimeout(() => { gone = true; }, 20);
+  const state = await guard.waitUntilPinned({ isAborted: () => gone });
+  assert.equal(state.ok, false);
+  assert.ok(state.waitedMs < 5_000);                     // returned early, not at the budget
+});

--- a/test/egress-hold.test.js
+++ b/test/egress-hold.test.js
@@ -1,0 +1,121 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyRequestListener } from '../src/server.js';
+import { EgressGuard } from '../src/egress-guard.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// Counts what actually reached upstream — the point of the guard is that a
+// request made from the wrong address never gets there.
+function countingUpstream() {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  return { server, seen };
+}
+
+function probeReturning(ips) {
+  let i = 0;
+  return async () => {
+    const ip = Array.isArray(ips) ? ips[Math.min(i, ips.length - 1)] : ips;
+    i++;
+    return { text: async () => ip };
+  };
+}
+
+async function post(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'x', messages: [] }),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+async function proxyWith(guard, upstreamPort) {
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k' }], 0.98);
+  const listener = createProxyRequestListener({
+    accountManager: am, upstream: `http://127.0.0.1:${upstreamPort}`, egress: guard,
+  });
+  const proxy = http.createServer(listener);
+  return { proxy, port: await listen(proxy) };
+}
+
+test('with the egress pinned and matching, requests pass through untouched', async () => {
+  const { server: upstream, seen } = countingUpstream();
+  const upstreamPort = await listen(upstream);
+  const guard = new EgressGuard({ pin: '203.0.113.7', fetchImpl: probeReturning('203.0.113.7') });
+  const { proxy, port } = await proxyWith(guard, upstreamPort);
+
+  try {
+    assert.equal((await post(port)).status, 200);
+    assert.equal(seen.length, 1);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// The core guarantee: a VPN that dropped must not leak the account onto the
+// machine's own address. Upstream must see nothing at all.
+test('an unpinned egress holds the request and never reaches upstream', async () => {
+  const { server: upstream, seen } = countingUpstream();
+  const upstreamPort = await listen(upstream);
+  const guard = new EgressGuard({
+    pin: '203.0.113.7', ttlMs: 0, holdMs: 40, pollMs: 5,
+    fetchImpl: probeReturning('192.0.2.55'),          // VPN down: home address
+  });
+  const { proxy, port } = await proxyWith(guard, upstreamPort);
+
+  try {
+    const { status, body } = await post(port);
+    assert.equal(status, 503);                        // not a 403 — nothing was asked upstream
+    assert.match(body, /192\.0\.2\.55/);              // says what it saw
+    assert.match(body, /203\.0\.113\.7/);             // and what it expected
+    assert.deepEqual(seen, []);                       // upstream never heard from us
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// A flap shorter than the hold budget should be invisible to the client beyond
+// the delay: the request waits, then goes out from the right address.
+test('a request held through a flap is sent once the pinned egress returns', async () => {
+  const { server: upstream, seen } = countingUpstream();
+  const upstreamPort = await listen(upstream);
+  const guard = new EgressGuard({
+    pin: '203.0.113.7', ttlMs: 0, holdMs: 5_000, pollMs: 5,
+    fetchImpl: probeReturning(['192.0.2.55', '192.0.2.55', '203.0.113.7']),
+  });
+  const { proxy, port } = await proxyWith(guard, upstreamPort);
+
+  try {
+    assert.equal((await post(port)).status, 200);
+    assert.equal(seen.length, 1);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+test('without a guard nothing changes', async () => {
+  const { server: upstream, seen } = countingUpstream();
+  const upstreamPort = await listen(upstream);
+  const { proxy, port } = await proxyWith(null, upstreamPort);
+
+  try {
+    assert.equal((await post(port)).status, 200);
+    assert.equal(seen.length, 1);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});


### PR DESCRIPTION
A VPN that drops mid-session does not stop traffic, it only changes where the traffic comes from. Upstream answers a request from an unexpected region with 403 "Request not allowed", and Claude Code reports that as a dead session and demands a re-login while the token is still perfectly valid — and by then the account has already been used from the new address. The same symptom shows up in [anthropics/claude-code#30318](https://github.com/anthropics/claude-code/issues/30318), where a direct (non-VPN) request gets redirected to `app-unavailable-in-region` while the same request through a proxy succeeds.

With `"egress": { "pin": "auto" }` — or one or more explicit addresses — the exit IP is checked before forwarding, and a request made while the address is wrong waits for the tunnel to come back instead of going out. A request that outlasts `holdSeconds` gets a 503 naming both the observed and the expected address. A probe that cannot answer counts as unknown, never as wrong, so an unreachable check service does not turn into an outage of our own.

Off entirely unless configured: no `egress.pin`, no guard, no probe, no change in behaviour.
