### PR TITLE
Bump to 1.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release 1.1.12.

Merging this triggers `publish.yml`: npm publish via Trusted Publishing, plus a `v1.1.12` tag and GitHub release.

### Fixes
- #147 — TUI settings rows that were reachable with the cursor but never drawn
- #148 — an upgraded relay socket dying mid-session no longer takes the whole proxy with it
- #149 — a 403 on the proxy's own credential is reported as a proxy error instead of reaching the client, which read it as a dead session and demanded a re-login
- #152 — a second organization of the same person is a new account rather than an overwrite

### Features
- #157 — configurable outbound proxy for all Anthropic-bound traffic, closing #155
- #153 — `teamclaude service install` (LaunchAgent on macOS, systemd `--user` unit on Linux)
- #151 — opt-in egress pin: hold requests when the exit IP is not the pinned one
- #150 — fatal errors recorded to a crash log before the process exits

### Docs
- #146 — README reorganised into an overview plus `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)