### PR TITLE
feat(net): configurable outbound proxy for all Anthropic-bound traffic

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -39,6 +39,7 @@
       "color": "magenta"
     }
   ],
+  "upstreamProxy": "http://proxy.corp.example:3128",
   "egress": {
     "pin": "auto",
     "checkUrl": "https://api.ipify.org",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,8 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `stormRamp` | Optional [storm-control](routing.md#storm-control) tuning (on by default). Object: `{ enabled, startConc, stepConc, stepMs, windowMs }` |
 | `routes` | Optional list of [routing rules](routing.md#model-routes) that pin model patterns to specific accounts |
 | `autoUpdate` | Set to `false` to disable the background [self-update](usage.md#auto-update) check |
+| `upstreamProxy` | Outbound HTTP proxy for **everything TeamClaude sends to Anthropic** — request forwarding, OAuth login, token refresh, profile and usage. `"http://user:pass@host:3128"`, or just `"host:3128"`. `false` disables it *and* ignores the environment. Unset = use `HTTPS_PROXY`/`ALL_PROXY` if present. TUI settings screen: **Upstream proxy**. See [Upstream proxy](proxy-modes.md#upstream-proxy) |
+| `noProxy` | Comma-separated hosts that bypass `upstreamProxy` (suffix match, `*` = all). Defaults to `NO_PROXY` from the environment |
 | `sx.apiKey` | [sx.org](https://sx.org) API key. When set, TeamClaude auto-provisions a residential proxy (egress-IP 429 workaround). Absent/empty = off — see [sx.org proxy mode](proxy-modes.md#sxorg-proxy-mode) |
 | `sx.mode` | `always` (route all upstream traffic), `429` (direct, fail over to the proxy after a 429), or `off` (keep the key but don't use it). Defaults to `always` when a key is set |
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
@@ -69,6 +71,8 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `TEAMCLAUDE_CONFIG` | Path to the config file (default `~/.config/teamclaude.json`) |
 | `TEAMCLAUDE_HOST` | Override `proxy.host` |
 | `TEAMCLAUDE_DISABLE_AUTOUPDATE` | Set to `1` to skip the background self-update check |
+| `HTTPS_PROXY` / `ALL_PROXY` | Outbound proxy used when the config sets no `upstreamProxy` (lowercase forms honoured too) |
+| `NO_PROXY` | Hosts that bypass the outbound proxy, when the config sets no `noProxy` |
 
 ```bash
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server

--- a/docs/proxy-modes.md
+++ b/docs/proxy-modes.md
@@ -39,6 +39,44 @@ curl --proxy http://localhost:3456 --cacert ~/.config/teamclaude-ca.pem https://
 # → {"teamclaude":"mitm-proxy-ok","host":"www.example.org",...}
 ```
 
+## Upstream proxy
+
+For a host that has **no direct route to the internet** — the corporate case, where
+every outbound connection must go through an HTTP proxy. Without it TeamClaude
+fails with `connect ETIMEDOUT` on the first upstream request, even though Claude
+Code itself works ([#155](https://github.com/KarpelesLab/teamclaude/issues/155)).
+
+```json
+{ "upstreamProxy": "http://user:pass@proxy.corp.example:3128" }
+```
+
+A bare `"proxy.corp.example:3128"` works too. Set it live from the TUI settings
+screen (**Network → Upstream proxy**) — it applies to the next request, without a
+restart.
+
+- Covers **all** Anthropic-bound traffic: request forwarding, OAuth login, token
+  refresh, profile and usage lookups. A proxy that covered only some of them
+  would leave you able to refresh an account but not add one, or the reverse.
+- `HTTPS_PROXY` / `ALL_PROXY` are picked up automatically when the config sets
+  nothing, so a machine already configured for other tools needs no extra setup.
+  When that happens the server says so on startup, and the TUI marks the row with
+  where the value came from — a proxy nobody typed into the config should never be
+  silently in force.
+- `NO_PROXY` (or `noProxy`) exempts hosts by suffix; `"upstreamProxy": false`
+  ignores the environment entirely.
+- **TLS stays end-to-end.** The tunnel is a plain `CONNECT`; the proxy sees
+  ciphertext only, and certificate verification is unchanged. A proxy that
+  intercepts TLS needs its CA in `NODE_EXTRA_CA_CERTS`.
+- SOCKS proxies are not supported — only HTTP `CONNECT`. A `socks5://` value is
+  rejected at startup rather than failing later at connect time.
+
+This is a property of the **network**, not a routing policy: when set, it is
+simply how this machine reaches Anthropic. That is what separates it from sx.org
+below, which is a specific egress *provider* chosen per request. If both are
+configured, a request routed via sx.org uses sx.org; everything else uses the
+upstream proxy. Neither is related to `proxy.port`, which is the local port
+Claude Code connects **to**.
+
 ## sx.org proxy mode
 
 Off by default. Some transient `429`s key on the proxy's **outbound IP**, not the account, so rotating accounts doesn't help. To work around them, TeamClaude can route upstream requests through a residential proxy from [sx.org](https://sx.org), giving a different egress IP.

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { resolveUpstreamProxy, setUpstreamProxy } from './upstream-proxy.js';
 
 export function getConfigPath() {
   if (process.env.TEAMCLAUDE_CONFIG) return process.env.TEAMCLAUDE_CONFIG;
@@ -66,10 +67,34 @@ export function createDefaultConfig() {
 export async function loadConfig() {
   const path = getConfigPath();
   try {
-    return JSON.parse(await readFile(path, 'utf-8'));
+    const config = JSON.parse(await readFile(path, 'utf-8'));
+    applyUpstreamProxy(config);
+    return config;
   } catch (err) {
     if (err.code === 'ENOENT') return null;
     throw err;
+  }
+}
+
+/**
+ * Publish the config's egress proxy to the process-wide setting.
+ *
+ * Done here, in the one place every command loads its config, rather than at
+ * each of the sixteen call sites: `login`, `import`, `accounts`, `probe` and the
+ * server all reach the network, and a proxy that applied to only some of them
+ * would be worse than none — the account list would refresh while logging in
+ * failed, or vice versa.
+ *
+ * A bad value is fatal on purpose. Falling back to a direct connection on a host
+ * that has no route to the internet would turn one clear error into a pile of
+ * ETIMEDOUTs pointing nowhere near the typo that caused them.
+ */
+function applyUpstreamProxy(config) {
+  try {
+    setUpstreamProxy(resolveUpstreamProxy(config));
+  } catch (err) {
+    console.error(`[TeamClaude] Bad proxy setting in ${getConfigPath()}: ${err.message}`);
+    process.exit(1);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import { renderStatus } from './status-renderer.js';
 import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
+import { getUpstreamProxy, describeProxy } from './upstream-proxy.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -414,6 +415,14 @@ async function serverCommand() {
     // benign runtime handler so a later 'error' is logged rather than thrown.
     server.removeListener('error', onListenError);
     server.on('error', err => console.error(`[TeamClaude] Server error: ${err.message}`));
+    // Announce an egress proxy, especially one inherited from the environment:
+    // it changes where every upstream byte goes, and a value nobody typed here
+    // should never be in force silently.
+    const egressProxy = getUpstreamProxy();
+    if (egressProxy.proxy) {
+      const via = egressProxy.source.startsWith('env:') ? ` (from ${egressProxy.source.slice(4)})` : '';
+      console.log(`[TeamClaude] Upstream proxy: ${describeProxy(egressProxy.proxy)}${via}`);
+    }
     if (tui) {
       tui.start();
       console.log(`Listening on port ${port} with ${accounts.length} account(s)`);
@@ -1419,6 +1428,15 @@ launched with and without --no-mitm can share one server.
 
 A running server re-syncs accounts from config on POST /teamclaude/reload
 (local only). add/login/enable/disable/priority trigger it automatically.
+
+Upstream proxy. On a host with no direct route to the internet, set
+"upstreamProxy": "http://user:pass@host:3128" (or just "host:3128") and every
+outbound connection — request forwarding, OAuth login, token refresh, profile
+and usage — is CONNECT-tunneled through it, TLS end to end. HTTPS_PROXY /
+ALL_PROXY are honored when the config says nothing, NO_PROXY exempts hosts, and
+"upstreamProxy": false ignores the environment entirely. Settable live in the
+TUI settings screen. Distinct from "proxy" (the local port Claude Code talks to)
+and from sx.org (a specific residential-egress provider with its own policy).
 
 Egress pin (opt-in, off unless configured). Set "egress": { "pin": "auto" } to
 hold requests whenever the exit IP is not the pinned one — a VPN that dropped

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -4,6 +4,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { exec } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import http from 'node:http';
+import { proxyFetch } from './upstream-fetch.js';
 
 /**
  * Import OAuth credentials from a Claude Code credentials file.
@@ -49,7 +50,7 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
         await new Promise(resolve => setTimeout(resolve, delay));
       }
 
-      const res = await fetch(endpoint, {
+      const res = await proxyFetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -137,7 +138,7 @@ export function isTokenExpired(expiresAt) {
  */
 export async function fetchProfile(accessToken) {
   try {
-    const res = await fetch(PROFILE_URL, {
+    const res = await proxyFetch(PROFILE_URL, {
       headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!res.ok) {
@@ -217,7 +218,7 @@ export function normalizeUsageBucket(bucket) {
  */
 export async function fetchUsage(accessToken) {
   try {
-    const res = await fetch(USAGE_URL, {
+    const res = await proxyFetch(USAGE_URL, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'anthropic-beta': OAUTH_USAGE_BETA,
@@ -293,7 +294,7 @@ export async function loginOAuth() {
 
   // Exchange code for tokens
   console.log('Exchanging authorization code for tokens...');
-  const tokenRes = await fetch(DEFAULT_TOKEN_ENDPOINT, {
+  const tokenRes = await proxyFetch(DEFAULT_TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/sx.js
+++ b/src/sx.js
@@ -62,14 +62,14 @@ function parsePort(p) {
  * Open a CONNECT tunnel through an HTTP proxy to targetHost:targetPort and
  * resolve with the raw (still-plaintext) socket once the proxy answers 200.
  */
-export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, targetPort, timeout = CONNECT_TIMEOUT_MS }) {
+export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, targetPort, timeout = CONNECT_TIMEOUT_MS, label = 'sx.org proxy' }) {
   return new Promise((resolve, reject) => {
     // autoSelectFamily (happy-eyeballs) — default on Node 20+ but not 18; set it
     // so a dual-stack proxy host whose IPv6 path is unreachable falls back to IPv4
     // instead of hanging the connect (sx.org returns an IP, but be robust).
     const sock = net.connect({ port: proxyPort, host: proxyHost, autoSelectFamily: true });
     let buf = '';
-    const timer = setTimeout(() => fail(new Error(`sx.org proxy CONNECT timed out after ${timeout}ms`)), timeout);
+    const timer = setTimeout(() => fail(new Error(`${label} CONNECT timed out after ${timeout}ms`)), timeout);
     const cleanup = () => {
       clearTimeout(timer);
       sock.removeListener('data', onData);
@@ -79,10 +79,10 @@ export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, ta
     const onData = (chunk) => {
       buf += chunk.toString('latin1');
       const idx = buf.indexOf('\r\n\r\n');
-      if (idx < 0) { if (buf.length > 65536) fail(new Error('sx.org proxy CONNECT response too large')); return; }
+      if (idx < 0) { if (buf.length > 65536) fail(new Error(`${label} CONNECT response too large`)); return; }
       const statusLine = buf.slice(0, buf.indexOf('\r\n'));
       const m = statusLine.match(/^HTTP\/\d\.\d\s+(\d{3})/);
-      if (!m || m[1] !== '200') { fail(new Error(`sx.org proxy refused CONNECT: ${statusLine}`)); return; }
+      if (!m || m[1] !== '200') { fail(new Error(`${label} refused CONNECT: ${statusLine}`)); return; }
       cleanup();
       sock.pause(); // stop flowing so the TLS layer we hand it to sees every byte
       const rest = Buffer.from(buf.slice(idx + 4), 'latin1'); // bytes already past the header

--- a/src/tui.js
+++ b/src/tui.js
@@ -1,6 +1,7 @@
 import { createWriteStream } from 'node:fs';
 import { importCredentials, fetchProfile } from './oauth.js';
 import { sameIdentity, findUpsertTarget } from './identity.js';
+import { parseProxyUrl, proxyToUrl, describeProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -427,6 +428,22 @@ export class TUI {
       });
     }
 
+    fields.push({
+      id: 'upstreamProxy',
+      label: 'Upstream proxy',
+      hint: 'Enter to set',
+      value: () => {
+        const { proxy, source } = getUpstreamProxy();
+        if (!proxy) return dim('(direct)');
+        // Name the environment when that is where it came from: a value the
+        // operator did not put in the config, silently in force, is exactly the
+        // thing that is hard to account for later.
+        const via = source.startsWith('env:') ? gray(` (${source.slice(4)})`) : '';
+        return green(describeProxy(proxy)) + via;
+      },
+      enter: () => this._promptInput('Upstream proxy (host:port, or blank for direct)', v => this._doSetUpstreamProxy(v.trim())),
+    });
+
     if (this.sx) {
       fields.push({
         id: 'sxmode',
@@ -656,6 +673,39 @@ export class TUI {
     } catch (e) {
       this._addLog(`Sync failed: ${e.message}`);
     }
+  }
+
+  // ── Network settings ───────────────────────────────
+
+  /**
+   * Set (or clear) the egress proxy live.
+   *
+   * Applied to the running process as well as saved, so the next request uses it
+   * without a restart — the operator is usually here BECAUSE requests are
+   * failing, and "set it, then restart to find out" is a poor loop to be in.
+   * An empty value clears it back to a direct connection; an explicit `false`
+   * survives in the config as "ignore the environment too".
+   */
+  async _doSetUpstreamProxy(value) {
+    let parsed;
+    try {
+      parsed = parseProxyUrl(value);
+    } catch (e) {
+      this._addLog(`Invalid proxy: ${e.message}`);
+      this.mode = 'settings';
+      return;
+    }
+
+    if (parsed) this.config.upstreamProxy = proxyToUrl(parsed);
+    else delete this.config.upstreamProxy;
+
+    try { await this.saveConfig(this.config); }
+    catch (e) { this._addLog(`Failed to save proxy setting: ${e.message}`); }
+
+    const resolved = setUpstreamProxy(resolveUpstreamProxy(this.config));
+    if (resolved.proxy) this._addLog(`Upstream proxy set to ${describeProxy(resolved.proxy)}`);
+    else this._addLog('Upstream proxy cleared — connecting directly');
+    this.mode = 'settings';
   }
 
   // ── sx.org settings ────────────────────────────────
@@ -1106,6 +1156,15 @@ export class TUI {
     lines.push(bold('  Accounts') + dim('  — add (import / API key) or remove an account'));
     lines.push(row(byId('addAccount')));
     if (byId('removeAccount')) lines.push(row(byId('removeAccount')));
+    lines.push('');
+    // ── Network
+    // Drawn before the sx.org block, which returns early when sx is unavailable:
+    // this setting is the one a host behind a corporate proxy needs, and it must
+    // not disappear along with an unrelated integration.
+    lines.push(bold('  Network') + dim('  — how this machine reaches Anthropic'));
+    lines.push(row(byId('upstreamProxy')));
+    lines.push(dim('  Set when the machine has no direct route out (HTTPS_PROXY is'));
+    lines.push(dim('  picked up automatically). Applies to requests, login and refresh.'));
     lines.push('');
     // ── sx.org
     lines.push(bold('  sx.org proxy') + dim('  — route upstream via a residential IP (429 workaround)'));

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -13,6 +13,7 @@ import http from 'node:http';
 import https from 'node:https';
 import { ReadableStream } from 'node:stream/web';
 import { tunnelTls } from './sx.js';
+import { proxyForHost, proxyAgent } from './upstream-proxy.js';
 
 // Pooled keep-alive agents for the direct (non-sx) path. Node's global fetch
 // multiplexes ALL requests to an origin over a SINGLE HTTP/2 connection; under
@@ -85,14 +86,46 @@ export function upstreamFetch(url, opts = {}, sx = null, useProxy = false) {
   const { headersTimeoutMs, ...fetchOpts } = opts;
   const timeoutMs = resolveHeadersTimeout(headersTimeoutMs);
   if (sx && useProxy && sx.isProvisioned()) return proxiedFetch(url, fetchOpts, sx, timeoutMs);
-  return USE_GLOBAL_FETCH ? directFetch(url, fetchOpts, timeoutMs) : pooledFetch(url, fetchOpts, timeoutMs);
+  // The global-fetch escape hatch cannot speak CONNECT (that is why the tunnel
+  // is hand-rolled at all), so an upstream proxy overrides it rather than being
+  // silently dropped — on a host that needs the proxy, ignoring it means every
+  // request fails.
+  const useGlobal = USE_GLOBAL_FETCH && !proxyForHost(new URL(url).hostname);
+  return useGlobal ? directFetch(url, fetchOpts, timeoutMs) : pooledFetch(url, fetchOpts, timeoutMs);
+}
+
+/**
+ * `fetch` for teamclaude's own control-plane calls — OAuth token exchange and
+ * refresh, profile, usage. Identical to global fetch when no upstream proxy is
+ * configured; tunneled through it when one is.
+ *
+ * These are not request-forwarding traffic, but they are the calls that decide
+ * whether an account can be added or kept alive at all. Leaving them direct
+ * would mean `login` fails and every token refresh dies on a host that can only
+ * reach the network through a proxy, which is precisely the reported setup.
+ */
+export function proxyFetch(url, opts = {}) {
+  const { headersTimeoutMs, ...rest } = opts;
+  if (!proxyForHost(new URL(url).hostname)) return fetch(url, rest);
+  return pooledFetch(url, rest, resolveHeadersTimeout(headersTimeoutMs));
 }
 
 // Default direct path: HTTP/1.1 over a pooled keep-alive agent, so N concurrent
 // requests use N connections instead of serializing over one h2 connection (#106).
+//
+// "Direct" here means "not via sx". A configured upstream proxy (config
+// `upstreamProxy`, or HTTPS_PROXY — see upstream-proxy.js) still applies: on
+// those hosts there is no such thing as a direct socket to api.anthropic.com,
+// which is the whole of issue #155.
 function pooledFetch(url, opts, timeoutMs) {
   const u = new URL(url);
   const isHttp = u.protocol === 'http:';
+  const port = Number(u.port) || (isHttp ? 80 : 443);
+  const proxy = proxyForHost(u.hostname);
+  if (proxy) {
+    const agent = proxyAgent(proxy, { targetHost: u.hostname, targetPort: port, tls: !isHttp, tlsOptions: opts.tlsOptions || {} });
+    return nodeRequest(u, opts, timeoutMs, { transport: isHttp ? http : https, agent });
+  }
   return nodeRequest(u, opts, timeoutMs, { transport: isHttp ? http : https, agent: isHttp ? httpAgent : httpsAgent });
 }
 
@@ -140,11 +173,23 @@ function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
     const req = transport.request(
       u,
       { method: opts.method || 'GET', headers: opts.headers || {}, agent },
-      (res) => { clearTimeout(timer); resolve(makeResponse(res)); },
+      (res) => { clearTimeout(timer); cleanupAbort(); resolve(makeResponse(res)); },
     );
     const timer = setTimeout(() => req.destroy(headersTimeoutError(timeoutMs)), timeoutMs);
     timer.unref?.();
-    req.once('error', (err) => { clearTimeout(timer); reject(err); });
+
+    // Honour an AbortSignal the way fetch does. Callers that already guard a
+    // hung call this way (oauth's refresh timeout, which otherwise wedges every
+    // request for that account) must keep working when the call is tunneled.
+    const signal = opts.signal;
+    const onAbort = () => req.destroy(signal?.reason ?? new Error('aborted'));
+    const cleanupAbort = () => signal?.removeEventListener?.('abort', onAbort);
+    if (signal) {
+      if (signal.aborted) { clearTimeout(timer); req.destroy(); reject(signal.reason ?? new Error('aborted')); return; }
+      signal.addEventListener?.('abort', onAbort, { once: true });
+    }
+
+    req.once('error', (err) => { clearTimeout(timer); cleanupAbort(); reject(err); });
 
     const body = opts.body;
     const method = (opts.method || 'GET').toUpperCase();
@@ -201,8 +246,10 @@ function makeResponse(res) {
   };
   return {
     status: res.statusCode,
+    ok: res.statusCode >= 200 && res.statusCode < 300,
     headers: makeHeaders(res.headers),
     body: web,
+    async json() { return JSON.parse((await collect()).toString('utf8')); },
     async text() { return (await collect()).toString('utf8'); },
     async arrayBuffer() { const b = await collect(); return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength); },
   };

--- a/src/upstream-proxy.js
+++ b/src/upstream-proxy.js
@@ -190,7 +190,15 @@ export function proxyAgent(proxy, { targetHost, targetPort, tls: useTls = true, 
       label: 'upstream proxy',
     })
       .then((sock) => {
-        if (!useTls) return cb(null, sock);
+        if (!useTls) {
+          // connectThroughProxy pauses the socket so a TLS layer sees every
+          // byte. Nothing resumes it on the plaintext path, so the HTTP parser
+          // would attach to a socket that never flows and the request would sit
+          // until the headers deadline. Resume after the caller has it.
+          cb(null, sock);
+          sock.resume();
+          return;
+        }
         // TLS is established end-to-end over the tunnel, so the proxy sees only
         // ciphertext and cert verification stays at its secure default.
         const tlsSock = tls.connect({ socket: sock, servername: targetHost, ...tlsOptions });

--- a/src/upstream-proxy.js
+++ b/src/upstream-proxy.js
@@ -1,0 +1,206 @@
+// Outbound (egress) proxy for everything teamclaude sends to Anthropic.
+//
+// Distinct from two other things that also say "proxy" in this codebase:
+//   - `config.proxy` is the LOCAL server Claude Code talks to (inbound).
+//   - `config.sx` is the sx.org residential-egress integration, a specific
+//     paid provider with its own provisioning API and its own routing policy
+//     (always / on-429 / off).
+// This one is the plain corporate case: the machine cannot open a socket to
+// api.anthropic.com at all, and every outbound connection has to go through an
+// HTTP CONNECT proxy (issue #155). It is not a routing policy — when set, it is
+// simply how this host reaches the internet.
+//
+// Node's global fetch cannot use a CONNECT proxy without undici, and "zero
+// dependencies" is a project feature, so the tunnel is built by hand on top of
+// the same connectThroughProxy() the sx path uses.
+//
+// Precedence: an explicit request to route via sx wins (sx IS an egress proxy;
+// chaining one through the other would be two hops to solve one problem). With
+// sx off or not selected for this attempt, the upstream proxy applies.
+
+import http from 'node:http';
+import https from 'node:https';
+import tls from 'node:tls';
+import { connectThroughProxy } from './sx.js';
+
+/**
+ * Parse a proxy URL into the shape connectThroughProxy wants.
+ *
+ * Accepts `http://host:port`, `http://user:pass@host:port`, and a bare
+ * `host:port` (people write proxies that way constantly, and rejecting it would
+ * be pedantry). Returns null for empty input; throws on input that looks like a
+ * URL but isn't usable, so a typo in the config surfaces at startup rather than
+ * as a mystery connection failure on the first request.
+ */
+export function parseProxyUrl(value) {
+  if (!value || typeof value !== 'string') return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  // A bare host:port has no scheme; give it one so URL can do the parsing.
+  const withScheme = /^[a-z0-9+.-]+:\/\//i.test(raw) ? raw : `http://${raw}`;
+  let u;
+  try {
+    u = new URL(withScheme);
+  } catch {
+    throw new Error(`invalid proxy URL: ${value}`);
+  }
+  if (!/^https?:$/.test(u.protocol)) {
+    // socks5:// is a different wire protocol, not a CONNECT proxy — say so
+    // plainly instead of failing later inside the tunnel.
+    throw new Error(`unsupported proxy protocol "${u.protocol.replace(/:$/, '')}" (only http/https): ${value}`);
+  }
+  if (!u.hostname) throw new Error(`proxy URL has no host: ${value}`);
+
+  const port = u.port ? Number(u.port) : (u.protocol === 'https:' ? 443 : 8080);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`proxy URL has an invalid port: ${value}`);
+  }
+  return {
+    host: u.hostname,
+    port,
+    // decodeURIComponent so a password containing e.g. %40 survives the round trip.
+    username: u.username ? decodeURIComponent(u.username) : null,
+    password: u.password ? decodeURIComponent(u.password) : null,
+  };
+}
+
+/**
+ * Render a proxy back to a storable URL, credentials intact. For writing the
+ * config — never for logs or the screen, which must use describeProxy().
+ */
+export function proxyToUrl(proxy) {
+  if (!proxy) return null;
+  const auth = proxy.username
+    ? `${encodeURIComponent(proxy.username)}${proxy.password ? `:${encodeURIComponent(proxy.password)}` : ''}@`
+    : '';
+  return `http://${auth}${proxy.host}:${proxy.port}`;
+}
+
+/** Render a proxy back to a string, with the password masked. For logs and the TUI. */
+export function describeProxy(proxy) {
+  if (!proxy) return 'none';
+  const auth = proxy.username ? `${proxy.username}:***@` : '';
+  return `http://${auth}${proxy.host}:${proxy.port}`;
+}
+
+/**
+ * NO_PROXY matching, in the form everyone else implements it: a comma-separated
+ * list of suffixes, where a leading dot is optional and `*` disables the proxy
+ * entirely. Matching is on the hostname only — the port-qualified form
+ * (`host:443`) is accepted and its port ignored, which is what curl does.
+ */
+export function bypassesProxy(hostname, noProxy) {
+  if (!noProxy || !hostname) return false;
+  const host = hostname.toLowerCase().replace(/\.$/, '');
+  for (const raw of String(noProxy).split(',')) {
+    const entry = raw.trim().toLowerCase().replace(/:\d+$/, '').replace(/^\./, '').replace(/\.$/, '');
+    if (!entry) continue;
+    if (entry === '*') return true;
+    if (host === entry || host.endsWith(`.${entry}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Where the proxy setting comes from, in precedence order: the config file
+ * first (explicit and persistent), then the conventional environment variables.
+ *
+ * Honouring the environment matters for the reported case — the operator had
+ * already set HTTPS_PROXY and reasonably expected it to be used (#155). It is
+ * also what every other CLI on that machine does. `config.upstreamProxy: false`
+ * opts out entirely, for a host where the variables are set for other tools but
+ * must not apply here.
+ */
+export function resolveUpstreamProxy(config = {}, env = process.env) {
+  if (config.upstreamProxy === false) return { proxy: null, source: 'disabled', noProxy: null };
+
+  const noProxy = config.noProxy ?? env.NO_PROXY ?? env.no_proxy ?? null;
+
+  if (config.upstreamProxy) {
+    return { proxy: parseProxyUrl(config.upstreamProxy), source: 'config', noProxy };
+  }
+  const candidates = [
+    ['HTTPS_PROXY', env.HTTPS_PROXY], ['https_proxy', env.https_proxy],
+    ['ALL_PROXY', env.ALL_PROXY], ['all_proxy', env.all_proxy],
+  ];
+  for (const [name, value] of candidates) {
+    if (value) return { proxy: parseProxyUrl(value), source: `env:${name}`, noProxy };
+  }
+  return { proxy: null, source: 'none', noProxy };
+}
+
+// ── Process-wide state ───────────────────────────────────────
+//
+// A single setting for the whole process rather than a value threaded through
+// every call: it describes how this HOST reaches the network, so every outbound
+// path (request forwarding, token refresh, profile and usage lookups) must agree
+// on it. Threading it would mean passing config into oauth.js, which has no
+// business knowing about config.
+
+// Undefined until something resolves it. Reading it falls back to the
+// environment alone, so short-lived commands that never load a config (and any
+// code path that runs before startup wiring) still honour HTTPS_PROXY instead of
+// silently going direct. A bad value in the environment must not take a command
+// down, so a parse failure degrades to "no proxy" here and is reported loudly at
+// startup, where the config value is validated eagerly.
+let current = null;
+
+export function setUpstreamProxy(resolved) {
+  current = resolved || { proxy: null, source: 'none', noProxy: null };
+  return current;
+}
+
+export function getUpstreamProxy() {
+  if (!current) {
+    try { current = resolveUpstreamProxy({}, process.env); } catch { current = { proxy: null, source: 'none', noProxy: null }; }
+  }
+  return current;
+}
+
+/** Reset the memo. Tests only. */
+export function resetUpstreamProxy() { current = null; }
+
+/** The proxy to use for `hostname`, or null when going direct. */
+export function proxyForHost(hostname) {
+  const { proxy, noProxy } = getUpstreamProxy();
+  if (!proxy) return null;
+  if (bypassesProxy(hostname, noProxy)) return null;
+  return proxy;
+}
+
+/**
+ * An http(s).Agent whose sockets are CONNECT tunnels through `proxy`.
+ *
+ * keepAlive is off: createConnection closes over one target, so a pooled socket
+ * could not be reused for a different host anyway, and parking it would leak an
+ * open proxy connection per request. The upstream path's reason for pooling
+ * (#106 — avoiding a single multiplexed h2 connection) still holds, because each
+ * tunnel is its own TCP connection carrying its own HTTP/1.1 exchange.
+ */
+export function proxyAgent(proxy, { targetHost, targetPort, tls: useTls = true, tlsOptions = {} }) {
+  const agent = new (useTls ? https : http).Agent({ keepAlive: false });
+  agent.createConnection = (_options, cb) => {
+    connectThroughProxy({
+      proxyHost: proxy.host,
+      proxyPort: proxy.port,
+      auth: proxy.username ? `${proxy.username}:${proxy.password ?? ''}` : null,
+      targetHost,
+      targetPort,
+      label: 'upstream proxy',
+    })
+      .then((sock) => {
+        if (!useTls) return cb(null, sock);
+        // TLS is established end-to-end over the tunnel, so the proxy sees only
+        // ciphertext and cert verification stays at its secure default.
+        const tlsSock = tls.connect({ socket: sock, servername: targetHost, ...tlsOptions });
+        const onErr = (err) => { tlsSock.removeListener('secureConnect', onOk); sock.destroy(); cb(err); };
+        const onOk = () => { tlsSock.removeListener('error', onErr); cb(null, tlsSock); };
+        tlsSock.once('secureConnect', onOk);
+        tlsSock.once('error', onErr);
+      })
+      .catch((err) => cb(err));
+    return undefined; // socket is delivered asynchronously through cb
+  };
+  return agent;
+}

--- a/test/upstream-proxy.test.js
+++ b/test/upstream-proxy.test.js
@@ -35,7 +35,9 @@ test('credentials survive a round trip through percent-encoding', () => {
 
 test('a wrong protocol is named rather than failing later inside the tunnel', () => {
   assert.throws(() => parseProxyUrl('socks5://host:1080'), /unsupported proxy protocol "socks5"/);
-  assert.throws(() => parseProxyUrl('http://host:99999'), /invalid port/);
+  // Node's URL rejects an out-of-range port itself; either message is fine as
+  // long as it names the offending value rather than failing at connect time.
+  assert.throws(() => parseProxyUrl('http://host:99999'), /invalid proxy URL|invalid port/);
 });
 
 test('describeProxy masks the password', () => {
@@ -144,7 +146,7 @@ test('an upstream request is tunneled through the configured proxy', async () =>
   setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
 
   try {
-    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/v1/messages`, { method: 'GET' });
+    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/v1/messages`, { method: 'GET', headersTimeoutMs: 8000 });
     assert.equal(res.status, 200);
     assert.deepEqual(JSON.parse(await res.text()), { ok: true, path: '/v1/messages' });
     assert.deepEqual(targets, [`127.0.0.1:${originPort}`]);   // it really went through the proxy
@@ -163,7 +165,7 @@ test('proxy credentials are offered as Proxy-Authorization', async () => {
   setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `http://bob:s3cret@127.0.0.1:${proxyPort}` }));
 
   try {
-    await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET' });
+    await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET', headersTimeoutMs: 8000 });
     assert.equal(auth(), `Basic ${Buffer.from('bob:s3cret').toString('base64')}`);
   } finally {
     proxy.close();
@@ -185,7 +187,7 @@ test('control-plane calls (oauth) are tunneled too', async () => {
   setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
 
   try {
-    const res = await proxyFetch(`http://127.0.0.1:${originPort}/oauth/token`, { method: 'POST', body: '{}' });
+    const res = await proxyFetch(`http://127.0.0.1:${originPort}/oauth/token`, { method: 'POST', body: '{}', headersTimeoutMs: 8000 });
     assert.equal(res.ok, true);
     assert.deepEqual(await res.json(), { access_token: 'a' });
     assert.equal(targets.length, 1);
@@ -205,7 +207,7 @@ test('a bypassed host goes direct even with a proxy configured', async () => {
   setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}`, noProxy: '127.0.0.1' }));
 
   try {
-    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET' });
+    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET', headersTimeoutMs: 8000 });
     assert.equal(await res.text(), 'direct');
     assert.deepEqual(targets, []);                            // the proxy was never asked
   } finally {
@@ -246,7 +248,7 @@ test('a refused CONNECT names the upstream proxy', async () => {
 
   try {
     await assert.rejects(
-      upstreamFetch('http://198.51.100.7:443/x', { method: 'GET' }),
+      upstreamFetch('http://198.51.100.7:443/x', { method: 'GET', headersTimeoutMs: 8000 }),
       /upstream proxy refused CONNECT: HTTP\/1\.1 403/,
     );
   } finally {

--- a/test/upstream-proxy.test.js
+++ b/test/upstream-proxy.test.js
@@ -1,0 +1,255 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { once } from 'node:events';
+import {
+  parseProxyUrl, proxyToUrl, describeProxy, bypassesProxy,
+  resolveUpstreamProxy, setUpstreamProxy, resetUpstreamProxy, proxyForHost,
+} from '../src/upstream-proxy.js';
+import { upstreamFetch, proxyFetch } from '../src/upstream-fetch.js';
+
+test.afterEach(() => resetUpstreamProxy());
+
+// ── Parsing ──────────────────────────────────────────────────
+
+test('parses the forms people actually write', () => {
+  assert.deepEqual(parseProxyUrl('http://host:3128'), { host: 'host', port: 3128, username: null, password: null });
+  // A bare host:port is what most corporate docs hand out; rejecting it would be pedantry.
+  assert.deepEqual(parseProxyUrl('host:3128'), { host: 'host', port: 3128, username: null, password: null });
+  assert.deepEqual(parseProxyUrl('http://u:p@host:8080'), { host: 'host', port: 8080, username: 'u', password: 'p' });
+  assert.equal(parseProxyUrl('http://host').port, 8080);       // default when unstated
+  assert.equal(parseProxyUrl('https://host').port, 443);
+  assert.equal(parseProxyUrl(''), null);
+  assert.equal(parseProxyUrl(null), null);
+});
+
+// A password with reserved characters is exactly the case that gets mangled by
+// naive string splitting, and it fails at connect time with a useless error.
+test('credentials survive a round trip through percent-encoding', () => {
+  const parsed = parseProxyUrl('http://user%40corp:p%40ss%3Aword@host:3128');
+  assert.equal(parsed.username, 'user@corp');
+  assert.equal(parsed.password, 'p@ss:word');
+  assert.deepEqual(parseProxyUrl(proxyToUrl(parsed)), parsed);
+});
+
+test('a wrong protocol is named rather than failing later inside the tunnel', () => {
+  assert.throws(() => parseProxyUrl('socks5://host:1080'), /unsupported proxy protocol "socks5"/);
+  assert.throws(() => parseProxyUrl('http://host:99999'), /invalid port/);
+});
+
+test('describeProxy masks the password', () => {
+  const p = parseProxyUrl('http://u:secret@host:3128');
+  assert.equal(describeProxy(p), 'http://u:***@host:3128');
+  assert.ok(!describeProxy(p).includes('secret'));
+  assert.equal(describeProxy(null), 'none');
+});
+
+// ── NO_PROXY ─────────────────────────────────────────────────
+
+test('NO_PROXY matches suffixes, with or without a leading dot', () => {
+  assert.equal(bypassesProxy('api.anthropic.com', 'anthropic.com'), true);
+  assert.equal(bypassesProxy('api.anthropic.com', '.anthropic.com'), true);
+  assert.equal(bypassesProxy('api.anthropic.com', 'example.com,anthropic.com'), true);
+  assert.equal(bypassesProxy('api.anthropic.com', 'example.com'), false);
+  assert.equal(bypassesProxy('api.anthropic.com', '*'), true);
+  assert.equal(bypassesProxy('localhost', 'localhost:8080'), true);   // port-qualified, port ignored
+  // A suffix must land on a label boundary: "notanthropic.com" is a different host.
+  assert.equal(bypassesProxy('notanthropic.com', 'anthropic.com'), false);
+});
+
+// ── Resolution precedence ────────────────────────────────────
+
+test('config wins over the environment', () => {
+  const r = resolveUpstreamProxy({ upstreamProxy: 'cfg:1' }, { HTTPS_PROXY: 'http://env:2' });
+  assert.equal(r.source, 'config');
+  assert.equal(r.proxy.host, 'cfg');
+});
+
+// The reporter had already set HTTPS_PROXY and reasonably expected it to work
+// (#155); every other CLI on that machine honours it.
+test('the environment is honoured when the config says nothing', () => {
+  const r = resolveUpstreamProxy({}, { HTTPS_PROXY: 'http://env:3128' });
+  assert.equal(r.source, 'env:HTTPS_PROXY');
+  assert.equal(r.proxy.port, 3128);
+  assert.equal(resolveUpstreamProxy({}, { all_proxy: 'http://e:1' }).source, 'env:all_proxy');
+  assert.equal(resolveUpstreamProxy({}, {}).proxy, null);
+});
+
+test('upstreamProxy:false opts out of the environment entirely', () => {
+  const r = resolveUpstreamProxy({ upstreamProxy: false }, { HTTPS_PROXY: 'http://env:2' });
+  assert.equal(r.proxy, null);
+  assert.equal(r.source, 'disabled');
+});
+
+test('proxyForHost applies NO_PROXY', () => {
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: 'p:3128', noProxy: 'internal.example' }));
+  assert.equal(proxyForHost('api.anthropic.com').host, 'p');
+  assert.equal(proxyForHost('svc.internal.example'), null);
+});
+
+// Nothing resolved it yet: a short-lived command that never loads a config must
+// still honour the environment rather than silently going direct.
+test('an unset proxy falls back to the environment on first read', () => {
+  resetUpstreamProxy();
+  const prev = process.env.HTTPS_PROXY;
+  process.env.HTTPS_PROXY = 'http://fallback:3128';
+  try {
+    assert.equal(proxyForHost('api.anthropic.com').host, 'fallback');
+  } finally {
+    if (prev === undefined) delete process.env.HTTPS_PROXY;
+    else process.env.HTTPS_PROXY = prev;
+  }
+});
+
+// ── End to end through a real CONNECT proxy ──────────────────
+
+// A minimal CONNECT proxy: answers 200, then splices bytes both ways. Records
+// every tunnel target so a test can prove the request really went through it.
+function connectProxy() {
+  const targets = [];
+  let authSeen = null;
+  const server = http.createServer((_req, res) => { res.writeHead(405); res.end(); });
+  server.on('connect', (req, clientSock, head) => {
+    targets.push(req.url);
+    authSeen = req.headers['proxy-authorization'] || null;
+    const [host, port] = req.url.split(':');
+    const upstream = net.connect(Number(port), host, () => {
+      clientSock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head?.length) upstream.write(head);
+      clientSock.pipe(upstream);
+      upstream.pipe(clientSock);
+    });
+    upstream.on('error', () => clientSock.destroy());
+    clientSock.on('error', () => upstream.destroy());
+  });
+  return { server, targets, auth: () => authSeen };
+}
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// The point of the whole feature: on a host with no direct route, the request
+// still reaches upstream — and it reaches it *through the proxy*.
+test('an upstream request is tunneled through the configured proxy', async () => {
+  const origin = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, path: req.url }));
+  });
+  const originPort = await listen(origin);
+  const { server: proxy, targets } = connectProxy();
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+
+  try {
+    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/v1/messages`, { method: 'GET' });
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(await res.text()), { ok: true, path: '/v1/messages' });
+    assert.deepEqual(targets, [`127.0.0.1:${originPort}`]);   // it really went through the proxy
+  } finally {
+    proxy.close();
+    origin.close();
+  }
+});
+
+test('proxy credentials are offered as Proxy-Authorization', async () => {
+  const origin = http.createServer((_req, res) => { res.writeHead(200); res.end('hi'); });
+  const originPort = await listen(origin);
+  const { server: proxy, auth } = connectProxy();
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `http://bob:s3cret@127.0.0.1:${proxyPort}` }));
+
+  try {
+    await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET' });
+    assert.equal(auth(), `Basic ${Buffer.from('bob:s3cret').toString('base64')}`);
+  } finally {
+    proxy.close();
+    origin.close();
+  }
+});
+
+// Login and token refresh go out the same way, or the account can never be added
+// or kept alive on a proxied host — which would leave the feature useless.
+test('control-plane calls (oauth) are tunneled too', async () => {
+  const origin = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ access_token: 'a' }));
+  });
+  const originPort = await listen(origin);
+  const { server: proxy, targets } = connectProxy();
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+
+  try {
+    const res = await proxyFetch(`http://127.0.0.1:${originPort}/oauth/token`, { method: 'POST', body: '{}' });
+    assert.equal(res.ok, true);
+    assert.deepEqual(await res.json(), { access_token: 'a' });
+    assert.equal(targets.length, 1);
+  } finally {
+    proxy.close();
+    origin.close();
+  }
+});
+
+// A NO_PROXY host must not be dragged through the tunnel.
+test('a bypassed host goes direct even with a proxy configured', async () => {
+  const origin = http.createServer((_req, res) => { res.writeHead(200); res.end('direct'); });
+  const originPort = await listen(origin);
+  const { server: proxy, targets } = connectProxy();
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}`, noProxy: '127.0.0.1' }));
+
+  try {
+    const res = await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET' });
+    assert.equal(await res.text(), 'direct');
+    assert.deepEqual(targets, []);                            // the proxy was never asked
+  } finally {
+    proxy.close();
+    origin.close();
+  }
+});
+
+// An AbortSignal has to keep working over the tunnel: oauth's refresh timeout
+// depends on it, and a refresh that hangs wedges every request for that account.
+test('an AbortSignal still cancels a tunneled request', async () => {
+  const origin = http.createServer(() => { /* never answers */ });
+  const originPort = await listen(origin);
+  const { server: proxy } = connectProxy();
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+
+  try {
+    await assert.rejects(
+      proxyFetch(`http://127.0.0.1:${originPort}/hang`, { signal: AbortSignal.timeout(150) }),
+    );
+  } finally {
+    proxy.close();
+    origin.close();
+    await once(origin, 'close').catch(() => {});
+  }
+});
+
+// A proxy that refuses the tunnel must surface as its own error, not as a
+// mystery socket failure attributed to sx.org.
+test('a refused CONNECT names the upstream proxy', async () => {
+  const proxy = http.createServer((_req, res) => { res.writeHead(405); res.end(); });
+  proxy.on('connect', (_req, sock) => { sock.write('HTTP/1.1 403 Forbidden\r\n\r\n'); sock.end(); });
+  const proxyPort = await listen(proxy);
+
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+
+  try {
+    await assert.rejects(
+      upstreamFetch('http://198.51.100.7:443/x', { method: 'GET' }),
+      /upstream proxy refused CONNECT: HTTP\/1\.1 403/,
+    );
+  } finally {
+    proxy.close();
+  }
+});


### PR DESCRIPTION
Closes #155.

## The problem

On a host that can only reach the internet through an HTTP proxy, teamclaude fails with `connect ETIMEDOUT` on the first upstream request — while Claude Code itself works fine, because it is being launched through teamclaude and never talks to Anthropic directly. Setting `HTTPS_PROXY` changes nothing: the only CONNECT machinery in the tree was hardcoded to sx.org, a specific paid residential-egress provider with its own provisioning API and its own per-request routing policy. There was no way to say "this machine reaches the internet through a proxy".

## What this adds

`upstreamProxy` in the config, or the **Network → Upstream proxy** row on the TUI settings screen (applies to the next request, no restart — the operator is usually there *because* requests are failing).

```json
{ "upstreamProxy": "http://user:pass@proxy.corp.example:3128" }
```

A bare `"host:3128"` is accepted, because that is how corporate docs hand these out.

## Decisions worth reviewing

**It covers the control plane, not just forwarding.** OAuth login, token refresh, profile and usage lookups go through the proxy too. Covering only `/v1/messages` would leave an operator able to refresh an account but not add one — the feature would look like it worked and then strand them.

**`HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` are honoured when the config is silent.** The reporter had already set them and reasonably expected them to apply; so does every other CLI on that machine. The risk is a value nobody typed into the config being silently in force, so an inherited proxy is announced at startup and the TUI row is tagged with where it came from. `"upstreamProxy": false` opts out of the environment entirely.

**Resolution is published process-wide from the config loader** rather than threaded through sixteen call sites. A proxy that applied to `server` but not `login` would be worse than none. That does mean `config.js` has a side effect; the alternative was passing config into `oauth.js`, which has no business knowing about it.

**A malformed value is fatal at startup.** On a host with no route out, degrading to a direct connection cannot work — it just converts one clear error into a pile of ETIMEDOUTs pointing nowhere near the typo.

**TLS stays end-to-end** over a plain CONNECT: the proxy sees ciphertext, and certificate verification is untouched. SOCKS is not supported and `socks5://` is rejected by name at startup rather than failing later inside the tunnel.

Also generalised `connectThroughProxy`'s error strings, which previously blamed sx.org for any tunnel failure.

## Tests

`test/upstream-proxy.test.js` — parsing (including percent-encoded credentials round-tripping), NO_PROXY suffix matching, resolution precedence, and end-to-end runs against a real in-process CONNECT proxy asserting the request actually went through it, that `Proxy-Authorization` is offered, that bypassed hosts stay direct, that an `AbortSignal` still cancels a tunneled request (oauth's refresh timeout depends on it), and that a refused CONNECT names the upstream proxy rather than sx.org.

Not covered: sx.org's own provisioning API calls still go direct, so a locked-down host cannot provision sx.org. Worth a follow-up if anyone hits it; it seemed better than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)