### PR TITLE
fix(tui): use black progress-bar labels on green and yellow fills

### DIFF
--- a/src/tui.js
+++ b/src/tui.js
@@ -126,7 +126,7 @@ function formatReset(resetTs) {
  * Render a progress bar using background colors with text overlaid.
  * The label (e.g. "Ses 2h30m" or "45%") is drawn on top of the bar.
  */
-function bar(ratio, w = 10, resetTs) {
+export function bar(ratio, w = 10, resetTs) {
   const rst = formatReset(resetTs);
 
   if (ratio == null || isNaN(ratio)) {
@@ -157,8 +157,13 @@ function bar(ratio, w = 10, resetTs) {
   const filled = chars.slice(0, f);
   const empty = chars.slice(f);
 
+  // Black label on green/yellow: terminal themes commonly render those
+  // backgrounds light, and bright-white text disappears on them. White stays
+  // on red, which is dark in practically every palette.
+  const fgc = bg === 41 ? 97 : 30;
+
   let out = '';
-  if (filled) out += `${ESC}${bg};97m${filled}`;
+  if (filled) out += `${ESC}${bg};${fgc}m${filled}`;
   if (empty) out += `${ESC}100;37m${empty}`;
   out += RESET;
   return out;

--- a/test/tui-bar.test.js
+++ b/test/tui-bar.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bar } from '../src/tui.js';
+
+// The label is overlaid on the bar's background, so its foreground must
+// contrast with each fill color: black on green/yellow (both render light in
+// many terminal themes), white only on red.
+test('green and yellow fills use a black label', () => {
+  assert.match(bar(0.5, 10), /\x1b\[42;30m/);
+  assert.match(bar(0.8, 10), /\x1b\[43;30m/);
+});
+
+test('red fill keeps a white label', () => {
+  assert.match(bar(0.95, 10), /\x1b\[41;97m/);
+});
+
+test('empty portion keeps gray-on-gray', () => {
+  assert.match(bar(0.5, 10), /\x1b\[100;37m/);
+});


### PR DESCRIPTION
The quota bar overlays its label (percentage or reset time) in bright white on the fill color. Terminal themes commonly render the green (42) and yellow (43) backgrounds light, which makes a white label unreadable.

Labels are now black on green and yellow fills; white stays only on the red fill, which is dark in practically every palette. The empty portion (gray on gray) is unchanged.