### PR TITLE
feat(codex): ChatGPT Codex accounts as a backend protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Notes and limits:
 - Reasoning effort is mapped onto the levels Codex accepts (`none`, `low`,
   `medium`, `high`, `xhigh`, `max`). `minimal`, `ultra` and `auto` have no
   equivalent and are clamped to `low`, `max` and `medium` respectively.
+- Prompt caching is scoped by a key derived from the session, sub-agent and
+  model, so it survives across a conversation's turns. On a 3k-token prompt
+  that caches ~93% of the input from the second turn onward. Cache reads and
+  writes are reported as `cache_read_input_tokens` /
+  `cache_creation_input_tokens`.
 - Reasoning summaries are not requested, so responses carry no thinking blocks.
 - A ChatGPT plan without Codex access (e.g. free) is rejected by the backend.
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ Anthropic's catalog back would just duplicate every entry in the picker. Set
 `"modelDiscovery": {"includeAnthropic": true}` if a client needs the full
 list.
 
+Models in `blockedModels` are left out of the listing —
+advertising a model the proxy would reject with a `400` just puts a choice in
+the picker that fails the moment it is used. Patterns anchor at both ends, so
+trim older generations explicitly or with a wildcard:
+
+```json
+"blockedModels": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.5"]
+```
+
 A `modelMap` is only needed for the other direction: making a codex account
 answer to Claude model names, so it can stand in as a fallback when Claude
 quota runs out. Pair it with a high `priority` so it stays a fallback:
@@ -437,7 +446,7 @@ When on, teamclaude routes each **new** session to the least-loaded eligible acc
 | `holdSeconds` | Maximum seconds to hold the connection when all accounts are exhausted, polling silently until one recovers (`0` = return 429 immediately, the default). `teamclaude run` raises `API_TIMEOUT_MS` automatically to match |
 | `distributeSessions` | Spread concurrent Claude Code sessions across equal-priority accounts, each session pinned to one account for cache reuse (`false` = quota-driven rotation only, the default). Session tracking/readout is always on regardless — see [Session-aware routing](#session-aware-routing-distributesessions-off-by-default) |
 | `eventLogging` | How to handle Claude Code's telemetry (`/api/event_logging/*`), which is high-volume activity-log noise: `hide` (default) forwards it but keeps it out of the activity log; `block` answers `200` locally without forwarding (no upstream round-trip); `show` forwards and displays it. Toggle live in the TUI settings screen (`g` → Event logging). |
-| `blockedModels` | Array of model glob patterns (e.g. `["*fable*"]`) whose requests are rejected with a fast, non-retryable `400` instead of being forwarded — avoids a model no account can serve getting rate-limited upstream and hanging the pipeline (issue #116). Edit live in the TUI settings screen (`g` → Blocked models). Empty (the default) blocks nothing. |
+| `blockedModels` | Array of model glob patterns (e.g. `["*fable*"]`) whose requests are rejected with a fast, non-retryable `400` instead of being forwarded — avoids a model no account can serve getting rate-limited upstream and hanging the pipeline (issue #116). Blocked models are also left out of the [`/v1/models`](#chatgpt-codex) discovery listing, so the picker never offers a model the proxy would refuse. Edit live in the TUI settings screen (`g` → Blocked models). Empty (the default) blocks nothing. |
 | `stormRamp` | Optional storm-control tuning (on by default) — see [Storm control](#storm-control-switchover-ramp-up). Object: `{ enabled, startConc, stepConc, stepMs, windowMs }` |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |

--- a/README.md
+++ b/README.md
@@ -121,13 +121,28 @@ independent of the Codex CLI's. Prefer it over importing:
 teamclaude import --codex
 ```
 
-Codex models are offered directly in Claude Code's own model picker. Set
-`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` and Claude Code reads
-`/v1/models` from the proxy at startup; TeamClaude answers with the Claude
-catalog **and** every codex account's, so selecting `gpt-5.6-sol` is a
-first-class choice. Requests naming a Codex model route to a codex account
-automatically — no `modelMap` needed, and a Claude account is never picked for
-one (or vice versa).
+Codex models are offered directly in Claude Code's own model picker:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
+export ANTHROPIC_AUTH_TOKEN=$(jq -r '.proxy.apiKey' ~/.config/teamclaude.json)
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+claude    # discovery runs at startup, so this must be a fresh session
+```
+
+TeamClaude answers `/v1/models` with the Codex catalog, and requests naming a
+Codex model route to a codex account automatically — no `modelMap` needed, and
+a Claude account is never picked for one (or vice versa).
+
+Two details worth knowing. Claude Code **drops any listed model whose id does
+not start with `claude-`**, so ids are encoded into claude-prefixed ones and
+decoded again on the way in; the picker still shows the real display name
+(`GPT-5.6-Sol`). This mirrors CLIProxyAPI's encoding exactly, so a setup
+written for one behaves the same on the other. And the listing carries only
+what TeamClaude *adds* — Claude Code already knows its own models, so echoing
+Anthropic's catalog back would just duplicate every entry in the picker. Set
+`"modelDiscovery": {"includeAnthropic": true}` if a client needs the full
+list.
 
 A `modelMap` is only needed for the other direction: making a codex account
 answer to Claude model names, so it can stand in as a fallback when Claude

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
 - **Third-party backend accounts** — route requests to any Anthropic-compatible API (e.g. DeepSeek, GLM) as a fallback when Claude accounts are exhausted; a per-account `upstream` URL and `modelMap` translate model names transparently. Use [model routes](#model-routes) to reserve a third-party account for sessions that explicitly name its models
+- **ChatGPT Codex accounts** — use a ChatGPT subscription as a backend alongside Claude accounts (`teamclaude login --codex`). Unlike the Anthropic-compatible backends above, Codex speaks the OpenAI Responses API, so requests and streamed responses are translated in both directions; quota is read from its own `x-codex-*` headers so rotation stays predictive. See [ChatGPT Codex](#chatgpt-codex)
 - **Model blocklist** — reject requests for unwanted models (glob patterns, e.g. `*fable*`) with a fast `400` instead of forwarding them; a model no account can serve otherwise gets rate-limited upstream and hangs the pipeline. Edit live in the TUI settings screen (`g` → Blocked models)
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
@@ -101,6 +102,50 @@ For Anthropic API key accounts (billed via Console):
 ```bash
 teamclaude login --api
 ```
+
+### ChatGPT Codex
+
+A ChatGPT subscription can serve requests alongside Claude accounts:
+
+```bash
+teamclaude login --codex
+```
+
+This performs its own OAuth authorization, so TeamClaude holds a credential
+independent of the Codex CLI's. Prefer it over importing:
+
+```bash
+# Copies ~/.codex/auth.json — both then hold ONE refresh token, and since
+# OpenAI rotates it on every refresh, whichever refreshes second is left with
+# a dead one. Use only when you need to reuse an existing credential.
+teamclaude import --codex
+```
+
+Codex accounts need a `modelMap`, since the backend rejects Claude model
+names, and usually a high `priority` so they act as a fallback:
+
+```json
+{
+  "name": "me@example.com",
+  "type": "oauth",
+  "protocol": "codex",
+  "priority": 100,
+  "modelMap": {
+    "claude-opus-4-6": "gpt-5.6-sol",
+    "claude-sonnet-4-6": "gpt-5.6-sol"
+  }
+}
+```
+
+Notes and limits:
+
+- Only `/v1/messages` has a Responses-API equivalent. Anthropic-only endpoints
+  (`count_tokens`, `oauth/usage`, `bootstrap`, `mcp_servers`) fail over to a
+  Claude account, so keep at least one in the fleet.
+- Reasoning effort is mapped onto the levels Codex accepts; `minimal` and
+  `auto` have no equivalent and are clamped to `low` and `medium`.
+- Reasoning summaries are not requested, so responses carry no thinking blocks.
+- A ChatGPT plan without Codex access (e.g. free) is rejected by the backend.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -132,18 +132,32 @@ names, and usually a high `priority` so they act as a fallback:
   "priority": 100,
   "modelMap": {
     "claude-opus-4-6": "gpt-5.6-sol",
-    "claude-sonnet-4-6": "gpt-5.6-sol"
+    "claude-sonnet-4-6": "gpt-5.6-terra",
+    "claude-haiku-4-5-20251001": "gpt-5.6-luna"
   }
 }
 ```
+
+The Codex models available to a ChatGPT plan, roughly strongest first — all
+three verified against the live backend:
+
+| Model | Description | Default effort |
+|---|---|---|
+| `gpt-5.6-sol` | Latest frontier agentic coding model | `low` |
+| `gpt-5.6-terra` | Balanced agentic coding model for everyday work | `medium` |
+| `gpt-5.6-luna` | Fast and affordable agentic coding model | `medium` |
+
+`modelMap` matches the model string exactly, so include every id your client
+sends — Claude Code may append a `[1m]` context suffix.
 
 Notes and limits:
 
 - Only `/v1/messages` has a Responses-API equivalent. Anthropic-only endpoints
   (`count_tokens`, `oauth/usage`, `bootstrap`, `mcp_servers`) fail over to a
   Claude account, so keep at least one in the fleet.
-- Reasoning effort is mapped onto the levels Codex accepts; `minimal` and
-  `auto` have no equivalent and are clamped to `low` and `medium`.
+- Reasoning effort is mapped onto the levels Codex accepts (`none`, `low`,
+  `medium`, `high`, `xhigh`, `max`). `minimal`, `ultra` and `auto` have no
+  equivalent and are clamped to `low`, `max` and `medium` respectively.
 - Reasoning summaries are not requested, so responses carry no thinking blocks.
 - A ChatGPT plan without Codex access (e.g. free) is rejected by the backend.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sits transparently between Claude Code and the Anthropic API, managing multiple 
 - **Headless mode** — run the proxy without the TUI (`--headless`) for backgrounding/services
 - **Org-aware accounts** — one email can hold multiple accounts across different organizations (e.g. corp + personal); dedup is keyed on account + org, and names disambiguate as `email (Org)`
 - **Third-party backend accounts** — route requests to any Anthropic-compatible API (e.g. DeepSeek, GLM) as a fallback when Claude accounts are exhausted; a per-account `upstream` URL and `modelMap` translate model names transparently. Use [model routes](#model-routes) to reserve a third-party account for sessions that explicitly name its models
-- **ChatGPT Codex accounts** — use a ChatGPT subscription as a backend alongside Claude accounts (`teamclaude login --codex`). Unlike the Anthropic-compatible backends above, Codex speaks the OpenAI Responses API, so requests and streamed responses are translated in both directions; quota is read from its own `x-codex-*` headers so rotation stays predictive. See [ChatGPT Codex](#chatgpt-codex)
+- **ChatGPT Codex accounts** — use a ChatGPT subscription as a backend alongside Claude accounts (`teamclaude login --codex`), with its models offered directly in Claude Code's picker via gateway model discovery. Unlike the Anthropic-compatible backends above, Codex speaks the OpenAI Responses API, so requests and streamed responses are translated in both directions; quota is read from its own `x-codex-*` headers so rotation stays predictive. See [ChatGPT Codex](#chatgpt-codex)
 - **Model blocklist** — reject requests for unwanted models (glob patterns, e.g. `*fable*`) with a fast `400` instead of forwarding them; a model no account can serve otherwise gets rate-limited upstream and hangs the pipeline. Edit live in the TUI settings screen (`g` → Blocked models)
 - **Rotation priority** — pin a preferred account order with `teamclaude priority`
 - **Enable/disable accounts** — temporarily pause an account without removing it (`teamclaude disable`/`enable`, or `d` in the TUI); re-enabling also clears a stuck error state
@@ -121,8 +121,17 @@ independent of the Codex CLI's. Prefer it over importing:
 teamclaude import --codex
 ```
 
-Codex accounts need a `modelMap`, since the backend rejects Claude model
-names, and usually a high `priority` so they act as a fallback:
+Codex models are offered directly in Claude Code's own model picker. Set
+`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` and Claude Code reads
+`/v1/models` from the proxy at startup; TeamClaude answers with the Claude
+catalog **and** every codex account's, so selecting `gpt-5.6-sol` is a
+first-class choice. Requests naming a Codex model route to a codex account
+automatically — no `modelMap` needed, and a Claude account is never picked for
+one (or vice versa).
+
+A `modelMap` is only needed for the other direction: making a codex account
+answer to Claude model names, so it can stand in as a fallback when Claude
+quota runs out. Pair it with a high `priority` so it stays a fallback:
 
 ```json
 {
@@ -138,14 +147,16 @@ names, and usually a high `priority` so they act as a fallback:
 }
 ```
 
-The Codex models available to a ChatGPT plan, roughly strongest first — all
-three verified against the live backend:
+The catalog is read live from Codex, so it stays current as models come and
+go. On a ChatGPT Plus plan today, all verified end to end:
 
 | Model | Description | Default effort |
 |---|---|---|
 | `gpt-5.6-sol` | Latest frontier agentic coding model | `low` |
 | `gpt-5.6-terra` | Balanced agentic coding model for everyday work | `medium` |
 | `gpt-5.6-luna` | Fast and affordable agentic coding model | `medium` |
+| `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` | Previous generations | `medium` |
+| `codex-auto-review` | Review-oriented alias | `medium` |
 
 `modelMap` matches the model string exactly, so include every id your client
 sends — Claude Code may append a `[1m]` context suffix.

--- a/scripts/codex-local-test.sh
+++ b/scripts/codex-local-test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Set up an isolated local test of the codex-protocol fork.
+#
+# Everything lives in its own config on its own port, so an already-installed
+# teamclaude and your real ~/.config/teamclaude.json are left alone.
+#
+#   ./scripts/codex-local-test.sh setup    # import codex account + write config
+#   ./scripts/codex-local-test.sh server   # run the proxy (foreground)
+#   ./scripts/codex-local-test.sh ask      # one-shot curl through the proxy
+#   ./scripts/codex-local-test.sh claude   # run Claude Code through the proxy
+#   ./scripts/codex-local-test.sh status   # accounts + quota
+#   ./scripts/codex-local-test.sh model    # show model ids seen in the logs
+#   ./scripts/codex-local-test.sh clean    # remove the test config + logs
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export TEAMCLAUDE_CONFIG="${TEAMCLAUDE_CONFIG:-$HOME/.config/teamclaude-codex-test.json}"
+LOG_DIR="${TC_TEST_LOGS:-/tmp/teamclaude-codex-logs}"
+PORT="${TC_TEST_PORT:-3499}"
+TC="node $REPO/src/index.js"
+
+case "${1:-}" in
+setup)
+  $TC import --codex
+  # modelMap is EXACT-match on the model string in the request body, and Claude
+  # Code may append a [1m] context suffix, so both spellings are mapped. Add any
+  # id you see via the `model` subcommand.
+  python3 - "$TEAMCLAUDE_CONFIG" "$PORT" <<'PY'
+import json, sys
+path, port = sys.argv[1], int(sys.argv[2])
+cfg = json.load(open(path))
+cfg['proxy']['port'] = port
+base = {
+    'claude-fable-5':  'gpt-5.6-sol',
+    'claude-opus-5':   'gpt-5.6-sol',
+    'claude-sonnet-5': 'gpt-5.6-sol',
+}
+model_map = {}
+for k, v in base.items():
+    model_map[k] = v
+    model_map[f'{k}[1m]'] = v
+for a in cfg['accounts']:
+    if a.get('protocol') == 'codex':
+        a['modelMap'] = model_map
+json.dump(cfg, open(path, 'w'), indent=2)
+print(f"\nconfig : {path}")
+print(f"port   : {port}")
+print("mapped : " + ", ".join(sorted(model_map)))
+PY
+  echo
+  echo "Everything maps to gpt-5.6-sol — the only codex model id confirmed to exist."
+  echo "Next: $0 server   (then, in another shell, $0 ask)"
+  ;;
+
+server)
+  mkdir -p "$LOG_DIR"
+  echo "config $TEAMCLAUDE_CONFIG"
+  echo "logs   $LOG_DIR"
+  exec $TC server --log-to "$LOG_DIR"
+  ;;
+
+ask)
+  shift || true
+  PROMPT="${*:-What is 17 times 23? Just the number.}"
+  curl -sS -N --max-time 90 "http://127.0.0.1:$PORT/v1/messages" \
+    -H 'content-type: application/json' \
+    -d "$(python3 -c '
+import json,sys
+print(json.dumps({
+  "model": "claude-fable-5", "max_tokens": 400, "stream": True,
+  "messages": [{"role": "user", "content": sys.argv[1]}],
+}))' "$PROMPT")" |
+    grep -oE '"text":"[^"]*"' | sed 's/^"text":"//; s/"$//' | tr -d '\n'
+  echo
+  ;;
+
+claude)
+  shift || true
+  # Requires the server to be running (see `server`). Routes via the MITM
+  # forward proxy so even hardcoded api.anthropic.com endpoints are intercepted.
+  exec $TC run "$@"
+  ;;
+
+status)
+  $TC accounts
+  echo
+  $TC status --json 2>/dev/null |
+    python3 -c '
+import json,sys,datetime
+d=json.load(sys.stdin)
+for a in d.get("accounts", []):
+    q=a.get("quota",{})
+    r=q.get("unified7dReset")
+    when=datetime.datetime.fromtimestamp(r/1000, datetime.UTC).isoformat() if r else "unknown"
+    u=q.get("unified7d")
+    print(f'\''{a["name"]}: weekly {"unknown" if u is None else f"{u*100:.1f}% used"}, resets {when}'\'')
+'
+  ;;
+
+model)
+  # The exact model string Claude Code sent, which is what modelMap must key on.
+  if ! ls "$LOG_DIR"/*.log >/dev/null 2>&1; then
+    echo "No request logs yet in $LOG_DIR — run the server with '$0 server' and send a request."
+    exit 1
+  fi
+  grep -ho '"model": *"[^"]*"' "$LOG_DIR"/*.log | sort -u
+  ;;
+
+clean)
+  rm -f "$TEAMCLAUDE_CONFIG"
+  rm -rf "$LOG_DIR"
+  echo "removed $TEAMCLAUDE_CONFIG and $LOG_DIR"
+  ;;
+
+*)
+  sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 1
+  ;;
+esac

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,4 +1,5 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
+import { refreshCodexToken } from './codex/oauth.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches } from './model.js';
 import { SessionTracker } from './session-tracker.js';
@@ -51,6 +52,15 @@ function makeAccount(acct, index) {
     index,
     name: acct.name,
     type: acct.type,
+    // Wire protocol this account speaks. 'anthropic' (the default) forwards the
+    // client's Messages API request essentially untouched; 'codex' translates it
+    // to the OpenAI Responses API. Everything outside the forwarding path —
+    // rotation, priority, routes, disable/enable, TC_ACCT pinning — is
+    // protocol-agnostic and must stay that way.
+    protocol: acct.protocol || 'anthropic',
+    // ChatGPT account id, sent as the chatgpt-account-id header on every codex
+    // request. Null for anthropic accounts.
+    accountId: acct.accountId || null,
     accountUuid: acct.accountUuid || null,
     orgUuid: acct.orgUuid || null,
     orgName: acct.orgName || null,
@@ -100,12 +110,13 @@ function modelMatches(declared, model) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, codexRefreshFn = refreshCodexToken, throttleProbeFloorMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
     // How long a just-minted token is trusted against a forced refresh.
     this._forcedRefreshFloorMs = forcedRefreshFloorMs;
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
-    // OAuth token refresh.
+    // OAuth token refresh. Separate refreshers per protocol — see ensureTokenFresh.
     this._refreshFn = refreshFn;
+    this._codexRefreshFn = codexRefreshFn;
     this.accounts = accounts.map((acct, index) => makeAccount(acct, index));
     this.currentIndex = 0;
     // Session awareness (issue #109). The tracker is always on (passive — it just
@@ -1186,10 +1197,20 @@ export class AccountManager {
     account._refreshPromise = (async () => {
       console.log(`[TeamClaude] Refreshing token for account "${account.name}"...`);
       try {
-        const newTokens = await this._refreshFn(account.refreshToken);
+        // Dispatch on protocol: codex accounts refresh against OpenAI's token
+        // endpoint with a different client id and wire format. Both refreshers
+        // share an error contract (err.status set on HTTP failures) so the
+        // auth-rejection handling below works identically for either.
+        const refreshFn = account.protocol === 'codex' ? this._codexRefreshFn : this._refreshFn;
+        const newTokens = await refreshFn(account.refreshToken);
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
+        // A codex refresh re-derives the account id from the fresh id_token, so
+        // a server-side account migration is picked up instead of staying
+        // pinned to whatever was imported. Guard against a null so a partial
+        // response can't erase a working id.
+        if (newTokens.accountId) account.accountId = newTokens.accountId;
         account._lastRefreshAt = Date.now();
         console.log(`[TeamClaude] Token refreshed for account "${account.name}"`);
         this._onTokenRefresh?.(accountIndex, newTokens);

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -373,8 +373,8 @@ export class AccountManager {
   /** Record that a session's request was served by an account (always on, even
    * when distribution is off — the readout is passive). This is what pins a
    * session for future affinity. */
