### PR TITLE
fix(import): read macOS Keychain when default credentials file is missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1399,7 +1399,8 @@ Commands:
 Options:
   --name NAME         Set account name (import/login)
   --org NAME|UUID     Disambiguate when an email spans multiple orgs (remove/priority/api)
-  --from PATH         Credentials path (import, default: ~/.claude/.credentials.json)
+  --from PATH         Credentials path (import, default: ~/.claude/.credentials.json;
+                      on macOS the default falls back to the Keychain)
   --json JSON         Import from inline JSON (import), e.g.:
                       --json '{"accessToken":"...","refreshToken":"...","expiresAt":1234}'
   --log-to DIR        Log full requests/responses to DIR (server, one file per request)

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -1,17 +1,46 @@
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { randomBytes, createHash } from 'node:crypto';
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createInterface } from 'node:readline';
 import http from 'node:http';
 import { proxyFetch } from './upstream-fetch.js';
 
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_CREDENTIALS_PATH = '~/.claude/.credentials.json';
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+/**
+ * Read Claude Code credentials from the macOS Keychain, where Claude Code
+ * stores them on darwin (there is no ~/.claude/.credentials.json on macOS).
+ */
+async function readKeychainCredentials() {
+  const { stdout } = await execFileAsync('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w']);
+  return JSON.parse(stdout.trim());
+}
+
 /**
  * Import OAuth credentials from a Claude Code credentials file.
+ * On macOS the default credentials location is the Keychain, not a file, so
+ * when the default path is missing the Keychain is tried before giving up.
  */
-export async function importCredentials(filePath) {
-  const resolvedPath = filePath.replace(/^~/, homedir());
-  const raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
+export async function importCredentials(filePath, {
+  home = homedir(), platform = process.platform, readKeychain = readKeychainCredentials } = {}) {
+  const resolvedPath = filePath.replace(/^~/, home);
+  let raw;
+  try {
+    raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
+  } catch (err) {
+    const isDefaultPath = resolvedPath === DEFAULT_CREDENTIALS_PATH.replace(/^~/, home);
+    if (err.code !== 'ENOENT' || platform !== 'darwin' || !isDefaultPath) throw err;
+    try {
+      raw = await readKeychain();
+    } catch (kcErr) {
+      throw new Error(`${err.message}; macOS Keychain lookup for "${KEYCHAIN_SERVICE}" also failed: ${kcErr.message}`);
+    }
+  }
 
   // Claude Code stores credentials nested under "claudeAiOauth"
   const data = raw.claudeAiOauth || raw;

--- a/test/import-credentials.test.js
+++ b/test/import-credentials.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { importCredentials } from '../src/oauth.js';
+
+const CREDS = { accessToken: 'at', refreshToken: 'rt', expiresAt: 1754500000000 };
+
+async function tmpHome() {
+  return mkdtemp(join(tmpdir(), 'tc-import-'));
+}
+
+test('reads nested claudeAiOauth credentials from file', async () => {
+  const home = await tmpHome();
+  await mkdir(join(home, '.claude'), { recursive: true });
+  await writeFile(join(home, '.claude', '.credentials.json'), JSON.stringify({ claudeAiOauth: CREDS }));
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin' });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.refreshToken, 'rt');
+});
+
+test('reads flat credentials from file', async () => {
+  const home = await tmpHome();
+  await writeFile(join(home, 'creds.json'), JSON.stringify(CREDS));
+
+  const creds = await importCredentials(join(home, 'creds.json'), { home, platform: 'linux' });
+  assert.equal(creds.accessToken, 'at');
+});
+
+test('falls back to Keychain on macOS when default file is missing', async () => {
+  const home = await tmpHome();
+  let called = 0;
+  const readKeychain = async () => { called++; return { claudeAiOauth: CREDS }; };
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
+  assert.equal(called, 1);
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.expiresAt, CREDS.expiresAt);
+});
+
+test('does not touch Keychain on non-macOS platforms', async () => {
+  const home = await tmpHome();
+  let called = 0;
+  const readKeychain = async () => { called++; return { claudeAiOauth: CREDS }; };
+
+  await assert.rejects(
+    importCredentials('~/.claude/.credentials.json', { home, platform: 'linux', readKeychain }),
+    (err) => err.code === 'ENOENT',
+  );
+  assert.equal(called, 0);
+});
+
+test('does not touch Keychain for a non-default path on macOS', async () => {
+  const home = await tmpHome();
+  let called = 0;
+  const readKeychain = async () => { called++; return { claudeAiOauth: CREDS }; };
+
+  await assert.rejects(
+    importCredentials(join(home, 'other.json'), { home, platform: 'darwin', readKeychain }),
+    (err) => err.code === 'ENOENT',
+  );
+  assert.equal(called, 0);
+});
+
+test('reports both file and Keychain failure when fallback fails', async () => {
+  const home = await tmpHome();
+  const readKeychain = async () => { throw new Error('item not found in keychain'); };
+
+  await assert.rejects(
+    importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain }),
+    /Keychain.*item not found in keychain/,
+  );
+});


### PR DESCRIPTION
On macOS, Claude Code stores OAuth credentials in the Keychain (the "Claude Code-credentials" item), not in `~/.claude/.credentials.json`, so a plain `teamclaude import` always failed with ENOENT.

`importCredentials` now falls back to reading that Keychain item via `security find-generic-password` when the default path is missing on darwin. The fallback is limited to the default path: an explicit `--from` pointing at a missing file still fails loudly, so a custom path can never silently import credentials for a different account. The TUI account import flow goes through the same function and picks up the fix as well.

When both locations fail, the error reports both causes instead of a bare ENOENT.