### PR TITLE
fix(test): occupy the loopback address in the listen-error test

### DIFF
--- a/test/server-listen-error.test.js
+++ b/test/server-listen-error.test.js
@@ -9,8 +9,12 @@ import { fileURLToPath } from 'node:url';
 
 const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
 
+// Occupy the port on the exact address the spawned server binds (127.0.0.1).
+// A bare listen(0) binds the [::] dual-stack wildcard instead, and on macOS a
+// specific-address bind succeeds alongside a wildcard held by another socket —
+// the port would not actually be "in use" for the child there.
 function listen(server) {
-  return new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
 }
 
 function close(server) {


### PR DESCRIPTION
The listen-error test held the port on the `[::]` dual-stack wildcard while the spawned server binds `127.0.0.1`. On macOS a specific-address bind succeeds alongside a wildcard held by another socket, so the port was not actually in use for the child: the server started normally, never exited, and the test timed out after 5 seconds. Linux rejects that bind combination with `EADDRINUSE`, which is why CI stayed green while the suite failed on macOS.

Binding the occupying server to `127.0.0.1` collides with the child's bind on every platform. The test now passes on macOS in ~150 ms.