### PR TITLE
fix(test): make upstream-proxy e2e tests immune to the shell's proxy env

### DIFF
--- a/test/upstream-proxy.test.js
+++ b/test/upstream-proxy.test.js
@@ -85,7 +85,7 @@ test('upstreamProxy:false opts out of the environment entirely', () => {
 });
 
 test('proxyForHost applies NO_PROXY', () => {
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: 'p:3128', noProxy: 'internal.example' }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: 'p:3128', noProxy: 'internal.example' }, {}));
   assert.equal(proxyForHost('api.anthropic.com').host, 'p');
   assert.equal(proxyForHost('svc.internal.example'), null);
 });
@@ -143,7 +143,11 @@ test('an upstream request is tunneled through the configured proxy', async () =>
   const { server: proxy, targets } = connectProxy();
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+  // Every e2e test resolves with an explicit empty env: the developer's own
+  // shell commonly carries NO_PROXY=127.0.0.1 (and HTTP(S)_PROXY), which would
+  // silently bypass the mock proxy and fail the "went through the proxy"
+  // assertions. resolveUpstreamProxy falls back to process.env otherwise.
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }, {}));
 
   try {
     const res = await upstreamFetch(`http://127.0.0.1:${originPort}/v1/messages`, { method: 'GET', headersTimeoutMs: 8000 });
@@ -162,7 +166,7 @@ test('proxy credentials are offered as Proxy-Authorization', async () => {
   const { server: proxy, auth } = connectProxy();
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `http://bob:s3cret@127.0.0.1:${proxyPort}` }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `http://bob:s3cret@127.0.0.1:${proxyPort}` }, {}));
 
   try {
     await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET', headersTimeoutMs: 8000 });
@@ -184,7 +188,7 @@ test('control-plane calls (oauth) are tunneled too', async () => {
   const { server: proxy, targets } = connectProxy();
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }, {}));
 
   try {
     const res = await proxyFetch(`http://127.0.0.1:${originPort}/oauth/token`, { method: 'POST', body: '{}', headersTimeoutMs: 8000 });
@@ -204,7 +208,7 @@ test('a bypassed host goes direct even with a proxy configured', async () => {
   const { server: proxy, targets } = connectProxy();
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}`, noProxy: '127.0.0.1' }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}`, noProxy: '127.0.0.1' }, {}));
 
   try {
     const res = await upstreamFetch(`http://127.0.0.1:${originPort}/x`, { method: 'GET', headersTimeoutMs: 8000 });
@@ -224,7 +228,7 @@ test('an AbortSignal still cancels a tunneled request', async () => {
   const { server: proxy } = connectProxy();
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }, {}));
 
   try {
     await assert.rejects(
@@ -244,7 +248,7 @@ test('a refused CONNECT names the upstream proxy', async () => {
   proxy.on('connect', (_req, sock) => { sock.write('HTTP/1.1 403 Forbidden\r\n\r\n'); sock.end(); });
   const proxyPort = await listen(proxy);
 
-  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }));
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: `127.0.0.1:${proxyPort}` }, {}));
 
   try {
     await assert.rejects(


### PR DESCRIPTION
The e2e tunnel tests resolved the proxy without an explicit env argument, so `resolveUpstreamProxy` fell back to `process.env`. With `NO_PROXY=127.0.0.1` exported in the shell (common when a local proxy is in use) the code under test went direct instead of through the mock CONNECT proxy, and three assertions failed. CI is clean, so this only shows up on a developer machine.

Now every e2e resolution passes an explicit empty env, so the tests exercise exactly the config they construct. 16/16 with and without the proxy variables in the shell.