-  recordSession(sessionId, accountIndex) {
-    if (sessionId) this.sessionTracker.touch(sessionId, accountIndex);
+  recordSession(sessionId, accountIndex, served = null) {
+    if (sessionId) this.sessionTracker.touch(sessionId, accountIndex, undefined, served);
   }
 
   /** Mark a session request as in flight / finished. Paired around the whole

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,6 +1,7 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { refreshCodexToken } from './codex/oauth.js';
 import { parseCodexQuota } from './codex/quota.js';
+import { isCodexNativeModel } from './codex/models.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches } from './model.js';
 import { SessionTracker } from './session-tracker.js';
@@ -571,6 +572,12 @@ export class AccountManager {
     // that family — the account still serves every other model normally.
     if (this._isNearQuota(account, model)) return false;
 
+    // Protocol capability: an account can only be picked for a model its
+    // backend actually serves. Without this a request naming a GPT model could
+    // land on a Claude account (and vice versa) and fail upstream, which is how
+    // a codex account with no modelMap used to 400 on every claude-* request.
+    if (model && !this._protocolServesModel(account, model)) return false;
+
     // Route/ownership restriction: a configured route can pin a model pattern to
     // an exclusive set of accounts; failing that, a per-account `models` claim
     // restricts an owned model to its owners. Either way an account not eligible
@@ -629,6 +636,20 @@ export class AccountManager {
    * list is exclusive (only listed accounts, by name or index). With no matching
    * route — or a route that lists no accounts — it falls back to the per-account
    * `models` ownership claim (deprecated — use `routes` instead). */
+  /**
+   * Can this account's backend serve `model` at all?
+   *
+   * A codex account serves models Codex knows natively, plus anything its
+   * modelMap redirects onto one. An Anthropic account serves everything else —
+   * it has no way to answer a GPT model name, so it must not be selected for one
+   * even when it is the only account left.
+   */
+  _protocolServesModel(account, model) {
+    const native = isCodexNativeModel(model);
+    if (account.protocol === 'codex') return native || !!account.modelMap?.[model];
+    return !native;
+  }
+
   _routeAllows(account, model) {
     const route = this._routeForModel(model);
     if (route && route.accounts.length) {

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,5 +1,6 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { refreshCodexToken } from './codex/oauth.js';
+import { parseCodexQuota } from './codex/quota.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches } from './model.js';
 import { SessionTracker } from './session-tracker.js';
@@ -1014,6 +1015,14 @@ export class AccountManager {
     const account = this.accounts[accountIndex];
     if (!account) return;
 
+    // Codex reports quota in its own header family. It is normalized onto the
+    // same unified5h/unified7d fields so selection, the switch threshold,
+    // status rendering and state persistence need no protocol awareness.
+    if (account.protocol === 'codex') {
+      this._updateCodexQuota(account, headers);
+      return;
+    }
+
     // Unified rate limits (Claude Max)
     const u5h = parseFloat(headers['anthropic-ratelimit-unified-5h-utilization']);
     const u7d = parseFloat(headers['anthropic-ratelimit-unified-7d-utilization']);
@@ -1070,6 +1079,44 @@ export class AccountManager {
         ? (account.quota.unified7d * 100).toFixed(1)
         : account.quota.tokensLimit
           ? ((1 - account.quota.tokensRemaining / account.quota.tokensLimit) * 100).toFixed(1)
+          : '?';
+      console.log(`[TeamClaude] Account "${account.name}" at ${pct}% usage — will switch on next request`);
+    }
+  }
+
+  /**
+   * Record quota for a codex account from its x-codex-* response headers.
+   *
+   * Mirrors the bookkeeping the Anthropic branch does — request counter, probe
+   * clearing, near-quota warning — so a codex account behaves identically to
+   * its peers everywhere downstream.
+   */
+  _updateCodexQuota(account, headers) {
+    const parsed = parseCodexQuota(headers);
+
+    if (parsed.unified5h !== undefined) account.quota.unified5h = parsed.unified5h;
+    if (parsed.unified5hReset !== undefined) account.quota.unified5hReset = parsed.unified5hReset;
+    if (parsed.unified7d !== undefined) account.quota.unified7d = parsed.unified7d;
+    if (parsed.unified7dReset !== undefined) account.quota.unified7dReset = parsed.unified7dReset;
+    if (parsed.planType) account.planType = parsed.planType;
+
+    // Same trigger as the Anthropic path: the account was selected partly to
+    // discover its quota, and now that a real limit is known, selection should
+    // re-evaluate rather than stay on it by inertia.
+    if (account.probing && account.quota.unified7dReset != null) {
+      account.probing = false;
+      account.requalify = true;
+      console.log(`[TeamClaude] Learned weekly quota for "${account.name}", re-evaluating selection`);
+    }
+
+    account.usage.totalRequests++;
+    account.usage.lastUsed = new Date().toISOString();
+
+    if (this._isNearQuota(account)) {
+      const pct = account.quota.unified7d != null
+        ? (account.quota.unified7d * 100).toFixed(1)
+        : account.quota.unified5h != null
+          ? (account.quota.unified5h * 100).toFixed(1)
           : '?';
       console.log(`[TeamClaude] Account "${account.name}" at ${pct}% usage — will switch on next request`);
     }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1216,12 +1216,17 @@ export class AccountManager {
    * Ensure an OAuth account's token is fresh, refreshing if needed.
    * Pass force=true to refresh regardless of expiry (e.g. after a 401).
    * Concurrent calls for the same account coalesce into a single refresh.
+   *
+   * `thresholdMs` widens what counts as "expiring soon". The default suits the
+   * request path, where a token only has to survive the request about to be
+   * sent. A scheduled refresher passes a larger window so it can renew a token
+   * well before expiry rather than at the last moment.
    */
-  async ensureTokenFresh(accountIndex, force = false) {
+  async ensureTokenFresh(accountIndex, force = false, thresholdMs = undefined) {
     const account = this.accounts[accountIndex];
     if (!account || account.type !== 'oauth' || !account.refreshToken) return;
 
-    if (!force && !isTokenExpiringSoon(account.expiresAt)) return;
+    if (!force && !isTokenExpiringSoon(account.expiresAt, thresholdMs)) return;
 
     // A forced refresh answers a 401, but 401s arrive in bursts: every request
     // already in flight when the token went bad comes back rejected, and each

--- a/src/codex/models.js
+++ b/src/codex/models.js
@@ -1,0 +1,122 @@
+import { codexHeaders, CODEX_BASE_URL } from './protocol.js';
+
+// The Codex model catalog, fetched from the backend and translated into the
+// shape Anthropic's /v1/models returns.
+//
+// This is what lets Claude Code list GPT models in its own picker: with
+// CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY set, it reads /v1/models from the
+// gateway at startup and offers whatever comes back. Serving the codex models
+// there means selecting one is a first-class choice rather than something you
+// have to disguise as a Claude model via modelMap.
+
+// The catalog endpoint requires a client_version query parameter and 400s
+// without one; the value only has to parse, not match any released build.
+const CLIENT_VERSION = '0.146.0';
+
+// The catalog changes on the order of model launches, so a long TTL is fine.
+// It is refreshed lazily on the next request after it lapses.
+const CACHE_TTL_MS = 60 * 60_000;
+
+// Models Codex serves natively. Used for routing rather than the fetched
+// catalog on purpose: selection has to work before any catalog fetch has
+// happened (and when the fetch fails), and a request naming an unknown gpt-*
+// model is better rejected by the backend than mis-routed to Anthropic.
+const NATIVE_MODEL_PATTERN = /^(gpt-|codex-|o\d)/i;
+
+/**
+ * Does this model name belong to Codex rather than Anthropic?
+ *
+ * Deliberately a name test, not a catalog lookup — see NATIVE_MODEL_PATTERN.
+ */
+export function isCodexNativeModel(model) {
+  return typeof model === 'string' && NATIVE_MODEL_PATTERN.test(model.trim());
+}
+
+/**
+ * Translate one catalog entry into an Anthropic /v1/models entry.
+ *
+ * Claude Code reads `id` and `display_name` for the picker; the capability
+ * block is filled in from what the catalog reports so an effort a model cannot
+ * serve isn't advertised as available.
+ */
+export function codexModelToAnthropic(entry, createdAt) {
+  const id = entry.slug || entry.id;
+  if (!id) return null;
+
+  const efforts = (entry.supported_reasoning_levels || [])
+    .map(l => l && l.effort)
+    .filter(Boolean);
+
+  const effort = { supported: efforts.length > 0 };
+  for (const level of efforts) effort[level] = { supported: true };
+
+  return {
+    type: 'model',
+    id,
+    display_name: entry.display_name || id,
+    created_at: createdAt,
+    ...(entry.context_window ? { max_input_tokens: entry.context_window } : {}),
+    capabilities: {
+      effort,
+      // Codex reasons internally but is not asked for summaries, so no thinking
+      // blocks come back; advertising thinking support would be a lie the client
+      // would act on.
+      thinking: { supported: false },
+      image_input: { supported: true },
+      structured_outputs: { supported: true },
+    },
+    // Not part of Anthropic's schema — a marker so a caller can tell where an
+    // entry came from without re-testing the name.
+    _codex: true,
+  };
+}
+
+const cache = new Map(); // accountId -> { at, models }
+
+/**
+ * Fetch the Codex model catalog for an account, as Anthropic-format entries.
+ *
+ * Returns [] rather than throwing: this feeds a model listing, and a listing
+ * that loses its Claude models because a ChatGPT token expired would be worse
+ * than one missing its GPT models.
+ */
+export async function fetchCodexModels(account, { now = Date.now(), fetchImpl = fetch } = {}) {
+  const key = account?.accountId || account?.name || 'default';
+  const hit = cache.get(key);
+  if (hit && now - hit.at < CACHE_TTL_MS) return hit.models;
+
+  try {
+    const headers = codexHeaders(account, { stream: false });
+    // The catalog is a plain GET; drop the streaming Accept the request path uses.
+    headers['accept'] = 'application/json';
+    delete headers['content-type'];
+
+    const base = (account.upstream || CODEX_BASE_URL).replace(/\/$/, '');
+    const res = await fetchImpl(`${base}/models?client_version=${CLIENT_VERSION}`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      await res.body?.cancel?.();
+      return hit ? hit.models : [];
+    }
+
+    const data = await res.json();
+    const entries = Array.isArray(data?.models) ? data.models : [];
+    // One timestamp for the batch: the catalog carries no per-model release
+    // date, and the field is required by the schema Claude Code parses.
+    const createdAt = new Date(now).toISOString().replace(/\.\d+Z$/, 'Z');
+    const models = entries.map(e => codexModelToAnthropic(e, createdAt)).filter(Boolean);
+
+    cache.set(key, { at: now, models });
+    return models;
+  } catch {
+    return hit ? hit.models : [];
+  }
+}
+
+/** Drop cached catalogs — used by tests and after an account set changes. */
+export function clearCodexModelCache() {
+  cache.clear();
+}

--- a/src/codex/models.js
+++ b/src/codex/models.js
@@ -32,6 +32,49 @@ export function isCodexNativeModel(model) {
   return typeof model === 'string' && NATIVE_MODEL_PATTERN.test(model.trim());
 }
 
+// Claude Code drops any model from a gateway listing whose id does not start
+// with `claude-`, so a GPT id offered as-is never reaches its picker. Encoding
+// the real id inside a claude-prefixed one is how CLIProxyAPI gets around that
+// (internal/client/claude/models, EnsureClaudeModelIDPrefix), and this mirrors
+// it byte-for-byte so a config written for one works with the other.
+//
+// The id is reversed rather than appended plainly so the result cannot collide
+// with, or be mistaken for, a real Anthropic model name.
+const CLOAK_PREFIX = 'claude-fable-5-dd-';
+
+const reverse = s => [...s].reverse().join('');
+
+/** Encode a model id so Claude Code's picker will accept it. */
+export function cloakModelId(id) {
+  if (!id || id.startsWith('claude-')) return id;
+  return CLOAK_PREFIX + reverse(id);
+}
+
+/**
+ * Decode a cloaked id back to the real model name.
+ *
+ * Any thinking suffix in `model(value)` form is preserved, matching the
+ * reference implementation — the suffix is not part of the encoded id.
+ */
+export function uncloakModelId(id) {
+  if (typeof id !== 'string' || !id) return id;
+
+  let base = id;
+  let suffix = null;
+  const open = id.lastIndexOf('(');
+  if (open !== -1 && id.endsWith(')')) {
+    base = id.slice(0, open);
+    suffix = id.slice(open + 1, -1);
+  }
+
+  if (!base.startsWith(CLOAK_PREFIX)) return id;
+  const encoded = base.slice(CLOAK_PREFIX.length);
+  if (!encoded) return id;
+
+  const resolved = reverse(encoded);
+  return suffix === null ? resolved : `${resolved}(${suffix})`;
+}
+
 /**
  * Translate one catalog entry into an Anthropic /v1/models entry.
  *

--- a/src/codex/oauth.js
+++ b/src/codex/oauth.js
@@ -1,0 +1,199 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// OAuth configuration for ChatGPT-backed Codex accounts. The client id is the
+// public one the Codex CLI ships with: these credentials authenticate a ChatGPT
+// subscription, not a platform API key, so there is no secret to protect here.
+const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const SCOPE = 'openid profile email';
+
+// The account id lives in a namespaced claim on the id_token rather than a
+// plain field. It is required on every upstream call (as chatgpt-account-id),
+// so an account that loses it is unusable even with a valid access token.
+const ACCOUNT_ID_CLAIM = 'https://api.openai.com/auth';
+
+export const CODEX_DEFAULT_AUTH_PATH = join(homedir(), '.codex', 'auth.json');
+
+/**
+ * Decode a JWT's payload without verifying its signature. We never make a trust
+ * decision from these claims — they only supply the account id and an expiry
+ * hint for a token the issuer already handed us — so verification would buy
+ * nothing and would require fetching OpenAI's JWKS.
+ */
+export function decodeJwtClaims(token) {
+  const payload = typeof token === 'string' ? token.split('.')[1] : null;
+  if (!payload) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the ChatGPT account id out of an id_token. Falls back through the
+ * flattened spelling some token versions use before giving up.
+ */
+export function extractAccountId(idToken) {
+  const claims = decodeJwtClaims(idToken);
+  if (!claims) return null;
+  return claims[ACCOUNT_ID_CLAIM]?.chatgpt_account_id
+    || claims[`${ACCOUNT_ID_CLAIM}.chatgpt_account_id`]
+    || null;
+}
+
+/**
+ * Read the plan type (e.g. "plus", "pro") for display in account listings.
+ */
+export function extractPlanType(idToken) {
+  const claims = decodeJwtClaims(idToken);
+  if (!claims) return null;
+  return claims[ACCOUNT_ID_CLAIM]?.chatgpt_plan_type
+    || claims[`${ACCOUNT_ID_CLAIM}.chatgpt_plan_type`]
+    || null;
+}
+
+/**
+ * Read the account's email, used as the default account name on import.
+ */
+export function extractEmail(idToken) {
+  return decodeJwtClaims(idToken)?.email || null;
+}
+
+/**
+ * Derive an expiry (ms epoch) for an access token. OpenAI's refresh response
+ * carries expires_in, but a credential file imported from the Codex CLI has no
+ * expiry field at all — for those we read `exp` off the token itself so an
+ * already-dead token is refreshed before its first use rather than after a 401.
+ */
+export function expiryFromToken(accessToken) {
+  const exp = decodeJwtClaims(accessToken)?.exp;
+  return typeof exp === 'number' ? exp * 1000 : null;
+}
+
+/**
+ * Refresh a Codex access token using its refresh token.
+ *
+ * Deliberately mirrors the retry/error contract of the Anthropic
+ * refreshAccessToken: retry 5xx and network errors with exponential backoff,
+ * and set `err.status` on HTTP failures. AccountManager.ensureTokenFresh keys
+ * off that status to tell a dead refresh token (sideline the account, needs
+ * re-login) apart from a transient blip (keep the account, retry later), so a
+ * codex refresh that threw a bare Error would wrongly look transient forever.
+ *
+ * Note the wire format differs from Anthropic's: OpenAI wants form-encoded
+ * fields, not JSON.
+ */
+export async function refreshCodexToken(refreshToken) {
+  const maxRetries = 2;
+  const baseDelayMs = 500;
+  const timeoutMs = Number(process.env.TEAMCLAUDE_REFRESH_TIMEOUT_MS) || 30_000;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      if (attempt > 0) {
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+
+      const res = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        },
+        body: new URLSearchParams({
+          client_id: CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          scope: SCOPE,
+        }).toString(),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (!res.ok) {
+        if (res.status >= 500 && attempt < maxRetries) {
+          await res.body?.cancel();
+          continue;
+        }
+        const text = await res.text();
+        const err = new Error(`Codex token refresh failed (${res.status}): ${text}`);
+        err.status = res.status;
+        throw err;
+      }
+
+      const data = await res.json();
+      const accessToken = data.access_token;
+      return {
+        accessToken,
+        // OpenAI may or may not rotate the refresh token; keep the old one when
+        // the response omits it, matching the Anthropic path.
+        refreshToken: data.refresh_token || refreshToken,
+        expiresAt: data.expires_in
+          ? Date.now() + data.expires_in * 1000
+          : expiryFromToken(accessToken),
+        // A refresh returns a fresh id_token; re-derive the account id from it
+        // so a server-side account migration is picked up rather than pinned to
+        // whatever was imported.
+        accountId: extractAccountId(data.id_token) || null,
+        idToken: data.id_token || null,
+      };
+    } catch (err) {
+      const isNetworkError = err instanceof Error &&
+        (err.name === 'TimeoutError' || err.name === 'AbortError' ||
+          err.message.includes('fetch failed') ||
+          (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
+           err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT'));
+
+      if (attempt < maxRetries && isNetworkError) {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Import credentials from a Codex CLI auth file (~/.codex/auth.json).
+ *
+ * Only ChatGPT OAuth credentials are accepted. An `apikey` auth_mode file holds
+ * a platform API key, which talks to a different host with different billing
+ * and would fail in confusing ways if we silently accepted it here.
+ */
+export async function importCodexCredentials(filePath = CODEX_DEFAULT_AUTH_PATH) {
+  const resolvedPath = filePath.replace(/^~/, homedir());
+  const raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
+
+  const tokens = raw.tokens || {};
+  if (raw.auth_mode && raw.auth_mode !== 'chatgpt') {
+    throw new Error(
+      `Unsupported Codex auth_mode "${raw.auth_mode}" in ${resolvedPath}. ` +
+      'Only ChatGPT OAuth credentials are supported; run `codex login` to create them.'
+    );
+  }
+  if (!tokens.access_token || !tokens.refresh_token) {
+    throw new Error(`No Codex OAuth tokens found in ${resolvedPath} — run \`codex login\` first.`);
+  }
+
+  const accountId = tokens.account_id || extractAccountId(tokens.id_token);
+  if (!accountId) {
+    throw new Error(
+      `Could not determine the ChatGPT account id from ${resolvedPath}. ` +
+      'Re-run `codex login` to refresh the credential file.'
+    );
+  }
+
+  return {
+    protocol: 'codex',
+    type: 'oauth',
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    idToken: tokens.id_token || null,
+    accountId,
+    expiresAt: expiryFromToken(tokens.access_token),
+    email: extractEmail(tokens.id_token),
+    planType: extractPlanType(tokens.id_token),
+  };
+}

--- a/src/codex/oauth.js
+++ b/src/codex/oauth.js
@@ -1,13 +1,24 @@
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { randomBytes, createHash } from 'node:crypto';
+import { exec } from 'node:child_process';
+import http from 'node:http';
 
 // OAuth configuration for ChatGPT-backed Codex accounts. The client id is the
 // public one the Codex CLI ships with: these credentials authenticate a ChatGPT
 // subscription, not a platform API key, so there is no secret to protect here.
 const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const AUTH_URL = 'https://auth.openai.com/oauth/authorize';
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const SCOPE = 'openid profile email';
+
+// The authorization flow needs offline_access to be issued a refresh token at
+// all. The redirect URI is fixed: it is registered against the Codex CLI's
+// client id, so the callback listener has to bind this exact port.
+const LOGIN_SCOPE = 'openid email profile offline_access';
+const REDIRECT_PORT = 1455;
+const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/auth/callback`;
 
 // The account id lives in a namespaced claim on the id_token rather than a
 // plain field. It is required on every upstream call (as chatgpt-account-id),
@@ -153,6 +164,165 @@ export async function refreshCodexToken(refreshToken) {
       throw err;
     }
   }
+}
+
+function openBrowser(url) {
+  const cmd = process.platform === 'darwin' ? 'open'
+    : process.platform === 'win32' ? 'start'
+    : 'xdg-open';
+  exec(`${cmd} ${JSON.stringify(url)}`, () => {});
+}
+
+/**
+ * Listen for the OAuth redirect.
+ *
+ * Unlike the Anthropic flow this cannot take an ephemeral port: the redirect
+ * URI is registered against the Codex CLI's client id, so the callback must
+ * arrive on exactly REDIRECT_PORT. A busy port therefore means something else
+ * is mid-login (most likely the Codex CLI), which is worth saying plainly
+ * rather than surfacing as a bare EADDRINUSE.
+ */
+function startCodexCallbackServer(expectedState) {
+  return new Promise((resolve, reject) => {
+    let resolveCode, rejectCode;
+    const codePromise = new Promise((res, rej) => { resolveCode = res; rejectCode = rej; });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://localhost');
+      if (url.pathname !== '/auth/callback') {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const done = (message) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body style="font-family:system-ui;padding:3rem"><h2>${message}</h2><p>You can close this tab.</p></body></html>`);
+      };
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        done('Authentication failed');
+        rejectCode(new Error(`OAuth error: ${error} — ${url.searchParams.get('error_description') || ''}`));
+        return;
+      }
+      if (url.searchParams.get('state') !== expectedState) {
+        done('Authentication failed');
+        rejectCode(new Error('OAuth state mismatch'));
+        return;
+      }
+      const code = url.searchParams.get('code');
+      if (code) {
+        done('Signed in to TeamClaude');
+        resolveCode(code);
+      }
+    });
+
+    server.listen(REDIRECT_PORT, () => resolve({ codePromise, server }));
+    server.on('error', err => {
+      reject(err.code === 'EADDRINUSE'
+        ? new Error(`Port ${REDIRECT_PORT} is in use — close any running \`codex login\` and try again.`)
+        : err);
+    });
+
+    const timer = setTimeout(() => {
+      rejectCode(new Error('Timed out waiting for the OAuth callback'));
+      server.close();
+    }, 5 * 60_000);
+    timer.unref?.();
+  });
+}
+
+/**
+ * Log in to ChatGPT and obtain a Codex credential of our own.
+ *
+ * This is the alternative to `import --codex`, and the reason to prefer it: an
+ * imported credential is a COPY of the Codex CLI's, so both hold one refresh
+ * token, and since OpenAI rotates it on every refresh whichever party refreshes
+ * second is left holding a dead one. A separate authorization mints an
+ * independent refresh-token lineage, so teamclaude and the CLI can refresh on
+ * their own schedules without invalidating each other.
+ *
+ * `prompt=login` forces a fresh authorization rather than silently reusing an
+ * existing session, which is what makes the grant independent.
+ */
+export function buildCodexAuthUrl({ state, codeChallenge }) {
+  const authUrl = new URL(AUTH_URL);
+  authUrl.searchParams.set('client_id', CLIENT_ID);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('redirect_uri', REDIRECT_URI);
+  // offline_access is what gets a refresh token issued at all.
+  authUrl.searchParams.set('scope', LOGIN_SCOPE);
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('code_challenge', codeChallenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+  // Forces a fresh authorization instead of silently reusing an existing
+  // session. This is the parameter that makes the resulting grant — and so the
+  // refresh-token lineage — independent of the Codex CLI's.
+  authUrl.searchParams.set('prompt', 'login');
+  authUrl.searchParams.set('id_token_add_organizations', 'true');
+  authUrl.searchParams.set('codex_cli_simplified_flow', 'true');
+  return authUrl.toString();
+}
+
+export async function loginCodex() {
+  const codeVerifier = randomBytes(64).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const state = randomBytes(32).toString('base64url');
+
+  const { codePromise, server } = await startCodexCallbackServer(state);
+  const authUrl = new URL(buildCodexAuthUrl({ state, codeChallenge }));
+
+  console.log('Opening browser to sign in to ChatGPT...');
+  console.log(`If it doesn't open, visit:\n  ${authUrl.toString()}\n`);
+  openBrowser(authUrl.toString());
+
+  let code;
+  try {
+    code = await codePromise;
+  } finally {
+    server.close();
+  }
+
+  console.log('Exchanging authorization code for tokens...');
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: codeVerifier,
+    }).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    const err = new Error(`Codex token exchange failed (${res.status}): ${text}`);
+    err.status = res.status;
+    throw err;
+  }
+
+  const data = await res.json();
+  const accountId = extractAccountId(data.id_token);
+  if (!accountId) {
+    throw new Error('Sign-in succeeded but the response carried no ChatGPT account id.');
+  }
+
+  return {
+    protocol: 'codex',
+    type: 'oauth',
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    idToken: data.id_token || null,
+    accountId,
+    expiresAt: data.expires_in
+      ? Date.now() + data.expires_in * 1000
+      : expiryFromToken(data.access_token),
+    email: extractEmail(data.id_token),
+    planType: extractPlanType(data.id_token),
+  };
 }
 
 /**

--- a/src/codex/protocol.js
+++ b/src/codex/protocol.js
@@ -1,0 +1,127 @@
+import { randomUUID } from 'node:crypto';
+
+// ChatGPT's Codex backend. Requests go to `${BASE}/responses` rather than the
+// Anthropic `/v1/messages` path the client asked for, so the codex path builds
+// its URL explicitly instead of appending req.url to an upstream base.
+export const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+// These credentials authenticate a ChatGPT subscription through the Codex CLI's
+// OAuth client, and the backend expects requests to look like they came from
+// that CLI. The version string is the surface most likely to need bumping when
+// the backend tightens validation.
+const CODEX_USER_AGENT = 'codex-tui/0.146.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.146.0)';
+const CODEX_ORIGINATOR = 'codex-tui';
+
+/**
+ * Build the upstream URL for a codex account.
+ *
+ * `path` is the client's original request path. Only the Messages endpoint has
+ * a Responses-API equivalent; anything else (token counting, and the various
+ * Anthropic-only endpoints) has no mapping and is rejected by the caller rather
+ * than silently forwarded somewhere wrong.
+ */
+export function codexUrlForPath(path, baseUrl = CODEX_BASE_URL) {
+  const base = baseUrl.replace(/\/$/, '');
+  if (/^\/v1\/messages\/?$/.test(path.split('?')[0])) return `${base}/responses`;
+  return null;
+}
+
+/**
+ * Headers for a codex upstream request.
+ *
+ * Built from scratch rather than copied from the client: the inbound request
+ * carries Anthropic-specific headers (anthropic-version, anthropic-beta,
+ * x-api-key) that mean nothing here, and forwarding the client's user-agent
+ * would defeat the CLI impersonation the backend expects.
+ */
+export function codexHeaders(account, { stream = false, sessionId = null } = {}) {
+  const headers = {
+    'content-type': 'application/json',
+    'authorization': `Bearer ${account.credential}`,
+    'user-agent': CODEX_USER_AGENT,
+    'originator': CODEX_ORIGINATOR,
+    'accept': stream ? 'text/event-stream' : 'application/json',
+    // A missing account id reads as "not a subscription request" upstream and
+    // fails in a way that looks like an auth problem, so treat its absence as a
+    // programming error at the seam rather than letting the request go out bare.
+    'chatgpt-account-id': account.accountId,
+    // The backend groups turns by session; reuse the client's session id when we
+    // have one so multi-turn conversations stay coherent, and mint a stable one
+    // per request otherwise.
+    'session_id': sessionId || randomUUID(),
+  };
+  return headers;
+}
+
+/**
+ * Does this account speak the Codex wire protocol?
+ */
+export function isCodexAccount(account) {
+  return account?.protocol === 'codex';
+}
+
+/**
+ * Is this request asking for a streamed response?
+ *
+ * Deliberately a full parse rather than the streaming TopLevelFieldFinder used
+ * elsewhere: that machine only captures string values (bare literals fall
+ * through its scalar case), so it reports null for `"stream": true`. The codex
+ * path parses the whole body during translation anyway, so nothing is lost.
+ */
+export function isStreamingRequest(body) {
+  if (!body || body.length === 0) return false;
+  try {
+    return JSON.parse(Buffer.isBuffer(body) ? body.toString('utf-8') : String(body)).stream === true;
+  } catch {
+    return false;
+  }
+}
+
+class NotImplemented extends Error {
+  constructor(what) {
+    super(`${what} is not implemented yet (codex protocol translator, milestone 2)`);
+    this.name = 'NotImplemented';
+    this.notImplemented = true;
+  }
+}
+
+/**
+ * Translate an Anthropic Messages API request body into an OpenAI Responses API
+ * request body.
+ *
+ * Shape of the work (see CLIProxyAPI internal/translator/codex/claude for a
+ * reference implementation): `system` becomes a developer-role input message,
+ * each Anthropic content block (text / image / tool_use / tool_result) maps to a
+ * Responses input item, Anthropic tool schemas become function declarations, and
+ * `thinking` maps onto `reasoning`.
+ *
+ * @param {Buffer} body - raw Anthropic request body
+ * @param {string} model - upstream model name, already mapped via account.modelMap
+ * @returns {Buffer} raw Responses API request body
+ */
+export function claudeRequestToCodex(body, model) { // eslint-disable-line no-unused-vars
+  throw new NotImplemented('claudeRequestToCodex');
+}
+
+/**
+ * Create a stateful translator that converts a Codex SSE stream into an
+ * Anthropic SSE stream.
+ *
+ * Stateful because the two event models do not line up one-to-one: Anthropic
+ * requires content blocks to be opened and closed with monotonically increasing
+ * indices, while Codex emits output items that can interleave reasoning, text,
+ * and tool calls. The translator owns that block bookkeeping across the stream.
+ *
+ * @returns {{ push(chunk: Buffer): Buffer[], end(): Buffer[] }}
+ */
+export function createCodexStreamTranslator() {
+  throw new NotImplemented('createCodexStreamTranslator');
+}
+
+/**
+ * Translate a complete (non-streaming) Codex response body into an Anthropic
+ * Messages response body.
+ */
+export function codexResponseToClaude(body) { // eslint-disable-line no-unused-vars
+  throw new NotImplemented('codexResponseToClaude');
+}

--- a/src/codex/protocol.js
+++ b/src/codex/protocol.js
@@ -77,51 +77,6 @@ export function isStreamingRequest(body) {
   }
 }
 
-class NotImplemented extends Error {
-  constructor(what) {
-    super(`${what} is not implemented yet (codex protocol translator, milestone 2)`);
-    this.name = 'NotImplemented';
-    this.notImplemented = true;
-  }
-}
-
-/**
- * Translate an Anthropic Messages API request body into an OpenAI Responses API
- * request body.
- *
- * Shape of the work (see CLIProxyAPI internal/translator/codex/claude for a
- * reference implementation): `system` becomes a developer-role input message,
- * each Anthropic content block (text / image / tool_use / tool_result) maps to a
- * Responses input item, Anthropic tool schemas become function declarations, and
- * `thinking` maps onto `reasoning`.
- *
- * @param {Buffer} body - raw Anthropic request body
- * @param {string} model - upstream model name, already mapped via account.modelMap
- * @returns {Buffer} raw Responses API request body
- */
-export function claudeRequestToCodex(body, model) { // eslint-disable-line no-unused-vars
-  throw new NotImplemented('claudeRequestToCodex');
-}
-
-/**
- * Create a stateful translator that converts a Codex SSE stream into an
- * Anthropic SSE stream.
- *
- * Stateful because the two event models do not line up one-to-one: Anthropic
- * requires content blocks to be opened and closed with monotonically increasing
- * indices, while Codex emits output items that can interleave reasoning, text,
- * and tool calls. The translator owns that block bookkeeping across the stream.
- *
- * @returns {{ push(chunk: Buffer): Buffer[], end(): Buffer[] }}
- */
-export function createCodexStreamTranslator() {
-  throw new NotImplemented('createCodexStreamTranslator');
-}
-
-/**
- * Translate a complete (non-streaming) Codex response body into an Anthropic
- * Messages response body.
- */
-export function codexResponseToClaude(body) { // eslint-disable-line no-unused-vars
-  throw new NotImplemented('codexResponseToClaude');
-}
+// The body translators live in ./request-translate.js and ./response-translate.js;
+// this module stays limited to transport concerns (URL, headers, account shape)
+// so the translation layer can be tested without a server.

--- a/src/codex/protocol.js
+++ b/src/codex/protocol.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
 
 // ChatGPT's Codex backend. Requests go to `${BASE}/responses` rather than the
 // Anthropic `/v1/messages` path the client asked for, so the codex path builds
@@ -34,7 +34,7 @@ export function codexUrlForPath(path, baseUrl = CODEX_BASE_URL) {
  * x-api-key) that mean nothing here, and forwarding the client's user-agent
  * would defeat the CLI impersonation the backend expects.
  */
-export function codexHeaders(account, { stream = false, sessionId = null } = {}) {
+export function codexHeaders(account, { stream = false, cacheKey = null } = {}) {
   const headers = {
     'content-type': 'application/json',
     'authorization': `Bearer ${account.credential}`,
@@ -45,10 +45,11 @@ export function codexHeaders(account, { stream = false, sessionId = null } = {})
     // fails in a way that looks like an auth problem, so treat its absence as a
     // programming error at the seam rather than letting the request go out bare.
     'chatgpt-account-id': account.accountId,
-    // The backend groups turns by session; reuse the client's session id when we
-    // have one so multi-turn conversations stay coherent, and mint a stable one
-    // per request otherwise.
-    'session_id': sessionId || randomUUID(),
+    // The backend groups turns by this header AND, when the body names no
+    // prompt_cache_key, echoes it back as one — so it must carry the derived
+    // cache key rather than a per-request UUID, or nothing is ever cached.
+    // randomUUID only stands in for a caller that supplied no key at all.
+    'session_id': cacheKey || randomUUID(),
   };
   return headers;
 }
@@ -58,6 +59,44 @@ export function codexHeaders(account, { stream = false, sessionId = null } = {})
  */
 export function isCodexAccount(account) {
   return account?.protocol === 'codex';
+}
+
+// Claude Code identifies a session and (for sub-agents) the agent within it.
+// CLIProxyAPI keys its Codex prompt cache off the same pair.
+export const SESSION_HEADER = 'x-claude-code-session-id';
+export const AGENT_HEADER = 'x-claude-code-agent-id';
+const MAIN_AGENT = 'main';
+
+/**
+ * Derive the prompt cache key for a request.
+ *
+ * Codex caches on a prompt prefix but scopes the cache by this key, so it has
+ * to be STABLE across the turns of a conversation — a fresh key each request
+ * means every turn re-reads the whole prefix at full price. Measured on a 3k
+ * token prompt: a stable key caches 2816 of 3016 input tokens from the second
+ * turn on, a per-request key caches nothing at all.
+ *
+ * Derived rather than random so it is stable without having to store anything,
+ * and hashed so a session id never travels to the backend in the clear.
+ *
+ * The fallback matters as much as the main path: a client that sends no session
+ * header (a plain SDK call, curl, anything that is not Claude Code) previously
+ * got a fresh UUID per request and therefore no caching whatsoever. Falling back
+ * to the account plus model keeps a stable key for those callers too.
+ */
+export function codexPromptCacheKey(account, { sessionId = null, agentId = null, model = null } = {}) {
+  const scope = sessionId
+    ? `session:${sessionId}:agent:${agentId || MAIN_AGENT}`
+    : `account:${account?.accountId || account?.name || 'unknown'}`;
+  const digest = createHash('sha256')
+    .update(`teamclaude:codex:prompt-cache\0${model || ''}\0${scope}`)
+    .digest('hex');
+  // Formatted as a UUID because that is the shape the backend echoes back as
+  // prompt_cache_key; an arbitrary string works but reads as a foreign value.
+  return [
+    digest.slice(0, 8), digest.slice(8, 12), digest.slice(12, 16),
+    digest.slice(16, 20), digest.slice(20, 32),
+  ].join('-');
 }
 
 /**

--- a/src/codex/quota.js
+++ b/src/codex/quota.js
@@ -1,0 +1,133 @@
+// Codex quota, read from the x-codex-* headers that ride along on every
+// response.
+//
+// This is what makes rotation predictive for codex accounts rather than
+// reactive: without it the proxy only learns an account is spent by getting a
+// 429, so the first request after exhaustion always fails before failing over.
+// Anthropic accounts get the same treatment from anthropic-ratelimit-*.
+//
+// A live response carries:
+//   x-codex-primary-used-percent: 0
+//   x-codex-primary-window-minutes: 10080
+//   x-codex-primary-reset-after-seconds: 604709
+//   x-codex-primary-reset-at: 1786201952
+//   x-codex-secondary-...            (same shape; zeroed when inactive)
+//   x-codex-plan-type: plus
+
+export const CODEX_HEADER_PREFIX = 'x-codex-';
+
+// A window at or under this length is treated as the session bucket, anything
+// longer as the weekly one. Buckets are classified by DURATION rather than by
+// the primary/secondary naming: which slot carries which window varies by plan
+// (the observed `plus` account reports its 7-day limit as primary and leaves
+// secondary inactive), so keying off the name would silently mis-file a bucket
+// on a plan that orders them the other way.
+const SESSION_WINDOW_MAX_MINUTES = 24 * 60;
+
+function num(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve a bucket's reset time to a ms timestamp.
+ *
+ * Prefers the absolute `reset-at` and falls back to the relative
+ * `reset-after-seconds`. Both are reported, but the relative one is only
+ * meaningful against the moment the response arrived.
+ */
+function resolveReset(resetAt, resetAfterSeconds, now) {
+  const at = num(resetAt);
+  if (at !== null && at > 0) return at * 1000;
+  const after = num(resetAfterSeconds);
+  if (after !== null && after > 0) return now + after * 1000;
+  return null;
+}
+
+function readBucket(headers, slot, now) {
+  const windowMinutes = num(headers[`${CODEX_HEADER_PREFIX}${slot}-window-minutes`]);
+  // A zero/absent window means the plan does not have this bucket. Recording a
+  // 0% utilization for it would look like abundant headroom on a limit that
+  // does not exist.
+  if (windowMinutes === null || windowMinutes <= 0) return null;
+
+  const usedPercent = num(headers[`${CODEX_HEADER_PREFIX}${slot}-used-percent`]);
+  if (usedPercent === null) return null;
+
+  return {
+    // Kept as a fraction to match the Anthropic side. It can exceed 1 in
+    // overage, which _isNearQuota reads as "past the threshold" either way.
+    utilization: usedPercent / 100,
+    windowMinutes,
+    resetAt: resolveReset(
+      headers[`${CODEX_HEADER_PREFIX}${slot}-reset-at`],
+      headers[`${CODEX_HEADER_PREFIX}${slot}-reset-after-seconds`],
+      now,
+    ),
+  };
+}
+
+/**
+ * Parse x-codex-* headers into the same quota shape the Anthropic path
+ * produces.
+ *
+ * Deliberately reuses unified5h/unified7d rather than introducing codex-specific
+ * fields: selection, the switch threshold, status rendering and state
+ * persistence all already read those, so codex accounts stay peers in one fleet
+ * instead of needing a parallel code path.
+ *
+ * @returns {{unified5h?: number, unified5hReset?: number,
+ *            unified7d?: number, unified7dReset?: number,
+ *            planType?: string}} only the fields the headers actually reported
+ */
+export function parseCodexQuota(headers, now = Date.now()) {
+  const out = {};
+  if (!headers) return out;
+
+  for (const slot of ['primary', 'secondary']) {
+    const bucket = readBucket(headers, slot, now);
+    if (!bucket) continue;
+
+    const isSession = bucket.windowMinutes <= SESSION_WINDOW_MAX_MINUTES;
+    const utilKey = isSession ? 'unified5h' : 'unified7d';
+    const resetKey = isSession ? 'unified5hReset' : 'unified7dReset';
+
+    // Two active windows can land in the same class (e.g. a plan reporting both
+    // a 1-hour and a 5-hour limit). Keep the more exhausted one — it is the one
+    // that will actually stop the account.
+    if (out[utilKey] === undefined || bucket.utilization > out[utilKey]) {
+      out[utilKey] = bucket.utilization;
+      if (bucket.resetAt !== null) out[resetKey] = bucket.resetAt;
+    }
+  }
+
+  const plan = headers[`${CODEX_HEADER_PREFIX}plan-type`];
+  if (plan) out.planType = String(plan);
+
+  return out;
+}
+
+/**
+ * Is a codex bucket spent, judged from the headers on a 429?
+ *
+ * The Anthropic path distinguishes a durable quota rejection from a transient
+ * throttle via anthropic-ratelimit-*-status. Codex reports no such status, so
+ * exhaustion has to be inferred from utilization: at 100% the limit is spent
+ * and retrying the same account before its reset is futile.
+ */
+export function isCodexQuotaExhausted(headers, now = Date.now()) {
+  const quota = parseCodexQuota(headers, now);
+  return (quota.unified5h ?? 0) >= 1 || (quota.unified7d ?? 0) >= 1;
+}
+
+/**
+ * Seconds until the earliest reported bucket reset, for use as a hold window
+ * when a codex account is exhausted. Null when nothing is known.
+ */
+export function codexResetAfterSeconds(headers, now = Date.now()) {
+  const quota = parseCodexQuota(headers, now);
+  const resets = [quota.unified5hReset, quota.unified7dReset].filter(v => typeof v === 'number' && v > now);
+  if (resets.length === 0) return null;
+  return Math.ceil((Math.min(...resets) - now) / 1000);
+}

--- a/src/codex/request-translate.js
+++ b/src/codex/request-translate.js
@@ -119,6 +119,40 @@ export function normalizeToolParameters(schema) {
   return out;
 }
 
+// Reasoning levels the Codex backend accepts. Reported verbatim by a live 400:
+// "Unsupported value: 'minimal' is not supported with the 'gpt-5.6-sol' model.
+//  Supported values are: 'none', 'low', 'medium', 'high', 'xhigh', and 'max'."
+const CODEX_SUPPORTED_EFFORTS = new Set(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
+
+// Anthropic's budget bands include levels Codex has no equivalent for. Map each
+// onto the nearest level that preserves intent: `minimal` means "think a
+// little", so it becomes `low` rather than `none`, which would switch reasoning
+// off entirely. `auto` means "you decide", which is what `medium` (the API
+// default) expresses.
+const EFFORT_SUBSTITUTES = { minimal: 'low', auto: 'medium' };
+
+/**
+ * Force a translated request's reasoning effort onto a level Codex accepts.
+ *
+ * Kept OUT of claudeRequestToCodex on purpose. That function is held
+ * byte-identical to CLIProxyAPI's translator and verified against it by
+ * fixtures; CLIProxyAPI does its own clamping in a later pipeline stage
+ * (ApplyThinking), which the fixtures do not capture. Folding the clamp into
+ * the translator would make those fixtures disagree with ground truth for a
+ * reason that has nothing to do with translation being wrong.
+ *
+ * Without this a thinking budget of 512 or less produced effort `minimal` and
+ * the backend rejected the whole request with a 400.
+ */
+export function applyCodexEffortSupport(body) {
+  const request = Buffer.isBuffer(body) ? JSON.parse(body.toString('utf-8')) : body;
+  const effort = request?.reasoning?.effort;
+  if (!effort || CODEX_SUPPORTED_EFFORTS.has(effort)) return body;
+
+  request.reasoning.effort = EFFORT_SUBSTITUTES[effort] ?? 'medium';
+  return Buffer.from(JSON.stringify(request), 'utf-8');
+}
+
 function dataUrlFromSource(source) {
   if (!source) return null;
   const data = source.data || source.base64;

--- a/src/codex/request-translate.js
+++ b/src/codex/request-translate.js
@@ -247,7 +247,7 @@ function resolveReasoningEffort(request) {
  * @param {string} model - upstream model name, already resolved through modelMap
  * @returns {Buffer} the Responses API request body
  */
-export function claudeRequestToCodex(body, model) {
+export function claudeRequestToCodex(body, model, { promptCacheKey = null } = {}) {
   const request = typeof body === 'object' && !Buffer.isBuffer(body)
     ? body
     : JSON.parse(Buffer.isBuffer(body) ? body.toString('utf-8') : String(body));
@@ -419,6 +419,11 @@ export function claudeRequestToCodex(body, model) {
   out.store = false;
   // Reasoning must come back encrypted so it can be replayed on the next turn.
   out.include = ['reasoning.encrypted_content'];
+
+  // Scope the prompt cache explicitly. The backend will fall back to echoing the
+  // Session_id header when this is absent, but that is undocumented behaviour to
+  // depend on, and naming the key here is what CLIProxyAPI does.
+  if (promptCacheKey) out.prompt_cache_key = promptCacheKey;
 
   return Buffer.from(JSON.stringify(out), 'utf-8');
 }

--- a/src/codex/request-translate.js
+++ b/src/codex/request-translate.js
@@ -1,0 +1,391 @@
+import { createHash } from 'node:crypto';
+import { compatibleGptSignature } from './signature.js';
+
+// Anthropic Messages API request -> OpenAI Responses API request.
+//
+// Ported from CLIProxyAPI (internal/translator/codex/claude/codex_claude_request.go),
+// which is the reference implementation this is differential-tested against; the
+// fixtures in test/fixtures/codex-requests were generated from it.
+
+// The Responses API caps tool names and call ids at 64 characters. Claude Code's
+// MCP tool names routinely exceed that, so both are shortened deterministically.
+const NAME_LIMIT = 64;
+const CALL_ID_LIMIT = 64;
+
+// Claude Code prefixes a billing header onto the system prompt. It is an
+// artifact of the client, not instruction content, so it is dropped rather than
+// forwarded as a developer message.
+const ATTRIBUTION_PREFIX = 'x-anthropic-billing-header:';
+
+const REMINDER_START = '<system-reminder>';
+const REMINDER_END = '</system-reminder>';
+
+// thinking.budget_tokens -> reasoning.effort. Upper bound of each band.
+const BUDGET_MINIMAL = 512;
+const BUDGET_LOW = 1024;
+const BUDGET_MEDIUM = 8192;
+const BUDGET_HIGH = 24576;
+
+const WEB_SEARCH_TOOL_TYPES = new Set(['web_search_20250305', 'web_search_20260209']);
+
+function isAttributionText(text) {
+  return typeof text === 'string' && text.replace(/^\s+/, '').startsWith(ATTRIBUTION_PREFIX);
+}
+
+/**
+ * Map a thinking budget onto a reasoning effort level. Returns null for values
+ * that carry no level (negative below -1), leaving the caller's default.
+ */
+export function budgetToEffort(budget) {
+  if (typeof budget !== 'number' || budget < -1) return null;
+  if (budget === -1) return 'auto';
+  if (budget === 0) return 'none';
+  if (budget <= BUDGET_MINIMAL) return 'minimal';
+  if (budget <= BUDGET_LOW) return 'low';
+  if (budget <= BUDGET_MEDIUM) return 'medium';
+  if (budget <= BUDGET_HIGH) return 'high';
+  return 'xhigh';
+}
+
+/**
+ * Shorten one name to the Responses API limit.
+ *
+ * MCP names (mcp__server__tool) keep their last segment, which is the part that
+ * distinguishes them; everything else is truncated.
+ */
+export function shortenName(name) {
+  if (name.length <= NAME_LIMIT) return name;
+  if (name.startsWith('mcp__')) {
+    const idx = name.lastIndexOf('__');
+    if (idx > 0) {
+      const cand = 'mcp__' + name.slice(idx + 2);
+      return cand.length > NAME_LIMIT ? cand.slice(0, NAME_LIMIT) : cand;
+    }
+  }
+  return name.slice(0, NAME_LIMIT);
+}
+
+/**
+ * Build original -> shortened name map for a request's tools, guaranteeing the
+ * shortened names stay unique. Two MCP tools whose names differ only past the
+ * truncation point would otherwise collapse onto one name and the model would
+ * be unable to address them separately.
+ */
+export function buildShortNameMap(names) {
+  const used = new Set();
+  const map = new Map();
+
+  for (const name of names) {
+    let cand = shortenName(name);
+    if (used.has(cand)) {
+      const base = cand;
+      for (let i = 1; ; i++) {
+        const suffix = '_' + i;
+        const allowed = Math.max(0, NAME_LIMIT - suffix.length);
+        const tmp = (base.length > allowed ? base.slice(0, allowed) : base) + suffix;
+        if (!used.has(tmp)) { cand = tmp; break; }
+      }
+    }
+    used.add(cand);
+    map.set(name, cand);
+  }
+  return map;
+}
+
+/**
+ * Shorten a tool-use id, keeping a stable low-collision mapping: a hash suffix
+ * so two long ids sharing a prefix don't collapse onto the same call_id, which
+ * would mis-pair tool results with their calls.
+ */
+export function shortenCallId(id) {
+  if (id.length <= CALL_ID_LIMIT) return id;
+  const suffix = '_' + createHash('sha256').update(id).digest('hex').slice(0, 16);
+  const prefixLen = CALL_ID_LIMIT - suffix.length;
+  if (prefixLen <= 0) return suffix.slice(suffix.length - CALL_ID_LIMIT);
+  return id.slice(0, prefixLen) + suffix;
+}
+
+/**
+ * Ensure a tool's JSON schema is shaped the way the Responses API expects:
+ * an object schema always carries a properties map, even an empty one.
+ */
+export function normalizeToolParameters(schema) {
+  if (schema === null || schema === undefined || typeof schema !== 'object' || Array.isArray(schema)) {
+    return { type: 'object', properties: {} };
+  }
+  const out = { ...schema };
+  if (!out.type) out.type = 'object';
+  if (out.type === 'object' && out.properties === undefined) out.properties = {};
+  return out;
+}
+
+function dataUrlFromSource(source) {
+  if (!source) return null;
+  const data = source.data || source.base64;
+  if (!data) return null;
+  const mediaType = source.media_type || source.mime_type || 'application/octet-stream';
+  return `data:${mediaType};base64,${data}`;
+}
+
+// Collect the text parts of a system-role message, dropping attribution noise.
+function systemTextParts(content) {
+  if (content === undefined || content === null) return [];
+  if (typeof content === 'string') {
+    return content === '' || isAttributionText(content) ? [] : [content];
+  }
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(item => item?.type === 'text' && item.text && !isAttributionText(item.text))
+    .map(item => item.text);
+}
+
+function toolChoiceToCodex(toolChoice, nameMap, webSearchNames) {
+  if (toolChoice === undefined || toolChoice === null) return 'auto';
+  const type = typeof toolChoice === 'string' ? toolChoice : toolChoice.type;
+
+  switch (type) {
+    case 'auto':
+    case undefined:
+    case '':
+      return 'auto';
+    case 'any': return 'required';
+    case 'none': return 'none';
+    case 'tool': {
+      const raw = toolChoice.name;
+      if (webSearchNames.has(raw)) return { type: 'web_search' };
+      const name = nameMap.get(raw) ?? (raw ? shortenName(raw) : '');
+      if (!name) return 'auto';
+      return { type: 'function', name };
+    }
+    default: return 'auto';
+  }
+}
+
+function webSearchToolToCodex(tool) {
+  const out = { type: 'web_search' };
+  if (Array.isArray(tool.allowed_domains)) out.filters = { allowed_domains: tool.allowed_domains };
+  if (tool.user_location && typeof tool.user_location === 'object') out.user_location = tool.user_location;
+  return out;
+}
+
+function normalizeServiceTier(request) {
+  if (request.speed === 'fast') return 'priority';
+  const tier = request.service_tier;
+  if (typeof tier !== 'string') return null;
+  return ['fast', 'priority'].includes(tier.trim().toLowerCase()) ? 'priority' : null;
+}
+
+function resolveReasoningEffort(request) {
+  const thinking = request.thinking;
+  if (!thinking || typeof thinking !== 'object') return 'medium';
+
+  switch (thinking.type) {
+    case 'enabled': {
+      const effort = budgetToEffort(thinking.budget_tokens);
+      return effort || 'medium';
+    }
+    case 'adaptive':
+    case 'auto': {
+      // Adaptive thinking can name an explicit effort; otherwise it means "as
+      // much as the model wants", which maps to the top level.
+      const explicit = request.output_config?.effort;
+      if (typeof explicit === 'string' && explicit.trim()) return explicit.trim().toLowerCase();
+      return 'xhigh';
+    }
+    case 'disabled':
+      return budgetToEffort(0) || 'medium';
+    default:
+      return 'medium';
+  }
+}
+
+/**
+ * Translate an Anthropic Messages request into an OpenAI Responses request.
+ *
+ * @param {Buffer|string|object} body - the Anthropic request
+ * @param {string} model - upstream model name, already resolved through modelMap
+ * @returns {Buffer} the Responses API request body
+ */
+export function claudeRequestToCodex(body, model) {
+  const request = typeof body === 'object' && !Buffer.isBuffer(body)
+    ? body
+    : JSON.parse(Buffer.isBuffer(body) ? body.toString('utf-8') : String(body));
+
+  const toolNames = Array.isArray(request.tools)
+    ? request.tools.map(t => t?.name).filter(Boolean)
+    : [];
+  const nameMap = buildShortNameMap(toolNames);
+  const mapName = raw => nameMap.get(raw) ?? shortenName(raw ?? '');
+
+  const input = [];
+
+  // The system prompt becomes a developer-role message.
+  const systemParts = systemTextParts(request.system);
+  if (systemParts.length > 0) {
+    input.push({
+      type: 'message',
+      role: 'developer',
+      content: systemParts.map(text => ({ type: 'input_text', text })),
+    });
+  }
+
+  for (const message of Array.isArray(request.messages) ? request.messages : []) {
+    const role = message?.role;
+
+    // A system-role message mid-conversation is Claude Code's system-reminder
+    // channel. Codex has no equivalent role, so it is replayed as a user
+    // message wrapped in the same markers the model already knows.
+    if (role === 'system') {
+      const parts = systemTextParts(message.content);
+      const text = parts.join('\n');
+      if (parts.length > 0 && text.trim() !== '') {
+        input.push({
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: `${REMINDER_START}\n${text}\n${REMINDER_END}` }],
+        });
+      }
+      continue;
+    }
+
+    const content = message?.content;
+    let pending = [];
+
+    // Anthropic keeps tool calls inside a message's content array; the Responses
+    // API hoists them to top-level input items. Flushing keeps the surrounding
+    // text in the right order relative to the hoisted items.
+    const flush = () => {
+      if (pending.length === 0) return;
+      input.push({ type: 'message', role, content: pending });
+      pending = [];
+    };
+
+    const pushText = text => {
+      pending.push({ type: role === 'assistant' ? 'output_text' : 'input_text', text });
+    };
+
+    if (typeof content === 'string') {
+      pushText(content);
+      flush();
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+
+    for (const part of content) {
+      switch (part?.type) {
+        case 'text':
+          pushText(part.text ?? '');
+          break;
+
+        case 'thinking': {
+          // Only an assistant turn can carry reasoning, and only reasoning this
+          // backend itself issued can be replayed. A conversation that ran on a
+          // Claude account carries Anthropic signatures; forwarding one makes
+          // the backend reject the whole request, so drop the block instead.
+          if (role !== 'assistant') break;
+          const signature = compatibleGptSignature(part.signature);
+          if (!signature) break;
+          flush();
+          input.push({ type: 'reasoning', summary: [], content: null, encrypted_content: signature });
+          break;
+        }
+
+        case 'image': {
+          const url = dataUrlFromSource(part.source);
+          if (url) pending.push({ type: 'input_image', image_url: url });
+          break;
+        }
+
+        case 'tool_use':
+          flush();
+          input.push({
+            type: 'function_call',
+            call_id: shortenCallId(part.id ?? ''),
+            name: mapName(part.name),
+            // Arguments cross the wire as a JSON string, not an object.
+            arguments: JSON.stringify(part.input ?? {}),
+          });
+          break;
+
+        case 'tool_result': {
+          flush();
+          const item = { type: 'function_call_output', call_id: shortenCallId(part.tool_use_id ?? '') };
+          const rc = part.content;
+          if (Array.isArray(rc)) {
+            const parts = [];
+            for (const c of rc) {
+              if (c?.type === 'image') {
+                const url = dataUrlFromSource(c.source);
+                if (url) parts.push({ type: 'input_image', image_url: url });
+              } else if (c?.type === 'text') {
+                parts.push({ type: 'input_text', text: c.text ?? '' });
+              }
+            }
+            item.output = parts.length > 0 ? parts : stringifyToolOutput(rc);
+          } else {
+            item.output = stringifyToolOutput(rc);
+          }
+          input.push(item);
+          break;
+        }
+
+        default:
+          break;
+      }
+    }
+    flush();
+  }
+
+  const out = {
+    model,
+    instructions: '',
+    input,
+  };
+
+  if (Array.isArray(request.tools)) {
+    const webSearchNames = new Set(
+      request.tools.filter(t => WEB_SEARCH_TOOL_TYPES.has(t?.type) && t.name).map(t => t.name)
+    );
+    out.tool_choice = toolChoiceToCodex(request.tool_choice, nameMap, webSearchNames);
+    out.tools = request.tools.map(tool => {
+      if (WEB_SEARCH_TOOL_TYPES.has(tool?.type)) return webSearchToolToCodex(tool);
+      const { input_schema, cache_control, defer_loading, ...rest } = tool; // eslint-disable-line no-unused-vars
+      const converted = {
+        ...rest,
+        type: 'function',
+        parameters: normalizeToolParameters(input_schema),
+        strict: false,
+      };
+      if (tool?.name) converted.name = mapName(tool.name);
+      // $schema is a JSON Schema authoring artifact the Responses API rejects.
+      if (converted.parameters && typeof converted.parameters === 'object') {
+        delete converted.parameters.$schema;
+      }
+      return converted;
+    });
+  }
+
+  out.parallel_tool_calls = request.tool_choice?.disable_parallel_tool_use === undefined
+    ? true
+    : !request.tool_choice.disable_parallel_tool_use;
+
+  out.reasoning = { effort: resolveReasoningEffort(request) };
+
+  const serviceTier = normalizeServiceTier(request);
+  if (serviceTier) out.service_tier = serviceTier;
+
+  out.stream = true;
+  out.store = false;
+  // Reasoning must come back encrypted so it can be replayed on the next turn.
+  out.include = ['reasoning.encrypted_content'];
+
+  return Buffer.from(JSON.stringify(out), 'utf-8');
+}
+
+// A non-array tool_result content is forwarded as a plain string. Objects are
+// serialized rather than stringified to "[object Object]".
+function stringifyToolOutput(content) {
+  if (content === undefined || content === null) return '';
+  if (typeof content === 'string') return content;
+  return JSON.stringify(content);
+}

--- a/src/codex/request-translate.js
+++ b/src/codex/request-translate.js
@@ -119,17 +119,24 @@ export function normalizeToolParameters(schema) {
   return out;
 }
 
-// Reasoning levels the Codex backend accepts. Reported verbatim by a live 400:
-// "Unsupported value: 'minimal' is not supported with the 'gpt-5.6-sol' model.
-//  Supported values are: 'none', 'low', 'medium', 'high', 'xhigh', and 'max'."
+// Reasoning levels the Codex backend accepts, established by probing it: every
+// value below returns 200 on gpt-5.6-sol/terra/luna, and everything else 400s.
+//
+// Two traps here. The API's own enum message advertises `minimal`, but sending
+// it draws a model-specific rejection ("'minimal' is not supported with the
+// 'gpt-5.6-sol' model"), so the documented enum is wider than any model accepts.
+// And the Codex CLI's model cache lists `ultra` as a supported level for sol and
+// terra, but the API rejects it outright — that cache describes the CLI's own
+// menu, not the wire contract. Neither source is trustworthy alone; this set is
+// what the backend actually answered.
 const CODEX_SUPPORTED_EFFORTS = new Set(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
 
-// Anthropic's budget bands include levels Codex has no equivalent for. Map each
-// onto the nearest level that preserves intent: `minimal` means "think a
-// little", so it becomes `low` rather than `none`, which would switch reasoning
-// off entirely. `auto` means "you decide", which is what `medium` (the API
-// default) expresses.
-const EFFORT_SUBSTITUTES = { minimal: 'low', auto: 'medium' };
+// Levels with no equivalent, mapped to the nearest neighbour that preserves
+// intent: `minimal` means "think a little", so it becomes `low` rather than
+// `none`, which would switch reasoning off entirely; `ultra` sits above `max`,
+// so it lands on `max` rather than falling all the way to the default; `auto`
+// means "you decide", which is what `medium` (the API default) expresses.
+const EFFORT_SUBSTITUTES = { minimal: 'low', ultra: 'max', auto: 'medium' };
 
 /**
  * Force a translated request's reasoning effort onto a level Codex accepts.

--- a/src/codex/response-translate.js
+++ b/src/codex/response-translate.js
@@ -1,0 +1,684 @@
+import { shortenCallId, buildShortNameMap } from './request-translate.js';
+
+// OpenAI Responses API SSE -> Anthropic Messages API SSE.
+//
+// Ported from CLIProxyAPI (internal/translator/codex/claude/codex_claude_response.go)
+// and differential-tested against it; see test/fixtures/codex-streams.
+//
+// The two event models do not line up one-to-one. Anthropic requires content
+// blocks to be opened and closed around a monotonically increasing index, while
+// Codex emits output items that interleave reasoning, text and tool calls
+// freely. This translator owns that block bookkeeping, which is why it is
+// stateful across the whole stream rather than a pure per-event mapping.
+
+const SUMMARY_PART_SEPARATOR = '\n\n';
+const TOOL_ID_INVALID = /[^a-zA-Z0-9_-]/g;
+
+/** Format one Anthropic SSE frame. */
+function sse(event, payload) {
+  return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Anthropic tool_use ids allow only [a-zA-Z0-9_-]; a Codex call_id can carry
+ * other characters. An id that sanitizes to nothing gets a synthetic one, since
+ * the client pairs tool results by this value.
+ */
+function sanitizeToolId(id, fallbackSeq) {
+  const s = String(id ?? '').replace(TOOL_ID_INVALID, '_');
+  return s === '' ? `toolu_codex_${fallbackSeq}` : s;
+}
+
+/**
+ * Codex sees shortened tool names (the request translator truncates them to 64
+ * chars); the client only knows the originals. Invert that mapping so tool_use
+ * blocks name the tool the client actually declared.
+ */
+function buildShortToOriginal(originalRequest) {
+  const names = Array.isArray(originalRequest?.tools)
+    ? originalRequest.tools.map(t => t?.name).filter(Boolean)
+    : [];
+  const forward = buildShortNameMap(names);
+  const reverse = new Map();
+  for (const [original, short] of forward) reverse.set(short, original);
+  return reverse;
+}
+
+function codexStopReason(response) {
+  const stopSequence = response?.stop_sequence;
+  const hasStopSequence = stopSequence !== undefined && stopSequence !== null && stopSequence !== '';
+
+  if (response?.stop_reason) {
+    if (response.stop_reason === 'stop' && hasStopSequence) return 'stop_sequence';
+    return response.stop_reason;
+  }
+  if (response?.incomplete_details?.reason) return response.incomplete_details.reason;
+  if (hasStopSequence) return 'stop_sequence';
+  return '';
+}
+
+function mapStopReason(stopReason, hasToolCall) {
+  if (hasToolCall) return 'tool_use';
+  switch (stopReason) {
+    case '': case 'stop': case 'completed': return 'end_turn';
+    case 'max_tokens': case 'max_output_tokens': return 'max_tokens';
+    // A tool-call stop with no tool block actually emitted is not a tool turn.
+    case 'tool_use': case 'tool_calls': case 'function_call': return 'end_turn';
+    case 'end_turn': case 'stop_sequence': case 'pause_turn':
+    case 'refusal': case 'model_context_window_exceeded': return stopReason;
+    case 'content_filter': return 'refusal';
+    default: return 'end_turn';
+  }
+}
+
+/**
+ * Split Codex usage into Anthropic's shape. Codex reports cached tokens inside
+ * the input total; Anthropic reports them alongside it, so the cached count is
+ * subtracted out to avoid double-counting.
+ */
+function extractUsage(usage) {
+  if (!usage || typeof usage !== 'object') return { input: 0, output: 0, cached: 0 };
+  let input = usage.input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  const cached = usage.input_tokens_details?.cached_tokens ?? 0;
+  if (cached > 0) input = input >= cached ? input - cached : 0;
+  return { input, output, cached };
+}
+
+function errorFrame(event) {
+  const err = event?.error ?? {};
+  let type = String(err.type ?? '').trim() || String(event?.error_type ?? '').trim() || 'api_error';
+  const code = String(err.code ?? '').trim();
+  const message = String(err.message ?? '').trim()
+    || String(event?.message ?? '').trim()
+    || code
+    || type;
+  if (code === 'cyber_policy' || type === 'invalid_request') type = 'invalid_request_error';
+  return sse('error', { type: 'error', error: { type, message } });
+}
+
+// Events that must wait behind an in-flight tool call. Anthropic cannot
+// interleave a second block into an open tool_use block, so anything that would
+// open one is buffered until the active call closes.
+function shouldDefer(type, event) {
+  switch (type) {
+    case 'error':
+    case 'response.completed':
+    case 'response.incomplete':
+    case 'response.function_call_arguments.delta':
+    case 'response.function_call_arguments.done':
+      return false;
+    case 'response.output_item.added':
+    case 'response.output_item.done':
+      return event?.item?.type !== 'function_call';
+    default:
+      return true;
+  }
+}
+
+class FunctionCall {
+  constructor() {
+    this.callId = '';
+    this.name = '';
+    this.blockIndex = -1;
+    this.args = '';
+    this.emittedLength = 0;
+    this.hasArgsDelta = false;
+    this.emitInitialEmptyDelta = false;
+    this.started = false;
+    this.done = false;
+    this.closed = false;
+  }
+}
+
+class CodexStreamTranslator {
+  constructor(originalRequest = null) {
+    this.shortToOriginal = buildShortToOriginal(originalRequest);
+    this.blockIndex = 0;
+    this.textBlockOpen = false;
+    this.thinkingBlockOpen = false;
+    this.thinkingSignature = '';
+    this.thinkingSummarySeen = false;
+    this.hasTextDelta = false;
+    this.hasEmittedToolUse = false;
+    this.calls = new Map();       // alias key -> FunctionCall
+    this.queue = [];
+    this.activeCall = null;
+    this.lastCall = null;
+    this.deferred = [];
+    this.toolIdSeq = 0;
+  }
+
+  // ── content block lifecycle ───────────────────────────────
+
+  #startText(out) {
+    if (this.textBlockOpen) return;
+    out.push(sse('content_block_start', {
+      type: 'content_block_start', index: this.blockIndex,
+      content_block: { type: 'text', text: '' },
+    }));
+    this.textBlockOpen = true;
+  }
+
+  #stopText(out) {
+    if (!this.textBlockOpen) return;
+    out.push(sse('content_block_stop', { type: 'content_block_stop', index: this.blockIndex }));
+    this.textBlockOpen = false;
+    this.blockIndex++;
+  }
+
+  #startThinking(out) {
+    if (this.thinkingBlockOpen) return;
+    out.push(sse('content_block_start', {
+      type: 'content_block_start', index: this.blockIndex,
+      content_block: { type: 'thinking', thinking: '' },
+    }));
+    this.thinkingBlockOpen = true;
+  }
+
+  #thinkingDelta(out, text) {
+    if (!text) return;
+    out.push(sse('content_block_delta', {
+      type: 'content_block_delta', index: this.blockIndex,
+      delta: { type: 'thinking_delta', thinking: text },
+    }));
+  }
+
+  #finalizeThinking(out) {
+    if (!this.thinkingBlockOpen) return;
+    if (this.thinkingSignature) {
+      out.push(sse('content_block_delta', {
+        type: 'content_block_delta', index: this.blockIndex,
+        delta: { type: 'signature_delta', signature: this.thinkingSignature },
+      }));
+    }
+    out.push(sse('content_block_stop', { type: 'content_block_stop', index: this.blockIndex }));
+    this.blockIndex++;
+    this.thinkingBlockOpen = false;
+  }
+
+  // A reasoning item can finish having produced a signature but no summary
+  // text. The signature still has to reach the client for the next turn to
+  // replay it, so an empty thinking block is opened purely to carry it.
+  #finalizeSignatureOnlyThinking(out) {
+    if (!this.thinkingSignature) return;
+    this.#startThinking(out);
+    this.#finalizeThinking(out);
+  }
+
+  // ── function call bookkeeping ─────────────────────────────
+
+  // Codex identifies a call inconsistently across its events — sometimes by
+  // output_index, sometimes call_id, sometimes item_id — so every seen
+  // identifier is registered as an alias for the same call object.
+  #keysFor(event, item) {
+    const keys = [];
+    const add = k => { if (k && !keys.includes(k)) keys.push(k); };
+    if (event?.output_index !== undefined) add(`output:${JSON.stringify(event.output_index)}`);
+    if (item?.call_id) add(`call:${item.call_id}`);
+    if (event?.call_id) add(`call:${event.call_id}`);
+    if (item?.id) add(`item:${item.id}`);
+    if (event?.item_id) add(`item:${event.item_id}`);
+    return keys;
+  }
+
+  #callForKeys(keys) {
+    for (const key of keys) {
+      const call = this.calls.get(key);
+      if (call) return call;
+    }
+    return null;
+  }
+
+  #callForEvent(event, item) {
+    const keys = this.#keysFor(event, item);
+    if (keys.length > 0) return this.#callForKeys(keys);
+    return this.lastCall;
+  }
+
+  #addAliases(call, keys) {
+    for (const key of keys) this.calls.set(key, call);
+  }
+
+  #recordCall(event, item) {
+    const keys = this.#keysFor(event, item);
+    let call = this.#callForKeys(keys);
+    if (!call) {
+      call = new FunctionCall();
+      this.queue.push(call);
+    }
+    this.#addAliases(call, keys);
+    this.lastCall = call;
+    return call;
+  }
+
+  #updateIdentity(call, event, item) {
+    if (!call) return;
+    if (item?.call_id) call.callId = item.call_id;
+    if (item?.name) call.name = item.name;
+    this.#addAliases(call, this.#keysFor(event, item));
+  }
+
+  #updateArguments(call, args, isDelta) {
+    if (!call || !args) return;
+    if (isDelta) {
+      call.args += args;
+      call.hasArgsDelta = true;
+      return;
+    }
+    if (!call.hasArgsDelta) { call.args = args; return; }
+    // A terminal `arguments` that extends what the deltas already built is the
+    // authoritative value; one that disagrees is stale and ignored.
+    if (args.startsWith(call.args)) call.args = args;
+  }
+
+  #flushBufferedArguments(out, call) {
+    if (!call || this.activeCall !== call || !call.started || call.closed) return;
+    if (call.emittedLength >= call.args.length) return;
+    out.push(sse('content_block_delta', {
+      type: 'content_block_delta', index: call.blockIndex,
+      delta: { type: 'input_json_delta', partial_json: call.args.slice(call.emittedLength) },
+    }));
+    call.emittedLength = call.args.length;
+  }
+
+  // Drain the queue: only one tool_use block may be open at a time, so calls
+  // start in order and the next one waits for the previous to close.
+  #pumpQueue(out) {
+    for (;;) {
+      const active = this.activeCall;
+      if (active) {
+        this.#flushBufferedArguments(out, active);
+        if (!active.done) return;
+        out.push(sse('content_block_stop', { type: 'content_block_stop', index: active.blockIndex }));
+        if (this.blockIndex <= active.blockIndex) this.blockIndex = active.blockIndex + 1;
+        active.closed = true;
+        this.activeCall = null;
+        const at = this.queue.indexOf(active);
+        if (at >= 0) this.queue.splice(at, 1);
+      }
+
+      while (this.queue.length > 0 && this.queue[0].closed) this.queue.shift();
+      if (this.queue.length === 0) return;
+
+      const call = this.queue[0];
+      // Without a name there is nothing to open a tool_use block with; wait for
+      // the event that supplies it.
+      if (!call.name) return;
+
+      call.blockIndex = this.blockIndex;
+      const name = this.shortToOriginal.get(call.name) ?? call.name;
+      out.push(sse('content_block_start', {
+        type: 'content_block_start', index: call.blockIndex,
+        content_block: {
+          type: 'tool_use',
+          id: shortenCallId(sanitizeToolId(call.callId, ++this.toolIdSeq)),
+          name,
+          input: {},
+        },
+      }));
+      if (call.emitInitialEmptyDelta) {
+        out.push(sse('content_block_delta', {
+          type: 'content_block_delta', index: call.blockIndex,
+          delta: { type: 'input_json_delta', partial_json: '' },
+        }));
+      }
+      call.started = true;
+      this.activeCall = call;
+      this.hasEmittedToolUse = true;
+      this.#flushBufferedArguments(out, call);
+    }
+  }
+
+  // Reconcile against the terminal response: any call the stream announced but
+  // never completed is finished from the final output array, so a truncated
+  // stream still produces well-formed tool_use blocks.
+  #callsFromTerminal(out, response) {
+    const output = Array.isArray(response?.output) ? response.output : [];
+    output.forEach((item, index) => {
+      if (item?.type !== 'function_call') return;
+      const keys = this.#keysFor(null, item);
+      const add = k => { if (k && !keys.includes(k)) keys.push(k); };
+      if (item.output_index !== undefined) add(`output:${JSON.stringify(item.output_index)}`);
+      add(`output:${index}`);
+
+      let call = this.#callForKeys(keys);
+      if (!call) { call = new FunctionCall(); this.queue.push(call); }
+      this.#addAliases(call, keys);
+      this.#updateIdentity(call, null, item);
+      this.#updateArguments(call, item.arguments, false);
+      call.done = true;
+    });
+
+    this.queue = this.queue.filter(call => {
+      if (call.closed) return false;
+      if (!call.name) { call.closed = true; return false; }
+      call.done = true;
+      return true;
+    });
+    this.#pumpQueue(out);
+
+    this.calls.clear();
+    this.queue = [];
+    this.activeCall = null;
+    this.lastCall = null;
+  }
+
+  #drainDeferred(out) {
+    if (this.deferred.length === 0) return;
+    const events = this.deferred;
+    this.deferred = [];
+    for (const event of events) out.push(...this.#handle(event));
+  }
+
+  // ── event dispatch ────────────────────────────────────────
+
+  #handle(event) {
+    const out = [];
+    const type = event?.type;
+
+    if (this.activeCall && shouldDefer(type, event)) {
+      this.deferred.push(event);
+      return out;
+    }
+
+    switch (type) {
+      case 'error':
+        out.push(errorFrame(event));
+        break;
+
+      case 'response.created':
+        out.push(sse('message_start', {
+          type: 'message_start',
+          message: {
+            id: event.response?.id ?? '',
+            type: 'message',
+            role: 'assistant',
+            model: event.response?.model ?? '',
+            stop_sequence: null,
+            usage: { input_tokens: 0, output_tokens: 0 },
+            content: [],
+            stop_reason: null,
+          },
+        }));
+        break;
+
+      case 'response.reasoning_summary_part.added':
+        this.#stopText(out);
+        // Codex splits one reasoning item into several summary parts, but only
+        // output_item.done carries the item's final encrypted_content. Keep a
+        // single thinking block open across the parts, separated by a blank
+        // line, so exactly one signature is ever emitted.
+        if (this.thinkingBlockOpen) this.#thinkingDelta(out, SUMMARY_PART_SEPARATOR);
+        else this.#startThinking(out);
+        this.thinkingSummarySeen = true;
+        break;
+
+      case 'response.reasoning_summary_text.delta':
+        this.#stopText(out);
+        this.#startThinking(out);
+        this.#thinkingDelta(out, event.delta ?? '');
+        break;
+
+      case 'response.reasoning_summary_part.done':
+        // Deliberately does not close the block — see the comment above.
+        break;
+
+      case 'response.content_part.added':
+        this.#finalizeThinking(out);
+        if (event.part?.type === 'output_text') this.#startText(out);
+        break;
+
+      case 'response.output_text.delta':
+        this.hasTextDelta = true;
+        this.#finalizeThinking(out);
+        this.#startText(out);
+        out.push(sse('content_block_delta', {
+          type: 'content_block_delta', index: this.blockIndex,
+          delta: { type: 'text_delta', text: event.delta ?? '' },
+        }));
+        break;
+
+      case 'response.content_part.done':
+        if (event.part?.type === 'output_text') this.#stopText(out);
+        break;
+
+      case 'response.web_search_call.searching':
+      case 'response.web_search_call.completed':
+      case 'response.web_search_call.in_progress':
+        // Populated web_search_call items only arrive on output_item.done.
+        break;
+
+      case 'response.completed':
+      case 'response.incomplete': {
+        const response = event.response ?? {};
+        this.#finalizeThinking(out);
+        this.#stopText(out);
+        this.#callsFromTerminal(out, response);
+        this.#drainDeferred(out);
+        this.#finalizeThinking(out);
+        this.#stopText(out);
+
+        const { input, output, cached } = extractUsage(response.usage);
+        const delta = {
+          stop_reason: mapStopReason(codexStopReason(response), this.hasEmittedToolUse),
+          stop_sequence: null,
+        };
+        if (response.stop_sequence) delta.stop_sequence = response.stop_sequence;
+        const usage = { input_tokens: input, output_tokens: output };
+        if (cached > 0) usage.cache_read_input_tokens = cached;
+
+        out.push(sse('message_delta', { type: 'message_delta', delta, usage }));
+        out.push(sse('message_stop', { type: 'message_stop' }));
+        break;
+      }
+
+      case 'response.output_item.added': {
+        const item = event.item ?? {};
+        if (item.type === 'function_call') {
+          this.#finalizeThinking(out);
+          this.#stopText(out);
+          const call = this.#recordCall(event, item);
+          this.#updateIdentity(call, event, item);
+          if (call.name) call.emitInitialEmptyDelta = true;
+          this.#pumpQueue(out);
+        } else if (item.type === 'reasoning') {
+          this.#stopText(out);
+          // A previous reasoning item that never reported done must not leak
+          // its still-open block into this one.
+          this.#finalizeThinking(out);
+          this.thinkingSummarySeen = false;
+          // Pre-content snapshot, kept only as a fallback for streams whose
+          // output_item.done omits encrypted_content.
+          this.thinkingSignature = item.encrypted_content ?? '';
+        }
+        // web_search_call: deferred until output_item.done carries the query.
+        break;
+      }
+
+      case 'response.output_item.done': {
+        const item = event.item ?? {};
+        if (item.type === 'message') {
+          // Only synthesize text if none was streamed — otherwise this would
+          // duplicate the whole message.
+          if (this.hasTextDelta) break;
+          if (!Array.isArray(item.content)) break;
+          const text = item.content
+            .filter(p => p?.type === 'output_text' && p.text)
+            .map(p => p.text)
+            .join('');
+          if (!text) break;
+          this.#finalizeThinking(out);
+          this.#startText(out);
+          out.push(sse('content_block_delta', {
+            type: 'content_block_delta', index: this.blockIndex,
+            delta: { type: 'text_delta', text },
+          }));
+          this.#stopText(out);
+          this.hasTextDelta = true;
+        } else if (item.type === 'function_call') {
+          this.#finalizeThinking(out);
+          this.#stopText(out);
+          let call = this.#callForEvent(event, item);
+          if (!call) call = this.#recordCall(event, item);
+          this.#updateIdentity(call, event, item);
+          this.#updateArguments(call, item.arguments, false);
+          call.done = true;
+          this.#pumpQueue(out);
+        } else if (item.type === 'reasoning') {
+          this.#stopText(out);
+          if (item.encrypted_content) this.thinkingSignature = item.encrypted_content;
+          if (this.thinkingSummarySeen) this.#finalizeThinking(out);
+          else this.#finalizeSignatureOnlyThinking(out);
+          this.thinkingSignature = '';
+          this.thinkingSummarySeen = false;
+        }
+        break;
+      }
+
+      case 'response.function_call_arguments.delta': {
+        let call = this.#callForEvent(event, null);
+        if (!call) call = this.#recordCall(event, null);
+        this.#updateArguments(call, event.delta ?? '', true);
+        this.#flushBufferedArguments(out, call);
+        break;
+      }
+
+      case 'response.function_call_arguments.done': {
+        let call = this.#callForEvent(event, null);
+        if (!call) call = this.#recordCall(event, null);
+        this.#updateArguments(call, event.arguments ?? '', false);
+        this.#flushBufferedArguments(out, call);
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    if (this.queue.length === 0) this.#drainDeferred(out);
+    return out;
+  }
+
+  /**
+   * Feed one raw Codex SSE line ("data: {...}").
+   * @returns {string[]} Anthropic SSE frames to forward, possibly empty.
+   */
+  push(line) {
+    const text = Buffer.isBuffer(line) ? line.toString('utf-8') : String(line);
+    if (!text.startsWith('data:')) return [];
+    const payload = text.slice(5).trim();
+    // The Responses API does not send [DONE], but tolerate it rather than
+    // throwing on a sentinel some proxies add.
+    if (payload === '' || payload === '[DONE]') return [];
+    let event;
+    try {
+      event = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+    return this.#handle(event);
+  }
+
+  /**
+   * Close out a stream that ended without a terminal event, so the client is
+   * never left waiting on an unclosed block.
+   */
+  end() {
+    const out = [];
+    this.#finalizeThinking(out);
+    this.#stopText(out);
+    if (this.activeCall) {
+      const active = this.activeCall;
+      out.push(sse('content_block_stop', { type: 'content_block_stop', index: active.blockIndex }));
+      active.closed = true;
+      this.activeCall = null;
+    }
+    return out;
+  }
+}
+
+export function createCodexStreamTranslator(originalRequest = null) {
+  return new CodexStreamTranslator(originalRequest);
+}
+
+/**
+ * Fold a translated Anthropic SSE sequence back into a single Messages
+ * response.
+ *
+ * Needed because the request translator always asks Codex for a stream (the
+ * Responses API is streaming-first here), while the client may have asked for a
+ * plain JSON response. Rather than maintaining a second translator for that
+ * case, the streamed frames are replayed into the object they describe.
+ */
+export function aggregateAnthropicStream(frames) {
+  const message = {
+    id: '', type: 'message', role: 'assistant', model: '',
+    content: [], stop_reason: null, stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+  const blocks = new Map();
+
+  for (const frame of frames) {
+    const dataLine = String(frame).split('\n').find(l => l.startsWith('data:'));
+    if (!dataLine) continue;
+    let event;
+    try { event = JSON.parse(dataLine.slice(5).trim()); } catch { continue; }
+
+    switch (event.type) {
+      case 'message_start':
+        Object.assign(message, {
+          id: event.message?.id ?? '',
+          model: event.message?.model ?? '',
+        });
+        break;
+
+      case 'content_block_start':
+        blocks.set(event.index, { ...(event.content_block ?? {}) });
+        break;
+
+      case 'content_block_delta': {
+        const block = blocks.get(event.index);
+        if (!block) break;
+        const d = event.delta ?? {};
+        if (d.type === 'text_delta') block.text = (block.text ?? '') + d.text;
+        else if (d.type === 'thinking_delta') block.thinking = (block.thinking ?? '') + d.thinking;
+        else if (d.type === 'signature_delta') block.signature = d.signature;
+        else if (d.type === 'input_json_delta') block._json = (block._json ?? '') + d.partial_json;
+        break;
+      }
+
+      case 'message_delta':
+        if (event.delta?.stop_reason !== undefined) message.stop_reason = event.delta.stop_reason;
+        if (event.delta?.stop_sequence !== undefined) message.stop_sequence = event.delta.stop_sequence;
+        if (event.usage) Object.assign(message.usage, event.usage);
+        break;
+
+      case 'error':
+        // An error frame replaces the response entirely; the caller forwards it
+        // as the error body rather than a half-built message.
+        return { error: event.error ?? { type: 'api_error', message: 'unknown error' } };
+
+      default:
+        break;
+    }
+  }
+
+  message.content = [...blocks.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, block]) => {
+      if (block.type === 'tool_use') {
+        // Arguments streamed as a JSON string; the non-streaming shape wants the
+        // parsed object. A malformed fragment degrades to an empty input rather
+        // than failing the whole response.
+        let input = {};
+        if (block._json) { try { input = JSON.parse(block._json); } catch { input = {}; } }
+        return { type: 'tool_use', id: block.id, name: block.name, input };
+      }
+      return block;
+    });
+
+  return message;
+}
+
+export { mapStopReason, extractUsage, sanitizeToolId };

