### PR TITLE
fix(accounts): a second org of the same person no longer overwrites the first

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -37,6 +37,37 @@ export function sameIdentity(a, b) {
   return a?.name === b?.name;
 }
 
+/**
+ * Are these two records definitely NOT the same account? True only when both
+ * sides are fully identified and point at different account+org pairs — an
+ * unknown UUID or org on either side means "cannot tell", never "different".
+ */
+export function distinctAccounts(a, b) {
+  if (!a?.accountUuid || !b?.accountUuid) return false;
+  if (a.accountUuid !== b.accountUuid) return true;
+  const ka = orgKey(a);
+  const kb = orgKey(b);
+  return !!(ka && kb && ka !== kb);
+}
+
+/**
+ * Index of the config entry an incoming login should UPDATE, or -1 to add it as
+ * a new one.
+ *
+ * Identity decides first: the same account+org is the same entry. A bare display
+ * name match is accepted only when nothing contradicts it — one person's two
+ * organizations share an email, and the display name is derived from that email,
+ * so treating equal names as one account overwrites the other org's entry and
+ * silently drops an account from the config. The account keeps working until the
+ * process that still holds it in memory restarts, which is what makes the loss
+ * hard to trace back to the login that caused it.
+ */
+export function findUpsertTarget(accounts, incoming) {
+  const byIdentity = accounts.findIndex(a => sameIdentity(a, incoming));
+  if (byIdentity >= 0) return byIdentity;
+  return accounts.findIndex(a => a.name === incoming.name && !distinctAccounts(a, incoming));
+}
+
 /** The email portion of a display name, stripping any " (org)" suffix. */
 export function emailOf(acct) {
   return (acct?.name || '').replace(/ \(.*\)$/, '');

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
-import { sameIdentity, orgKey, matchAccounts } from './identity.js';
+import { sameIdentity, orgKey, matchAccounts, findUpsertTarget } from './identity.js';
 import { resolveAccounts } from './resolve-accounts.js';
 import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
@@ -1406,9 +1406,9 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
   };
 
   // Deduplicate by account+org identity (same email in a different org is a
