### PR TITLE
feat(service): run the proxy as a user service on macOS and Linux

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
 import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
+import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 
 const args = process.argv.slice(2);
@@ -73,6 +74,10 @@ switch (command) {
     break;
   case 'alias':
     aliasCommand();
+    process.exit(0);
+    break;
+  case 'service':
+    await serviceCommand();
     process.exit(0);
     break;
   case 'probe':
@@ -984,6 +989,50 @@ function aliasCommand() {
   }
 }
 
+// ── service ─────────────────────────────────────────────────
+
+async function serviceCommand() {
+  const sub = args[1] || 'status';
+  const kind = serviceKind();
+  if (!kind) {
+    console.error(`teamclaude service: no service integration for ${process.platform}`);
+    console.error('Run the proxy yourself with: teamclaude server --headless');
+    process.exit(1);
+  }
+  // Carry an explicit config path into the unit: a service started by launchd or
+  // systemd does not inherit the shell's TEAMCLAUDE_CONFIG, so a non-default
+  // config would silently be ignored and the service would serve a different
+  // (or empty) account list than the CLI does.
+  const configPath = process.env.TEAMCLAUDE_CONFIG || null;
+
+  switch (sub) {
+    case 'install': {
+      const res = await installService({ configPath });
+      if (!res.ok) { console.error(`teamclaude service install failed: ${res.error}`); process.exit(1); }
+      break;
+    }
+    case 'uninstall': {
+      const res = await uninstallService();
+      if (!res.ok) { console.error(`teamclaude service uninstall failed: ${res.error}`); process.exit(1); }
+      break;
+    }
+    case 'print':
+      process.stdout.write(renderService({ configPath }));
+      break;
+    case 'status': {
+      const s = await serviceStatus();
+      console.log(`Service:   ${s.installed ? s.file : 'not installed'}`);
+      console.log(`State:     ${s.running ? `running${s.pid ? ` (pid ${s.pid})` : ''}` : s.detail}`);
+      if (kind === 'launchd') console.log(`Logs:      ${logPath()}`);
+      else console.log('Logs:      journalctl --user --unit teamclaude.service');
+      break;
+    }
+    default:
+      console.error('Usage: teamclaude service <install|uninstall|status|print>');
+      process.exit(1);
+  }
+}
+
 // ── probe ───────────────────────────────────────────────────
 
 async function probeCommand() {
@@ -1307,6 +1356,10 @@ Commands:
                       the session to one account (see Environment below)
   alias               Print a shell alias so plain 'claude' routes via the proxy
                       (--install to write it to your shell rc; --uninstall to remove)
+  service <sub>       Run the proxy as a user service that starts at login and
+                      restarts on its own: install | uninstall | status | print
+                      (LaunchAgent on macOS, systemd --user unit on Linux;
+                      'print' writes the unit to stdout without touching anything)
   status [--json]     Show rich proxy/account/probe status (live)
                       Use --color=always|never to control ANSI colors
   accounts            List configured accounts

--- a/src/service.js
+++ b/src/service.js
@@ -149,6 +149,7 @@ const guiDomain = (uid = process.getuid?.() ?? 0) => `gui/${uid}`;
 export async function installService({
   kind = serviceKind(), home = homedir(), platform = process.platform,
   exec = resolveExec(), run = runCommand, configPath = null, log = console.log,
+  xdgConfig = process.env.XDG_CONFIG_HOME,
 } = {}) {
   if (!kind) return { ok: false, error: `No service integration for ${platform}` };
   const logFile = logPath(home, platform);
@@ -170,7 +171,7 @@ export async function installService({
     return { ok: true, file: plist, logFile };
   }
 
-  const unit = systemdUnitPath(home);
+  const unit = systemdUnitPath(home, xdgConfig);
   await mkdir(dirname(unit), { recursive: true });
   await writeFile(unit, renderSystemdUnit({ ...exec, path, configPath }), { mode: 0o644 });
   run('systemctl', ['--user', 'daemon-reload']);
@@ -186,6 +187,7 @@ export async function installService({
 
 export async function uninstallService({
   kind = serviceKind(), home = homedir(), run = runCommand, log = console.log,
+  xdgConfig = process.env.XDG_CONFIG_HOME,
 } = {}) {
   if (!kind) return { ok: false, error: 'No service integration for this platform' };
   if (kind === 'launchd') {
@@ -195,7 +197,7 @@ export async function uninstallService({
     log(`[TeamClaude] Service removed: ${plist}`);
     return { ok: true, file: plist };
   }
-  const unit = systemdUnitPath(home);
+  const unit = systemdUnitPath(home, xdgConfig);
   run('systemctl', ['--user', 'disable', '--now', UNIT_NAME]);
   await rm(unit, { force: true });
   run('systemctl', ['--user', 'daemon-reload']);
@@ -203,7 +205,10 @@ export async function uninstallService({
   return { ok: true, file: unit };
 }
 
-export async function serviceStatus({ kind = serviceKind(), home = homedir(), run = runCommand } = {}) {
+export async function serviceStatus({
+  kind = serviceKind(), home = homedir(), run = runCommand,
+  xdgConfig = process.env.XDG_CONFIG_HOME,
+} = {}) {
   if (!kind) return { installed: false, running: false, detail: 'unsupported platform' };
   if (kind === 'launchd') {
     const plist = launchAgentPath(home);
@@ -212,7 +217,7 @@ export async function serviceStatus({ kind = serviceKind(), home = homedir(), ru
     const pid = /\bpid = (\d+)/.exec(r.stdout)?.[1] || null;
     return { installed, running: r.code === 0 && !!pid, pid, file: plist, detail: r.code === 0 ? 'loaded' : 'not loaded' };
   }
-  const unit = systemdUnitPath(home);
+  const unit = systemdUnitPath(home, xdgConfig);
   const r = run('systemctl', ['--user', 'is-active', UNIT_NAME]);
   return { installed: existsSync(unit), running: r.stdout.trim() === 'active', file: unit, detail: r.stdout.trim() || r.stderr.trim() };
 }
@@ -227,8 +232,10 @@ export function renderService({ kind = serviceKind(), home = homedir(), platform
 }
 
 /** Read back what is installed, for diffing against what we would write now. */
-export async function readInstalled({ kind = serviceKind(), home = homedir() } = {}) {
+export async function readInstalled({
+  kind = serviceKind(), home = homedir(), xdgConfig = process.env.XDG_CONFIG_HOME,
+} = {}) {
   if (!kind) return null;
-  const file = kind === 'launchd' ? launchAgentPath(home) : systemdUnitPath(home);
+  const file = kind === 'launchd' ? launchAgentPath(home) : systemdUnitPath(home, xdgConfig);
   return readFile(file, 'utf8').catch(() => null);
 }

--- a/src/service.js
+++ b/src/service.js
@@ -1,0 +1,234 @@
+// Run the proxy as a user service — `teamclaude service install`.
+//
+// npm has no equivalent of `brew services`, and a postinstall hook is the wrong
+// place for this (it is skipped under --ignore-scripts, surprises CI, and
+// installs system state nobody asked for). So the CLI does it explicitly, the
+// same way `teamclaude alias --install` handles the shell alias.
+//
+// macOS gets a LaunchAgent, Linux a systemd --user unit. Both are per-user: no
+// root, no system-wide daemon, and the proxy runs as the user whose accounts and
+// config it serves.
+
+import { writeFile, mkdir, rm, readFile } from 'node:fs/promises';
+import { existsSync, realpathSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+export const LABEL = 'com.karpeleslab.teamclaude';
+export const UNIT_NAME = 'teamclaude.service';
+
+/** Which service manager to target, or null where we have nothing to offer. */
+export function serviceKind(platform = process.platform) {
+  if (platform === 'darwin') return 'launchd';
+  if (platform === 'linux') return 'systemd';
+  return null;
+}
+
+export function launchAgentPath(home = homedir()) {
+  return join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`);
+}
+
+export function systemdUnitPath(home = homedir(), xdgConfig = process.env.XDG_CONFIG_HOME) {
+  return join(xdgConfig || join(home, '.config'), 'systemd', 'user', UNIT_NAME);
+}
+
+export function logPath(home = homedir(), platform = process.platform) {
+  return platform === 'darwin'
+    ? join(home, 'Library', 'Logs', 'teamclaude.log')
+    : join(home, '.local', 'state', 'teamclaude.log');
+}
+
+/**
+ * The interpreter and script to bake into the unit.
+ *
+ * `process.execPath` is NOT usable as-is: on a Homebrew install it points into
+ * the versioned Cellar directory (…/Cellar/node/26.5.0_1/bin/node), which the
+ * next `brew upgrade node` deletes — the service would then fail to start with
+ * no obvious connection to the upgrade. Prefer a `node` on PATH that resolves to
+ * the same binary, since that is the stable symlink maintained across upgrades.
+ *
+ * The script is `argv[1]` unresolved for the same reason: the bin symlink
+ * survives a package reinstall, the versioned path inside node_modules may not.
+ */
+export function resolveExec({
+  execPath = process.execPath,
+  argv1 = process.argv[1],
+  pathEnv = process.env.PATH || '',
+  realpath = realpathSync,
+  exists = existsSync,
+} = {}) {
+  const same = (candidate) => {
+    try { return realpath(candidate) === realpath(execPath); } catch { return false; }
+  };
+  let node = execPath;
+  for (const dir of pathEnv.split(':')) {
+    if (!dir) continue;
+    const candidate = join(dir, 'node');
+    if (exists(candidate) && same(candidate)) { node = candidate; break; }
+  }
+  return { node, entry: argv1 };
+}
+
+/**
+ * PATH for the service. launchd starts with an empty environment, so without
+ * this the background self-update cannot find npm, and any child process the
+ * proxy spawns inherits nothing. Built from the directories that actually
+ * matter rather than copying the interactive shell's PATH, which is full of
+ * per-session entries that mean nothing to a daemon.
+ */
+export function servicePath({ node, entry }) {
+  const dirs = [dirname(node), dirname(entry), '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
+  return [...new Set(dirs.filter(Boolean))].join(':');
+}
+
+const xmlEscape = (s) => String(s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+export function renderLaunchAgent({ node, entry, log, path, configPath = null }) {
+  const args = [node, entry, 'server', '--headless'];
+  const env = [`    <key>PATH</key>\n    <string>${xmlEscape(path)}</string>`];
+  if (configPath) env.push(`    <key>TEAMCLAUDE_CONFIG</key>\n    <string>${xmlEscape(configPath)}</string>`);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.map(a => `    <string>${xmlEscape(a)}</string>`).join('\n')}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(log)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(log)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+${env.join('\n')}
+  </dict>
+</dict>
+</plist>
+`;
+}
+
+export function renderSystemdUnit({ node, entry, path, configPath = null }) {
+  const environment = [`Environment=PATH=${path}`];
+  if (configPath) environment.push(`Environment=TEAMCLAUDE_CONFIG=${configPath}`);
+  return `[Unit]
+Description=TeamClaude multi-account Claude proxy
+Documentation=https://github.com/KarpelesLab/teamclaude
+After=network-online.target
+
+[Service]
+ExecStart=${node} ${entry} server --headless
+Restart=always
+RestartSec=5
+${environment.join('\n')}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+/** Run a command, returning { code, stdout, stderr }. Injected in tests. */
+function runCommand(cmd, args) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8' });
+  return { code: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+/** `gui/<uid>` — the launchd domain a per-user agent lives in. */
+const guiDomain = (uid = process.getuid?.() ?? 0) => `gui/${uid}`;
+
+export async function installService({
+  kind = serviceKind(), home = homedir(), platform = process.platform,
+  exec = resolveExec(), run = runCommand, configPath = null, log = console.log,
+} = {}) {
+  if (!kind) return { ok: false, error: `No service integration for ${platform}` };
+  const logFile = logPath(home, platform);
+  const path = servicePath(exec);
+
+  if (kind === 'launchd') {
+    const plist = launchAgentPath(home);
+    await mkdir(dirname(plist), { recursive: true });
+    await mkdir(dirname(logFile), { recursive: true });
+    await writeFile(plist, renderLaunchAgent({ ...exec, log: logFile, path, configPath }), { mode: 0o644 });
+    // Replace any previous registration first: bootstrap fails outright when the
+    // label is already loaded, and an install that reports success while the old
+    // definition keeps running is worse than a loud failure.
+    run('launchctl', ['bootout', `${guiDomain()}/${LABEL}`]);
+    const boot = run('launchctl', ['bootstrap', guiDomain(), plist]);
+    if (boot.code !== 0) return { ok: false, error: boot.stderr.trim() || `launchctl bootstrap exited ${boot.code}`, file: plist };
+    log(`[TeamClaude] Service installed: ${plist}`);
+    log(`[TeamClaude] Logs: ${logFile}`);
+    return { ok: true, file: plist, logFile };
+  }
+
+  const unit = systemdUnitPath(home);
+  await mkdir(dirname(unit), { recursive: true });
+  await writeFile(unit, renderSystemdUnit({ ...exec, path, configPath }), { mode: 0o644 });
+  run('systemctl', ['--user', 'daemon-reload']);
+  const enable = run('systemctl', ['--user', 'enable', '--now', UNIT_NAME]);
+  if (enable.code !== 0) return { ok: false, error: enable.stderr.trim() || `systemctl exited ${enable.code}`, file: unit };
+  log(`[TeamClaude] Service installed: ${unit}`);
+  log('[TeamClaude] Logs: journalctl --user --unit teamclaude.service --follow');
+  // Without lingering the unit dies with the last login session, which is not
+  // what "install a service" is expected to mean.
+  log('[TeamClaude] To keep it running with no session open: loginctl enable-linger $USER');
+  return { ok: true, file: unit, logFile: null };
+}
+
+export async function uninstallService({
+  kind = serviceKind(), home = homedir(), run = runCommand, log = console.log,
+} = {}) {
+  if (!kind) return { ok: false, error: 'No service integration for this platform' };
+  if (kind === 'launchd') {
+    const plist = launchAgentPath(home);
+    run('launchctl', ['bootout', `${guiDomain()}/${LABEL}`]);
+    await rm(plist, { force: true });
+    log(`[TeamClaude] Service removed: ${plist}`);
+    return { ok: true, file: plist };
+  }
+  const unit = systemdUnitPath(home);
+  run('systemctl', ['--user', 'disable', '--now', UNIT_NAME]);
+  await rm(unit, { force: true });
+  run('systemctl', ['--user', 'daemon-reload']);
+  log(`[TeamClaude] Service removed: ${unit}`);
+  return { ok: true, file: unit };
+}
+
+export async function serviceStatus({ kind = serviceKind(), home = homedir(), run = runCommand } = {}) {
+  if (!kind) return { installed: false, running: false, detail: 'unsupported platform' };
+  if (kind === 'launchd') {
+    const plist = launchAgentPath(home);
+    const installed = existsSync(plist);
+    const r = run('launchctl', ['print', `${guiDomain()}/${LABEL}`]);
+    const pid = /\bpid = (\d+)/.exec(r.stdout)?.[1] || null;
+    return { installed, running: r.code === 0 && !!pid, pid, file: plist, detail: r.code === 0 ? 'loaded' : 'not loaded' };
+  }
+  const unit = systemdUnitPath(home);
+  const r = run('systemctl', ['--user', 'is-active', UNIT_NAME]);
+  return { installed: existsSync(unit), running: r.stdout.trim() === 'active', file: unit, detail: r.stdout.trim() || r.stderr.trim() };
+}
+
+/** The unit file contents, for `service print` — inspect before installing. */
+export function renderService({ kind = serviceKind(), home = homedir(), platform = process.platform, exec = resolveExec(), configPath = null } = {}) {
+  if (!kind) return null;
+  const path = servicePath(exec);
+  return kind === 'launchd'
+    ? renderLaunchAgent({ ...exec, log: logPath(home, platform), path, configPath })
+    : renderSystemdUnit({ ...exec, path, configPath });
+}
+
+/** Read back what is installed, for diffing against what we would write now. */
+export async function readInstalled({ kind = serviceKind(), home = homedir() } = {}) {
+  if (!kind) return null;
+  const file = kind === 'launchd' ? launchAgentPath(home) : systemdUnitPath(home);
+  return readFile(file, 'utf8').catch(() => null);
+}

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -153,8 +153,12 @@ test('installing on systemd reloads the daemon before enabling', async () => {
   const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
   try {
     const { run, calls } = recorder();
+    // xdgConfig: null keeps the unit under `home`. Without it the call honours
+    // the ambient XDG_CONFIG_HOME — set on CI and on plenty of desktops — and
+    // the test would write a real unit file into the developer's own config dir
+    // while asserting against a temp path that was never written.
     const res = await installService({
-      kind: 'systemd', home, platform: 'linux', run, log: () => {},
+      kind: 'systemd', home, platform: 'linux', run, log: () => {}, xdgConfig: null,
       exec: { node: '/usr/bin/node', entry: '/usr/bin/teamclaude' },
     });
     assert.equal(res.ok, true);
@@ -163,6 +167,26 @@ test('installing on systemd reloads the daemon before enabling', async () => {
       'systemctl --user daemon-reload',
       'systemctl --user enable --now teamclaude.service',
     ]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+// XDG_CONFIG_HOME wins over ~/.config for the unit's location — that is where a
+// systemd --user unit belongs on a machine that sets it. Asserted explicitly
+// because the same knob decides whether a test can reach the real config dir.
+test('the systemd unit follows XDG_CONFIG_HOME when one is set', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const xdg = join(home, 'xdg');
+    const { run } = recorder();
+    const res = await installService({
+      kind: 'systemd', home, platform: 'linux', run, log: () => {}, xdgConfig: xdg,
+      exec: { node: '/usr/bin/node', entry: '/usr/bin/teamclaude' },
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.file, join(xdg, 'systemd', 'user', 'teamclaude.service'));
+    assert.match(await readFile(res.file, 'utf8'), /ExecStart=/);
   } finally {
     await rm(home, { recursive: true, force: true });
   }

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,0 +1,213 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  serviceKind, launchAgentPath, systemdUnitPath, logPath, resolveExec, servicePath,
+  renderLaunchAgent, renderSystemdUnit, installService, uninstallService, serviceStatus, LABEL,
+} from '../src/service.js';
+
+// Records every command a call would run, and answers each with a canned result.
+function recorder(results = {}) {
+  const calls = [];
+  const run = (cmd, args) => {
+    calls.push([cmd, ...args].join(' '));
+    const key = Object.keys(results).find(k => [cmd, ...args].join(' ').includes(k));
+    return results[key] || { code: 0, stdout: '', stderr: '' };
+  };
+  return { run, calls };
+}
+
+test('service kind follows the platform', () => {
+  assert.equal(serviceKind('darwin'), 'launchd');
+  assert.equal(serviceKind('linux'), 'systemd');
+  assert.equal(serviceKind('win32'), null);
+});
+
+test('unit files land in the per-user locations', () => {
+  assert.equal(launchAgentPath('/Users/x'), `/Users/x/Library/LaunchAgents/${LABEL}.plist`);
+  assert.equal(systemdUnitPath('/home/x', null), '/home/x/.config/systemd/user/teamclaude.service');
+  assert.equal(systemdUnitPath('/home/x', '/cfg'), '/cfg/systemd/user/teamclaude.service');
+  assert.equal(logPath('/Users/x', 'darwin'), '/Users/x/Library/Logs/teamclaude.log');
+});
+
+// The regression this guards: process.execPath on a Homebrew node points into
+// the versioned Cellar directory, which the next `brew upgrade node` deletes.
+// The PATH symlink survives upgrades and is what belongs in a unit file.
+test('resolveExec prefers a PATH symlink over the versioned real path', () => {
+  const exec = resolveExec({
+    execPath: '/opt/homebrew/Cellar/node/26.5.0_1/bin/node',
+    argv1: '/opt/homebrew/bin/teamclaude',
+    pathEnv: '/usr/bin:/opt/homebrew/bin',
+    exists: (p) => p === '/opt/homebrew/bin/node',
+    realpath: (p) => (p === '/opt/homebrew/bin/node' ? '/opt/homebrew/Cellar/node/26.5.0_1/bin/node' : p),
+  });
+  assert.equal(exec.node, '/opt/homebrew/bin/node');
+  assert.equal(exec.entry, '/opt/homebrew/bin/teamclaude');
+});
+
+test('resolveExec keeps the real path when no PATH entry matches it', () => {
+  const exec = resolveExec({
+    execPath: '/usr/local/n/versions/node/24/bin/node',
+    argv1: '/usr/local/bin/teamclaude',
+    pathEnv: '/usr/bin',
+    exists: () => false,
+    realpath: (p) => p,
+  });
+  assert.equal(exec.node, '/usr/local/n/versions/node/24/bin/node');
+});
+
+// A different node on PATH must not be substituted for the one actually running.
+test('resolveExec ignores a PATH node that is a different binary', () => {
+  const exec = resolveExec({
+    execPath: '/opt/homebrew/Cellar/node/26.5.0_1/bin/node',
+    argv1: '/x/teamclaude',
+    pathEnv: '/usr/bin',
+    exists: () => true,
+    realpath: (p) => (p === '/usr/bin/node' ? '/usr/bin/node-18' : p),
+  });
+  assert.equal(exec.node, '/opt/homebrew/Cellar/node/26.5.0_1/bin/node');
+});
+
+// launchd starts with an empty environment — an inherited-looking PATH is not
+// inherited at all, so the unit has to carry one or self-update can't find npm.
+test('the service PATH covers both binaries and the system directories', () => {
+  const p = servicePath({ node: '/opt/homebrew/bin/node', entry: '/opt/homebrew/bin/teamclaude' });
+  assert.match(p, /^\/opt\/homebrew\/bin:/);
+  assert.match(p, /\/usr\/bin/);
+  assert.equal(p.split(':').filter(d => d === '/opt/homebrew/bin').length, 1); // deduped
+});
+
+test('the LaunchAgent asks for restart-on-exit and headless mode', () => {
+  const plist = renderLaunchAgent({
+    node: '/opt/homebrew/bin/node', entry: '/opt/homebrew/bin/teamclaude',
+    log: '/Users/x/Library/Logs/teamclaude.log', path: '/opt/homebrew/bin:/usr/bin',
+  });
+  assert.match(plist, /<key>Label<\/key>\s*<string>com\.karpeleslab\.teamclaude<\/string>/);
+  assert.match(plist, /<string>server<\/string>\s*<string>--headless<\/string>/);
+  assert.match(plist, /<key>KeepAlive<\/key>\s*<true\/>/);
+  assert.match(plist, /<key>RunAtLoad<\/key>\s*<true\/>/);
+  assert.match(plist, /<key>PATH<\/key>\s*<string>\/opt\/homebrew\/bin:\/usr\/bin<\/string>/);
+});
+
+test('paths with XML metacharacters are escaped, not injected', () => {
+  const plist = renderLaunchAgent({
+    node: '/n', entry: '/opt/a&b/<teamclaude>', log: '/l', path: '/p',
+  });
+  assert.match(plist, /&amp;b\/&lt;teamclaude&gt;/);
+  assert.ok(!plist.includes('/opt/a&b/<teamclaude>'));
+});
+
+test('the systemd unit restarts and starts at login', () => {
+  const unit = renderSystemdUnit({
+    node: '/usr/bin/node', entry: '/usr/bin/teamclaude', path: '/usr/bin',
+  });
+  assert.match(unit, /ExecStart=\/usr\/bin\/node \/usr\/bin\/teamclaude server --headless/);
+  assert.match(unit, /Restart=always/);
+  assert.match(unit, /WantedBy=default\.target/);
+  assert.match(unit, /Environment=PATH=\/usr\/bin/);
+});
+
+test('an optional config path is carried into both unit formats', () => {
+  const opts = { node: '/n', entry: '/e', log: '/l', path: '/p', configPath: '/cfg/teamclaude.json' };
+  assert.match(renderLaunchAgent(opts), /TEAMCLAUDE_CONFIG<\/key>\s*<string>\/cfg\/teamclaude\.json/);
+  assert.match(renderSystemdUnit(opts), /Environment=TEAMCLAUDE_CONFIG=\/cfg\/teamclaude\.json/);
+});
+
+test('installing on launchd writes the plist and loads it', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const { run, calls } = recorder();
+    const res = await installService({
+      kind: 'launchd', home, platform: 'darwin', run, log: () => {},
+      exec: { node: '/opt/homebrew/bin/node', entry: '/opt/homebrew/bin/teamclaude' },
+    });
+    assert.equal(res.ok, true);
+    const written = await readFile(launchAgentPath(home), 'utf8');
+    assert.match(written, /teamclaude/);
+    // bootout before bootstrap: bootstrap fails outright if the label is loaded.
+    assert.match(calls[0], /^launchctl bootout gui\/\d+\/com\.karpeleslab\.teamclaude$/);
+    assert.match(calls[1], /^launchctl bootstrap gui\/\d+ /);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('a failed load is reported as a failure, not a silent success', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const { run } = recorder({ bootstrap: { code: 5, stdout: '', stderr: 'Load failed: 5: Input/output error' } });
+    const res = await installService({
+      kind: 'launchd', home, platform: 'darwin', run, log: () => {},
+      exec: { node: '/n', entry: '/e' },
+    });
+    assert.equal(res.ok, false);
+    assert.match(res.error, /Load failed/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('installing on systemd reloads the daemon before enabling', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const { run, calls } = recorder();
+    const res = await installService({
+      kind: 'systemd', home, platform: 'linux', run, log: () => {},
+      exec: { node: '/usr/bin/node', entry: '/usr/bin/teamclaude' },
+    });
+    assert.equal(res.ok, true);
+    assert.match(await readFile(systemdUnitPath(home, null), 'utf8'), /ExecStart=/);
+    assert.deepEqual(calls, [
+      'systemctl --user daemon-reload',
+      'systemctl --user enable --now teamclaude.service',
+    ]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('uninstall unloads before deleting the unit file', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const { run, calls } = recorder();
+    await installService({
+      kind: 'launchd', home, platform: 'darwin', run, log: () => {},
+      exec: { node: '/n', entry: '/e' },
+    });
+    calls.length = 0;
+    const res = await uninstallService({ kind: 'launchd', home, run, log: () => {} });
+    assert.equal(res.ok, true);
+    assert.match(calls[0], /launchctl bootout/);
+    await assert.rejects(readFile(launchAgentPath(home), 'utf8'));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('status reports loaded-but-not-running distinctly from running', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-svc-'));
+  try {
+    const loaded = recorder({ print: { code: 0, stdout: 'state = running\n\tpid = 4242\n', stderr: '' } });
+    const running = await serviceStatus({ kind: 'launchd', home, run: loaded.run });
+    assert.equal(running.running, true);
+    assert.equal(running.pid, '4242');
+
+    const idle = recorder({ print: { code: 0, stdout: 'state = not running\n', stderr: '' } });
+    assert.equal((await serviceStatus({ kind: 'launchd', home, run: idle.run })).running, false);
+
+    const absent = recorder({ print: { code: 113, stdout: '', stderr: 'Could not find service' } });
+    const gone = await serviceStatus({ kind: 'launchd', home, run: absent.run });
+    assert.equal(gone.running, false);
+    assert.equal(gone.detail, 'not loaded');
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('an unsupported platform refuses instead of writing anything', async () => {
+  const res = await installService({ kind: null, platform: 'win32', log: () => {} });
+  assert.equal(res.ok, false);
+  assert.match(res.error, /win32/);
+});


### PR DESCRIPTION
npm has no `brew services` equivalent, so this is an explicit command rather than a postinstall hook. Hooks get skipped under `--ignore-scripts` and surprise CI. Same shape as `teamclaude alias --install`.

`teamclaude service install` writes a LaunchAgent on macOS or a systemd `--user` unit on Linux. Per-user, no root, starts at login, restarts on its own. `print` writes the unit to stdout so you can read it before anything lands on disk, `status` says whether it is loaded and running, `uninstall` unloads and removes it.

Two things the unit cannot leave to the environment:

* `process.execPath` on a Homebrew node is `/opt/homebrew/Cellar/node/26.5.0_1/bin/node`, and the next node upgrade deletes that directory. The service would stop starting, with nothing pointing back at the upgrade. So a `node` on PATH that resolves to the same binary wins, and the versioned path is used only when nothing on PATH matches it.
* launchd starts with an empty environment, so the unit carries its own PATH. Without it the background self-update cannot find npm. `TEAMCLAUDE_CONFIG` is baked in for the same reason.

The generated plist passes `plutil -lint`. Tests cover both unit formats, XML escaping of paths, the exec resolution above, command order (`bootout` before `bootstrap`, `daemon-reload` before `enable`), failure reporting, and the refusal on unsupported platforms.