--- a/src/codex/response-translate.js
+++ b/src/codex/response-translate.js
@@ -77,12 +77,17 @@ function mapStopReason(stopReason, hasToolCall) {
  * subtracted out to avoid double-counting.
  */
 function extractUsage(usage) {
-  if (!usage || typeof usage !== 'object') return { input: 0, output: 0, cached: 0 };
+  if (!usage || typeof usage !== 'object') return { input: 0, output: 0, cached: 0, cacheWrite: 0 };
   let input = usage.input_tokens ?? 0;
   const output = usage.output_tokens ?? 0;
-  const cached = usage.input_tokens_details?.cached_tokens ?? 0;
+  const details = usage.input_tokens_details || {};
+  const cached = details.cached_tokens ?? 0;
+  // Tokens written INTO the cache on this turn. Anthropic reports these
+  // separately as cache_creation_input_tokens; dropping them made a
+  // cache-priming turn look cheaper than it was. Codex has used both spellings.
+  const cacheWrite = details.cache_write_tokens ?? details.cache_creation_tokens ?? 0;
   if (cached > 0) input = input >= cached ? input - cached : 0;
-  return { input, output, cached };
+  return { input, output, cached, cacheWrite };
 }
 
 function errorFrame(event) {
@@ -459,7 +464,7 @@ class CodexStreamTranslator {
         this.#finalizeThinking(out);
         this.#stopText(out);
 
-        const { input, output, cached } = extractUsage(response.usage);
+        const { input, output, cached, cacheWrite } = extractUsage(response.usage);
         const delta = {
           stop_reason: mapStopReason(codexStopReason(response), this.hasEmittedToolUse),
           stop_sequence: null,
@@ -467,6 +472,7 @@ class CodexStreamTranslator {
         if (response.stop_sequence) delta.stop_sequence = response.stop_sequence;
         const usage = { input_tokens: input, output_tokens: output };
         if (cached > 0) usage.cache_read_input_tokens = cached;
+        if (cacheWrite > 0) usage.cache_creation_input_tokens = cacheWrite;
 
         out.push(sse('message_delta', { type: 'message_delta', delta, usage }));
         out.push(sse('message_stop', { type: 'message_stop' }));

--- a/src/codex/signature.js
+++ b/src/codex/signature.js
@@ -1,0 +1,89 @@
+// Validation for GPT reasoning signatures (the `encrypted_content` a Codex
+// response carries and a later turn replays).
+//
+// Why validate at all: only reasoning the GPT backend itself issued can be
+// replayed to it. A conversation that previously ran on a Claude account
+// carries Anthropic-issued thinking signatures, and forwarding one as
+// encrypted_content makes the backend reject the whole request. Dropping the
+// block instead degrades gracefully — the turn loses its replayed reasoning but
+// still completes.
+//
+// Ported from CLIProxyAPI internal/signature/gpt_validation.go.
+
+// A Fernet token: version(1) + timestamp(8) + IV(16) + ciphertext(16n) + HMAC(32).
+const VERSION_BYTE = 0x80;
+const MIN_DECODED_LEN = 73;
+const HEADER_LEN = 1 + 8 + 16; // version + timestamp + IV
+const HMAC_LEN = 32;
+const AES_BLOCK = 16;
+
+// 32 MiB. A signature this large is certainly not one, and decoding it would be
+// the expensive way to find that out.
+const MAX_SIGNATURE_LEN = 32 * 1024 * 1024;
+
+// Base64url alphabet, padding included.
+const CHARSET = /^[A-Za-z0-9\-_=]*$/;
+
+// Signatures may arrive tagged with the provider that issued them
+// ("claude#<sig>"). An untagged one is inspected structurally.
+const PROVIDER_PREFIXES = new Set(['claude', 'gemini', 'gpt', 'grok']);
+
+/**
+ * Split a "provider#signature" tag. Returns { provider, signature } with
+ * provider null when the value carries no recognized tag.
+ */
+export function splitProviderPrefix(raw) {
+  const sig = String(raw ?? '').trim();
+  const hash = sig.indexOf('#');
+  if (hash < 0) return { provider: null, signature: sig };
+  const prefix = sig.slice(0, hash).toLowerCase();
+  if (!PROVIDER_PREFIXES.has(prefix)) return { provider: null, signature: sig };
+  return { provider: prefix, signature: sig.slice(hash + 1).trim() };
+}
+
+function decodeBase64Url(sig) {
+  try {
+    const buf = Buffer.from(sig, 'base64url');
+    // Node's base64 decoder is lenient and silently drops trailing garbage, so
+    // a round-trip check stands in for Go's strict decoder.
+    if (buf.length === 0 && sig.length > 0) return null;
+    return buf;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is this a structurally valid GPT reasoning signature?
+ *
+ * Structural only — we cannot verify the HMAC without the backend's key. The
+ * point is to reject signatures issued by a different provider, not to
+ * authenticate our own.
+ */
+export function isValidGptReasoningSignature(raw) {
+  const sig = String(raw ?? '').trim();
+  if (sig === '' || sig.length > MAX_SIGNATURE_LEN) return false;
+
+  // The literal prefix is the cheapest discriminator and rejects every other
+  // provider's envelope before the charset scan or decode.
+  if (!sig.startsWith('gAAAA')) return false;
+  if (!CHARSET.test(sig)) return false;
+
+  const decoded = decodeBase64Url(sig);
+  if (!decoded || decoded.length < MIN_DECODED_LEN) return false;
+  if (decoded[0] !== VERSION_BYTE) return false;
+
+  const ciphertextLen = decoded.length - HEADER_LEN - HMAC_LEN;
+  return ciphertextLen > 0 && ciphertextLen % AES_BLOCK === 0;
+}
+
+/**
+ * Return the signature to send as encrypted_content, or null when the value
+ * cannot be replayed to a GPT backend and its reasoning block should be dropped.
+ */
+export function compatibleGptSignature(raw) {
+  const { provider, signature } = splitProviderPrefix(raw);
+  // An explicit tag from another provider is authoritative: don't second-guess it.
+  if (provider !== null && provider !== 'gpt') return null;
+  return isValidGptReasoningSignature(signature) ? signature : null;
+}

--- a/src/codex/token-refresher.js
+++ b/src/codex/token-refresher.js
@@ -1,0 +1,119 @@
+// Scheduled token refresh for codex accounts.
+//
+// Every other account type has something that keeps its token current as a side
+// effect: a request refreshes on the way through, and the opt-in prober and
+// keep-warm scheduler both call ensureTokenFresh. Codex accounts are excluded
+// from both of those (the prober reads an Anthropic endpoint that rejects a
+// ChatGPT token; warming holds open a session window this plan does not have),
+// so on an idle proxy nothing renews them and the token simply expires.
+//
+// That is survivable — the next request refreshes synchronously before sending
+// — but it leaves the proxy holding a stale credential for as long as it stays
+// idle, and OpenAI rotates the refresh token on every refresh. The longer
+// teamclaude sits on an old one, the likelier some other holder (the Codex CLI)
+// rotates the family out from under it, at which point the refresh fails and
+// the account drops out of rotation until it is re-imported.
+//
+// Unlike the prober and warmer this is ON by default and spends no quota: the
+// check is a clock comparison, and a refresh only happens near expiry. With the
+// observed ~10-day token lifetime that works out to roughly one refresh per
+// token, so it does not churn the refresh-token family any harder than the
+// lazy path already would.
+
+const DEFAULT_CHECK_INTERVAL_MS = 60_000;
+
+// How far ahead of expiry to renew. Comfortably wider than the request path's
+// 5-minute window so a token is replaced well before anything needs it, and far
+// short of the token's lifetime so this doesn't refresh on every tick.
+const DEFAULT_REFRESH_AHEAD_MS = 30 * 60_000;
+
+export class CodexTokenRefresher {
+  constructor(accountManager, {
+    intervalMs = DEFAULT_CHECK_INTERVAL_MS,
+    refreshAheadMs = DEFAULT_REFRESH_AHEAD_MS,
+    log = console.log,
+  } = {}) {
+    this.am = accountManager;
+    this.intervalMs = intervalMs;
+    this.refreshAheadMs = refreshAheadMs;
+    this.log = log;
+    this.timer = null;
+    this._running = false;
+    this.lastRunAt = null;
+    this.refreshCount = 0;
+  }
+
+  /** Accounts this refresher is responsible for. */
+  targets() {
+    return this.am.accounts.filter(
+      a => a.protocol === 'codex' && a.type === 'oauth' && a.refreshToken && !a.disabled);
+  }
+
+  start() {
+    if (this.timer) return;
+    // Run once immediately: a proxy started after sitting idle for days would
+    // otherwise serve its first request on an expired token and pay a
+    // synchronous refresh, which is the exact latency this exists to remove.
+    this.checkAll().catch(() => {});
+    this.timer = setInterval(() => this.checkAll().catch(() => {}), this.intervalMs);
+    // Don't hold the event loop open — this must never keep the process alive.
+    this.timer.unref?.();
+  }
+
+  stop() {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /**
+   * Refresh every codex account whose token expires within the lookahead
+   * window. ensureTokenFresh coalesces with any in-flight refresh and is a
+   * no-op for a token that is still comfortably valid, so this is cheap to call
+   * often.
+   */
+  async checkAll() {
+    if (this._running) return;
+    this._running = true;
+    this.lastRunAt = Date.now();
+    try {
+      const due = this.targets().filter(a => this._isDue(a));
+      if (due.length === 0) return;
+
+      await Promise.all(due.map(async account => {
+        const secondsLeft = account.expiresAt
+          ? Math.round((account.expiresAt - Date.now()) / 1000)
+          : null;
+        this.log(`[TeamClaude] Codex token for "${account.name}" expires in ${secondsLeft ?? '?'}s — refreshing ahead of use`);
+        // Errors are already handled inside ensureTokenFresh, which distinguishes
+        // a dead refresh token (sidelines the account) from a transient failure
+        // (leaves it serving and retries next tick).
+        await this.am.ensureTokenFresh(account.index, false, this.refreshAheadMs);
+        this.refreshCount++;
+      }));
+    } finally {
+      this._running = false;
+    }
+  }
+
+  _isDue(account) {
+    // No expiry recorded means we cannot tell how long the token has left.
+    // Refreshing on every tick would hammer the token endpoint, so leave it to
+    // the request path, which refreshes on a 401.
+    if (!account.expiresAt) return false;
+    return Date.now() + this.refreshAheadMs >= account.expiresAt;
+  }
+
+  status() {
+    return {
+      enabled: !!this.timer,
+      intervalMs: this.intervalMs,
+      refreshAheadMs: this.refreshAheadMs,
+      lastRunAt: this.lastRunAt ? new Date(this.lastRunAt).toISOString() : null,
+      refreshCount: this.refreshCount,
+      accounts: this.targets().map(a => ({
+        name: a.name,
+        expiresAt: a.expiresAt ? new Date(a.expiresAt).toISOString() : null,
+        due: this._isDue(a),
+      })),
+    };
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
+import { importCodexCredentials, refreshCodexToken, CODEX_DEFAULT_AUTH_PATH } from './codex/oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
 import { resolveAccounts } from './resolve-accounts.js';
 import * as alias from './alias.js';
@@ -186,6 +187,9 @@ async function serverCommand() {
       config.accounts[idx].accessToken = newTokens.accessToken;
       config.accounts[idx].refreshToken = newTokens.refreshToken;
       config.accounts[idx].expiresAt = newTokens.expiresAt;
+      // Codex refreshes re-derive the account id; persist it so a migrated
+      // account survives a restart. Absent for anthropic accounts.
+      if (newTokens.accountId) config.accounts[idx].accountId = newTokens.accountId;
     }
     atomicConfigUpdate(diskConfig => {
       // Pick up any new accounts from disk so index matching stays correct
@@ -203,6 +207,7 @@ async function serverCommand() {
         diskConfig.accounts[cfgIdx].accessToken = newTokens.accessToken;
         diskConfig.accounts[cfgIdx].refreshToken = newTokens.refreshToken;
         diskConfig.accounts[cfgIdx].expiresAt = newTokens.expiresAt;
+        if (newTokens.accountId) diskConfig.accounts[cfgIdx].accountId = newTokens.accountId;
       }
     }).catch(err => console.error(`[TeamClaude] Failed to save refreshed token: ${err.message}`));
   });
@@ -486,6 +491,11 @@ async function serverCommand() {
 async function importCommand() {
   const config = await loadOrCreateConfig();
 
+  if (args.includes('--codex')) {
+    await importCodexCommand(config);
+    return;
+  }
+
   let name = argValue('--name');
   const jsonStr = argValue('--json');
 
@@ -520,6 +530,73 @@ async function importCommand() {
   }
 
   await upsertOAuthAccount(config, name, creds, 'import');
+}
+
+// ── codex import ────────────────────────────────────────────
+
+async function importCodexCommand(config) {
+  const name = argValue('--name');
+  const fromPath = argValue('--from') || CODEX_DEFAULT_AUTH_PATH;
+
+  let creds;
+  try {
+    creds = await importCodexCredentials(fromPath);
+  } catch (err) {
+    console.error(`Failed to import Codex credentials from ${fromPath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  await upsertCodexAccount(config, name, creds, fromPath);
+}
+
+/**
+ * Add or update a codex-protocol account.
+ *
+ * Identity is the ChatGPT account id: unlike Anthropic accounts there is no
+ * org dimension, and the email can change without the account changing.
+ */
+async function upsertCodexAccount(config, name, creds, fromPath) {
+  if (!name) name = creds.email || `codex-${creds.accountId.slice(0, 8)}`;
+
+  const account = {
+    name,
+    type: 'oauth',
+    protocol: 'codex',
+    source: 'import --codex',
+    accountId: creds.accountId,
+    // Display-only, refreshed on each import. Not read from the live token
+    // because the id_token isn't persisted.
+    planType: creds.planType || null,
+    accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt,
+  };
+
+  let idx = config.accounts.findIndex(a => a.protocol === 'codex' && a.accountId === creds.accountId);
+  if (idx < 0) idx = config.accounts.findIndex(a => a.name === name);
+
+  if (idx >= 0) {
+    const prev = config.accounts[idx];
+    config.accounts[idx] = { ...prev, ...account, name: prev.name };
+    console.log(`Updated codex account "${prev.name}"`);
+  } else {
+    config.accounts.push(account);
+    console.log(`Added codex account "${account.name}"${creds.planType ? ` (ChatGPT ${creds.planType})` : ''}`);
+  }
+
+  await saveConfig(config);
+  console.log(`Saved to ${getConfigPath()}`);
+
+  // OpenAI rotates the refresh token on every refresh, so this credential and
+  // the Codex CLI's copy are now two holders of one rotating family: whichever
+  // refreshes second gets invalidated. Worth stating plainly at import time —
+  // the failure mode otherwise shows up much later as a confusing re-login prompt.
+  console.log('');
+  console.log(`Note: ${fromPath} holds the same refresh token. OpenAI rotates it on each`);
+  console.log('refresh, so running the Codex CLI and TeamClaude side by side can invalidate');
+  console.log("one of them. Re-run this import after a `codex login` to resync.");
+
+  await notifyRunningServer(config);
 }
 
 // ── login ───────────────────────────────────────────────────
@@ -816,10 +893,12 @@ async function accountsCommand() {
     if (a.type !== 'oauth' || !a.refreshToken) return;
     if (!isTokenExpiringSoon(a.expiresAt)) return;
     try {
-      const newTokens = await refreshAccessToken(a.refreshToken);
+      const refresh = a.protocol === 'codex' ? refreshCodexToken : refreshAccessToken;
+      const newTokens = await refresh(a.refreshToken);
       a.accessToken = newTokens.accessToken;
       a.refreshToken = newTokens.refreshToken;
       a.expiresAt = newTokens.expiresAt;
+      if (newTokens.accountId) a.accountId = newTokens.accountId;
       configDirty = true;
     } catch {
       // refresh failed — fetchProfile will report the specific error
@@ -827,10 +906,12 @@ async function accountsCommand() {
   }));
   if (configDirty) await saveConfig(config);
 
-  // Fetch profiles in parallel for all OAuth accounts
+  // Fetch profiles in parallel for all OAuth accounts. Codex accounts are
+  // skipped: fetchProfile talks to Anthropic's OAuth profile endpoint, which
+  // rejects a ChatGPT token and would render every codex account as a 401.
   const profiles = await Promise.all(
     config.accounts.map(a =>
-      a.type === 'oauth' && a.accessToken ? fetchProfile(a.accessToken) : null
+      a.type === 'oauth' && a.accessToken && a.protocol !== 'codex' ? fetchProfile(a.accessToken) : null
     )
   );
 
@@ -884,6 +965,15 @@ async function accountsCommand() {
 
     if (a.type === 'apikey') {
       console.log(`  [${i + 1}] ${a.name} (apikey)  ${a.apiKey?.slice(0, 15)}...`);
+      continue;
+    }
+
+    if (a.protocol === 'codex') {
+      // No Anthropic profile for these; describe them from what import recorded.
+      const label = a.planType ? `ChatGPT ${a.planType}` : 'ChatGPT Codex';
+      const src = a.source ? `, ${a.source}` : '';
+      console.log(`  [${i + 1}] ${a.name} (${label}${src})`);
+      if (a.accountId) console.log(`       ID:    ${a.accountId}`);
       continue;
     }
 
@@ -1292,6 +1382,7 @@ Usage: teamclaude [command] [options]
 Commands:
   server              Start the proxy server (default; --headless to skip the TUI)
   import              Import credentials from Claude Code
+  import --codex      Import ChatGPT Codex credentials (~/.codex/auth.json)
   login               OAuth login via browser
   login --api         Add an API key account
   env [--no-mitm]     Print export lines to point Claude Code at the proxy, for
@@ -1329,7 +1420,8 @@ Commands:
 Options:
   --name NAME         Set account name (import/login)
   --org NAME|UUID     Disambiguate when an email spans multiple orgs (remove/priority/api)
-  --from PATH         Credentials path (import, default: ~/.claude/.credentials.json)
+  --from PATH         Credentials path (import, default: ~/.claude/.credentials.json;
+                      with --codex, default: ~/.codex/auth.json)
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
 import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
-import { importCodexCredentials, refreshCodexToken, CODEX_DEFAULT_AUTH_PATH } from './codex/oauth.js';
+import { importCodexCredentials, refreshCodexToken, loginCodex, CODEX_DEFAULT_AUTH_PATH } from './codex/oauth.js';
 import { sameIdentity, orgKey, matchAccounts } from './identity.js';
 import { resolveAccounts } from './resolve-accounts.js';
 import * as alias from './alias.js';
@@ -547,6 +547,20 @@ async function importCommand() {
 
 // ── codex import ────────────────────────────────────────────
 
+async function loginCodexCommand() {
+  const config = await loadOrCreateConfig();
+  let creds;
+  try {
+    creds = await loginCodex();
+  } catch (err) {
+    console.error(`Codex login failed: ${err.message}`);
+    process.exit(1);
+  }
+  // Credentials from a login are teamclaude's own grant, so unlike an import
+  // there is no shared refresh token to warn about.
+  await upsertCodexAccount(config, argValue('--name'), creds, null);
+}
+
 async function importCodexCommand(config) {
   const name = argValue('--name');
   const fromPath = argValue('--from') || CODEX_DEFAULT_AUTH_PATH;
@@ -567,6 +581,10 @@ async function importCodexCommand(config) {
  *
  * Identity is the ChatGPT account id: unlike Anthropic accounts there is no
  * org dimension, and the email can change without the account changing.
+ *
+ * `fromPath` is the credential file an import copied from, or null when the
+ * credential came from our own login. It decides whether the shared-refresh-token
+ * warning applies — a login has its own grant and shares nothing.
  */
 async function upsertCodexAccount(config, name, creds, fromPath) {
   if (!name) name = creds.email || `codex-${creds.accountId.slice(0, 8)}`;
@@ -575,7 +593,7 @@ async function upsertCodexAccount(config, name, creds, fromPath) {
     name,
     type: 'oauth',
     protocol: 'codex',
-    source: 'import --codex',
+    source: fromPath ? 'import --codex' : 'login --codex',
     accountId: creds.accountId,
     // Display-only, refreshed on each import. Not read from the live token
     // because the id_token isn't persisted.
@@ -600,14 +618,18 @@ async function upsertCodexAccount(config, name, creds, fromPath) {
   await saveConfig(config);
   console.log(`Saved to ${getConfigPath()}`);
 
-  // OpenAI rotates the refresh token on every refresh, so this credential and
-  // the Codex CLI's copy are now two holders of one rotating family: whichever
-  // refreshes second gets invalidated. Worth stating plainly at import time —
-  // the failure mode otherwise shows up much later as a confusing re-login prompt.
-  console.log('');
-  console.log(`Note: ${fromPath} holds the same refresh token. OpenAI rotates it on each`);
-  console.log('refresh, so running the Codex CLI and TeamClaude side by side can invalidate');
-  console.log("one of them. Re-run this import after a `codex login` to resync.");
+  // An IMPORT copies the Codex CLI's credential, so both hold one refresh token.
+  // OpenAI rotates it on every refresh, meaning whichever party refreshes second
+  // is left with a dead one. Say so plainly here — otherwise the failure surfaces
+  // much later as a baffling re-login prompt — and point at the flow that avoids
+  // it entirely. A login has its own grant and shares nothing, so it says nothing.
+  if (fromPath) {
+    console.log('');
+    console.log(`Note: ${fromPath} holds the same refresh token. OpenAI rotates it on each`);
+    console.log('refresh, so running the Codex CLI and TeamClaude side by side can invalidate');
+    console.log('one of them. Re-run this import after a `codex login` to resync, or use');
+    console.log('`teamclaude login --codex` to get an independent credential instead.');
+  }
 
   await notifyRunningServer(config);
 }
@@ -615,6 +637,10 @@ async function upsertCodexAccount(config, name, creds, fromPath) {
 // ── login ───────────────────────────────────────────────────
 
 async function loginCommand() {
+  if (args.includes('--codex')) {
+    await loginCodexCommand();
+    return;
+  }
   if (args.includes('--api')) {
     await loginApiCommand();
     return;
@@ -1395,7 +1421,10 @@ Usage: teamclaude [command] [options]
 Commands:
   server              Start the proxy server (default; --headless to skip the TUI)
   import              Import credentials from Claude Code
-  import --codex      Import ChatGPT Codex credentials (~/.codex/auth.json)
+  import --codex      Import ChatGPT Codex credentials (~/.codex/auth.json).
+                      Shares a refresh token with the Codex CLI — prefer
+                      'login --codex' unless you need the existing credential
+  login --codex       Sign in to ChatGPT for an independent Codex credential
   login               OAuth login via browser
   login --api         Add an API key account
   env [--no-mitm]     Print export lines to point Claude Code at the proxy, for

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
 import { Warmer } from './warmer.js';
+import { CodexTokenRefresher } from './codex/token-refresher.js';
 import { TUI } from './tui.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
@@ -224,6 +225,8 @@ async function serverCommand() {
   let prober = null;
   // Opt-in keep-warm scheduler (config.warmupSeconds, default 0 = off).
   let warmer = null;
+  // Scheduled codex token refresh (on by default — nothing else renews them).
+  let codexTokenRefresher = null;
   const serverStartedAt = Date.now();
 
   // sx.org proxy (IP-based-429 workaround). Dormant unless an API key is set in
@@ -453,6 +456,15 @@ async function serverCommand() {
   });
   warmer.start();
 
+  // Keep codex tokens fresh. Unlike the two schedulers above this is on by
+  // default and spends no quota: codex accounts are excluded from both of them,
+  // so nothing else renews their token while the proxy is idle.
+  codexTokenRefresher = new CodexTokenRefresher(accountManager, {
+    intervalMs: (config.codexTokenCheckSeconds ?? 60) * 1000,
+    refreshAheadMs: (config.codexRefreshAheadSeconds ?? 1800) * 1000,
+  });
+  codexTokenRefresher.start();
+
   // Background self-update for a backgrounded (headless) server. Skipped under
   // the TUI, where npm's install output would corrupt the display — interactive
   // users update via `teamclaude run` (post-session) or `teamclaude update`.
@@ -473,6 +485,7 @@ async function serverCommand() {
     if (!tui) console.log('\n[TeamClaude] Shutting down...');
     prober?.stop();
     warmer?.stop();
+    codexTokenRefresher?.stop();
     if (quotaSaveInterval) clearInterval(quotaSaveInterval);
     await persistQuotaState();
     // Don't linger waiting on keep-alive / streaming connections: actively

--- a/src/index.js
+++ b/src/index.js
@@ -603,8 +603,23 @@ async function upsertCodexAccount(config, name, creds, fromPath) {
     expiresAt: creds.expiresAt,
   };
 
+  // Match only within the codex protocol. The name fallback used to be
+  // unscoped, copied from the Anthropic upsert where every account is the same
+  // protocol — here it meant a codex login whose email happened to equal an
+  // existing Claude account's name silently merged codex fields over that
+  // account and destroyed its credential. One person's Claude and ChatGPT
+  // accounts routinely share an email, so this was the common case, not an edge.
   let idx = config.accounts.findIndex(a => a.protocol === 'codex' && a.accountId === creds.accountId);
-  if (idx < 0) idx = config.accounts.findIndex(a => a.name === name);
+  if (idx < 0) idx = config.accounts.findIndex(a => a.protocol === 'codex' && a.name === name);
+
+  // The default name is derived from the email, so it can collide with an
+  // account of another protocol. Names are the user-facing key for
+  // remove/priority/TC_ACCT, so they have to stay unique — disambiguate rather
+  // than let two entries answer to the same name.
+  if (idx < 0 && config.accounts.some(a => a.name === name)) {
+    name = `${name} (codex)`;
+    account.name = name;
+  }
 
   if (idx >= 0) {
     const prev = config.accounts[idx];

--- a/src/prober.js
+++ b/src/prober.js
@@ -60,7 +60,13 @@ export class Prober {
     this.lastRunStartedAt = Date.now();
     this.nextRunAt = this.intervalMs > 0 ? this.lastRunStartedAt + this.intervalMs : null;
     try {
-      const accounts = this.am.accounts.filter(account => account.type === 'oauth' && account.credential);
+      // Codex accounts are excluded: probeFn reads Anthropic's OAuth usage
+      // endpoint, which rejects a ChatGPT token, so probing one would 401, force
+      // a needless token refresh, 401 again and record a permanent error. They
+      // need no probe anyway — codex quota rides in on every response header,
+      // so it is always as fresh as the account's last request.
+      const accounts = this.am.accounts.filter(
+        account => account.type === 'oauth' && account.credential && account.protocol !== 'codex');
       await Promise.all(accounts.map(account => this.probeAccount(account)));
     } finally {
       this.lastRunFinishedAt = Date.now();

--- a/src/server.js
+++ b/src/server.js
@@ -941,11 +941,13 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       responseHeaders[key] = value;
     }
 
-    // A codex request is always sent as a stream, so upstream answers
-    // text/event-stream even when the client asked for a plain response. Correct
-    // the content type before the headers go out, or the client would try to
-    // parse a JSON body as SSE.
-    if (isCodex && !clientWantsStream) responseHeaders['content-type'] = 'application/json';
+    // Codex sends no content-type of its own, so set the one that matches what
+    // this proxy is about to emit: SSE when the client asked to stream, JSON
+    // when the frames are folded back into a Messages object. Without this the
+    // client has to guess, and guesses wrong.
+    if (isCodex) {
+      responseHeaders['content-type'] = clientWantsStream ? 'text/event-stream' : 'application/json';
+    }
 
     res.writeHead(upstreamRes.status, responseHeaders);
 
@@ -957,7 +959,10 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     }
 
     const contentType = upstreamRes.headers.get('content-type') || '';
-    const isStreaming = contentType.includes('text/event-stream');
+    // Codex sends its SSE responses with no content-type header at all, so the
+    // upstream header cannot decide this. A codex request is always sent with
+    // stream:true and accept: text/event-stream, so its response is always SSE.
+    const isStreaming = isCodex || contentType.includes('text/event-stream');
 
     if (isStreaming) {
       // Stream each chunk straight to the log as it is relayed — never hold the

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,8 @@ import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
 import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODEX_BASE_URL } from './codex/protocol.js';
+import { claudeRequestToCodex } from './codex/request-translate.js';
+import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -673,6 +675,10 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // Build upstream request headers
   const isCodex = isCodexAccount(account);
   const isOAuth = account.type === 'oauth';
+  // The codex request translator always asks for a stream (the Responses API is
+  // streaming-first here), so what the CLIENT asked for is tracked separately
+  // and the response is folded back into a Messages object when it wanted one.
+  const clientWantsStream = isStreamingRequest(body);
   let headers = {};
   let upstreamUrl;
 
@@ -693,7 +699,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       return;
     }
     headers = codexHeaders(account, {
-      stream: isStreamingRequest(body),
+      stream: true,
       sessionId: req.headers['x-claude-code-session-id'] || null,
     });
   } else {
@@ -732,8 +738,29 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // Rewrite the model name for accounts that target a different upstream (e.g.
   // GLM), which uses different model identifiers than Anthropic.
   if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);
-  // If the body changed length (sanitize or model rewrite), update Content-Length
-  // so the upstream doesn't receive a mismatched framing and truncate or stall.
+
+  // Codex accounts need the body converted to the Responses API, not just
+  // relabelled. Done after the model rewrite so modelMap still selects which
+  // upstream model the translated request names.
+  let codexRequest = null;
+  if (isCodex) {
+    try {
+      codexRequest = JSON.parse(sendBody.toString('utf-8'));
+      sendBody = claudeRequestToCodex(codexRequest, codexRequest.model);
+    } catch (err) {
+      console.error(`[TeamClaude] Codex request translation failed (account "${account.name}"): ${err.message}`);
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: `codex translation failed: ${err.message}` },
+      }));
+      return;
+    }
+  }
+
+  // If the body changed length (sanitize, model rewrite or codex translation),
+  // update Content-Length so the upstream doesn't receive a mismatched framing
+  // and truncate or stall.
   if (sendBody !== body) headers['content-length'] = String(sendBody.length);
 
   // Streaming request log, opened lazily on the first terminal outcome (a
@@ -914,6 +941,12 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       responseHeaders[key] = value;
     }
 
+    // A codex request is always sent as a stream, so upstream answers
+    // text/event-stream even when the client asked for a plain response. Correct
+    // the content type before the headers go out, or the client would try to
+    // parse a JSON body as SSE.
+    if (isCodex && !clientWantsStream) responseHeaders['content-type'] = 'application/json';
+
     res.writeHead(upstreamRes.status, responseHeaders);
 
     if (!upstreamRes.body) {
@@ -931,7 +964,15 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // whole (potentially ~1M-token) SSE body in memory.
       const l = getLog();
       const bw = l ? l.bodyWriter('RESPONSE BODY (streamed)', contentType) : null;
-      await streamResponse(upstreamRes.body, res, account.index, accountManager, bw);
+      // Codex answers in the Responses API's SSE dialect; translate it back to
+      // Anthropic events on the way through. Usage accounting reads the
+      // translated frames, so quota tracking works unchanged.
+      const translator = isCodex ? createCodexStreamTranslator(codexRequest) : null;
+      if (translator && !clientWantsStream) {
+        await collectTranslatedResponse(upstreamRes.body, res, account.index, accountManager, bw, translator);
+      } else {
+        await streamResponse(upstreamRes.body, res, account.index, accountManager, bw, translator);
+      }
       l?.end();
     } else {
       const buf = Buffer.from(await upstreamRes.arrayBuffer());
@@ -1034,7 +1075,20 @@ export function readWithIdleTimeout(reader, ms) {
 /**
  * Stream an SSE response to the client, parsing usage data along the way.
  */
-async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter) {
+/**
+ * Feed one complete upstream SSE event through a codex translator, returning the
+ * Anthropic frames to forward. Codex frames carry an `event:` line alongside the
+ * `data:` line; the translator only reads the latter.
+ */
+function translateSSEEvent(event, translator) {
+  const out = [];
+  for (const line of event.split('\n')) {
+    if (line.startsWith('data:')) out.push(...translator.push(line));
+  }
+  return out;
+}
+
+async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, translator = null) {
   const reader = webStream.getReader();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
@@ -1049,10 +1103,14 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
       // Client disconnected — stop reading from upstream
       if (res.destroyed) break;
 
-      // Forward chunk immediately
-      const ok = res.write(value);
+      // Without a translator the chunk is relayed verbatim and immediately. A
+      // codex stream cannot be: an event has to arrive whole before it can be
+      // translated, so forwarding is driven by the parsed events below.
+      let ok = true;
+      if (!translator) ok = res.write(value);
 
-      // Append to the log as it streams (no whole-body buffering)
+      // Append to the log as it streams (no whole-body buffering). This records
+      // the raw upstream body, which is what a translation bug is diagnosed from.
       if (bodyWriter) bodyWriter.chunk(Buffer.from(value));
 
       const text = decoder.decode(value, { stream: true });
@@ -1063,7 +1121,17 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
       sseBuffer = events.pop(); // keep incomplete event
 
       for (const event of events) {
-        parseSSEUsage(event, accountIndex, accountManager);
+        if (translator) {
+          const frames = translateSSEEvent(event, translator);
+          for (const frame of frames) {
+            ok = res.write(frame);
+            // Usage is read off the translated frames, so quota accounting works
+            // the same for both protocols.
+            parseSSEUsage(frame, accountIndex, accountManager);
+          }
+        } else {
+          parseSSEUsage(event, accountIndex, accountManager);
+        }
       }
 
       // Handle backpressure — also bail out if client disconnects,
@@ -1083,7 +1151,19 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
 
     // Parse any remaining buffer
     if (sseBuffer.trim()) {
-      parseSSEUsage(sseBuffer, accountIndex, accountManager);
+      if (translator) {
+        for (const frame of translateSSEEvent(sseBuffer, translator)) {
+          res.write(frame);
+          parseSSEUsage(frame, accountIndex, accountManager);
+        }
+      } else {
+        parseSSEUsage(sseBuffer, accountIndex, accountManager);
+      }
+    }
+    // Close any block the upstream left open, so a stream that ends without a
+    // terminal event doesn't leave the client waiting on an unfinished block.
+    if (translator && !res.destroyed) {
+      for (const frame of translator.end()) res.write(frame);
     }
   } catch (err) {
     // A mid-stream idle timeout (or any read error) means the upstream went
@@ -1098,6 +1178,57 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
     // timeout path, to destroy the dead socket so the pool drops it).
     reader.cancel().catch(() => {});
     if (!errored && !res.writableEnded) res.end();
+  }
+}
+
+/**
+ * Consume a codex SSE stream, translate it, and answer with a single Messages
+ * response. Used when the client asked for a non-streaming reply — the codex
+ * request is sent as a stream regardless, so the events are folded back into
+ * the object the client expected.
+ */
+async function collectTranslatedResponse(webStream, res, accountIndex, accountManager, bodyWriter, translator) {
+  const reader = webStream.getReader();
+  const idleMs = resolveBodyIdleTimeout();
+  const decoder = new TextDecoder();
+  let sseBuffer = '';
+  const frames = [];
+  let errored = false;
+
+  try {
+    while (true) {
+      const { done, value } = await readWithIdleTimeout(reader, idleMs);
+      if (done) break;
+      if (res.destroyed) break;
+
+      if (bodyWriter) bodyWriter.chunk(Buffer.from(value));
+      sseBuffer += decoder.decode(value, { stream: true });
+      const events = sseBuffer.split('\n\n');
+      sseBuffer = events.pop();
+
+      for (const event of events) {
+        for (const frame of translateSSEEvent(event, translator)) {
+          frames.push(frame);
+          parseSSEUsage(frame, accountIndex, accountManager);
+        }
+      }
+    }
+
+    if (sseBuffer.trim()) {
+      for (const frame of translateSSEEvent(sseBuffer, translator)) {
+        frames.push(frame);
+        parseSSEUsage(frame, accountIndex, accountManager);
+      }
+    }
+    frames.push(...translator.end());
+  } catch (err) {
+    errored = true;
+    throw err;
+  } finally {
+    reader.cancel().catch(() => {});
+    if (!errored && !res.writableEnded) {
+      res.end(JSON.stringify(aggregateAnthropicStream(frames)));
+    }
   }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,7 @@ import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODE
 import { claudeRequestToCodex, applyCodexEffortSupport } from './codex/request-translate.js';
 import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
 import { CODEX_HEADER_PREFIX, isCodexQuotaExhausted, codexResetAfterSeconds } from './codex/quota.js';
-import { fetchCodexModels } from './codex/models.js';
+import { fetchCodexModels, cloakModelId, uncloakModelId } from './codex/models.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -97,7 +97,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       // nothing to add and the request should reach Anthropic untouched.
       if (req.method === 'GET' && (req.url || '').split('?')[0] === '/v1/models'
           && accountManager.accounts.some(a => a.protocol === 'codex' && !a.disabled)) {
-        await handleModelsRequest(req, res, accountManager, upstream, sx);
+        await handleModelsRequest(req, res, accountManager, upstream, sx, config?.modelDiscovery?.includeAnthropic === true);
         return;
       }
 
@@ -355,9 +355,20 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           if (found && !hideActivity) hooks.onRequestModel?.(reqId, { model: found });
         }
       }
-      const body = Buffer.concat(bodyChunks);
+      let body = Buffer.concat(bodyChunks);
 
-      const model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
+      let model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
+      // A model picked from the discovery listing comes back cloaked (Claude
+      // Code only accepts claude-prefixed ids there). Decode it here, before
+      // anything else reads the model: blocklists, routing, quota buckets and
+      // the activity log should all see the real name, and upstream must
+      // receive it rather than an id no backend knows.
+      const realModel = uncloakModelId(model);
+      if (realModel !== model) {
+        body = rewriteModel(body, { [model]: realModel });
+        model = realModel;
+        if (!hideActivity) hooks.onRequestModel?.(reqId, { model });
+      }
       // An advisor request (Claude Code's advisor tool) carries a SECOND model
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).
@@ -1320,8 +1331,8 @@ async function collectTranslatedResponse(webStream, res, accountIndex, accountMa
  * problem, whereas failing the whole request leaves the client with no models
  * at all and no explanation.
  */
-async function handleModelsRequest(req, res, accountManager, upstream, sx) {
-  const anthropicAccount = accountManager.accounts.find(
+async function handleModelsRequest(req, res, accountManager, upstream, sx, includeAnthropic = false) {
+  const anthropicAccount = includeAnthropic && accountManager.accounts.find(
     a => a.protocol !== 'codex' && !a.disabled && a.status !== 'error' && a.credential);
 
   let anthropicModels = [];
@@ -1359,7 +1370,13 @@ async function handleModelsRequest(req, res, accountManager, upstream, sx) {
     codexModels.push(model);
   }
 
-  const data = [...anthropicModels, ...codexModels];
+  // Claude Code discards any listed model whose id does not begin with
+  // `claude-`, so a GPT id offered as-is never reaches its picker. Encode it
+  // into a claude-prefixed one; the request path decodes it back before routing.
+  const data = [...anthropicModels, ...codexModels].map(m => (
+    m.id === cloakModelId(m.id) ? m : { ...m, id: cloakModelId(m.id) }
+  ));
+
   res.writeHead(200, { 'content-type': 'application/json' });
   res.end(JSON.stringify({
     data,

--- a/src/server.js
+++ b/src/server.js
@@ -689,9 +689,22 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // the backend expects the Codex CLI's identity (see codexHeaders).
     upstreamUrl = codexUrlForPath(req.url, account.upstream || CODEX_BASE_URL);
     if (!upstreamUrl) {
-      // Only /v1/messages has a Responses-API equivalent. Fail loudly instead of
-      // forwarding an Anthropic-only endpoint (e.g. count_tokens) to a backend
-      // that would answer it wrongly or not at all.
+      // Only /v1/messages has a Responses-API equivalent. Claude Code also calls
+      // a set of Anthropic-only endpoints (bootstrap, oauth/usage, mcp_servers,
+      // count_tokens); a codex account cannot answer those, so hand the request
+      // to an account that can rather than failing it. Answering 404 here broke
+      // those features outright whenever rotation happened to land on codex.
+      //
+      // Only retry when some non-codex account could actually take it. Retrying
+      // regardless would exhaust the rotation and surface as a 429 — "rate
+      // limited", which is the wrong diagnosis for "no account speaks this API".
+      const hasAnthropicAccount = accountManager.accounts.some(
+        a => a.protocol !== 'codex' && !a.disabled && a.status !== 'error');
+      if (hasAnthropicAccount && retryCount < maxRetries) {
+        ctx.tried.add(account.index);
+        if (res.destroyed) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+      }
       res.writeHead(404, { 'content-type': 'application/json' });
       res.end(JSON.stringify({
         type: 'error',
@@ -962,11 +975,19 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       responseHeaders[key] = value;
     }
 
-    // Codex sends no content-type of its own, so set the one that matches what
-    // this proxy is about to emit: SSE when the client asked to stream, JSON
-    // when the frames are folded back into a Messages object. Without this the
-    // client has to guess, and guesses wrong.
-    if (isCodex) {
+    // Codex answers with SSE only when the request succeeded; an error comes
+    // back as a plain JSON body with its own content-type. Scoping this to 200
+    // matters: forcing the streaming path on an error fed the error body to the
+    // SSE translator, which found no events in it and emitted nothing, so the
+    // client saw a bare "400 (no body)" and the actual message — the reason the
+    // request failed — was destroyed.
+    const codexStreaming = isCodex && upstreamRes.status === 200;
+
+    // Codex sends no content-type of its own on success, so set the one that
+    // matches what this proxy is about to emit: SSE when the client asked to
+    // stream, JSON when the frames are folded into a Messages object. On an
+    // error the upstream content-type is already correct and is left alone.
+    if (codexStreaming) {
       responseHeaders['content-type'] = clientWantsStream ? 'text/event-stream' : 'application/json';
     }
 
@@ -981,9 +1002,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
 
     const contentType = upstreamRes.headers.get('content-type') || '';
     // Codex sends its SSE responses with no content-type header at all, so the
-    // upstream header cannot decide this. A codex request is always sent with
-    // stream:true and accept: text/event-stream, so its response is always SSE.
-    const isStreaming = isCodex || contentType.includes('text/event-stream');
+    // upstream header cannot decide this for a successful codex response. Errors
+    // do carry a content-type and must NOT take the streaming path (see above).
+    const isStreaming = codexStreaming || contentType.includes('text/event-stream');
 
     if (isStreaming) {
       // Stream each chunk straight to the log as it is relayed — never hold the
@@ -993,7 +1014,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // Codex answers in the Responses API's SSE dialect; translate it back to
       // Anthropic events on the way through. Usage accounting reads the
       // translated frames, so quota tracking works unchanged.
-      const translator = isCodex ? createCodexStreamTranslator(codexRequest) : null;
+      const translator = codexStreaming ? createCodexStreamTranslator(codexRequest) : null;
       if (translator && !clientWantsStream) {
         await collectTranslatedResponse(upstreamRes.body, res, account.index, accountManager, bw, translator);
       } else {

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,7 @@ import { tunnelTls } from './sx.js';
 import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODEX_BASE_URL } from './codex/protocol.js';
 import { claudeRequestToCodex } from './codex/request-translate.js';
 import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
+import { CODEX_HEADER_PREFIX, isCodexQuotaExhausted, codexResetAfterSeconds } from './codex/quota.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -799,10 +800,12 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       accountManager.release(account.index);
     }
 
-    // Extract rate limit headers
+    // Extract rate limit headers. Each protocol reports quota in its own header
+    // family; updateQuota normalizes both onto the same fields.
+    const quotaPrefix = isCodex ? CODEX_HEADER_PREFIX : 'anthropic-ratelimit-';
     const rateLimitHeaders = {};
     for (const [key, value] of upstreamRes.headers.entries()) {
-      if (key.startsWith('anthropic-ratelimit-')) {
+      if (key.startsWith(quotaPrefix)) {
         rateLimitHeaders[key] = value;
       }
     }
@@ -831,9 +834,25 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // account is futile — switch to another account now (updateQuota above
       // already recorded the spent bucket's utilization from the headers).
       const rl = rateLimitHeaders;
-      const generalRejected = rl['anthropic-ratelimit-unified-5h-status'] === 'rejected'
+      // Codex reports no per-bucket status, so a spent bucket has to be inferred
+      // from its utilization instead. Without this a codex 429 would read as a
+      // transient throttle and the proxy would keep retrying an account whose
+      // weekly limit is gone until its reset — for a 7-day window, that is a
+      // very long time to be stuck.
+      const codexExhausted = isCodex && isCodexQuotaExhausted(rl);
+      const generalRejected = codexExhausted
+        || rl['anthropic-ratelimit-unified-5h-status'] === 'rejected'
         || rl['anthropic-ratelimit-unified-7d-status'] === 'rejected';
       const fableRejected = rl['anthropic-ratelimit-unified-7d_oi-status'] === 'rejected' && !generalRejected;
+      if (codexExhausted) {
+        // Prefer the bucket's own reset over Retry-After. The hold below is
+        // still capped at an hour, so this does not keep a week-long exhaustion
+        // held for a week — the recorded utilization is what actually bars the
+        // account (selection skips anything past the switch threshold until the
+        // reset clears it). This just stops the hold being shorter than needed.
+        const resetIn = codexResetAfterSeconds(rl);
+        if (resetIn !== null) retryAfter = resetIn;
+      }
       if ((generalRejected || fableRejected) && retryCount < maxRetries) {
         // A Fable-only rejection leaves the account fine for other models, so we
         // do NOT throttle it globally — the recorded Fable utilization makes

--- a/src/server.js
+++ b/src/server.js
@@ -97,7 +97,10 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       // nothing to add and the request should reach Anthropic untouched.
       if (req.method === 'GET' && (req.url || '').split('?')[0] === '/v1/models'
           && accountManager.accounts.some(a => a.protocol === 'codex' && !a.disabled)) {
-        await handleModelsRequest(req, res, accountManager, upstream, sx, config?.modelDiscovery?.includeAnthropic === true);
+        await handleModelsRequest(req, res, accountManager, upstream, sx, {
+          includeAnthropic: config?.modelDiscovery?.includeAnthropic === true,
+          blockedModels: config?.blockedModels || [],
+        });
         return;
       }
 
@@ -1331,7 +1334,7 @@ async function collectTranslatedResponse(webStream, res, accountIndex, accountMa
  * problem, whereas failing the whole request leaves the client with no models
  * at all and no explanation.
  */
-async function handleModelsRequest(req, res, accountManager, upstream, sx, includeAnthropic = false) {
+async function handleModelsRequest(req, res, accountManager, upstream, sx, { includeAnthropic = false, blockedModels = [] } = {}) {
   const anthropicAccount = includeAnthropic && accountManager.accounts.find(
     a => a.protocol !== 'codex' && !a.disabled && a.status !== 'error' && a.credential);
 
@@ -1370,10 +1373,17 @@ async function handleModelsRequest(req, res, accountManager, upstream, sx, inclu
     codexModels.push(model);
   }
 
+  // Don't advertise a model this proxy would refuse to serve: blockedModels
+  // already rejects such a request with a 400, so listing it would put a choice
+  // in the picker that fails the moment it is used. Matched on the real id,
+  // before cloaking, so a pattern reads the way a user wrote it.
+  const listed = [...anthropicModels, ...codexModels].filter(
+    m => !blockedModels.some(p => modelGlobMatches(p, m.id)));
+
   // Claude Code discards any listed model whose id does not begin with
   // `claude-`, so a GPT id offered as-is never reaches its picker. Encode it
   // into a claude-prefixed one; the request path decodes it back before routing.
-  const data = [...anthropicModels, ...codexModels].map(m => (
+  const data = listed.map(m => (
     m.id === cloakModelId(m.id) ? m : { ...m, id: cloakModelId(m.id) }
   ));
 

--- a/src/server.js
+++ b/src/server.js
@@ -379,7 +379,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         }
       } finally {
         accountManager.endSession(sessionId);
-        if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId, pinned: ctx.pinnedIndex != null });
+        if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, upstreamModel: ctx.upstreamModel, sessionId, pinned: ctx.pinnedIndex != null });
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
@@ -663,7 +663,22 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   ctx.account = account.name;
   // Pin this session to the serving account (for affinity) and keep it "active"
   // in the running-sessions readout. Passive when distribution is off.
-  accountManager.recordSession(ctx.sessionId, account.index);
+  //
+  // Also record what will actually answer. The client only ever knows the model
+  // it asked for, so once modelMap redirects a request to another provider this
+  // is the sole record of which model really ran — which is what a status line
+  // needs to show "you asked for opus, this came from gpt".
+  const requestedModel = ctx.model || null;
+  const upstreamModel = (requestedModel && account.modelMap?.[requestedModel]) || requestedModel;
+  // Surfaced in the activity log so a glance shows which model actually ran.
+  ctx.upstreamModel = upstreamModel !== requestedModel ? upstreamModel : null;
+  accountManager.recordSession(ctx.sessionId, account.index, requestedModel ? {
+    account: account.name,
+    protocol: account.protocol || 'anthropic',
+    requestedModel,
+    upstreamModel,
+    translated: upstreamModel !== requestedModel,
+  } : null);
   hooks.onRequestRouted?.(reqId, { account: account.name });
 
   // Refresh OAuth token if needed

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
+import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODEX_BASE_URL } from './codex/protocol.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -670,28 +671,54 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   }
 
   // Build upstream request headers
+  const isCodex = isCodexAccount(account);
   const isOAuth = account.type === 'oauth';
-  const headers = {};
-  for (const [key, value] of Object.entries(req.headers)) {
-    const lk = key.toLowerCase();
-    // HTTP/2 pseudo-headers (:method, :path, :authority, :scheme) live in
-    // req.headers on the h2 server path; fetch rejects `:`-prefixed names.
-    if (lk.startsWith(':')) continue;
-    if (HOP_BY_HOP_HEADERS.has(lk)) continue;
-    if (lk === 'x-api-key') continue;
-    // Strip accept-encoding: Node fetch auto-decompresses, which would
-    // mismatch the Content-Encoding header we forward to the client
-    if (lk === 'accept-encoding') continue;
-    headers[key] = value;
-  }
+  let headers = {};
+  let upstreamUrl;
 
-  if (isOAuth) {
-    headers['authorization'] = `Bearer ${account.credential}`;
+  if (isCodex) {
+    // Codex accounts speak the OpenAI Responses API. Headers are built from
+    // scratch rather than forwarded: the inbound set is Anthropic-specific and
+    // the backend expects the Codex CLI's identity (see codexHeaders).
+    upstreamUrl = codexUrlForPath(req.url, account.upstream || CODEX_BASE_URL);
+    if (!upstreamUrl) {
+      // Only /v1/messages has a Responses-API equivalent. Fail loudly instead of
+      // forwarding an Anthropic-only endpoint (e.g. count_tokens) to a backend
+      // that would answer it wrongly or not at all.
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        type: 'error',
+        error: { type: 'not_found_error', message: `No codex equivalent for ${req.url}` },
+      }));
+      return;
+    }
+    headers = codexHeaders(account, {
+      stream: isStreamingRequest(body),
+      sessionId: req.headers['x-claude-code-session-id'] || null,
+    });
   } else {
-    headers['x-api-key'] = account.credential;
+    for (const [key, value] of Object.entries(req.headers)) {
+      const lk = key.toLowerCase();
+      // HTTP/2 pseudo-headers (:method, :path, :authority, :scheme) live in
+      // req.headers on the h2 server path; fetch rejects `:`-prefixed names.
+      if (lk.startsWith(':')) continue;
+      if (HOP_BY_HOP_HEADERS.has(lk)) continue;
+      if (lk === 'x-api-key') continue;
+      // Strip accept-encoding: Node fetch auto-decompresses, which would
+      // mismatch the Content-Encoding header we forward to the client
+      if (lk === 'accept-encoding') continue;
+      headers[key] = value;
+    }
+
+    if (isOAuth) {
+      headers['authorization'] = `Bearer ${account.credential}`;
+    } else {
+      headers['x-api-key'] = account.credential;
+    }
+
+    upstreamUrl = `${account.upstream || upstream}${req.url}`;
   }
 
-  const upstreamUrl = `${account.upstream || upstream}${req.url}`;
   const method = req.method;
 
   // Strip orphaned tool_use / tool_result blocks so a client that compacted or

--- a/src/server.js
+++ b/src/server.js
@@ -12,7 +12,7 @@ import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
-import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODEX_BASE_URL } from './codex/protocol.js';
+import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, codexPromptCacheKey, SESSION_HEADER, AGENT_HEADER, CODEX_BASE_URL } from './codex/protocol.js';
 import { claudeRequestToCodex, applyCodexEffortSupport } from './codex/request-translate.js';
 import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
 import { CODEX_HEADER_PREFIX, isCodexQuotaExhausted, codexResetAfterSeconds } from './codex/quota.js';
@@ -726,6 +726,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   const clientWantsStream = isStreamingRequest(body);
   let headers = {};
   let upstreamUrl;
+  let codexCacheKey = null;
 
   if (isCodex) {
     // Codex accounts speak the OpenAI Responses API. Headers are built from
@@ -756,10 +757,14 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       }));
       return;
     }
-    headers = codexHeaders(account, {
-      stream: true,
-      sessionId: req.headers['x-claude-code-session-id'] || null,
+    // One derived key scopes the prompt cache for this conversation. It must be
+    // stable across turns or nothing is cached — see codexPromptCacheKey.
+    codexCacheKey = codexPromptCacheKey(account, {
+      sessionId: req.headers[SESSION_HEADER] || null,
+      agentId: req.headers[AGENT_HEADER] || null,
+      model: ctx.model || null,
     });
+    headers = codexHeaders(account, { stream: true, cacheKey: codexCacheKey });
   } else {
     for (const [key, value] of Object.entries(req.headers)) {
       const lk = key.toLowerCase();
@@ -806,7 +811,8 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       codexRequest = JSON.parse(sendBody.toString('utf-8'));
       // Clamp after translating: the translator mirrors CLIProxyAPI exactly,
       // and this is the equivalent of the clamping it does in a later stage.
-      sendBody = applyCodexEffortSupport(claudeRequestToCodex(codexRequest, codexRequest.model));
+      sendBody = applyCodexEffortSupport(
+        claudeRequestToCodex(codexRequest, codexRequest.model, { promptCacheKey: codexCacheKey }));
     } catch (err) {
       console.error(`[TeamClaude] Codex request translation failed (account "${account.name}"): ${err.message}`);
       res.writeHead(400, { 'content-type': 'application/json' });

--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,7 @@ import { BodyWriter } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
 import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODEX_BASE_URL } from './codex/protocol.js';
-import { claudeRequestToCodex } from './codex/request-translate.js';
+import { claudeRequestToCodex, applyCodexEffortSupport } from './codex/request-translate.js';
 import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
 import { CODEX_HEADER_PREFIX, isCodexQuotaExhausted, codexResetAfterSeconds } from './codex/quota.js';
 
@@ -747,7 +747,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   if (isCodex) {
     try {
       codexRequest = JSON.parse(sendBody.toString('utf-8'));
-      sendBody = claudeRequestToCodex(codexRequest, codexRequest.model);
+      // Clamp after translating: the translator mirrors CLIProxyAPI exactly,
+      // and this is the equivalent of the clamping it does in a later stage.
+      sendBody = applyCodexEffortSupport(claudeRequestToCodex(codexRequest, codexRequest.model));
     } catch (err) {
       console.error(`[TeamClaude] Codex request translation failed (account "${account.name}"): ${err.message}`);
       res.writeHead(400, { 'content-type': 'application/json' });

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,7 @@ import { isCodexAccount, codexHeaders, codexUrlForPath, isStreamingRequest, CODE
 import { claudeRequestToCodex, applyCodexEffortSupport } from './codex/request-translate.js';
 import { createCodexStreamTranslator, aggregateAnthropicStream } from './codex/response-translate.js';
 import { CODEX_HEADER_PREFIX, isCodexQuotaExhausted, codexResetAfterSeconds } from './codex/quota.js';
+import { fetchCodexModels } from './codex/models.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -85,6 +86,20 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       // manage (the Anthropic upstream, which is HTTPS-only and never arrives
       // this way); forward anything else transparently instead of hijacking it.
       if (/^https?:\/\//i.test(req.url || '')) { relayHttpForward(req, res); return; }
+
+      // Model discovery. Claude Code reads /v1/models from the gateway at
+      // startup when CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY is set and
+      // offers whatever comes back in its picker, so serving the Codex catalog
+      // here makes a GPT model a first-class choice instead of something that
+      // has to be disguised as a Claude model via modelMap.
+      //
+      // Only intercepted when a codex account is present: otherwise there is
+      // nothing to add and the request should reach Anthropic untouched.
+      if (req.method === 'GET' && (req.url || '').split('?')[0] === '/v1/models'
+          && accountManager.accounts.some(a => a.protocol === 'codex' && !a.disabled)) {
+        await handleModelsRequest(req, res, accountManager, upstream, sx);
+        return;
+      }
 
       // Status endpoint
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
@@ -1292,6 +1307,66 @@ async function collectTranslatedResponse(webStream, res, accountIndex, accountMa
       res.end(JSON.stringify(aggregateAnthropicStream(frames)));
     }
   }
+}
+
+/**
+ * Serve /v1/models as the union of Anthropic's catalog and every codex
+ * account's.
+ *
+ * The Anthropic half is fetched with a real Claude account's credential rather
+ * than synthesised, so the list stays correct as models come and go. If that
+ * fetch fails — no Claude account, expired token — the codex models are still
+ * returned: a picker missing its Claude entries is a visible, recoverable
+ * problem, whereas failing the whole request leaves the client with no models
+ * at all and no explanation.
+ */
+async function handleModelsRequest(req, res, accountManager, upstream, sx) {
+  const anthropicAccount = accountManager.accounts.find(
+    a => a.protocol !== 'codex' && !a.disabled && a.status !== 'error' && a.credential);
+
+  let anthropicModels = [];
+  if (anthropicAccount) {
+    try {
+      await accountManager.ensureTokenFresh(anthropicAccount.index);
+      const headers = { 'anthropic-version': req.headers['anthropic-version'] || '2023-06-01', accept: 'application/json' };
+      if (anthropicAccount.type === 'oauth') headers.authorization = `Bearer ${anthropicAccount.credential}`;
+      else headers['x-api-key'] = anthropicAccount.credential;
+
+      const res2 = await upstreamFetch(`${anthropicAccount.upstream || upstream}${req.url}`, {
+        method: 'GET', headers, signal: AbortSignal.timeout(10_000),
+      }, sx);
+      // upstreamFetch returns a shim, not a WHATWG Response: it exposes
+      // status/headers/text() but no `ok` and no `json()`. Treating it like a
+      // real Response silently dropped every Claude model from this listing.
+      if (res2.status >= 200 && res2.status < 300) {
+        const body = JSON.parse(await res2.text());
+        if (Array.isArray(body?.data)) anthropicModels = body.data;
+      } else {
+        await res2.body?.cancel?.();
+      }
+    } catch { /* fall through with codex models only */ }
+  }
+
+  const codexAccounts = accountManager.accounts.filter(a => a.protocol === 'codex' && !a.disabled);
+  const catalogs = await Promise.all(codexAccounts.map(a => fetchCodexModels(a)));
+
+  // Two accounts on the same plan report the same catalog; list each model once.
+  const seen = new Set(anthropicModels.map(m => m.id));
+  const codexModels = [];
+  for (const model of catalogs.flat()) {
+    if (seen.has(model.id)) continue;
+    seen.add(model.id);
+    codexModels.push(model);
+  }
+
+  const data = [...anthropicModels, ...codexModels];
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({
+    data,
+    has_more: false,
+    first_id: data[0]?.id ?? null,
+    last_id: data[data.length - 1]?.id ?? null,
+  }));
 }
 
 function parseSSEUsage(event, accountIndex, accountManager) {

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -29,12 +29,16 @@ export class SessionTracker {
   // lastSeen (keeping the session "active"/"known") and, when an account is
   // given, (re)pins the session to it. Throttled sweep keeps the map bounded
   // even in a headless server that never renders status.
-  touch(sessionId, accountIndex = null, now = this._now()) {
+  touch(sessionId, accountIndex = null, now = this._now(), served = null) {
     if (!sessionId) return null;
     const s = this._ensure(sessionId, now);
     s.lastSeen = now;
     s.count += 1;
     if (accountIndex != null) s.accountIndex = accountIndex;
+    // What actually answered this session's last request. The client only knows
+    // the model it asked for, so when a request is translated to another
+    // provider this is the only record of which model really ran.
+    if (served) s.served = served;
     if (now - this._lastSweep > SWEEP_INTERVAL_MS) this.sweep(now);
     return s;
   }
@@ -117,17 +121,21 @@ export class SessionTracker {
     let known = 0;
     let active = 0;
     const perAccount = {};
+    // Keyed by session id so a caller holding one (a status line, say) can ask
+    // what served ITS session rather than guessing from fleet-wide state.
+    const byId = {};
     for (const [id, s] of this.sessions) {
       if (this._isExpired(s, now)) {
         this.sessions.delete(id);
         continue;
       }
       known += 1;
+      if (s.served) byId[id] = { ...s.served, accountIndex: s.accountIndex ?? null };
       if (this._isActive(s, now)) {
         active += 1;
         if (s.accountIndex != null) perAccount[s.accountIndex] = (perAccount[s.accountIndex] || 0) + 1;
       }
     }
-    return { known, active, perAccount };
+    return { known, active, perAccount, byId };
   }
 }

--- a/src/tui.js
+++ b/src/tui.js
@@ -272,7 +272,11 @@ export class TUI {
     this.active.delete(id);
     const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
     const acct = info.account || r?.account || '?';
-    const model = info.model ? ` (${info.model})` : ''; // shown when the request named a model
+    // Show the redirect when modelMap sent the request to a different model, so
+    // "asked for opus, answered by gpt" is visible without reading a log file.
+    const model = info.model
+      ? ` (${info.model}${info.upstreamModel ? ` → ${info.upstreamModel}` : ''})`
+      : '';
     const sid = info.sessionId || r?.sessionId || null;
     const pin = (info.pinned || r?.pinned) ? dim(' [pin]') : '';
     this._addLog(`${sessionTag(sid)} ${info.method} ${info.path}${model} → ${acct}${pin} (${info.status}, ${dur}s)`);

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -94,6 +94,11 @@ export class Warmer {
    */
   _isWarmTarget(account) {
     if (account.type !== 'oauth' || !account.credential) return false;
+    // Warming exists to keep an idle account's 5-hour session timer running, a
+    // Claude subscription concept. The observed codex plan has only a rolling
+    // weekly window with no session to hold open, so a warm request would spend
+    // real quota to accomplish nothing.
+    if (account.protocol === 'codex') return false;
     if (account.upstream) return false;
     if (account.disabled) return false;
     if (account.status === 'error' || account.status === 'exhausted' || account.status === 'throttled') return false;
@@ -178,7 +183,7 @@ export class Warmer {
       nextRunAt: iso(this.nextRunAt),
       accounts: this.am.accounts.map(account => {
         const status = this.accountStatus.get(account.name);
-        const applicable = account.type === 'oauth' && !account.upstream;
+        const applicable = account.type === 'oauth' && !account.upstream && account.protocol !== 'codex';
         return {
           name: account.name,
           status: applicable ? (status?.status || 'never') : 'not-applicable',

--- a/test/codex-account-upsert.test.js
+++ b/test/codex-account-upsert.test.js
@@ -1,0 +1,135 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// End-to-end through the CLI, because the bug this covers lived in how the
+// upsert reconciled a new codex account against the accounts already on disk.
+//
+// Regression: the codex upsert's name fallback was unscoped, copied from the
+// Anthropic upsert where every account shares a protocol. A codex credential
+// whose email matched an existing Claude account's NAME therefore merged codex
+// fields over that account and destroyed its credential. One person's Claude
+// and ChatGPT accounts routinely share an email, so this was the common case.
+
+const CLI = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'index.js');
+
+function jwt(payload) {
+  const b64 = obj => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64({ alg: 'none' })}.${b64(payload)}.sig`;
+}
+
+function codexAuthFile(dir, { email, accountId }) {
+  const path = join(dir, 'auth.json');
+  writeFileSync(path, JSON.stringify({
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: jwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+      refresh_token: 'rt.codex.1',
+      id_token: jwt({
+        email,
+        'https://api.openai.com/auth': { chatgpt_account_id: accountId, chatgpt_plan_type: 'plus' },
+      }),
+      account_id: accountId,
+    },
+  }));
+  return path;
+}
+
+function setup(accounts) {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-upsert-'));
+  const configPath = join(dir, 'teamclaude.json');
+  writeFileSync(configPath, JSON.stringify({
+    proxy: { port: 39999, apiKey: 'tc-test' },
+    upstream: 'https://api.anthropic.com',
+    accounts,
+  }, null, 2));
+  return { dir, configPath };
+}
+
+function importCodex(configPath, authPath) {
+  execFileSync('node', [CLI, 'import', '--codex', '--from', authPath], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    stdio: 'pipe',
+  });
+  return JSON.parse(readFileSync(configPath, 'utf-8'));
+}
+
+const claudeAccount = {
+  name: 'person@example.com',
+  type: 'oauth',
+  accountUuid: 'anthropic-uuid',
+  orgUuid: 'org-uuid',
+  accessToken: 'claude-access',
+  refreshToken: 'claude-refresh',
+  expiresAt: Date.now() + 3600_000,
+};
+
+test('a codex credential sharing a Claude account name does not overwrite it', () => {
+  const { dir, configPath } = setup([claudeAccount]);
+  const authPath = codexAuthFile(dir, { email: 'person@example.com', accountId: 'chatgpt-1' });
+
+  const cfg = importCodex(configPath, authPath);
+
+  assert.equal(cfg.accounts.length, 2);
+  const claude = cfg.accounts.find(a => a.accountUuid === 'anthropic-uuid');
+  assert.ok(claude, 'the Claude account must still exist');
+  assert.equal(claude.accessToken, 'claude-access', 'its credential must be untouched');
+  assert.equal(claude.refreshToken, 'claude-refresh');
+  assert.equal(claude.protocol, undefined, 'it must not have been converted to codex');
+});
+
+test('the colliding codex account is added under a disambiguated name', () => {
+  const { dir, configPath } = setup([claudeAccount]);
+  const authPath = codexAuthFile(dir, { email: 'person@example.com', accountId: 'chatgpt-1' });
+
+  const cfg = importCodex(configPath, authPath);
+
+  const codex = cfg.accounts.find(a => a.protocol === 'codex');
+  assert.ok(codex);
+  assert.equal(codex.accountId, 'chatgpt-1');
+  // Names are the user-facing key for remove/priority/TC_ACCT, so they must
+  // stay unique across protocols.
+  assert.notEqual(codex.name, claudeAccount.name);
+  assert.equal(new Set(cfg.accounts.map(a => a.name)).size, cfg.accounts.length);
+});
+
+test('re-importing the same codex account updates it in place', () => {
+  const { dir, configPath } = setup([claudeAccount]);
+  const authPath = codexAuthFile(dir, { email: 'person@example.com', accountId: 'chatgpt-1' });
+
+  importCodex(configPath, authPath);
+  const cfg = importCodex(configPath, authPath);
+
+  assert.equal(cfg.accounts.length, 2, 'must not accumulate duplicates');
+  assert.equal(cfg.accounts.filter(a => a.protocol === 'codex').length, 1);
+});
+
+test('two distinct ChatGPT accounts both land as separate entries', () => {
+  const { dir, configPath } = setup([]);
+  const first = codexAuthFile(mkdtempSync(join(tmpdir(), 'a-')), { email: 'a@example.com', accountId: 'chatgpt-1' });
+  const second = codexAuthFile(mkdtempSync(join(tmpdir(), 'b-')), { email: 'b@example.com', accountId: 'chatgpt-2' });
+
+  importCodex(configPath, first);
+  const cfg = importCodex(configPath, second);
+
+  assert.equal(cfg.accounts.length, 2);
+  assert.deepEqual(
+    cfg.accounts.map(a => a.accountId).sort(),
+    ['chatgpt-1', 'chatgpt-2'],
+  );
+  void dir;
+});
+
+test('a codex account with no name collision keeps its plain email name', () => {
+  const { dir, configPath } = setup([claudeAccount]);
+  const authPath = codexAuthFile(dir, { email: 'other@example.com', accountId: 'chatgpt-9' });
+
+  const cfg = importCodex(configPath, authPath);
+
+  const codex = cfg.accounts.find(a => a.protocol === 'codex');
+  assert.equal(codex.name, 'other@example.com');
+});

--- a/test/codex-e2e.test.js
+++ b/test/codex-e2e.test.js
@@ -20,8 +20,16 @@ function codexAccount(extra = {}) {
 
 const d = obj => `event: ${obj.type}\ndata: ${JSON.stringify(obj)}\n\n`;
 
-/** A fake Codex backend that records what it received and replays a script. */
-async function startFakeCodex(events, { status = 200 } = {}) {
+/**
+ * A fake Codex backend that records what it received and replays a script.
+ *
+ * It deliberately sends NO content-type, because the real backend doesn't. An
+ * earlier version of this mock set `text/event-stream` and passed while the
+ * live backend failed: the proxy decided "is this a stream?" from that header,
+ * so against the real thing it buffered the SSE and dumped it raw. Setting a
+ * header the real server omits is how a mock hides a bug — leave this alone.
+ */
+async function startFakeCodex(events, { status = 200, contentType = null } = {}) {
   const received = [];
   const server = http.createServer((req, res) => {
     let body = '';
@@ -33,7 +41,7 @@ async function startFakeCodex(events, { status = 200 } = {}) {
         res.end(JSON.stringify({ error: { type: 'server_error', message: 'boom' } }));
         return;
       }
-      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.writeHead(200, contentType ? { 'content-type': contentType } : {});
       for (const e of events) res.write(e);
       res.end();
     });
@@ -237,6 +245,43 @@ test('an endpoint with no Responses equivalent is refused, not forwarded', async
     assert.equal(JSON.parse(res.body).error.type, 'not_found_error');
     // Nothing reached the backend.
     assert.equal(codex.received.length, 0);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a codex response with no content-type is still treated as a stream', async () => {
+  // Regression: the live backend omits content-type entirely. Deciding
+  // "is this SSE?" from that header made the proxy buffer the whole stream and
+  // return raw Responses-API events to the client.
+  const codex = await startFakeCodex(SCRIPT); // no content-type, like the real one
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    assert.match(res.headers['content-type'], /text\/event-stream/);
+    assert.match(res.body, /event: message_start/);
+    assert.doesNotMatch(res.body, /response\.output_text\.delta/);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a codex response that does declare event-stream still works', async () => {
+  const codex = await startFakeCodex(SCRIPT, { contentType: 'text/event-stream' });
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    assert.match(res.body, /event: message_start/);
   } finally {
     proxy.server.close();
     codex.server.close();

--- a/test/codex-e2e.test.js
+++ b/test/codex-e2e.test.js
@@ -362,3 +362,90 @@ test('a truncated codex stream still closes its content block', async () => {
     codex.server.close();
   }
 });
+
+test('an upstream error body reaches the client instead of being swallowed', async () => {
+  // Regression: codex responses were forced down the SSE path regardless of
+  // status, so a JSON error body was fed to the stream translator, which found
+  // no events and emitted nothing. The client saw "400 (no body)" and the
+  // message explaining the failure was destroyed.
+  const codex = await startFakeCodex([], { status: 400 });
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    assert.equal(res.status, 400);
+    assert.notEqual(res.body.trim(), '', 'the error body must not be empty');
+    assert.match(res.body, /server_error/);
+    assert.match(res.headers['content-type'], /application\/json/);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('an anthropic-only endpoint fails over to an account that can serve it', async () => {
+  // Claude Code calls bootstrap/usage/mcp_servers alongside /v1/messages.
+  // Rotation landing on codex used to 404 them outright.
+  const anthropic = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, path: req.url }));
+  });
+  anthropic.listen(0, '127.0.0.1');
+  await once(anthropic, 'listening');
+  const anthropicUrl = `http://127.0.0.1:${anthropic.address().port}`;
+
+  const codex = await startFakeCodex(SCRIPT);
+  const am = new AccountManager([
+    codexAccount({ name: 'codex-1', upstream: codex.url }),
+    { name: 'claude-1', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const server = createProxyServer(am, { proxy: { port: 0 }, upstream: anthropicUrl });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  try {
+    const res = await new Promise((resolve, reject) => {
+      const r = http.request(`http://127.0.0.1:${server.address().port}/api/oauth/usage`, { method: 'GET' }, resp => {
+        let body = '';
+        resp.on('data', c => { body += c; });
+        resp.on('end', () => resolve({ status: resp.statusCode, body }));
+      });
+      r.on('error', reject);
+      r.end();
+    });
+
+    assert.equal(res.status, 200, 'must be served by the anthropic account, not 404ed');
+    assert.equal(JSON.parse(res.body).ok, true);
+    assert.equal(codex.received.length, 0, 'nothing should have reached codex');
+  } finally {
+    server.close();
+    codex.server.close();
+    anthropic.close();
+  }
+});
+
+test('an unservable path still 404s when every account is codex', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await new Promise((resolve, reject) => {
+      const r = http.request(`${proxy.url}/api/oauth/usage`, { method: 'GET' }, resp => {
+        let body = '';
+        resp.on('data', c => { body += c; });
+        resp.on('end', () => resolve({ status: resp.statusCode, body }));
+      });
+      r.on('error', reject);
+      r.end();
+    });
+    assert.equal(res.status, 404);
+    assert.equal(JSON.parse(res.body).error.type, 'not_found_error');
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});

--- a/test/codex-e2e.test.js
+++ b/test/codex-e2e.test.js
@@ -1,0 +1,267 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// End-to-end through the real proxy against a stand-in Codex backend. The
+// fixture tests prove the translators; this proves the wiring around them —
+// that a codex account rewrites the URL, sends Codex headers, translates the
+// request body, and streams back Anthropic events.
+
+function codexAccount(extra = {}) {
+  return {
+    name: 'codex-1', type: 'oauth', protocol: 'codex', accountId: 'acct-xyz',
+    accessToken: 'codex-token', refreshToken: 'r',
+    expiresAt: Date.now() + 3600_000, ...extra,
+  };
+}
+
+const d = obj => `event: ${obj.type}\ndata: ${JSON.stringify(obj)}\n\n`;
+
+/** A fake Codex backend that records what it received and replays a script. */
+async function startFakeCodex(events, { status = 200 } = {}) {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      received.push({ url: req.url, method: req.method, headers: req.headers, body });
+      if (status !== 200) {
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: { type: 'server_error', message: 'boom' } }));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      for (const e of events) res.write(e);
+      res.end();
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { server, received, url: `http://127.0.0.1:${server.address().port}` };
+}
+
+async function startProxy(account) {
+  const am = new AccountManager([account], 0.98);
+  const server = createProxyServer(am, { proxy: { port: 0 }, upstream: 'https://api.anthropic.com' });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { am, server, url: `http://127.0.0.1:${server.address().port}` };
+}
+
+function request(url, payload) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(`${url}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    }, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.end(JSON.stringify(payload));
+  });
+}
+
+const SCRIPT = [
+  d({ type: 'response.created', response: { id: 'resp_e2e', model: 'gpt-5.6-sol' } }),
+  d({ type: 'response.output_item.added', output_index: 0, item: { type: 'message', id: 'm' } }),
+  d({ type: 'response.content_part.added', output_index: 0, part: { type: 'output_text' } }),
+  d({ type: 'response.output_text.delta', output_index: 0, delta: 'Hello' }),
+  d({ type: 'response.output_text.delta', output_index: 0, delta: ' from codex' }),
+  d({ type: 'response.content_part.done', output_index: 0, part: { type: 'output_text', text: 'Hello from codex' } }),
+  d({ type: 'response.completed', response: { id: 'resp_e2e', usage: { input_tokens: 12, output_tokens: 4 } } }),
+];
+
+test('a streaming request round-trips through a codex account', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      system: 'Be brief.',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    assert.equal(res.status, 200);
+
+    // Upstream saw a Responses API call, not an Anthropic one.
+    const sent = codex.received[0];
+    assert.equal(sent.url, '/responses');
+    assert.equal(sent.headers['authorization'], 'Bearer codex-token');
+    assert.equal(sent.headers['chatgpt-account-id'], 'acct-xyz');
+    assert.equal(sent.headers['originator'], 'codex-tui');
+    assert.match(sent.headers['user-agent'], /^codex-tui\//);
+    assert.ok(sent.headers['session_id']);
+
+    const sentBody = JSON.parse(sent.body);
+    assert.equal(sentBody.stream, true);
+    assert.equal(sentBody.store, false);
+    assert.deepEqual(sentBody.input[0], {
+      type: 'message', role: 'developer',
+      content: [{ type: 'input_text', text: 'Be brief.' }],
+    });
+
+    // Client saw Anthropic events, not Responses ones.
+    assert.match(res.body, /event: message_start/);
+    assert.match(res.body, /event: content_block_start/);
+    assert.match(res.body, /"text_delta"/);
+    assert.match(res.body, /event: message_stop/);
+    assert.doesNotMatch(res.body, /response\.output_text\.delta/);
+
+    const text = [...res.body.matchAll(/"text_delta","text":"([^"]*)"/g)].map(m => m[1]).join('');
+    assert.equal(text, 'Hello from codex');
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('usage from a translated stream is credited to the account', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    // Quota accounting reads the translated frames, so it works for codex too.
+    const usage = proxy.am.accounts[0].usage;
+    assert.equal(usage.totalOutputTokens, 4);
+    assert.equal(usage.totalRequests > 0, true);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a non-streaming request gets a Messages object, not SSE', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    assert.equal(res.status, 200);
+    assert.match(res.headers['content-type'], /application\/json/);
+
+    const message = JSON.parse(res.body);
+    assert.equal(message.type, 'message');
+    assert.equal(message.role, 'assistant');
+    assert.equal(message.stop_reason, 'end_turn');
+    assert.deepEqual(message.content, [{ type: 'text', text: 'Hello from codex' }]);
+    assert.equal(message.usage.output_tokens, 4);
+
+    // Codex is always asked for a stream regardless of what the client wanted.
+    assert.equal(JSON.parse(codex.received[0].body).stream, true);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a tool call round-trips into an Anthropic tool_use block', async () => {
+  const script = [
+    d({ type: 'response.created', response: { id: 'r', model: 'gpt-5.6-sol' } }),
+    d({ type: 'response.output_item.added', output_index: 0, item: { type: 'function_call', id: 'fc', call_id: 'c1', name: 'get_weather' } }),
+    d({ type: 'response.function_call_arguments.delta', output_index: 0, item_id: 'fc', delta: '{"city":"NYC"}' }),
+    d({ type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', id: 'fc', call_id: 'c1', name: 'get_weather', arguments: '{"city":"NYC"}' } }),
+    d({ type: 'response.completed', response: { id: 'r', output: [{ type: 'function_call', id: 'fc', call_id: 'c1', name: 'get_weather', arguments: '{"city":"NYC"}' }], usage: { input_tokens: 5, output_tokens: 9 } } }),
+  ];
+  const codex = await startFakeCodex(script);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100,
+      messages: [{ role: 'user', content: 'weather?' }],
+      tools: [{ name: 'get_weather', description: 'w', input_schema: { type: 'object', properties: { city: { type: 'string' } } } }],
+    });
+
+    const message = JSON.parse(res.body);
+    assert.equal(message.stop_reason, 'tool_use');
+    assert.deepEqual(message.content, [
+      { type: 'tool_use', id: 'c1', name: 'get_weather', input: { city: 'NYC' } },
+    ]);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('modelMap selects the upstream model named in the translated request', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({
+    upstream: codex.url,
+    modelMap: { 'claude-fable-5': 'gpt-5.6-sol', 'claude-opus-5': 'gpt-5.6-terra' },
+  }));
+
+  try {
+    await request(proxy.url, {
+      model: 'claude-opus-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    assert.equal(JSON.parse(codex.received[0].body).model, 'gpt-5.6-terra');
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('an endpoint with no Responses equivalent is refused, not forwarded', async () => {
+  const codex = await startFakeCodex(SCRIPT);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await new Promise((resolve, reject) => {
+      const req = http.request(`${proxy.url}/v1/messages/count_tokens`, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+      }, r => {
+        let body = '';
+        r.on('data', c => { body += c; });
+        r.on('end', () => resolve({ status: r.statusCode, body }));
+      });
+      req.on('error', reject);
+      req.end(JSON.stringify({ model: 'claude-fable-5', messages: [] }));
+    });
+
+    assert.equal(res.status, 404);
+    assert.equal(JSON.parse(res.body).error.type, 'not_found_error');
+    // Nothing reached the backend.
+    assert.equal(codex.received.length, 0);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a truncated codex stream still closes its content block', async () => {
+  // Upstream dies after opening a text block and never sends response.completed.
+  const truncated = [
+    d({ type: 'response.created', response: { id: 'r', model: 'gpt-5.6-sol' } }),
+    d({ type: 'response.content_part.added', output_index: 0, part: { type: 'output_text' } }),
+    d({ type: 'response.output_text.delta', output_index: 0, delta: 'partial' }),
+  ];
+  const codex = await startFakeCodex(truncated);
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    const res = await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    // Without the end() flush the client would wait forever on an open block.
+    assert.match(res.body, /event: content_block_stop/);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});

--- a/test/codex-e2e.test.js
+++ b/test/codex-e2e.test.js
@@ -29,7 +29,7 @@ const d = obj => `event: ${obj.type}\ndata: ${JSON.stringify(obj)}\n\n`;
  * so against the real thing it buffered the SSE and dumped it raw. Setting a
  * header the real server omits is how a mock hides a bug — leave this alone.
  */
-async function startFakeCodex(events, { status = 200, contentType = null } = {}) {
+async function startFakeCodex(events, { status = 200, contentType = null, quotaHeaders = null } = {}) {
   const received = [];
   const server = http.createServer((req, res) => {
     let body = '';
@@ -37,11 +37,11 @@ async function startFakeCodex(events, { status = 200, contentType = null } = {})
     req.on('end', () => {
       received.push({ url: req.url, method: req.method, headers: req.headers, body });
       if (status !== 200) {
-        res.writeHead(status, { 'content-type': 'application/json' });
+        res.writeHead(status, { 'content-type': 'application/json', ...(quotaHeaders || {}) });
         res.end(JSON.stringify({ error: { type: 'server_error', message: 'boom' } }));
         return;
       }
-      res.writeHead(200, contentType ? { 'content-type': contentType } : {});
+      res.writeHead(200, { ...(contentType ? { 'content-type': contentType } : {}), ...(quotaHeaders || {}) });
       for (const e of events) res.write(e);
       res.end();
     });
@@ -282,6 +282,58 @@ test('a codex response that does declare event-stream still works', async () => 
       messages: [{ role: 'user', content: 'hi' }],
     });
     assert.match(res.body, /event: message_start/);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('codex quota headers are recorded from a normal response', async () => {
+  // Quota rides in on every response, which is what makes rotation predictive:
+  // the account's headroom is known before the next request is routed.
+  const codex = await startFakeCodex(SCRIPT, {
+    quotaHeaders: {
+      'x-codex-plan-type': 'plus',
+      'x-codex-primary-window-minutes': '10080',
+      'x-codex-primary-used-percent': '73.5',
+      'x-codex-primary-reset-at': String(Math.floor(Date.now() / 1000) + 86400),
+    },
+  });
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const acct = proxy.am.accounts[0];
+    assert.equal(acct.quota.unified7d, 0.735);
+    assert.equal(acct.planType, 'plus');
+    // Still below the switch threshold, so it keeps serving.
+    assert.equal(proxy.am._isAvailable(acct), true);
+  } finally {
+    proxy.server.close();
+    codex.server.close();
+  }
+});
+
+test('a spent codex account is skipped on the next request', async () => {
+  const codex = await startFakeCodex(SCRIPT, {
+    quotaHeaders: {
+      'x-codex-primary-window-minutes': '10080',
+      'x-codex-primary-used-percent': '100',
+      'x-codex-primary-reset-at': String(Math.floor(Date.now() / 1000) + 86400),
+    },
+  });
+  const proxy = await startProxy(codexAccount({ upstream: codex.url }));
+
+  try {
+    await request(proxy.url, {
+      model: 'claude-fable-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    // Learned from the response, before any 429 was ever seen.
+    assert.equal(proxy.am._isAvailable(proxy.am.accounts[0]), false);
   } finally {
     proxy.server.close();
     codex.server.close();

--- a/test/codex-models.test.js
+++ b/test/codex-models.test.js
@@ -1,0 +1,246 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import {
+  isCodexNativeModel,
+  codexModelToAnthropic,
+  fetchCodexModels,
+  clearCodexModelCache,
+} from '../src/codex/models.js';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// Captured from the live catalog endpoint.
+const CATALOG_ENTRY = {
+  slug: 'gpt-5.6-sol',
+  display_name: 'GPT-5.6-Sol',
+  context_window: 272000,
+  default_reasoning_level: 'low',
+  supported_reasoning_levels: [
+    { effort: 'low' }, { effort: 'medium' }, { effort: 'high' },
+    { effort: 'xhigh' }, { effort: 'max' }, { effort: 'ultra' },
+  ],
+};
+
+function codexAcct(extra = {}) {
+  return {
+    name: 'cx', type: 'oauth', protocol: 'codex', accountId: 'acct-1',
+    accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra,
+  };
+}
+const anthropicAcct = (extra = {}) => ({
+  name: 'claude', type: 'oauth', accessToken: 't', refreshToken: 'r',
+  expiresAt: Date.now() + 3600_000, ...extra,
+});
+
+// ── native model detection ──────────────────────────────────
+
+test('codex-native model names are recognised', () => {
+  for (const id of ['gpt-5.6-sol', 'gpt-5.4-mini', 'GPT-5.5', 'codex-auto-review', 'o3-mini']) {
+    assert.equal(isCodexNativeModel(id), true, id);
+  }
+});
+
+test('Claude model names are not treated as codex-native', () => {
+  for (const id of ['claude-opus-5', 'claude-haiku-4-5-20251001', 'claude-fable-5[1m]']) {
+    assert.equal(isCodexNativeModel(id), false, id);
+  }
+});
+
+test('isCodexNativeModel is safe on non-strings', () => {
+  assert.equal(isCodexNativeModel(null), false);
+  assert.equal(isCodexNativeModel(undefined), false);
+  assert.equal(isCodexNativeModel(42), false);
+});
+
+// ── catalog translation ─────────────────────────────────────
+
+test('a catalog entry becomes an Anthropic model entry', () => {
+  const m = codexModelToAnthropic(CATALOG_ENTRY, '2026-08-02T00:00:00Z');
+  assert.equal(m.type, 'model');
+  assert.equal(m.id, 'gpt-5.6-sol');
+  assert.equal(m.display_name, 'GPT-5.6-Sol');
+  assert.equal(m.max_input_tokens, 272000);
+  assert.equal(m._codex, true);
+});
+
+test('reported reasoning levels become effort capabilities', () => {
+  const caps = codexModelToAnthropic(CATALOG_ENTRY, 'x').capabilities;
+  assert.equal(caps.effort.supported, true);
+  assert.equal(caps.effort.max.supported, true);
+  // The catalog advertises `ultra`, which the API rejects — but this listing
+  // reports what the catalog says; the request path is what clamps it.
+  assert.equal(caps.effort.ultra.supported, true);
+});
+
+test('thinking is advertised as unsupported', () => {
+  // Codex reasons internally but is never asked for summaries, so no thinking
+  // blocks come back. Claiming support would be a lie the client acts on.
+  assert.equal(codexModelToAnthropic(CATALOG_ENTRY, 'x').capabilities.thinking.supported, false);
+});
+
+test('an entry with no id is dropped rather than emitted half-formed', () => {
+  assert.equal(codexModelToAnthropic({ display_name: 'Nameless' }, 'x'), null);
+});
+
+// ── catalog fetch ───────────────────────────────────────────
+
+test('fetchCodexModels returns translated entries and caches them', async () => {
+  clearCodexModelCache();
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls++;
+    return { ok: true, status: 200, json: async () => ({ models: [CATALOG_ENTRY] }) };
+  };
+  const acct = { ...codexAcct(), credential: 't' };
+
+  const first = await fetchCodexModels(acct, { fetchImpl });
+  assert.equal(first.length, 1);
+  assert.equal(first[0].id, 'gpt-5.6-sol');
+
+  await fetchCodexModels(acct, { fetchImpl });
+  assert.equal(calls, 1, 'second call within the TTL must be served from cache');
+});
+
+test('the catalog request carries the required client_version', async () => {
+  clearCodexModelCache();
+  let url = '';
+  const fetchImpl = async (u) => {
+    url = u;
+    return { ok: true, status: 200, json: async () => ({ models: [] }) };
+  };
+  await fetchCodexModels({ ...codexAcct(), credential: 't' }, { fetchImpl });
+  // The endpoint 400s without it.
+  assert.match(url, /[?&]client_version=/);
+});
+
+test('a failed fetch yields an empty list rather than throwing', async () => {
+  // This feeds a model listing; losing the Claude models because a ChatGPT
+  // token expired would be worse than returning no GPT models.
+  clearCodexModelCache();
+  const acct = { ...codexAcct(), credential: 't' };
+  assert.deepEqual(await fetchCodexModels(acct, { fetchImpl: async () => { throw new Error('down'); } }), []);
+  clearCodexModelCache();
+  assert.deepEqual(await fetchCodexModels(acct, {
+    fetchImpl: async () => ({ ok: false, status: 401, body: null }),
+  }), []);
+});
+
+test('a stale cache is preferred over an empty list when a refresh fails', async () => {
+  clearCodexModelCache();
+  const acct = { ...codexAcct(), credential: 't' };
+  await fetchCodexModels(acct, {
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ models: [CATALOG_ENTRY] }) }),
+  });
+  const stale = await fetchCodexModels(acct, {
+    now: Date.now() + 10 * 3600_000, // past the TTL
+    fetchImpl: async () => { throw new Error('down'); },
+  });
+  assert.equal(stale.length, 1);
+});
+
+// ── protocol-aware routing ──────────────────────────────────
+
+test('a GPT model selects the codex account, not the Claude one', () => {
+  const am = new AccountManager([anthropicAcct(), codexAcct()], 0.98);
+  assert.equal(am._isAvailable(am.accounts[0], 'gpt-5.6-sol'), false);
+  assert.equal(am._isAvailable(am.accounts[1], 'gpt-5.6-sol'), true);
+  assert.equal(am.getActiveAccount(null, 'gpt-5.6-sol').name, 'cx');
+});
+
+test('a Claude model never selects a codex account without a modelMap', () => {
+  // Otherwise the request reaches Codex under a name it rejects — the 400 loop
+  // this replaced.
+  const am = new AccountManager([anthropicAcct(), codexAcct()], 0.98);
+  assert.equal(am._isAvailable(am.accounts[1], 'claude-opus-5'), false);
+  assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'claude');
+});
+
+test('a modelMap re-opens a codex account to the models it maps', () => {
+  const am = new AccountManager([
+    anthropicAcct(),
+    codexAcct({ modelMap: { 'claude-opus-5': 'gpt-5.6-sol' } }),
+  ], 0.98);
+  assert.equal(am._isAvailable(am.accounts[1], 'claude-opus-5'), true);
+  assert.equal(am._isAvailable(am.accounts[1], 'claude-sonnet-5'), false);
+});
+
+test('a request naming no model stays eligible everywhere', () => {
+  const am = new AccountManager([anthropicAcct(), codexAcct()], 0.98);
+  assert.equal(am._isAvailable(am.accounts[0], null), true);
+  assert.equal(am._isAvailable(am.accounts[1], null), true);
+});
+
+// ── /v1/models endpoint ─────────────────────────────────────
+
+async function startUpstream(models) {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ data: models, has_more: false }));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { server, url: `http://127.0.0.1:${server.address().port}` };
+}
+
+function getModels(port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(`http://127.0.0.1:${port}/v1/models`,
+      { method: 'GET', headers: { 'anthropic-version': '2023-06-01' } }, res => {
+        let body = '';
+        res.on('data', c => { body += c; });
+        res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(body) }));
+      });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test('/v1/models merges the Claude catalog with the codex one', async () => {
+  clearCodexModelCache();
+  const upstream = await startUpstream([{ type: 'model', id: 'claude-opus-5', display_name: 'Claude Opus 5' }]);
+  const am = new AccountManager([
+    anthropicAcct({ upstream: upstream.url }),
+    codexAcct({ upstream: upstream.url }),
+  ], 0.98);
+  // Stand in for the codex catalog fetch, which would otherwise hit the network.
+  await fetchCodexModels(am.accounts[1], {
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ models: [CATALOG_ENTRY] }) }),
+  });
+
+  const proxy = createProxyServer(am, { proxy: { port: 0 }, upstream: upstream.url });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+
+  try {
+    const { status, body } = await getModels(proxy.address().port);
+    assert.equal(status, 200);
+    const ids = body.data.map(m => m.id);
+    assert.ok(ids.includes('claude-opus-5'), 'Claude models must survive the merge');
+    assert.ok(ids.includes('gpt-5.6-sol'), 'codex models must be appended');
+    assert.equal(body.has_more, false);
+    assert.equal(body.last_id, ids[ids.length - 1]);
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});
+
+test('/v1/models is left alone when no codex account is configured', async () => {
+  const upstream = await startUpstream([{ type: 'model', id: 'claude-opus-5' }]);
+  const am = new AccountManager([anthropicAcct({ upstream: upstream.url })], 0.98);
+  const proxy = createProxyServer(am, { proxy: { port: 0 }, upstream: upstream.url });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+
+  try {
+    const { body } = await getModels(proxy.address().port);
+    // Forwarded, not synthesised — no _codex marker anywhere.
+    assert.deepEqual(body.data.map(m => m.id), ['claude-opus-5']);
+    assert.ok(!body.data.some(m => m._codex));
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});

--- a/test/codex-models.test.js
+++ b/test/codex-models.test.js
@@ -319,3 +319,95 @@ test('a thinking suffix survives decoding', () => {
 test('a bare prefix with no payload is not treated as cloaked', () => {
   assert.equal(uncloakModelId('claude-fable-5-dd-'), 'claude-fable-5-dd-');
 });
+
+// ── blocked models are not advertised ───────────────────────
+
+test('a blocked model is left out of the listing', async () => {
+  // blockedModels already rejects such a request with a 400, so listing it
+  // would put a choice in the picker that fails the moment it is used.
+  clearCodexModelCache();
+  const upstream = await startUpstream([]);
+  const am = new AccountManager([codexAcct({ upstream: upstream.url })], 0.98);
+  await fetchCodexModels(am.accounts[0], {
+    fetchImpl: async () => ({
+      ok: true, status: 200,
+      json: async () => ({ models: [CATALOG_ENTRY, { slug: 'gpt-5.4', display_name: 'GPT-5.4' }] }),
+    }),
+  });
+
+  const proxy = createProxyServer(am, {
+    proxy: { port: 0 }, upstream: upstream.url, blockedModels: ['gpt-5.4'],
+  });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+
+  try {
+    const { body } = await getModels(proxy.address().port);
+    const ids = body.data.map(m => uncloakModelId(m.id));
+    assert.deepEqual(ids, ['gpt-5.6-sol']);
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});
+
+test('a blocklist glob does not over-match a longer model name', async () => {
+  // Patterns anchor at both ends, so `gpt-5.4` must not also remove
+  // `gpt-5.4-mini` — a user blocking one generation should say so explicitly.
+  clearCodexModelCache();
+  const upstream = await startUpstream([]);
+  const am = new AccountManager([codexAcct({ upstream: upstream.url })], 0.98);
+  await fetchCodexModels(am.accounts[0], {
+    fetchImpl: async () => ({
+      ok: true, status: 200,
+      json: async () => ({ models: [
+        { slug: 'gpt-5.4', display_name: 'GPT-5.4' },
+        { slug: 'gpt-5.4-mini', display_name: 'GPT-5.4-Mini' },
+      ] }),
+    }),
+  });
+
+  const proxy = createProxyServer(am, {
+    proxy: { port: 0 }, upstream: upstream.url, blockedModels: ['gpt-5.4'],
+  });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+
+  try {
+    const { body } = await getModels(proxy.address().port);
+    assert.deepEqual(body.data.map(m => uncloakModelId(m.id)), ['gpt-5.4-mini']);
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});
+
+test('a wildcard blocks a whole generation', async () => {
+  clearCodexModelCache();
+  const upstream = await startUpstream([]);
+  const am = new AccountManager([codexAcct({ upstream: upstream.url })], 0.98);
+  await fetchCodexModels(am.accounts[0], {
+    fetchImpl: async () => ({
+      ok: true, status: 200,
+      json: async () => ({ models: [
+        CATALOG_ENTRY,
+        { slug: 'gpt-5.4', display_name: 'GPT-5.4' },
+        { slug: 'gpt-5.4-mini', display_name: 'GPT-5.4-Mini' },
+      ] }),
+    }),
+  });
+
+  const proxy = createProxyServer(am, {
+    proxy: { port: 0 }, upstream: upstream.url, blockedModels: ['gpt-5.4*'],
+  });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+
+  try {
+    const { body } = await getModels(proxy.address().port);
+    assert.deepEqual(body.data.map(m => uncloakModelId(m.id)), ['gpt-5.6-sol']);
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});

--- a/test/codex-models.test.js
+++ b/test/codex-models.test.js
@@ -7,6 +7,8 @@ import {
   codexModelToAnthropic,
   fetchCodexModels,
   clearCodexModelCache,
+  cloakModelId,
+  uncloakModelId,
 } from '../src/codex/models.js';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer } from '../src/server.js';
@@ -197,7 +199,7 @@ function getModels(port) {
   });
 }
 
-test('/v1/models merges the Claude catalog with the codex one', async () => {
+async function startProxyWithCatalog(config = {}) {
   clearCodexModelCache();
   const upstream = await startUpstream([{ type: 'model', id: 'claude-opus-5', display_name: 'Claude Opus 5' }]);
   const am = new AccountManager([
@@ -208,19 +210,50 @@ test('/v1/models merges the Claude catalog with the codex one', async () => {
   await fetchCodexModels(am.accounts[1], {
     fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ models: [CATALOG_ENTRY] }) }),
   });
-
-  const proxy = createProxyServer(am, { proxy: { port: 0 }, upstream: upstream.url });
+  const proxy = createProxyServer(am, { proxy: { port: 0 }, upstream: upstream.url, ...config });
   proxy.listen(0, '127.0.0.1');
   await once(proxy, 'listening');
+  return { proxy, upstream, am };
+}
 
+test('/v1/models lists codex models only by default', async () => {
+  // Claude Code merges a gateway listing with its own built-in Claude models,
+  // so echoing Anthropic's catalog back just duplicates every Claude entry in
+  // the picker. The listing carries what teamclaude ADDS.
+  const { proxy, upstream } = await startProxyWithCatalog();
   try {
     const { status, body } = await getModels(proxy.address().port);
     assert.equal(status, 200);
-    const ids = body.data.map(m => m.id);
-    assert.ok(ids.includes('claude-opus-5'), 'Claude models must survive the merge');
-    assert.ok(ids.includes('gpt-5.6-sol'), 'codex models must be appended');
-    assert.equal(body.has_more, false);
-    assert.equal(body.last_id, ids[ids.length - 1]);
+    assert.equal(body.data.length, 1);
+    assert.ok(!body.data.some(m => m.id.includes('opus')), 'Claude models must not be echoed back');
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});
+
+test('/v1/models includes the Claude catalog when asked to', async () => {
+  const { proxy, upstream } = await startProxyWithCatalog({ modelDiscovery: { includeAnthropic: true } });
+  try {
+    const { body } = await getModels(proxy.address().port);
+    assert.ok(body.data.some(m => m.id === 'claude-opus-5'));
+    assert.equal(body.data.length, 2);
+  } finally {
+    proxy.close();
+    upstream.server.close();
+  }
+});
+
+test('/v1/models cloaks codex ids so the picker accepts them', async () => {
+  // Claude Code drops any listed model whose id is not claude-prefixed.
+  const { proxy, upstream } = await startProxyWithCatalog();
+  try {
+    const { body } = await getModels(proxy.address().port);
+    const entry = body.data[0];
+    assert.ok(entry.id.startsWith('claude-'), `id must be claude-prefixed, got ${entry.id}`);
+    assert.equal(uncloakModelId(entry.id), 'gpt-5.6-sol');
+    // The human-readable name is untouched, so the picker still reads "GPT-5.6-Sol".
+    assert.equal(entry.display_name, 'GPT-5.6-Sol');
   } finally {
     proxy.close();
     upstream.server.close();
@@ -243,4 +276,46 @@ test('/v1/models is left alone when no codex account is configured', async () =>
     proxy.close();
     upstream.server.close();
   }
+});
+
+// ── id cloaking ─────────────────────────────────────────────
+//
+// Claude Code drops any model from a gateway listing whose id does not start
+// with `claude-`, so a GPT id offered as-is never reaches its picker. The
+// encoding mirrors CLIProxyAPI's byte-for-byte (EnsureClaudeModelIDPrefix), so
+// a setup written against one proxy behaves the same against the other.
+
+test('a codex id is encoded into a claude-prefixed one', () => {
+  const cloaked = cloakModelId('gpt-5.6-sol');
+  assert.ok(cloaked.startsWith('claude-'));
+  assert.equal(cloaked, 'claude-fable-5-dd-' + [...'gpt-5.6-sol'].reverse().join(''));
+});
+
+test('a Claude id is left alone', () => {
+  assert.equal(cloakModelId('claude-opus-5'), 'claude-opus-5');
+  assert.equal(uncloakModelId('claude-opus-5'), 'claude-opus-5');
+});
+
+test('cloaking round-trips every model the live catalog exposes', () => {
+  for (const id of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
+                    'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'codex-auto-review']) {
+    assert.equal(uncloakModelId(cloakModelId(id)), id, id);
+  }
+});
+
+test('an id that was never cloaked passes through untouched', () => {
+  // Selecting a GPT model with --model sends the real name; it must not be
+  // mangled on the way in.
+  assert.equal(uncloakModelId('gpt-5.6-sol'), 'gpt-5.6-sol');
+  assert.equal(uncloakModelId(''), '');
+  assert.equal(uncloakModelId(null), null);
+});
+
+test('a thinking suffix survives decoding', () => {
+  // The suffix is not part of the encoded id, so it is split off and restored.
+  assert.equal(uncloakModelId(cloakModelId('gpt-5.6-sol') + '(high)'), 'gpt-5.6-sol(high)');
+});
+
+test('a bare prefix with no payload is not treated as cloaked', () => {
+  assert.equal(uncloakModelId('claude-fable-5-dd-'), 'claude-fable-5-dd-');
 });

--- a/test/codex-oauth.test.js
+++ b/test/codex-oauth.test.js
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  decodeJwtClaims,
+  extractAccountId,
+  extractPlanType,
+  extractEmail,
+  expiryFromToken,
+  importCodexCredentials,
+} from '../src/codex/oauth.js';
+
+const ACCOUNT_CLAIM = 'https://api.openai.com/auth';
+
+// Build an unsigned JWT with the given payload. Signature is never checked —
+// these claims only carry an account id and expiry for a token the issuer
+// already handed us.
+function jwt(payload) {
+  const b64 = obj => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64({ alg: 'none' })}.${b64(payload)}.sig`;
+}
+
+async function writeAuthFile(contents) {
+  const dir = await mkdtemp(join(tmpdir(), 'codex-auth-'));
+  const path = join(dir, 'auth.json');
+  await writeFile(path, JSON.stringify(contents));
+  return path;
+}
+
+test('decodeJwtClaims reads the payload, and returns null for junk', () => {
+  assert.deepEqual(decodeJwtClaims(jwt({ sub: 'u1' })), { sub: 'u1' });
+  assert.equal(decodeJwtClaims('not-a-jwt'), null);
+  assert.equal(decodeJwtClaims(''), null);
+  assert.equal(decodeJwtClaims(null), null);
+});
+
+test('extractAccountId reads the namespaced claim', () => {
+  const token = jwt({ [ACCOUNT_CLAIM]: { chatgpt_account_id: 'acct-1' } });
+  assert.equal(extractAccountId(token), 'acct-1');
+});
+
+test('extractAccountId falls back to the flattened claim spelling', () => {
+  const token = jwt({ [`${ACCOUNT_CLAIM}.chatgpt_account_id`]: 'acct-2' });
+  assert.equal(extractAccountId(token), 'acct-2');
+});
+
+test('extractAccountId returns null when the claim is absent', () => {
+  assert.equal(extractAccountId(jwt({ sub: 'u1' })), null);
+});
+
+test('extractPlanType and extractEmail read their claims', () => {
+  const token = jwt({ [ACCOUNT_CLAIM]: { chatgpt_plan_type: 'pro' }, email: 'a@b.c' });
+  assert.equal(extractPlanType(token), 'pro');
+  assert.equal(extractEmail(token), 'a@b.c');
+});
+
+test('expiryFromToken converts the exp claim from seconds to milliseconds', () => {
+  assert.equal(expiryFromToken(jwt({ exp: 1_700_000_000 })), 1_700_000_000_000);
+  assert.equal(expiryFromToken(jwt({})), null);
+});
+
+test('importCodexCredentials reads a ChatGPT OAuth auth file', async () => {
+  const path = await writeAuthFile({
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: jwt({ exp: 1_700_000_000 }),
+      refresh_token: 'rt.1.abc',
+      id_token: jwt({ [ACCOUNT_CLAIM]: { chatgpt_account_id: 'acct-1', chatgpt_plan_type: 'plus' }, email: 'a@b.c' }),
+      account_id: 'acct-1',
+    },
+  });
+
+  const creds = await importCodexCredentials(path);
+  assert.equal(creds.protocol, 'codex');
+  assert.equal(creds.type, 'oauth');
+  assert.equal(creds.accountId, 'acct-1');
+  assert.equal(creds.planType, 'plus');
+  assert.equal(creds.email, 'a@b.c');
+  assert.equal(creds.refreshToken, 'rt.1.abc');
+  assert.equal(creds.expiresAt, 1_700_000_000_000);
+});
+
+test('importCodexCredentials derives the account id from the id_token when the field is absent', async () => {
+  const path = await writeAuthFile({
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: jwt({ exp: 1 }),
+      refresh_token: 'rt.1.abc',
+      id_token: jwt({ [ACCOUNT_CLAIM]: { chatgpt_account_id: 'acct-from-jwt' } }),
+    },
+  });
+  assert.equal((await importCodexCredentials(path)).accountId, 'acct-from-jwt');
+});
+
+test('importCodexCredentials rejects an API-key auth file', async () => {
+  const path = await writeAuthFile({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-x' });
+  await assert.rejects(importCodexCredentials(path), /Unsupported Codex auth_mode "apikey"/);
+});
+
+test('importCodexCredentials rejects a file with no OAuth tokens', async () => {
+  const path = await writeAuthFile({ auth_mode: 'chatgpt', tokens: {} });
+  await assert.rejects(importCodexCredentials(path), /No Codex OAuth tokens/);
+});
+
+test('importCodexCredentials rejects a file with no derivable account id', async () => {
+  const path = await writeAuthFile({
+    auth_mode: 'chatgpt',
+    tokens: { access_token: jwt({ exp: 1 }), refresh_token: 'rt.1.abc', id_token: jwt({ sub: 'u' }) },
+  });
+  await assert.rejects(importCodexCredentials(path), /Could not determine the ChatGPT account id/);
+});

--- a/test/codex-oauth.test.js
+++ b/test/codex-oauth.test.js
@@ -10,6 +10,7 @@ import {
   extractEmail,
   expiryFromToken,
   importCodexCredentials,
+  buildCodexAuthUrl,
 } from '../src/codex/oauth.js';
 
 const ACCOUNT_CLAIM = 'https://api.openai.com/auth';
@@ -110,4 +111,40 @@ test('importCodexCredentials rejects a file with no derivable account id', async
     tokens: { access_token: jwt({ exp: 1 }), refresh_token: 'rt.1.abc', id_token: jwt({ sub: 'u' }) },
   });
   await assert.rejects(importCodexCredentials(path), /Could not determine the ChatGPT account id/);
+});
+
+// ── independent login flow ──────────────────────────────────
+//
+// `import --codex` copies the Codex CLI's credential, so both hold one refresh
+// token and — since OpenAI rotates it on every refresh — whichever refreshes
+// second is left with a dead one. A login performs its own authorization,
+// which mints a separate refresh-token lineage. These assertions pin the
+// parameters that make that separation real.
+
+test('the authorize URL requests offline_access so a refresh token is issued', () => {
+  const url = new URL(buildCodexAuthUrl({ state: 's', codeChallenge: 'c' }));
+  assert.ok(url.searchParams.get('scope').split(' ').includes('offline_access'));
+});
+
+test('the authorize URL forces a fresh authorization', () => {
+  // Without prompt=login the provider may reuse the existing session and hand
+  // back a grant tied to it, which is exactly the sharing we are avoiding.
+  const url = new URL(buildCodexAuthUrl({ state: 's', codeChallenge: 'c' }));
+  assert.equal(url.searchParams.get('prompt'), 'login');
+});
+
+test('the authorize URL carries a PKCE S256 challenge and state', () => {
+  const url = new URL(buildCodexAuthUrl({ state: 'st8', codeChallenge: 'chal' }));
+  assert.equal(url.searchParams.get('code_challenge'), 'chal');
+  assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+  assert.equal(url.searchParams.get('state'), 'st8');
+  assert.equal(url.searchParams.get('response_type'), 'code');
+});
+
+test('the authorize URL targets the registered redirect and OpenAI host', () => {
+  // The redirect URI is registered against the Codex CLI client id, so it is
+  // not free to change — the callback listener must bind this exact port.
+  const url = new URL(buildCodexAuthUrl({ state: 's', codeChallenge: 'c' }));
+  assert.equal(url.origin, 'https://auth.openai.com');
+  assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:1455/auth/callback');
 });

--- a/test/codex-protocol.test.js
+++ b/test/codex-protocol.test.js
@@ -5,9 +5,6 @@ import {
   isStreamingRequest,
   codexUrlForPath,
   codexHeaders,
-  claudeRequestToCodex,
-  createCodexStreamTranslator,
-  codexResponseToClaude,
   CODEX_BASE_URL,
 } from '../src/codex/protocol.js';
 import { AccountManager } from '../src/account-manager.js';
@@ -74,14 +71,6 @@ test('isStreamingRequest is safe on empty and malformed bodies', () => {
 test('isStreamingRequest ignores a nested stream key', () => {
   // A `stream` inside message content must not be mistaken for the request flag.
   assert.equal(isStreamingRequest(Buffer.from('{"messages":[{"stream":true}]}')), false);
-});
-
-test('the body translators are declared but not yet implemented', () => {
-  // Milestone 1 wires the seam; the translators land in milestone 2. These
-  // assertions exist so the stubs cannot be mistaken for working code.
-  assert.throws(() => claudeRequestToCodex(Buffer.from('{}'), 'm'), { notImplemented: true });
-  assert.throws(() => createCodexStreamTranslator(), { notImplemented: true });
-  assert.throws(() => codexResponseToClaude(Buffer.from('{}')), { notImplemented: true });
 });
 
 // ── account manager integration ─────────────────────────────

--- a/test/codex-protocol.test.js
+++ b/test/codex-protocol.test.js
@@ -5,6 +5,7 @@ import {
   isStreamingRequest,
   codexUrlForPath,
   codexHeaders,
+  codexPromptCacheKey,
   CODEX_BASE_URL,
 } from '../src/codex/protocol.js';
 import { AccountManager } from '../src/account-manager.js';
@@ -36,10 +37,11 @@ test('codexUrlForPath honours a per-account upstream override', () => {
 });
 
 test('codexHeaders carries the credential, account id and CLI identity', () => {
-  const h = codexHeaders({ credential: 'tok', accountId: 'acct-1' }, { sessionId: 'sess-1' });
+  const h = codexHeaders({ credential: 'tok', accountId: 'acct-1' }, { cacheKey: 'ck-1' });
   assert.equal(h['authorization'], 'Bearer tok');
   assert.equal(h['chatgpt-account-id'], 'acct-1');
-  assert.equal(h['session_id'], 'sess-1');
+  // Session_id doubles as the prompt cache scope, so it carries the derived key.
+  assert.equal(h['session_id'], 'ck-1');
   assert.equal(h['originator'], 'codex-tui');
   assert.match(h['user-agent'], /^codex-tui\//);
   assert.equal(h['content-type'], 'application/json');
@@ -51,7 +53,7 @@ test('codexHeaders sets the accept header from the stream flag', () => {
   assert.equal(codexHeaders(acct, { stream: false })['accept'], 'application/json');
 });
 
-test('codexHeaders mints a session id when the client did not supply one', () => {
+test('codexHeaders mints a session id only when no cache key was derived', () => {
   const h = codexHeaders({ credential: 't', accountId: 'a' }, {});
   assert.match(h['session_id'], /^[0-9a-f-]{36}$/);
 });
@@ -139,4 +141,56 @@ test('codex and anthropic accounts rotate as peers in one fleet', () => {
   am.setDisabled(0, true);
   assert.equal(am.getActiveAccount().name, 'codex-1');
   assert.equal(am.getActiveAccount().protocol, 'codex');
+});
+
+// ── prompt cache key ────────────────────────────────────────
+//
+// Codex caches on a prompt prefix but scopes it by this key, so the key must be
+// stable across a conversation's turns. Measured against the live backend on a
+// 3k-token prompt: a stable key caches 2816 of 3016 input tokens from the
+// second turn on; a fresh key each request caches nothing at all.
+
+test('the same session yields the same cache key across turns', () => {
+  const acct = { accountId: 'acct-1', name: 'cx' };
+  const a = codexPromptCacheKey(acct, { sessionId: 's1', model: 'gpt-5.6-sol' });
+  const b = codexPromptCacheKey(acct, { sessionId: 's1', model: 'gpt-5.6-sol' });
+  assert.equal(a, b);
+  assert.match(a, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+});
+
+test('different sessions get different cache keys', () => {
+  const acct = { accountId: 'acct-1' };
+  assert.notEqual(
+    codexPromptCacheKey(acct, { sessionId: 's1', model: 'm' }),
+    codexPromptCacheKey(acct, { sessionId: 's2', model: 'm' }));
+});
+
+test('a sub-agent gets its own cache key within one session', () => {
+  // Sub-agents run a different prompt prefix, so sharing the parent's key would
+  // mean two prefixes competing for one cache scope.
+  const acct = { accountId: 'acct-1' };
+  assert.notEqual(
+    codexPromptCacheKey(acct, { sessionId: 's1', model: 'm' }),
+    codexPromptCacheKey(acct, { sessionId: 's1', agentId: 'sub-1', model: 'm' }));
+});
+
+test('a client sending no session id still gets a stable key', () => {
+  // The regression this fixes: such a caller previously got a fresh UUID per
+  // request and therefore never cached anything.
+  const acct = { accountId: 'acct-1' };
+  const a = codexPromptCacheKey(acct, { model: 'gpt-5.6-sol' });
+  const b = codexPromptCacheKey(acct, { model: 'gpt-5.6-sol' });
+  assert.equal(a, b);
+});
+
+test('two accounts do not share a cache key when neither sends a session', () => {
+  assert.notEqual(
+    codexPromptCacheKey({ accountId: 'acct-1' }, { model: 'm' }),
+    codexPromptCacheKey({ accountId: 'acct-2' }, { model: 'm' }));
+});
+
+test('the raw session id never reaches the backend', () => {
+  // The key is hashed, so a session identifier is not sent in the clear.
+  const key = codexPromptCacheKey({ accountId: 'a' }, { sessionId: 'secret-session', model: 'm' });
+  assert.ok(!key.includes('secret'));
 });

--- a/test/codex-protocol.test.js
+++ b/test/codex-protocol.test.js
@@ -1,0 +1,153 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isCodexAccount,
+  isStreamingRequest,
+  codexUrlForPath,
+  codexHeaders,
+  claudeRequestToCodex,
+  createCodexStreamTranslator,
+  codexResponseToClaude,
+  CODEX_BASE_URL,
+} from '../src/codex/protocol.js';
+import { AccountManager } from '../src/account-manager.js';
+
+test('isCodexAccount keys off the protocol field', () => {
+  assert.equal(isCodexAccount({ protocol: 'codex' }), true);
+  assert.equal(isCodexAccount({ protocol: 'anthropic' }), false);
+  assert.equal(isCodexAccount({}), false);
+  assert.equal(isCodexAccount(null), false);
+});
+
+test('codexUrlForPath maps the messages endpoint onto /responses', () => {
+  assert.equal(codexUrlForPath('/v1/messages'), `${CODEX_BASE_URL}/responses`);
+  assert.equal(codexUrlForPath('/v1/messages/'), `${CODEX_BASE_URL}/responses`);
+  assert.equal(codexUrlForPath('/v1/messages?beta=true'), `${CODEX_BASE_URL}/responses`);
+});
+
+test('codexUrlForPath refuses endpoints with no Responses-API equivalent', () => {
+  // Forwarding these would send an Anthropic-only request somewhere that
+  // answers it wrongly; the caller turns null into a 404.
+  assert.equal(codexUrlForPath('/v1/messages/count_tokens'), null);
+  assert.equal(codexUrlForPath('/v1/models'), null);
+  assert.equal(codexUrlForPath('/'), null);
+});
+
+test('codexUrlForPath honours a per-account upstream override', () => {
+  assert.equal(codexUrlForPath('/v1/messages', 'http://localhost:9999/codex'), 'http://localhost:9999/codex/responses');
+  assert.equal(codexUrlForPath('/v1/messages', 'http://localhost:9999/codex/'), 'http://localhost:9999/codex/responses');
+});
+
+test('codexHeaders carries the credential, account id and CLI identity', () => {
+  const h = codexHeaders({ credential: 'tok', accountId: 'acct-1' }, { sessionId: 'sess-1' });
+  assert.equal(h['authorization'], 'Bearer tok');
+  assert.equal(h['chatgpt-account-id'], 'acct-1');
+  assert.equal(h['session_id'], 'sess-1');
+  assert.equal(h['originator'], 'codex-tui');
+  assert.match(h['user-agent'], /^codex-tui\//);
+  assert.equal(h['content-type'], 'application/json');
+});
+
+test('codexHeaders sets the accept header from the stream flag', () => {
+  const acct = { credential: 't', accountId: 'a' };
+  assert.equal(codexHeaders(acct, { stream: true })['accept'], 'text/event-stream');
+  assert.equal(codexHeaders(acct, { stream: false })['accept'], 'application/json');
+});
+
+test('codexHeaders mints a session id when the client did not supply one', () => {
+  const h = codexHeaders({ credential: 't', accountId: 'a' }, {});
+  assert.match(h['session_id'], /^[0-9a-f-]{36}$/);
+});
+
+test('isStreamingRequest reads the top-level stream flag', () => {
+  assert.equal(isStreamingRequest(Buffer.from('{"model":"m","stream":true}')), true);
+  assert.equal(isStreamingRequest(Buffer.from('{"model":"m","stream":false}')), false);
+  assert.equal(isStreamingRequest(Buffer.from('{"model":"m"}')), false);
+});
+
+test('isStreamingRequest is safe on empty and malformed bodies', () => {
+  assert.equal(isStreamingRequest(Buffer.alloc(0)), false);
+  assert.equal(isStreamingRequest(Buffer.from('{not json')), false);
+  assert.equal(isStreamingRequest(null), false);
+});
+
+test('isStreamingRequest ignores a nested stream key', () => {
+  // A `stream` inside message content must not be mistaken for the request flag.
+  assert.equal(isStreamingRequest(Buffer.from('{"messages":[{"stream":true}]}')), false);
+});
+
+test('the body translators are declared but not yet implemented', () => {
+  // Milestone 1 wires the seam; the translators land in milestone 2. These
+  // assertions exist so the stubs cannot be mistaken for working code.
+  assert.throws(() => claudeRequestToCodex(Buffer.from('{}'), 'm'), { notImplemented: true });
+  assert.throws(() => createCodexStreamTranslator(), { notImplemented: true });
+  assert.throws(() => codexResponseToClaude(Buffer.from('{}')), { notImplemented: true });
+});
+
+// ── account manager integration ─────────────────────────────
+
+function codexAcct(name, extra = {}) {
+  return {
+    name, type: 'oauth', protocol: 'codex', accountId: 'acct-1',
+    accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra,
+  };
+}
+
+test('a codex account keeps its protocol and account id through makeAccount', () => {
+  const am = new AccountManager([codexAcct('cx')], 0.98);
+  assert.equal(am.accounts[0].protocol, 'codex');
+  assert.equal(am.accounts[0].accountId, 'acct-1');
+});
+
+test('an account with no protocol defaults to anthropic', () => {
+  const am = new AccountManager([{ name: 'a', type: 'oauth', accessToken: 't' }], 0.98);
+  assert.equal(am.accounts[0].protocol, 'anthropic');
+  assert.equal(am.accounts[0].accountId, null);
+});
+
+test('ensureTokenFresh routes a codex account to the codex refresher', async () => {
+  const calls = [];
+  const am = new AccountManager([codexAcct('cx', { expiresAt: Date.now() - 1000 })], 0.98, {
+    refreshFn: async () => { calls.push('anthropic'); return { accessToken: 'x', refreshToken: 'y', expiresAt: Date.now() + 3600_000 }; },
+    codexRefreshFn: async () => { calls.push('codex'); return { accessToken: 'cx-new', refreshToken: 'cx-r', expiresAt: Date.now() + 3600_000, accountId: 'acct-2' }; },
+  });
+
+  await am.ensureTokenFresh(0);
+  assert.deepEqual(calls, ['codex']);
+  assert.equal(am.accounts[0].credential, 'cx-new');
+  // A refresh re-derives the account id, so a migrated account is picked up.
+  assert.equal(am.accounts[0].accountId, 'acct-2');
+});
+
+test('ensureTokenFresh routes an anthropic account to the anthropic refresher', async () => {
+  const calls = [];
+  const am = new AccountManager([{ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() - 1000 }], 0.98, {
+    refreshFn: async () => { calls.push('anthropic'); return { accessToken: 'x', refreshToken: 'y', expiresAt: Date.now() + 3600_000 }; },
+    codexRefreshFn: async () => { calls.push('codex'); return {}; },
+  });
+
+  await am.ensureTokenFresh(0);
+  assert.deepEqual(calls, ['anthropic']);
+});
+
+test('a codex refresh that omits accountId leaves the existing one intact', async () => {
+  const am = new AccountManager([codexAcct('cx', { expiresAt: Date.now() - 1000 })], 0.98, {
+    codexRefreshFn: async () => ({ accessToken: 'n', refreshToken: 'r2', expiresAt: Date.now() + 3600_000, accountId: null }),
+  });
+
+  await am.ensureTokenFresh(0);
+  assert.equal(am.accounts[0].accountId, 'acct-1');
+});
+
+test('codex and anthropic accounts rotate as peers in one fleet', () => {
+  // The point of the fork: management and selection stay protocol-agnostic.
+  const am = new AccountManager([
+    { name: 'claude-1', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    codexAcct('codex-1'),
+  ], 0.98);
+
+  assert.equal(am.accounts.length, 2);
+  am.setDisabled(0, true);
+  assert.equal(am.getActiveAccount().name, 'codex-1');
+  assert.equal(am.getActiveAccount().protocol, 'codex');
+});

--- a/test/codex-quota.test.js
+++ b/test/codex-quota.test.js
@@ -1,0 +1,243 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCodexQuota, isCodexQuotaExhausted, codexResetAfterSeconds } from '../src/codex/quota.js';
+import { AccountManager } from '../src/account-manager.js';
+import { Prober } from '../src/prober.js';
+import { Warmer } from '../src/warmer.js';
+
+// Captured verbatim from a live ChatGPT Codex response (plan: plus). The
+// account reports its 7-day limit in the PRIMARY slot and leaves secondary
+// inactive — which is why buckets are classified by window duration rather
+// than by slot name.
+const LIVE_HEADERS = {
+  'x-codex-active-limit': 'premium',
+  'x-codex-plan-type': 'plus',
+  'x-codex-primary-used-percent': '0',
+  'x-codex-secondary-used-percent': '0',
+  'x-codex-primary-window-minutes': '10080',
+  'x-codex-primary-over-secondary-limit-percent': '0',
+  'x-codex-secondary-window-minutes': '0',
+  'x-codex-primary-reset-after-seconds': '604709',
+  'x-codex-secondary-reset-after-seconds': '0',
+  'x-codex-primary-reset-at': '1786201952',
+  'x-codex-secondary-reset-at': '',
+  'x-codex-credits-has-credits': 'False',
+  'x-codex-credits-balance': '0',
+  'x-codex-credits-unlimited': 'False',
+};
+
+const NOW = 1_785_597_000_000;
+
+test('the live header set parses into the weekly bucket', () => {
+  const q = parseCodexQuota(LIVE_HEADERS, NOW);
+  assert.equal(q.unified7d, 0);
+  assert.equal(q.unified7dReset, 1786201952 * 1000);
+  assert.equal(q.planType, 'plus');
+  // Secondary has a zero-length window, so it is not a real bucket.
+  assert.equal(q.unified5h, undefined);
+  assert.equal(q.unified5hReset, undefined);
+});
+
+test('an inactive bucket is ignored rather than read as 0% used', () => {
+  // A zero window with 0% used would otherwise look like a limit with full
+  // headroom, making an account seem more available than it is.
+  const q = parseCodexQuota({
+    'x-codex-secondary-window-minutes': '0',
+    'x-codex-secondary-used-percent': '0',
+  }, NOW);
+  assert.deepEqual(q, {});
+});
+
+test('a short window is classified as the session bucket', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-window-minutes': '300',
+    'x-codex-primary-used-percent': '42',
+    'x-codex-primary-reset-at': '1786201952',
+  }, NOW);
+  assert.equal(q.unified5h, 0.42);
+  assert.equal(q.unified5hReset, 1786201952 * 1000);
+  assert.equal(q.unified7d, undefined);
+});
+
+test('buckets are classified by duration, not by slot name', () => {
+  // Secondary carries the weekly here and primary the session — the reverse of
+  // the observed plan. Both must still land in the right place.
+  const q = parseCodexQuota({
+    'x-codex-primary-window-minutes': '300',
+    'x-codex-primary-used-percent': '10',
+    'x-codex-secondary-window-minutes': '10080',
+    'x-codex-secondary-used-percent': '80',
+  }, NOW);
+  assert.equal(q.unified5h, 0.1);
+  assert.equal(q.unified7d, 0.8);
+});
+
+test('percentages convert to fractions and overage is preserved', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-used-percent': '137.5',
+  }, NOW);
+  // Past 1 means overage; _isNearQuota reads anything past the threshold the
+  // same way, so clamping would only lose information.
+  assert.equal(q.unified7d, 1.375);
+});
+
+test('reset falls back to the relative seconds when reset-at is absent', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-used-percent': '5',
+    'x-codex-primary-reset-after-seconds': '3600',
+    'x-codex-primary-reset-at': '',
+  }, NOW);
+  assert.equal(q.unified7dReset, NOW + 3600_000);
+});
+
+test('two windows of the same class keep the more exhausted one', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-window-minutes': '60',
+    'x-codex-primary-used-percent': '20',
+    'x-codex-secondary-window-minutes': '300',
+    'x-codex-secondary-used-percent': '90',
+  }, NOW);
+  // The 90% bucket is the one that will actually stop the account.
+  assert.equal(q.unified5h, 0.9);
+});
+
+test('parseCodexQuota is safe on missing and malformed input', () => {
+  assert.deepEqual(parseCodexQuota(null), {});
+  assert.deepEqual(parseCodexQuota({}), {});
+  assert.deepEqual(parseCodexQuota({
+    'x-codex-primary-window-minutes': 'not-a-number',
+    'x-codex-primary-used-percent': '50',
+  }, NOW), {});
+});
+
+test('isCodexQuotaExhausted only fires at a spent bucket', () => {
+  assert.equal(isCodexQuotaExhausted(LIVE_HEADERS, NOW), false);
+  assert.equal(isCodexQuotaExhausted({
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-used-percent': '99.9',
+  }, NOW), false);
+  assert.equal(isCodexQuotaExhausted({
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-used-percent': '100',
+  }, NOW), true);
+});
+
+test('codexResetAfterSeconds reports the earliest future reset', () => {
+  const headers = {
+    'x-codex-primary-window-minutes': '300',
+    'x-codex-primary-used-percent': '100',
+    'x-codex-primary-reset-at': String(Math.floor(NOW / 1000) + 60),
+    'x-codex-secondary-window-minutes': '10080',
+    'x-codex-secondary-used-percent': '100',
+    'x-codex-secondary-reset-at': String(Math.floor(NOW / 1000) + 6000),
+  };
+  assert.equal(codexResetAfterSeconds(headers, NOW), 60);
+});
+
+test('codexResetAfterSeconds is null when nothing is known', () => {
+  assert.equal(codexResetAfterSeconds({}, NOW), null);
+});
+
+// ── account manager integration ─────────────────────────────
+
+function codexAcct(extra = {}) {
+  return {
+    name: 'cx', type: 'oauth', protocol: 'codex', accountId: 'a',
+    accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra,
+  };
+}
+
+test('updateQuota routes a codex account to the codex parser', () => {
+  const am = new AccountManager([codexAcct()], 0.98);
+  am.updateQuota(0, LIVE_HEADERS);
+  assert.equal(am.accounts[0].quota.unified7d, 0);
+  assert.equal(am.accounts[0].quota.unified7dReset, 1786201952 * 1000);
+  assert.equal(am.accounts[0].planType, 'plus');
+  assert.equal(am.accounts[0].usage.totalRequests, 1);
+});
+
+test('an anthropic account still uses the anthropic parser', () => {
+  const am = new AccountManager([{ name: 'a', type: 'oauth', accessToken: 't' }], 0.98);
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-5h-utilization': '0.5',
+    'anthropic-ratelimit-unified-7d-utilization': '0.25',
+  });
+  assert.equal(am.accounts[0].quota.unified5h, 0.5);
+  assert.equal(am.accounts[0].quota.unified7d, 0.25);
+});
+
+test('codex headers do not leak into an anthropic account', () => {
+  const am = new AccountManager([{ name: 'a', type: 'oauth', accessToken: 't' }], 0.98);
+  am.updateQuota(0, LIVE_HEADERS);
+  assert.equal(am.accounts[0].quota.unified7d, null);
+});
+
+test('a spent codex weekly bucket makes the account unavailable', () => {
+  // The point of the adapter: exhaustion is known from the previous response,
+  // so the next request never lands on a spent account.
+  const am = new AccountManager([codexAcct()], 0.98);
+  am.updateQuota(0, {
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-used-percent': '100',
+    'x-codex-primary-reset-at': String(Math.floor(Date.now() / 1000) + 600),
+  });
+  assert.equal(am._isAvailable(am.accounts[0]), false);
+});
+
+test('a codex account with headroom stays available', () => {
+  const am = new AccountManager([codexAcct()], 0.98);
+  am.updateQuota(0, LIVE_HEADERS);
+  assert.equal(am._isAvailable(am.accounts[0]), true);
+});
+
+test('rotation prefers the codex account once the claude one is spent', () => {
+  const am = new AccountManager([
+    { name: 'claude', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+    codexAcct({ name: 'codex' }),
+  ], 0.98);
+  am.updateQuota(0, { 'anthropic-ratelimit-unified-7d-utilization': '1.0' });
+  am.updateQuota(1, LIVE_HEADERS);
+  assert.equal(am._isAvailable(am.accounts[0]), false);
+  assert.equal(am.getActiveAccount().name, 'codex');
+});
+
+test('learning a codex weekly quota clears the probing flag', () => {
+  const am = new AccountManager([codexAcct()], 0.98);
+  assert.equal(am.accounts[0].probing, true);
+  am.updateQuota(0, LIVE_HEADERS);
+  assert.equal(am.accounts[0].probing, false);
+  assert.equal(am.accounts[0].requalify, true);
+});
+
+// ── probe / warm exclusion ──────────────────────────────────
+
+test('the prober skips codex accounts', async () => {
+  // fetchUsage talks to Anthropic's usage endpoint, which rejects a ChatGPT
+  // token; probing one would 401, force a refresh, 401 again and stick.
+  const probed = [];
+  const am = new AccountManager([
+    codexAcct({ name: 'codex' }),
+    { name: 'claude', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+  const prober = new Prober(am, {
+    probeFn: async () => { probed.push(true); return { unified: {} }; },
+    log: () => {},
+  });
+
+  await prober.probeAll();
+  assert.equal(probed.length, 1);
+});
+
+test('the warmer skips codex accounts', () => {
+  const am = new AccountManager([codexAcct()], 0.98);
+  const warmer = new Warmer(am, { spawnFn: async () => 0, log: () => {} });
+  assert.equal(warmer._isWarmTarget(am.accounts[0]), false);
+});
+
+test('the warmer still targets an ordinary oauth account', () => {
+  const am = new AccountManager([{ name: 'a', type: 'oauth', accessToken: 't' }], 0.98);
+  const warmer = new Warmer(am, { spawnFn: async () => 0, log: () => {} });
+  assert.equal(warmer._isWarmTarget(am.accounts[0]), true);
+});

--- a/test/codex-token-refresher.test.js
+++ b/test/codex-token-refresher.test.js
@@ -1,0 +1,219 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { CodexTokenRefresher } from '../src/codex/token-refresher.js';
+
+const HOUR = 3600_000;
+
+function codexAcct(name, expiresInMs, extra = {}) {
+  return {
+    name, type: 'oauth', protocol: 'codex', accountId: 'a',
+    accessToken: 'old', refreshToken: 'r',
+    expiresAt: Date.now() + expiresInMs, ...extra,
+  };
+}
+
+function anthropicAcct(name, expiresInMs) {
+  return {
+    name, type: 'oauth', accessToken: 'old', refreshToken: 'r',
+    expiresAt: Date.now() + expiresInMs,
+  };
+}
+
+/** AccountManager with both refreshers stubbed, recording which fired. */
+function managerWith(accounts) {
+  const calls = { codex: 0, anthropic: 0 };
+  const am = new AccountManager(accounts, 0.98, {
+    codexRefreshFn: async () => {
+      calls.codex++;
+      return { accessToken: 'new', refreshToken: 'r2', expiresAt: Date.now() + 10 * 24 * HOUR, accountId: 'a' };
+    },
+    refreshFn: async () => {
+      calls.anthropic++;
+      return { accessToken: 'new', refreshToken: 'r2', expiresAt: Date.now() + HOUR };
+    },
+  });
+  return { am, calls };
+}
+
+function refresher(am, opts = {}) {
+  // intervalMs is irrelevant when checkAll is driven manually; start() is only
+  // used in the timer tests below.
+  return new CodexTokenRefresher(am, { log: () => {}, ...opts });
+}
+
+test('a token expiring inside the lookahead window is refreshed', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', 10 * 60_000)]); // 10 min left
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 1);
+  assert.equal(am.accounts[0].credential, 'new');
+});
+
+test('a token with plenty of life left is left alone', async () => {
+  // The whole point of a lookahead rather than a fixed cadence: with a ~10-day
+  // token this refreshes about once per token, not once per tick.
+  const { am, calls } = managerWith([codexAcct('cx', 10 * 24 * HOUR)]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 0);
+  assert.equal(am.accounts[0].credential, 'old');
+});
+
+test('an already-expired token is refreshed', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', -HOUR)]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 1);
+});
+
+test('the boundary of the lookahead window is respected', async () => {
+  const { am: amIn, calls: cIn } = managerWith([codexAcct('cx', 29 * 60_000)]);
+  await refresher(amIn, { refreshAheadMs: 30 * 60_000 }).checkAll();
+  assert.equal(cIn.codex, 1);
+
+  const { am: amOut, calls: cOut } = managerWith([codexAcct('cx', 31 * 60_000)]);
+  await refresher(amOut, { refreshAheadMs: 30 * 60_000 }).checkAll();
+  assert.equal(cOut.codex, 0);
+});
+
+test('anthropic accounts are never touched by this refresher', async () => {
+  // They already refresh via the request path, the prober and the warmer. The
+  // codebase deliberately avoids being an extra holder rotating that token
+  // family, so this must not add itself as one.
+  const { am, calls } = managerWith([anthropicAcct('claude', 60_000)]);
+  await refresher(am).checkAll();
+  assert.equal(calls.anthropic, 0);
+  assert.equal(calls.codex, 0);
+});
+
+test('only the expiring codex account in a mixed fleet is refreshed', async () => {
+  const { am, calls } = managerWith([
+    anthropicAcct('claude', 60_000),
+    codexAcct('cx-fresh', 10 * 24 * HOUR),
+    codexAcct('cx-stale', 60_000),
+  ]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 1);
+  assert.equal(calls.anthropic, 0);
+  assert.equal(am.accounts[1].credential, 'old');
+  assert.equal(am.accounts[2].credential, 'new');
+});
+
+test('a disabled account is not refreshed', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', 60_000, { disabled: true })]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 0);
+});
+
+test('an account with no refresh token is skipped', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', 60_000, { refreshToken: null })]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 0);
+});
+
+test('an account with no recorded expiry is left to the request path', async () => {
+  // Refreshing on every tick would hammer the token endpoint; a 401 on the
+  // request path recovers it instead.
+  const { am, calls } = managerWith([codexAcct('cx', 0, { expiresAt: null })]);
+  await refresher(am).checkAll();
+  assert.equal(calls.codex, 0);
+});
+
+test('a dead refresh token sidelines the account rather than looping', async () => {
+  const am = new AccountManager([codexAcct('cx', 60_000)], 0.98, {
+    codexRefreshFn: async () => {
+      const err = new Error('invalid_grant');
+      err.status = 400; // genuine auth rejection
+      throw err;
+    },
+  });
+  const r = refresher(am);
+  await r.checkAll();
+  assert.equal(am.accounts[0].status, 'error');
+  assert.equal(am._isAvailable(am.accounts[0]), false);
+});
+
+test('a transient refresh failure leaves the account serving', async () => {
+  // A network blip must not drop a healthy account out of rotation.
+  let attempts = 0;
+  const am = new AccountManager([codexAcct('cx', 60_000)], 0.98, {
+    codexRefreshFn: async () => {
+      attempts++;
+      if (attempts === 1) throw new Error('fetch failed');
+      return { accessToken: 'new', refreshToken: 'r2', expiresAt: Date.now() + 10 * 24 * HOUR };
+    },
+  });
+  const r = refresher(am);
+
+  await r.checkAll();
+  assert.equal(am.accounts[0].status, 'active');
+  assert.equal(am.accounts[0].credential, 'old');
+
+  // Next tick retries and succeeds.
+  await r.checkAll();
+  assert.equal(am.accounts[0].credential, 'new');
+});
+
+test('overlapping runs do not double-refresh', async () => {
+  let inFlight = 0;
+  let maxConcurrent = 0;
+  const am = new AccountManager([codexAcct('cx', 60_000)], 0.98, {
+    codexRefreshFn: async () => {
+      inFlight++;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      await new Promise(r => setTimeout(r, 20));
+      inFlight--;
+      return { accessToken: 'new', refreshToken: 'r2', expiresAt: Date.now() + 10 * 24 * HOUR };
+    },
+  });
+  const r = refresher(am);
+  await Promise.all([r.checkAll(), r.checkAll(), r.checkAll()]);
+  assert.equal(maxConcurrent, 1);
+});
+
+test('start() refreshes immediately rather than waiting a full interval', async () => {
+  // A proxy started after days idle would otherwise serve its first request on
+  // an expired token and pay a synchronous refresh.
+  const { am, calls } = managerWith([codexAcct('cx', -HOUR)]);
+  const r = refresher(am, { intervalMs: HOUR });
+  r.start();
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+  r.stop();
+  assert.equal(calls.codex, 1);
+});
+
+test('the periodic timer refreshes a token that ages into the window', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', 10 * 24 * HOUR)]);
+  const r = refresher(am, { intervalMs: 10, refreshAheadMs: 60_000 });
+  r.start();
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(calls.codex, 0); // still far from expiry
+
+  // Token now expires inside the window; the next tick should catch it.
+  am.accounts[0].expiresAt = Date.now() + 30_000;
+  await new Promise(resolve => setTimeout(resolve, 40));
+  r.stop();
+  assert.equal(calls.codex, 1);
+});
+
+test('stop() halts further refreshes', async () => {
+  const { am, calls } = managerWith([codexAcct('cx', 10 * 24 * HOUR)]);
+  const r = refresher(am, { intervalMs: 10, refreshAheadMs: 60_000 });
+  r.start();
+  r.stop();
+  am.accounts[0].expiresAt = Date.now() + 30_000;
+  await new Promise(resolve => setTimeout(resolve, 40));
+  assert.equal(calls.codex, 0);
+});
+
+test('status reports what is scheduled and what is due', async () => {
+  const { am } = managerWith([codexAcct('cx', 10 * 60_000), anthropicAcct('claude', 60_000)]);
+  const r = refresher(am);
+  const before = r.status();
+  assert.equal(before.enabled, false);
+  assert.equal(before.accounts.length, 1); // codex only
+  assert.equal(before.accounts[0].due, true);
+
+  await r.checkAll();
+  assert.equal(r.status().refreshCount, 1);
+  assert.equal(r.status().accounts[0].due, false);
+});

--- a/test/codex-translate.test.js
+++ b/test/codex-translate.test.js
@@ -1,0 +1,234 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { claudeRequestToCodex, shortenName, shortenCallId, buildShortNameMap, normalizeToolParameters, budgetToEffort } from '../src/codex/request-translate.js';
+import { createCodexStreamTranslator, mapStopReason, extractUsage, sanitizeToolId } from '../src/codex/response-translate.js';
+import { isValidGptReasoningSignature, compatibleGptSignature, splitProviderPrefix } from '../src/codex/signature.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const load = name => JSON.parse(readFileSync(join(here, 'fixtures', name), 'utf-8'));
+
+// ── differential fixtures ───────────────────────────────────
+//
+// These assert byte-equality against output captured from CLIProxyAPI, the
+// reference implementation these translators were ported from. A failure means
+// the port drifted from the behaviour a real Codex backend expects — not that a
+// style preference changed. Regenerate the fixtures only against a known-good
+// CLIProxyAPI revision, never to make a failing test pass.
+
+const requestFixtures = load('codex-requests.json');
+const streamFixtures = load('codex-streams.json');
+
+for (const c of requestFixtures.cases) {
+  test(`request translation matches ground truth: ${c.name}`, () => {
+    const got = JSON.parse(claudeRequestToCodex(c.request, requestFixtures._model).toString('utf-8'));
+    assert.deepEqual(got, c.want);
+  });
+}
+
+// Frames rather than raw chunks: the client sees a flat SSE sequence, and how it
+// was batched across chunk boundaries is not part of the contract.
+function frames(text) {
+  return text.split(/\n\n(?=event: |$)/).map(s => s.trim()).filter(Boolean);
+}
+
+for (const c of streamFixtures.cases) {
+  test(`stream translation matches ground truth: ${c.name}`, () => {
+    const t = createCodexStreamTranslator(c.original);
+    const got = frames(c.chunks.flatMap(chunk => t.push(chunk)).join(''));
+    assert.deepEqual(got, c.want);
+  });
+}
+
+// ── unit coverage for helpers ───────────────────────────────
+
+test('shortenName leaves short names alone', () => {
+  assert.equal(shortenName('get_weather'), 'get_weather');
+});
+
+test('shortenName keeps the distinguishing tail of an MCP name', () => {
+  const name = 'mcp__' + 'server'.repeat(12) + '__the_actual_tool';
+  const short = shortenName(name);
+  assert.ok(short.length <= 64);
+  assert.ok(short.startsWith('mcp__'));
+  assert.ok(short.includes('the_actual_tool'));
+});
+
+test('buildShortNameMap disambiguates names that truncate to the same value', () => {
+  // Without disambiguation the model could not address these separately.
+  const a = 'mcp__' + 'x'.repeat(70) + '__same';
+  const b = 'mcp__' + 'y'.repeat(70) + '__same';
+  const map = buildShortNameMap([a, b]);
+  assert.notEqual(map.get(a), map.get(b));
+  assert.ok(map.get(a).length <= 64);
+  assert.ok(map.get(b).length <= 64);
+});
+
+test('shortenCallId keeps long ids distinct via a hash suffix', () => {
+  const prefix = 'toolu_' + 'a'.repeat(70);
+  const one = shortenCallId(prefix + 'one');
+  const two = shortenCallId(prefix + 'two');
+  assert.ok(one.length <= 64);
+  assert.notEqual(one, two);
+});
+
+test('shortenCallId leaves short ids untouched', () => {
+  assert.equal(shortenCallId('toolu_123'), 'toolu_123');
+});
+
+test('normalizeToolParameters fills in a missing properties map', () => {
+  assert.deepEqual(normalizeToolParameters({ type: 'object' }), { type: 'object', properties: {} });
+  assert.deepEqual(normalizeToolParameters(undefined), { type: 'object', properties: {} });
+  assert.deepEqual(normalizeToolParameters(null), { type: 'object', properties: {} });
+});
+
+test('normalizeToolParameters preserves a populated schema', () => {
+  const schema = { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] };
+  assert.deepEqual(normalizeToolParameters(schema), schema);
+});
+
+test('budgetToEffort maps each band', () => {
+  assert.equal(budgetToEffort(-1), 'auto');
+  assert.equal(budgetToEffort(0), 'none');
+  assert.equal(budgetToEffort(512), 'minimal');
+  assert.equal(budgetToEffort(1024), 'low');
+  assert.equal(budgetToEffort(8192), 'medium');
+  assert.equal(budgetToEffort(24576), 'high');
+  assert.equal(budgetToEffort(24577), 'xhigh');
+  assert.equal(budgetToEffort(-2), null);
+});
+
+test('mapStopReason returns tool_use whenever a tool block was emitted', () => {
+  assert.equal(mapStopReason('stop', true), 'tool_use');
+  assert.equal(mapStopReason('max_tokens', true), 'tool_use');
+});
+
+test('mapStopReason maps codex reasons without a tool block', () => {
+  assert.equal(mapStopReason('', false), 'end_turn');
+  assert.equal(mapStopReason('completed', false), 'end_turn');
+  assert.equal(mapStopReason('max_output_tokens', false), 'max_tokens');
+  assert.equal(mapStopReason('content_filter', false), 'refusal');
+  assert.equal(mapStopReason('pause_turn', false), 'pause_turn');
+  // Codex named a tool finish but nothing was emitted, so it is a normal turn.
+  assert.equal(mapStopReason('tool_calls', false), 'end_turn');
+  assert.equal(mapStopReason('something_new', false), 'end_turn');
+});
+
+test('extractUsage subtracts cached tokens from the input total', () => {
+  // Codex counts cached tokens inside input_tokens; Anthropic reports them
+  // alongside, so forwarding both unchanged would double-count.
+  assert.deepEqual(extractUsage({ input_tokens: 100, output_tokens: 20, input_tokens_details: { cached_tokens: 60 } }),
+    { input: 40, output: 20, cached: 60 });
+});
+
+test('extractUsage clamps when cached exceeds input', () => {
+  assert.deepEqual(extractUsage({ input_tokens: 10, output_tokens: 1, input_tokens_details: { cached_tokens: 50 } }),
+    { input: 0, output: 1, cached: 50 });
+});
+
+test('extractUsage handles a missing usage object', () => {
+  assert.deepEqual(extractUsage(null), { input: 0, output: 0, cached: 0 });
+});
+
+test('sanitizeToolId replaces characters Anthropic tool ids disallow', () => {
+  assert.equal(sanitizeToolId('call/with:bad chars', 1), 'call_with_bad_chars');
+  assert.equal(sanitizeToolId('fine_id-1', 1), 'fine_id-1');
+});
+
+test('sanitizeToolId maps every invalid character rather than dropping it', () => {
+  // Substitution, not deletion — so two distinct ids cannot collapse into one.
+  assert.equal(sanitizeToolId('///', 7), '___');
+});
+
+test('sanitizeToolId synthesizes an id only when the input is empty', () => {
+  assert.equal(sanitizeToolId('', 7), 'toolu_codex_7');
+  assert.equal(sanitizeToolId(null, 8), 'toolu_codex_8');
+});
+
+// ── signature validation ────────────────────────────────────
+
+function gptSig(blocks = 1) {
+  const p = Buffer.alloc(1 + 8 + 16 + 16 * blocks + 32);
+  p[0] = 0x80;
+  for (let i = 9; i < p.length; i++) p[i] = i & 0xff;
+  return p.toString('base64url');
+}
+
+test('a well-formed GPT reasoning signature validates', () => {
+  assert.equal(isValidGptReasoningSignature(gptSig()), true);
+  assert.equal(isValidGptReasoningSignature(gptSig(4)), true);
+});
+
+test('signatures failing the Fernet structure are rejected', () => {
+  assert.equal(isValidGptReasoningSignature(''), false);
+  assert.equal(isValidGptReasoningSignature('gAAAAABtooshort'), false);
+  assert.equal(isValidGptReasoningSignature('notgpt' + gptSig()), false);
+  // Right prefix, wrong version byte.
+  const bad = Buffer.alloc(80); bad[0] = 0x79;
+  assert.equal(isValidGptReasoningSignature(bad.toString('base64url')), false);
+});
+
+test('a ciphertext that is not a whole number of AES blocks is rejected', () => {
+  const p = Buffer.alloc(1 + 8 + 16 + 17 + 32);
+  p[0] = 0x80;
+  assert.equal(isValidGptReasoningSignature(p.toString('base64url')), false);
+});
+
+test('compatibleGptSignature drops another provider tagged signature', () => {
+  // Replaying Anthropic-issued reasoning to a GPT backend makes it reject the
+  // whole request, so the block is dropped instead.
+  assert.equal(compatibleGptSignature(`claude#${gptSig()}`), null);
+  assert.equal(compatibleGptSignature('ErUBCkYIBxgCKkDxV3nOAnthropicSigned=='), null);
+});
+
+test('compatibleGptSignature accepts a gpt-tagged signature', () => {
+  const sig = gptSig();
+  assert.equal(compatibleGptSignature(`gpt#${sig}`), sig);
+  assert.equal(compatibleGptSignature(sig), sig);
+});
+
+test('splitProviderPrefix only splits on recognized providers', () => {
+  assert.deepEqual(splitProviderPrefix('claude#abc'), { provider: 'claude', signature: 'abc' });
+  assert.deepEqual(splitProviderPrefix('unknown#abc'), { provider: null, signature: 'unknown#abc' });
+  assert.deepEqual(splitProviderPrefix('abc'), { provider: null, signature: 'abc' });
+});
+
+// ── stream translator lifecycle ─────────────────────────────
+
+test('the translator ignores non-data lines and sentinels', () => {
+  const t = createCodexStreamTranslator();
+  assert.deepEqual(t.push('event: response.created'), []);
+  assert.deepEqual(t.push(''), []);
+  assert.deepEqual(t.push('data: '), []);
+  assert.deepEqual(t.push('data: [DONE]'), []);
+  assert.deepEqual(t.push('data: {not json'), []);
+});
+
+test('end() closes a text block left open by a truncated stream', () => {
+  // Without this the client waits forever on an unclosed content block.
+  const t = createCodexStreamTranslator();
+  t.push('data: ' + JSON.stringify({ type: 'response.created', response: { id: 'r' } }));
+  t.push('data: ' + JSON.stringify({ type: 'response.output_text.delta', delta: 'partial' }));
+  const tail = t.end().join('');
+  assert.match(tail, /content_block_stop/);
+});
+
+test('end() closes an unfinished tool_use block', () => {
+  const t = createCodexStreamTranslator();
+  t.push('data: ' + JSON.stringify({ type: 'response.created', response: { id: 'r' } }));
+  t.push('data: ' + JSON.stringify({
+    type: 'response.output_item.added', output_index: 0,
+    item: { type: 'function_call', id: 'fc', call_id: 'c', name: 'x' },
+  }));
+  const tail = t.end().join('');
+  assert.match(tail, /content_block_stop/);
+});
+
+test('end() on a clean stream emits nothing', () => {
+  const t = createCodexStreamTranslator();
+  t.push('data: ' + JSON.stringify({ type: 'response.created', response: { id: 'r' } }));
+  t.push('data: ' + JSON.stringify({ type: 'response.completed', response: { id: 'r', usage: {} } }));
+  assert.deepEqual(t.end(), []);
+});

--- a/test/codex-translate.test.js
+++ b/test/codex-translate.test.js
@@ -251,6 +251,16 @@ test('minimal effort is raised to the nearest supported level', () => {
   assert.equal(out.reasoning.effort, 'low');
 });
 
+test('ultra effort falls to max, not to the default', () => {
+  // The Codex CLI's model cache lists `ultra` for sol/terra, but the API
+  // rejects it — that cache describes the CLI's menu, not the wire contract.
+  // `max` is its nearest accepted neighbour, so dropping to `medium` would
+  // discard far more of the caller's intent than necessary.
+  const out = JSON.parse(applyCodexEffortSupport(
+    Buffer.from(JSON.stringify({ reasoning: { effort: 'ultra' } }))).toString());
+  assert.equal(out.reasoning.effort, 'max');
+});
+
 test('auto effort becomes the backend default', () => {
   const out = JSON.parse(applyCodexEffortSupport(
     Buffer.from(JSON.stringify({ reasoning: { effort: 'auto' } }))).toString());

--- a/test/codex-translate.test.js
+++ b/test/codex-translate.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { claudeRequestToCodex, shortenName, shortenCallId, buildShortNameMap, normalizeToolParameters, budgetToEffort } from '../src/codex/request-translate.js';
+import { claudeRequestToCodex, applyCodexEffortSupport, shortenName, shortenCallId, buildShortNameMap, normalizeToolParameters, budgetToEffort } from '../src/codex/request-translate.js';
 import { createCodexStreamTranslator, mapStopReason, extractUsage, sanitizeToolId } from '../src/codex/response-translate.js';
 import { isValidGptReasoningSignature, compatibleGptSignature, splitProviderPrefix } from '../src/codex/signature.js';
 
@@ -231,4 +231,58 @@ test('end() on a clean stream emits nothing', () => {
   t.push('data: ' + JSON.stringify({ type: 'response.created', response: { id: 'r' } }));
   t.push('data: ' + JSON.stringify({ type: 'response.completed', response: { id: 'r', usage: {} } }));
   assert.deepEqual(t.end(), []);
+});
+
+// ── reasoning effort support ────────────────────────────────
+//
+// Found live, not by fixture: a thinking budget of 512 or less translated to
+// effort "minimal", and the backend rejected the whole request —
+//   "Unsupported value: 'minimal' is not supported with the 'gpt-5.6-sol'
+//    model. Supported values are: 'none', 'low', 'medium', 'high', 'xhigh',
+//    and 'max'."
+// The differential fixtures could not catch this: they pin the translator
+// against CLIProxyAPI's translator, and CLIProxyAPI clamps in a separate
+// pipeline stage the fixtures never exercised.
+
+test('minimal effort is raised to the nearest supported level', () => {
+  // Not "none" — that would switch reasoning off rather than reduce it.
+  const out = JSON.parse(applyCodexEffortSupport(
+    Buffer.from(JSON.stringify({ reasoning: { effort: 'minimal' } }))).toString());
+  assert.equal(out.reasoning.effort, 'low');
+});
+
+test('auto effort becomes the backend default', () => {
+  const out = JSON.parse(applyCodexEffortSupport(
+    Buffer.from(JSON.stringify({ reasoning: { effort: 'auto' } }))).toString());
+  assert.equal(out.reasoning.effort, 'medium');
+});
+
+test('an unrecognized effort falls back rather than reaching the backend', () => {
+  const out = JSON.parse(applyCodexEffortSupport(
+    Buffer.from(JSON.stringify({ reasoning: { effort: 'ludicrous' } }))).toString());
+  assert.equal(out.reasoning.effort, 'medium');
+});
+
+test('every supported level passes through untouched', () => {
+  for (const effort of ['none', 'low', 'medium', 'high', 'xhigh', 'max']) {
+    const out = JSON.parse(applyCodexEffortSupport(
+      Buffer.from(JSON.stringify({ reasoning: { effort } }))).toString());
+    assert.equal(out.reasoning.effort, effort);
+  }
+});
+
+test('a body with no reasoning block is returned unchanged', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'm' }));
+  assert.equal(applyCodexEffortSupport(body), body);
+});
+
+test('a small thinking budget survives translation and clamping end to end', () => {
+  // The exact shape that produced the live 400.
+  const translated = claudeRequestToCodex({
+    model: 'claude-fable-5', max_tokens: 1024,
+    thinking: { type: 'enabled', budget_tokens: 256 },
+    messages: [{ role: 'user', content: 'x' }],
+  }, 'gpt-5.6-sol');
+  assert.equal(JSON.parse(translated.toString()).reasoning.effort, 'minimal');
+  assert.equal(JSON.parse(applyCodexEffortSupport(translated).toString()).reasoning.effort, 'low');
 });

--- a/test/codex-translate.test.js
+++ b/test/codex-translate.test.js
@@ -120,16 +120,16 @@ test('extractUsage subtracts cached tokens from the input total', () => {
   // Codex counts cached tokens inside input_tokens; Anthropic reports them
   // alongside, so forwarding both unchanged would double-count.
   assert.deepEqual(extractUsage({ input_tokens: 100, output_tokens: 20, input_tokens_details: { cached_tokens: 60 } }),
-    { input: 40, output: 20, cached: 60 });
+    { input: 40, output: 20, cached: 60, cacheWrite: 0 });
 });
 
 test('extractUsage clamps when cached exceeds input', () => {
   assert.deepEqual(extractUsage({ input_tokens: 10, output_tokens: 1, input_tokens_details: { cached_tokens: 50 } }),
-    { input: 0, output: 1, cached: 50 });
+    { input: 0, output: 1, cached: 50, cacheWrite: 0 });
 });
 
 test('extractUsage handles a missing usage object', () => {
-  assert.deepEqual(extractUsage(null), { input: 0, output: 0, cached: 0 });
+  assert.deepEqual(extractUsage(null), { input: 0, output: 0, cached: 0, cacheWrite: 0 });
 });
 
 test('sanitizeToolId replaces characters Anthropic tool ids disallow', () => {

--- a/test/fixtures/codex-requests.json
+++ b/test/fixtures/codex-requests.json
@@ -1,0 +1,2324 @@
+{
+  "_generator": "CLIProxyAPI (github.com/router-for-me/CLIProxyAPI) via cmd/tc_oracle",
+  "_note": "Golden output. Regenerate only against a known-good CLIProxyAPI revision.",
+  "_cliproxyapi_revision": "bc71c77",
+  "_model": "gpt-5.6-sol",
+  "cases": [
+    {
+      "name": "plain text with system",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "system": "You are terse.",
+        "messages": [
+          {
+            "role": "user",
+            "content": "hi"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "developer",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "You are terse."
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "hi"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "system as content-block array",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "system": [
+          {
+            "type": "text",
+            "text": "Part one."
+          },
+          {
+            "type": "text",
+            "text": "Part two."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": "hi"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "developer",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "Part one."
+              },
+              {
+                "type": "input_text",
+                "text": "Part two."
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "hi"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "system with billing attribution dropped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "system": [
+          {
+            "type": "text",
+            "text": "x-anthropic-billing-header: acct=1"
+          },
+          {
+            "type": "text",
+            "text": "Real instruction."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": "hi"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "developer",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "Real instruction."
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "hi"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "multi-turn conversation",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "first"
+          },
+          {
+            "role": "assistant",
+            "content": "reply"
+          },
+          {
+            "role": "user",
+            "content": "second"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "first"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "reply"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "assistant content array becomes output_text",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "q"
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "text",
+                "text": "a"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "q"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "a"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "mid-conversation system reminder",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "hi"
+          },
+          {
+            "role": "system",
+            "content": [
+              {
+                "type": "text",
+                "text": "be brief"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "hi"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "<system-reminder>\nbe brief\n</system-reminder>"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "image input",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "what is this"
+              },
+              {
+                "type": "image",
+                "source": {
+                  "type": "base64",
+                  "media_type": "image/png",
+                  "data": "iVBORw0KGgo="
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "what is this"
+              },
+              {
+                "type": "input_image",
+                "image_url": "data:image/png;base64,iVBORw0KGgo="
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "image with mime_type spelling",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "image",
+                "source": {
+                  "base64": "QUJD",
+                  "mime_type": "image/jpeg"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_image",
+                "image_url": "data:image/jpeg;base64,QUJD"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "image with no media type",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "image",
+                "source": {
+                  "data": "QUJD"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_image",
+                "image_url": "data:application/octet-stream;base64,QUJD"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "tools declared",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "weather?"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "Get weather",
+            "input_schema": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "city"
+              ]
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "weather?"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "Get weather",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "city"
+              ]
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool with empty schema normalized",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "nothing",
+            "input_schema": {}
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "nothing",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool schema carrying $schema is stripped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "nothing",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "nothing",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool with cache_control stripped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "d",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "cache_control": {
+              "type": "ephemeral"
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "d",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "long mcp tool names shortened uniquely",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "a",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_also_x",
+            "description": "b",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "mcp__a_tool_with_a_very_long_name_indeed",
+            "description": "a",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          },
+          {
+            "name": "mcp__a_tool_with_a_very_long_name_also_x",
+            "description": "b",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_use and tool_result round trip",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "weather in NYC?"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "text",
+                "text": "Let me check."
+              },
+              {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {
+                  "city": "NYC"
+                }
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": "Sunny, 72F"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "weather in NYC?"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "Let me check."
+              }
+            ]
+          },
+          {
+            "type": "function_call",
+            "call_id": "toolu_1",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"NYC\"}"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": "Sunny, 72F"
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              }
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "parallel tool calls in one assistant turn",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "compare"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_a",
+                "name": "get_weather",
+                "input": {
+                  "city": "NYC"
+                }
+              },
+              {
+                "type": "tool_use",
+                "id": "toolu_b",
+                "name": "get_weather",
+                "input": {
+                  "city": "LA"
+                }
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_a",
+                "content": "Sunny"
+              },
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_b",
+                "content": "Cloudy"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "compare"
+              }
+            ]
+          },
+          {
+            "type": "function_call",
+            "call_id": "toolu_a",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"NYC\"}"
+          },
+          {
+            "type": "function_call",
+            "call_id": "toolu_b",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"LA\"}"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "toolu_a",
+            "output": "Sunny"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "toolu_b",
+            "output": "Cloudy"
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                }
+              }
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_result with structured content blocks",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "shot",
+                "input": {}
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "here"
+                  },
+                  {
+                    "type": "image",
+                    "source": {
+                      "media_type": "image/png",
+                      "data": "QUJD"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "shot",
+            "description": "s",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "function_call",
+            "call_id": "toolu_1",
+            "name": "shot",
+            "arguments": "{}"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": [
+              {
+                "type": "input_text",
+                "text": "here"
+              },
+              {
+                "type": "input_image",
+                "image_url": "data:image/png;base64,QUJD"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "shot",
+            "description": "s",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "long tool_use id shortened",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "noop",
+                "input": {}
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "content": "ok"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "function_call",
+            "call_id": "toolu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_41a82204edcd94fe",
+            "name": "noop",
+            "arguments": "{}"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "toolu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_41a82204edcd94fe",
+            "output": "ok"
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "thinking block replayed with valid gpt signature",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "think"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "hmm",
+                "signature": "gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1g"
+              },
+              {
+                "type": "text",
+                "text": "done"
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": "more"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "think"
+              }
+            ]
+          },
+          {
+            "type": "reasoning",
+            "summary": [],
+            "content": null,
+            "encrypted_content": "gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1g"
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "done"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "more"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking block with malformed signature is dropped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "think"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "hmm",
+                "signature": "gAAAAABtooshort"
+              },
+              {
+                "type": "text",
+                "text": "done"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "think"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "done"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "anthropic-issued thinking signature is dropped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "think"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "hmm",
+                "signature": "ErUBCkYIBxgCKkDxV3nOSignedByAnthropic=="
+              },
+              {
+                "type": "text",
+                "text": "done"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "think"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "done"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking block with no signature is dropped",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "think"
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "hmm"
+              },
+              {
+                "type": "text",
+                "text": "done"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "think"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "output_text",
+                "text": "done"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking on a user turn is ignored",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "x",
+                "signature": "gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA"
+              }
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking budget low",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 4096,
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 1024
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "low"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking budget high",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 32000,
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 20000
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "high"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking budget xhigh",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 64000,
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 50000
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "xhigh"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking minimal",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 256
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "minimal"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking disabled",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "thinking": {
+          "type": "disabled"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "none"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking adaptive",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "thinking": {
+          "type": "adaptive"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "xhigh"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "thinking adaptive with explicit effort",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "thinking": {
+          "type": "adaptive"
+        },
+        "output_config": {
+          "effort": "Low"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "low"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "tool_choice auto",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "tool_choice": {
+          "type": "auto"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_choice any",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "tool_choice": {
+          "type": "any"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "required",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_choice none",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "tool_choice": {
+          "type": "none"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "none",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_choice specific tool",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "tool_choice": {
+          "type": "tool",
+          "name": "noop"
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": {
+          "type": "function",
+          "name": "noop"
+        },
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "tool_choice disabling parallel tool use",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "tool_choice": {
+          "type": "auto",
+          "disable_parallel_tool_use": true
+        },
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "name": "noop",
+            "description": "n",
+            "type": "function",
+            "parameters": {
+              "type": "object",
+              "properties": {}
+            },
+            "strict": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "web search tool",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "search"
+          }
+        ],
+        "tools": [
+          {
+            "type": "web_search_20250305",
+            "name": "web_search",
+            "allowed_domains": [
+              "example.com"
+            ]
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "search"
+              }
+            ]
+          }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ],
+        "tools": [
+          {
+            "type": "web_search",
+            "filters": {
+              "allowed_domains": [
+                "example.com"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "service tier priority via speed",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "speed": "fast",
+        "messages": [
+          {
+            "role": "user",
+            "content": "x"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "x"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "service_tier": "priority",
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    },
+    {
+      "name": "no system, no tools",
+      "request": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "bare"
+          }
+        ]
+      },
+      "want": {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "bare"
+              }
+            ]
+          }
+        ],
+        "parallel_tool_calls": true,
+        "reasoning": {
+          "effort": "medium"
+        },
+        "stream": true,
+        "store": false,
+        "include": [
+          "reasoning.encrypted_content"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/codex-streams.json
+++ b/test/fixtures/codex-streams.json
@@ -1,0 +1,1152 @@
+{
+  "_generator": "CLIProxyAPI (github.com/router-for-me/CLIProxyAPI) via cmd/tc_oracle",
+  "_note": "Golden output. Regenerate only against a known-good CLIProxyAPI revision.",
+  "_cliproxyapi_revision": "bc71c77",
+  "_model": "gpt-5.6-sol",
+  "cases": [
+    {
+      "name": "plain text response",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"Hello\"}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\" world\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"Hello world\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello world\"}]}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "text arriving only in output_item.done (no deltas)",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"content\":[{\"type\":\"output_text\",\"text\":\"Whole thing\"}]}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Whole thing\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "reasoning summary then text",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.reasoning_summary_part.added\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\"}}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"Thinking\"}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\" hard\"}",
+        "data: {\"type\":\"response.reasoning_summary_part.done\",\"output_index\":0,\"summary_index\":0}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1g\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"Answer\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"text\":\"Answer\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Answer\"}]}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Thinking\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" hard\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1g\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Answer\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "multi-part reasoning summary stays one block",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.reasoning_summary_part.added\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\"}}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"First part\"}",
+        "data: {\"type\":\"response.reasoning_summary_part.done\",\"output_index\":0,\"summary_index\":0}",
+        "data: {\"type\":\"response.reasoning_summary_part.added\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\"}}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"Second part\"}",
+        "data: {\"type\":\"response.reasoning_summary_part.done\",\"output_index\":0,\"summary_index\":1}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"First part\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\n\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Second part\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "reasoning with signature but no summary text",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":1,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"ok\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"text\":\"ok\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "single tool call with streamed arguments",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_abc\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\"\"}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"delta\":\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_abc\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_abc\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_abc\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\":\\\"NYC\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "parallel tool calls serialize into ordered blocks",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"call_b\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"item_id\":\"fc_2\",\"delta\":\"{\\\"city\\\":\\\"LA\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"call_b\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"LA\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"},{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"call_b\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"LA\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_a\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_b\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"LA\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "text then tool call",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"Let me check.\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"Let me check.\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Let me check.\"}]}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":1,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Let me check.\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_a\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "reasoning then tool call",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.reasoning_summary_part.added\",\"output_index\":0,\"part\":{\"type\":\"summary_text\"}}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"need weather\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":1,\"item_id\":\"fc_1\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"need weather\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_a\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "tool name is mapped back to the original long name",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"mcp__a_tool_with_a_very_long_name_indeed\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"mcp__a_tool_with_a_very_long_name_indeed\",\"arguments\":\"{}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\",\"name\":\"mcp__a_tool_with_a_very_long_name_indeed\",\"arguments\":\"{}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_a\",\"name\":\"mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "tool call announced only in the terminal response",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_z\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"SF\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_z\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"SF\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "tool call with no name is dropped",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_a\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "call_id needing sanitization",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call/with:bad chars\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call/with:bad chars\",\"name\":\"get_weather\",\"arguments\":\"{}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call/with:bad chars\",\"name\":\"get_weather\",\"arguments\":\"{}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_with_bad_chars\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "usage with cached tokens",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"x\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"x\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"usage\":{\"input_tokens\":100,\"output_tokens\":20,\"input_tokens_details\":{\"cached_tokens\":60}}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":40,\"output_tokens\":20,\"cache_read_input_tokens\":60}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "max output tokens stop reason",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"trunc\"}",
+        "data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"r\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"usage\":{\"input_tokens\":5,\"output_tokens\":1024}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"trunc\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":5,\"output_tokens\":1024}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "refusal via content filter",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"stop_reason\":\"content_filter\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"refusal\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "stop sequence",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"stop_reason\":\"stop\",\"stop_sequence\":\"END\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"stop_sequence\",\"stop_sequence\":\"END\"},\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "error event",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow down\"}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow down\"}}"
+      ]
+    },
+    {
+      "name": "error with cyber_policy code remaps type",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"error\",\"error\":{\"code\":\"cyber_policy\",\"message\":\"blocked\"}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"blocked\"}}"
+      ]
+    },
+    {
+      "name": "error with no message falls back to type",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"server_error\"}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"server_error\",\"message\":\"server_error\"}}"
+      ]
+    },
+    {
+      "name": "unknown event types are ignored",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"r\"}}",
+        "data: {\"type\":\"response.some_future_event\",\"foo\":\"bar\"}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "interleaved reasoning between two tool calls",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{\\\"city\\\":\\\"A\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"A\\\"}\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.reasoning_summary_part.added\",\"output_index\":1,\"part\":{\"type\":\"summary_text\"}}",
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":1,\"delta\":\"now the other city\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"c2\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":2,\"item_id\":\"fc_2\",\"arguments\":\"{\\\"city\\\":\\\"B\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"c2\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"B\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"A\\\"}\"},{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"c2\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"B\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c1\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"A\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"now the other city\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c2\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"B\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":2}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "arguments done extends streamed deltas",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"delta\":\"{\\\"ci\"}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c1\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"ci\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"ty\\\":\\\"NYC\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "text after a tool call is deferred and replayed",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":1,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"after\"}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c1\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"after\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "terminal arguments disagreeing with streamed deltas are ignored",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\\\"NYC\\\"}\"}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{\\\"different\\\":\\\"value\\\"}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"different\\\":\\\"value\\\"}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{\\\"different\\\":\\\"value\\\"}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c1\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\\\"NYC\\\"}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "reasoning item arriving during an active tool call is deferred",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"arguments\":\"{}\"}",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{}\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"output\":[{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"c1\",\"name\":\"get_weather\",\"arguments\":\"{}\"}]}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"c1\",\"name\":\"get_weather\",\"input\":{}}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"gAAAAAAAAAAACQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSA\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "tool_calls stop reason with no emitted tool block",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "w",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          {
+            "name": "mcp__some-really-long-server-name__a_tool_with_a_very_long_name_indeed",
+            "description": "l",
+            "input_schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"no tools used\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"no tools used\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"stop_reason\":\"tool_calls\",\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"no tools used\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "function_call stop reason with no emitted tool block",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"stop_reason\":\"function_call\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "empty text deltas",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"\"}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"x\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"x\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    },
+    {
+      "name": "unicode and escaping in text",
+      "original": {
+        "model": "claude-fable-5",
+        "max_tokens": 1024,
+        "messages": [
+          {
+            "role": "user",
+            "content": "go"
+          }
+        ]
+      },
+      "chunks": [
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\"}}",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}",
+        "data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"part\":{\"type\":\"output_text\"}}",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"quote \\\" newline \\n emoji 🎉 tab \\t\"}",
+        "data: {\"type\":\"response.content_part.done\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"x\"}}",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}"
+      ],
+      "want": [
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"gpt-5.6-sol\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0},\"content\":[],\"stop_reason\":null}}",
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+        "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"quote \\\" newline \\n emoji 🎉 tab \\t\"}}",
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds ChatGPT Codex as a backend protocol, so a ChatGPT subscription can serve requests alongside Claude accounts.

This is deliberately different from the existing third-party backend support. That path works because DeepSeek and GLM publish Anthropic-compatible endpoints, so `upstream` + `modelMap` is enough. Codex speaks the OpenAI Responses API — different request shape, different SSE event model, different auth — so it needs real translation in both directions.

I've kept everything outside the forwarding path protocol-agnostic. Selection, rotation, priority, routes, `disable`/`enable`, `TC_ACCT` pinning, quota thresholds, status rendering and state persistence are untouched; a codex account is a peer in the same fleet, not a parallel code path. The one place that needed protocol awareness outside the wire layer was `accounts`, which was fetching an Anthropic profile for every OAuth account.

## What's here

- **`login --codex`** — its own PKCE authorization against `auth.openai.com`, so TeamClaude's credential is independent of the Codex CLI's. `import --codex` also works but copies `~/.codex/auth.json`, which means both hold one refresh token; OpenAI rotates it on every refresh, so whichever refreshes second is left with a dead one. The import path says so and points at login.
- **Request translation** — Anthropic Messages → Responses API: system prompt to a developer message, content blocks to input items, tool schemas to function declarations, thinking budget to reasoning effort.
- **Response translation** — a stateful Codex SSE → Anthropic SSE translator. The two event models don't line up: Anthropic needs content blocks opened and closed around a monotonic index, while Codex interleaves reasoning, text and tool calls freely.
- **Prompt caching** — the cache is scoped by a key derived from session, sub-agent and model, set both as `prompt_cache_key` and on the `Session_id` header, mirroring CLIProxyAPI's `ClaudeCodePromptCache`. Without it the backend falls back to echoing `Session_id`, which quietly meant *zero* caching for any client that sends no session header. Measured on a 3k-token prompt: a stable key caches 2816 of 3016 input tokens from the second turn on, a per-request key caches nothing. `cache_write_tokens` is also mapped onto `cache_creation_input_tokens`, which was being dropped.
- **Quota** — read from `x-codex-*` response headers and normalised onto the existing `unified5h`/`unified7d` fields, so rotation is predictive rather than waiting for a 429.
- **Token refresh** — codex accounts are excluded from the prober (it reads an Anthropic endpoint that rejects a ChatGPT token) and from keep-warm (their plan has no 5h session to hold open), so they get a small scheduled refresher instead. It checks often and refreshes only inside a 30-minute window, which works out to roughly one refresh per token.
- **Model discovery** — `/v1/models` answers with the Codex catalog, so Claude Code lists GPT models in its own picker when `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` is set. Claude Code drops any listed id not starting with `claude-`, so ids are encoded into claude-prefixed ones and decoded before anything reads the model — the same encoding CLIProxyAPI uses (`EnsureClaudeModelIDPrefix`), so a setup written for one behaves the same on the other. The listing carries only what TeamClaude adds, since echoing Anthropic's catalog back duplicates every Claude entry in the picker; `modelDiscovery.includeAnthropic` restores the full list. `blockedModels` now filters the listing too — advertising a model the proxy would reject with a 400 puts a choice in the picker that fails the moment it is used. Selecting one just works: selection is protocol-aware, so a Codex model routes to a codex account and a Claude model never does. That also fixes the reverse case — a codex account with no `modelMap` used to be picked for `claude-*` requests and 400 on every one. `modelMap` is now only needed to make a codex account answer to Claude model names as a quota fallback. Only intercepted when a codex account exists, so an Anthropic-only fleet is untouched.
- **Observability** — the serving account and resolved model are recorded per session and exposed at `GET /teamclaude/status` under `sessions.byId`, and the TUI activity line shows `(claude-opus-5 → gpt-5.6-sol)`. This one is useful beyond codex: a DeepSeek or GLM account with a `modelMap` has the same blind spot today, and it's easy to split out if you'd rather take it separately.

## How it was tested

The translators were ported from CLIProxyAPI's reference implementation and **differential-tested against it**: a small Go harness calls its translators directly, and the JS port is diffed against them. 38 request cases and 30 stream cases match byte-for-byte. Those outputs are committed as golden fixtures, so the suite asserts against ground truth without needing Go or a CLIProxyAPI checkout.

Both translators matched on the first run, which I didn't trust, so I mutation-tested the corpus — 12 plausible porting mistakes, of which the first pass killed only 9. The three survivors were real gaps (stale terminal arguments overwriting streamed deltas, missing deferral of items behind an active tool call, and the stop-reason path where Codex names a tool finish that produced no tool block). Cases were added to close them; it now kills all 12.

Fixtures only get you so far, though, and running a real Claude Code session against the live backend found four things they structurally could not:

- Codex sends its SSE responses with **no `content-type` header**, so deciding "is this a stream?" from that header meant every response was buffered and returned as raw Responses-API events. My e2e mock had been setting the header — more polite than the real server, which is exactly how a mock hides a bug.
- An error response is JSON, not SSE, so forcing the streaming path on non-200 fed the error body to the translator, which emitted nothing. The client saw `400 (no body)` and the message explaining the failure was destroyed.
- Claude Code calls Anthropic-only endpoints (`bootstrap`, `oauth/usage`, `mcp_servers`) alongside `/v1/messages`; refusing them broke those features whenever rotation landed on codex. They now fail over.
- A thinking budget of ≤512 became effort `minimal`, which the backend rejects outright. The fixtures couldn't catch it because CLIProxyAPI clamps in a later pipeline stage they don't cover — a blind spot in testing function-against-function rather than pipeline-against-pipeline.

Verified live end to end: streaming, non-streaming, tool calls, a tool_result round trip, `modelMap` selection, and quota going from unknown to a recorded weekly bucket after one request.

Probing the backend for the model and reasoning-effort matrix also settled a disagreement between the only two sources available. The API's enum message advertises `minimal`, but sending it draws a model-specific rejection (`'minimal' is not supported with the 'gpt-5.6-sol' model`), so the documented enum is wider than any model accepts. Conversely the Codex CLI's model cache lists `ultra` as a supported level for sol and terra, but the API rejects it — that cache describes the CLI's menu, not the wire contract. The accepted set is `none, low, medium, high, xhigh, max`, which is what the clamp uses; `ultra` now lands on `max` rather than falling to the default.

All seven models the live catalog exposes are verified end to end through the proxy — each returning its own id in `message_start`, with no `modelMap` configured:

| Model | Description |
|---|---|
| `gpt-5.6-sol` | Latest frontier agentic coding model |
| `gpt-5.6-terra` | Balanced agentic coding model for everyday work |
| `gpt-5.6-luna` | Fast and affordable agentic coding model |
| `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` | Previous generations |
| `codex-auto-review` | Review-oriented alias |

`npm test` is 581/582 and `npm run lint` is clean. The one failure is `test/server-listen-error.test.js`, which fails identically on an untouched `upstream/master` worktree here — environmental, not from this branch.

## Known limits

- Reasoning summaries aren't requested (matching CLIProxyAPI), so responses carry no thinking blocks. The thinking-block and signature-replay paths are fixture-verified but never exercised live, because the backend emits no reasoning events without an explicit summary opt-in.
- Only `/v1/messages` is translated; everything else needs a Claude account in the fleet.
- Auth impersonates the Codex CLI's client id and user agent, which is what makes a ChatGPT subscription usable here at all. Worth a deliberate decision on your side, and I'd understand a "no" on that basis alone.

Happy to restructure, split the observability commit out, or drop pieces — and equally happy to hear this is out of scope for the project, in which case it can live as a fork.