-  // distinct account), then by name.
-  let idx = config.accounts.findIndex(a => sameIdentity(a, account));
-  if (idx < 0) idx = config.accounts.findIndex(a => a.name === name);
+  // distinct account), then by name — but only where the name is not standing in
+  // for a different account+org, which is exactly the multi-org case below.
+  const idx = findUpsertTarget(config.accounts, account);
 
   if (idx >= 0) {
     // Same account+org: refresh credentials and org info, but keep the existing

--- a/src/tui.js
+++ b/src/tui.js
@@ -1,6 +1,6 @@
 import { createWriteStream } from 'node:fs';
 import { importCredentials, fetchProfile } from './oauth.js';
-import { sameIdentity } from './identity.js';
+import { sameIdentity, findUpsertTarget } from './identity.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -170,7 +170,10 @@ function timestamp() {
 // ── TUI class ────────────────────────────────────────────────
 
 export class TUI {
-  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null, activityLogPath = null }) {
+  constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null, activityLogPath = null,
+    // Injectable so the import path can be exercised without a real credentials
+    // file or a live profile call.
+    readCredentials = importCredentials, readProfile = fetchProfile }) {
     this.am = accountManager;
     this.config = config;
     this.saveConfig = saveConfig;
@@ -180,6 +183,8 @@ export class TUI {
     this.sxBalance = null;   // last fetched sx.org balance, for the settings screen
     this.probeQuota = probeQuota; // on-demand fleet-wide quota refresh (may be null)
     this.activityLogPath = activityLogPath;
+    this._readCredentials = readCredentials;
+    this._readProfile = readProfile;
     this._activityStream = null;
 
     this.log = [];           // completed activity entries
@@ -719,8 +724,8 @@ export class TUI {
   async _doImport() {
     try {
       this._addLog('Importing credentials...');
-      const creds = await importCredentials('~/.claude/.credentials.json');
-      const profile = await fetchProfile(creds.accessToken);
+      const creds = await this._readCredentials('~/.claude/.credentials.json');
+      const profile = await this._readProfile(creds.accessToken);
       const profileOk = profile && !profile.error;
 
       if (!profileOk) {
@@ -747,10 +752,11 @@ export class TUI {
         expiresAt: creds.expiresAt,
       };
 
-      // Deduplicate by account+org identity (same email in a different org is a
-      // distinct account), then by name.
-      let idx = this.config.accounts.findIndex(a => sameIdentity(a, entry));
-      if (idx < 0) idx = this.config.accounts.findIndex(a => a.name === name);
+      // Same rule as the login path: a name match counts only where it is not
+      // standing in for a different account+org. Both organizations of one person
+      // carry the same email-derived name, and overwriting on that match drops an
+      // account here AND rewrites the running one's identity below.
+      const idx = findUpsertTarget(this.config.accounts, entry);
 
       if (idx >= 0) {
         const prev = this.config.accounts[idx];

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { orgKey, sameIdentity, emailOf, matchAccounts } from '../src/identity.js';
+import { orgKey, sameIdentity, emailOf, matchAccounts, findUpsertTarget, distinctAccounts } from '../src/identity.js';
 
 test('orgKey prefers orgUuid, falls back to orgName, else null', () => {
   assert.equal(orgKey({ orgUuid: 'u1', orgName: 'Acme' }), 'u1');
@@ -103,4 +103,51 @@ test('matchAccounts: unique email needs no org', () => {
 
 test('matchAccounts: no match returns empty', () => {
   assert.equal(matchAccounts(ACCTS, 'nobody@z.com').length, 0);
+});
+
+// The failure this guards against: one person, two organizations. Both entries
+// are auto-named from the same email, so a name match is not evidence that the
+// incoming login is the same account — and taking it as such overwrites the
+// other org's entry. The account disappears from the config while the running
+// server still holds it in memory, so the loss only becomes visible at the next
+// restart, far from the login that caused it.
+test('findUpsertTarget: a second org of the same person is a NEW entry, not an overwrite', () => {
+  const accounts = [
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-personal', orgName: 'Personal' },
+  ];
+  const incoming = { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme', orgName: 'Acme' };
+  assert.equal(findUpsertTarget(accounts, incoming), -1);
+});
+
+test('findUpsertTarget: the same account+org updates in place', () => {
+  const accounts = [
+    { name: 'a@x.com (Personal)', accountUuid: 'u1', orgUuid: 'o-personal' },
+    { name: 'a@x.com (Acme)', accountUuid: 'u1', orgUuid: 'o-acme' },
+  ];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' }), 1);
+});
+
+// A legacy entry predating stored org UUIDs must still be backfilled rather than
+// duplicated — "org unknown" means cannot tell, not different.
+test('findUpsertTarget: an entry with no org backfills instead of duplicating', () => {
+  const accounts = [{ name: 'a@x.com', accountUuid: 'u1' }];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' }), 0);
+});
+
+test('findUpsertTarget: matches by name when neither side carries a UUID', () => {
+  const accounts = [{ name: 'a@x.com' }];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: null }), 0);
+});
+
+// Two different people whose entries somehow share a display name must not
+// collapse into one either.
+test('findUpsertTarget: a different person with the same name is a new entry', () => {
+  const accounts = [{ name: 'shared', accountUuid: 'u1', orgUuid: 'o1' }];
+  assert.equal(findUpsertTarget(accounts, { name: 'shared', accountUuid: 'u2', orgUuid: 'o2' }), -1);
+});
+
+test('distinctAccounts: unknown identity on either side is never "different"', () => {
+  assert.equal(distinctAccounts({ name: 'a' }, { name: 'a', accountUuid: 'u1' }), false);
+  assert.equal(distinctAccounts({ accountUuid: 'u1' }, { accountUuid: 'u1', orgUuid: 'o1' }), false);
+  assert.equal(distinctAccounts({ accountUuid: 'u1', orgUuid: 'o1' }, { accountUuid: 'u1', orgUuid: 'o2' }), true);
 });

--- a/test/tui-accounts.test.js
+++ b/test/tui-accounts.test.js
@@ -178,3 +178,38 @@ test('select mode entered from the dashboard still returns to normal', () => {
   tui._key('esc');
   assert.equal(tui.mode, 'normal');
 });
+
+// Importing the credentials of a second organization must not swallow the first.
+// Both entries are named from the same email, so matching on the name alone drops
+// one from the config and — worse here — rewrites the surviving in-memory
+// account's accountUuid/orgUuid, collapsing two live accounts into one without
+// even a restart.
+test('importing a second org adds an account instead of overwriting the first', async () => {
+  const accounts = [{ name: 'a@x.com', index: 0, type: 'oauth', credential: 'old', accountUuid: 'u1', orgUuid: 'o-personal', orgName: 'Personal' }];
+  const { tui, am, config, calls } = makeTUI({ accounts });
+  config.accounts = [{ name: 'a@x.com', type: 'oauth', accountUuid: 'u1', orgUuid: 'o-personal', orgName: 'Personal' }];
+  tui._readCredentials = async () => ({ accessToken: 'new', refreshToken: 'r', expiresAt: Date.now() + 3600_000 });
+  tui._readProfile = async () => ({ email: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme', orgName: 'Acme' });
+
+  await tui._doImport();
+
+  assert.equal(config.accounts.length, 2);
+  assert.equal(calls.added.length, 1);
+  assert.equal(am.accounts[0].orgUuid, 'o-personal');       // the running account kept its identity
+  assert.equal(am.accounts[0].credential, 'old');           // and its own token
+  assert.deepEqual(config.accounts.map(a => a.name), ['a@x.com (Personal)', 'a@x.com (Acme)']);
+});
+
+test('re-importing the same account+org still updates in place', async () => {
+  const accounts = [{ name: 'a@x.com', index: 0, type: 'oauth', credential: 'old', accountUuid: 'u1', orgUuid: 'o-acme', orgName: 'Acme' }];
+  const { tui, am, config, calls } = makeTUI({ accounts });
+  config.accounts = [{ name: 'a@x.com', type: 'oauth', accountUuid: 'u1', orgUuid: 'o-acme', orgName: 'Acme' }];
+  tui._readCredentials = async () => ({ accessToken: 'fresh', refreshToken: 'r2', expiresAt: Date.now() + 3600_000 });
+  tui._readProfile = async () => ({ email: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme', orgName: 'Acme' });
+
+  await tui._doImport();
+
+  assert.equal(config.accounts.length, 1);
+  assert.equal(calls.added.length, 0);
+  assert.equal(am.accounts[0].credential, 'fresh');
+});


### PR DESCRIPTION
One person in two organizations loses an account on login. Both entries are auto-named from the same email, so a login to the second org matches the first entry by name and replaces it. The disambiguation that renames both to `email (Org)` sits on the add path, and the name match skips that path entirely, so two accounts collapse into one.

What makes it hard to trace: a running server keeps the dropped account in memory and keeps rotating onto it. Nothing looks wrong until the process restarts and comes back one account short, by which point the login that caused it is days behind. It surfaced here as an account vanishing "during a network blip". The blip only restarted the process.

A name match is now accepted only when nothing contradicts it: two records with different account+org pairs are different accounts regardless of what their display names say. An unknown UUID or org still counts as "cannot tell", so a legacy entry without a stored org keeps backfilling rather than duplicating.

The TUI import path had its own copy of the same two lines, with a wider blast radius. On a name match it also rewrites the surviving in-memory account's `accountUuid` and `orgUuid`, so there the two accounts collapse immediately, with no restart needed to see it. Both paths now share one rule. The credentials and profile reads in the TUI became injectable so that path is reachable from a test.
