### PR TITLE
feat(cli): manual account switching without the TUI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,15 @@ curl -X POST http://localhost:3456/teamclaude/reload
 
 You usually don't need to call it directly. `login`, `import`, `enable`, `disable`, `priority`, `route`, `probe` and `warmup` notify a running server themselves.
 
+Switching the account by hand has the same headless path — the equivalent of pressing **s** in the TUI and confirming with the default target selected:
+
+```bash
+teamclaude switch                 # list accounts, marking the current one
+teamclaude switch me@example.com  # make that account the preferred one
+```
+
+Both forms need a running server: the choice is runtime state and is never written to the config, so there is nothing to apply on a later restart. The command wraps `POST /teamclaude/switch` with a `{"account": "<name>"}` body, and the account can be given as its display name, its bare email, its `accountUuid` or its `orgUuid`. The rotation index is deliberately not accepted — it is array position, so a script pinned to `1` would silently follow a different account after a removal. As in the TUI this sets a preference rather than a lock: rotation still moves off the account once it stops being eligible.
+
 ### TUI keyboard shortcuts
 
 | Key | Action |
@@ -95,6 +104,7 @@ teamclaude env               # Print export lines for routing claude yourself
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude status            # Show live proxy status (requires running server)
+teamclaude switch [name]     # Prefer one account (no name lists them)
 teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
 teamclaude enable <name>     # Re-enable it (also clears a stuck error state)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,8 @@ curl -X POST http://localhost:3456/teamclaude/reload
 
 You usually don't need to call it directly. `login`, `import`, `enable`, `disable`, `priority`, `route`, `probe` and `warmup` notify a running server themselves.
 
+Control-plane **writes** (`reload`, `switch`) are refused when the request carries a browser `Origin` or a cross-site `Sec-Fetch-Site`. Loopback is exempt from the proxy API key so the CLI needs no configuration, but that exemption also covers any web page you happen to visit: a page can POST to `127.0.0.1` cross-origin without a preflight, and while it cannot read the reply, the write would still land. `curl` and the CLI send neither header and are unaffected. Reads (`status`) are not restricted — the same-origin policy already stops a page from seeing the response.
+
 Switching the account by hand has the same headless path — the equivalent of pressing **s** in the TUI and confirming with the default target selected:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,14 @@ teamclaude switch                 # list accounts, marking the current one
 teamclaude switch me@example.com  # make that account the preferred one
 ```
 
-Both forms need a running server: the choice is runtime state and is never written to the config, so there is nothing to apply on a later restart. The command wraps `POST /teamclaude/switch` with a `{"account": "<name>"}` body, and the account can be given as its display name, its bare email, its `accountUuid` or its `orgUuid`. The rotation index is deliberately not accepted — it is array position, so a script pinned to `1` would silently follow a different account after a removal. As in the TUI this sets a preference rather than a lock: rotation still moves off the account once it stops being eligible.
+Both forms need a running server: the choice is runtime state and is never written to the config, so there is nothing to apply on a later restart. The command wraps `POST /teamclaude/switch` with a `{"account": "<name>"}` body, and the account can be given as its display name, its bare email, its `accountUuid`, its `orgUuid`, or the fully qualified `accountUuid/orgUuid` — the last being the only form that tells apart one email that holds accounts in several orgs. The rotation index is deliberately not accepted — it is array position, so a script pinned to `1` would silently follow a different account after a removal.
+
+As in the TUI, the choice is a weak preference rather than a lock, and it is worth knowing both ways it gets dropped. Rotation abandons it once the account becomes unusable (disabled, spent, throttled), and also whenever any available account carries a strictly lower `priority` value, since a higher-priority account preempts a healthy current one. A switch onto an account that cannot take traffic at all is still recorded, exactly as in the TUI, but the command says so instead of reporting a clean success:
+
+```text
+Switched to "me@example.com"
+Warning: "me@example.com" is disabled, so requests will not route to it until that changes.
+```
 
 ### TUI keyboard shortcuts
 
@@ -104,7 +111,7 @@ teamclaude env               # Print export lines for routing claude yourself
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude status            # Show live proxy status (requires running server)
-teamclaude switch [name]     # Prefer one account (no name lists them)
+teamclaude switch [name]     # Prefer an account; no name lists them (needs server)
 teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
 teamclaude enable <name>     # Re-enable it (also clears a stuck error state)

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -287,12 +287,7 @@ export class AccountManager {
       if (next) { current.requalify = false; return next; }
     }
     if (this._isAvailable(current, model, advisorModel) && !exclude?.has(current.index)) {
-      // A strictly higher-priority (lower value) available account preempts a
-      // healthy current one. Within the same priority tier we stay put, so the
-      // common case (all accounts at the default priority 0) is unchanged and
-      // never thrashes — preemption only triggers when priorities differ.
-      const betterExists = this.accounts.some(a =>
-        this._isAvailable(a, model, advisorModel) && !exclude?.has(a.index) && (a.priority || 0) < (current.priority || 0));
+      const betterExists = this._preemptedBy(current, model, advisorModel, exclude);
       return betterExists ? this._selectNext(exclude, model, advisorModel) : current;
     }
     const next = this._selectNext(exclude, model, advisorModel);
@@ -578,26 +573,48 @@ export class AccountManager {
   }
 
   /**
-   * Whether requests would actually route to an account right now, with a short
-   * reason when they would not. The public counterpart of the internal
-   * availability check: a caller that records a manual choice (the control
+   * The available account that would preempt `account` under the priority rule,
+   * or null. A strictly lower priority value wins; within the same tier we stay
+   * put, so the common case (every account at the default priority 0) never
+   * thrashes. Shared by _select, which enforces it, and eligibility(), which
+   * reports it — one predicate so the answer cannot drift from the behaviour.
+   */
+  _preemptedBy(account, model = null, advisorModel = null, exclude = null) {
+    return this.accounts.find(a => this._isAvailable(a, model, advisorModel)
+      && !exclude?.has(a.index)
+      && (a.priority || 0) < (account.priority || 0)) || null;
+  }
+
+  /**
+   * Whether a request right now would actually route to an account, with a short
+   * reason when it would not. A caller that records a manual choice (the control
    * plane's switch endpoint) needs to report whether that choice will take
-   * effect, not merely that it was stored — selection skips an unavailable
-   * account on the very next request.
+   * effect, not merely that it was stored: selection drops the choice on the very
+   * next request both when the account cannot serve traffic and when another
+   * available account outranks it on priority. Both are asked here through the
+   * same helpers _select uses, so the flag cannot promise more than the selector
+   * delivers.
    * @returns {{eligible: boolean, reason?: string}}
    */
   eligibility(accountIndex) {
     const account = this.accounts[accountIndex];
     if (!account) return { eligible: false, reason: 'no such account' };
-    // Ask the real predicate rather than re-deriving it, so the two can't drift.
-    // It also clears an expired throttle, which is why the reasons below are
-    // only consulted once it has said no.
-    if (this._isAvailable(account)) return { eligible: true };
-    if (account.disabled) return { eligible: false, reason: 'disabled' };
-    if (account.status === 'error') return { eligible: false, reason: 'in an error state and needs a re-login' };
-    if (account.status === 'exhausted') return { eligible: false, reason: 'out of quota' };
-    if (account.status === 'throttled') return { eligible: false, reason: 'rate-limited' };
-    return { eligible: false, reason: 'at or above the switch threshold' };
+    // _isAvailable also clears an expired throttle, so the specific reasons below
+    // are only consulted once it has actually said no.
+    if (!this._isAvailable(account)) {
+      if (account.disabled) return { eligible: false, reason: 'disabled' };
+      if (account.status === 'error') return { eligible: false, reason: 'in an error state and needs a re-login' };
+      if (account.status === 'exhausted') return { eligible: false, reason: 'out of quota' };
+      if (account.status === 'throttled') return { eligible: false, reason: 'rate-limited' };
+      return { eligible: false, reason: 'at or above the switch threshold' };
+    }
+    // Healthy, but a higher-priority account preempts it on the next selection.
+    // Phrased to read correctly after "<name> is ..." in the caller's message.
+    const preemptor = this._preemptedBy(account);
+    if (preemptor) {
+      return { eligible: false, reason: `outranked by higher-priority account "${preemptor.name}"` };
+    }
+    return { eligible: true };
   }
 
   /**

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -578,6 +578,29 @@ export class AccountManager {
   }
 
   /**
+   * Whether requests would actually route to an account right now, with a short
+   * reason when they would not. The public counterpart of the internal
+   * availability check: a caller that records a manual choice (the control
+   * plane's switch endpoint) needs to report whether that choice will take
+   * effect, not merely that it was stored — selection skips an unavailable
+   * account on the very next request.
+   * @returns {{eligible: boolean, reason?: string}}
+   */
+  eligibility(accountIndex) {
+    const account = this.accounts[accountIndex];
+    if (!account) return { eligible: false, reason: 'no such account' };
+    // Ask the real predicate rather than re-deriving it, so the two can't drift.
+    // It also clears an expired throttle, which is why the reasons below are
+    // only consulted once it has said no.
+    if (this._isAvailable(account)) return { eligible: true };
+    if (account.disabled) return { eligible: false, reason: 'disabled' };
+    if (account.status === 'error') return { eligible: false, reason: 'in an error state and needs a re-login' };
+    if (account.status === 'exhausted') return { eligible: false, reason: 'out of quota' };
+    if (account.status === 'throttled') return { eligible: false, reason: 'rate-limited' };
+    return { eligible: false, reason: 'at or above the switch threshold' };
+  }
+
+  /**
    * Normalize and store the configurable routing table. A route pins a set of
    * model globs to an exclusive set of accounts (and may override the governing
    * quota bucket). Called from the constructor and on config reload.

--- a/src/index.js
+++ b/src/index.js
@@ -840,14 +840,25 @@ async function switchCommand() {
   try {
     if (!name) {
       const res = await fetch(`http://localhost:${port}/teamclaude/status`, { headers });
-      const data = await res.json();
-      const accounts = data.accounts || [];
-      if (!accounts.length) {
+      // Something answered on the port. Whether it is our proxy is a separate
+      // question, and getting it wrong would blame a down server for a reply we
+      // simply could not read — or report an unreadable reply as an empty fleet.
+      const data = res.ok ? await res.json().catch(() => null) : null;
+      if (!data || !Array.isArray(data.accounts)) {
+        console.error(`Unexpected reply from localhost:${port} (HTTP ${res.status}) — no account list in it.`);
+        console.error('Something is listening there, but it does not answer like this teamclaude version.');
+        process.exit(1);
+      }
+      if (!data.accounts.length) {
         console.log('No accounts configured.');
         return;
       }
-      for (const a of accounts) {
-        console.log(`${a.name === data.currentAccount ? '*' : ' '} ${a.name}`);
+      for (const a of data.accounts) {
+        // Flag what would stop traffic reaching an account. The TUI shows this in
+        // its table, so leaving it out here would make the headless half of the
+        // feature the only place a disabled account looks switchable.
+        const state = a.disabled ? 'disabled' : (a.status && a.status !== 'active' ? a.status : null);
+        console.log(`${a.name === data.currentAccount ? '*' : ' '} ${a.name}${state ? `  (${state})` : ''}`);
       }
       console.log('\nSwitch with: teamclaude switch <name>');
       return;
@@ -860,7 +871,12 @@ async function switchCommand() {
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) {
-      console.error(data.error || `Switch failed (HTTP ${res.status})`);
+      // Our own errors are strings. A server too old to know this endpoint
+      // forwards the request upstream instead, and Anthropic's error is an
+      // object — printing that raw gives the user "[object Object]".
+      const detail = typeof data.error === 'string' ? data.error : null;
+      console.error(detail || `Switch failed: unexpected reply from localhost:${port} (HTTP ${res.status}).`);
+      if (!detail) console.error('An older server without this endpoint answers this way; restart it to pick up the new version.');
       if (data.accounts?.length) {
         console.error('Known accounts:');
         for (const n of data.accounts) console.error(`  ${n}`);
@@ -868,6 +884,11 @@ async function switchCommand() {
       process.exit(1);
     }
     console.log(`Switched to "${data.account}"`);
+    // Recorded is not the same as in effect: rotation skips an account it cannot
+    // use on the very next request, so saying nothing here would be a quiet lie.
+    if (data.eligible === false) {
+      console.error(`Warning: "${data.account}" is ${data.reason || 'not currently eligible'}, so requests will not route to it until that changes.`);
+    }
   } catch (err) {
     console.error('Cannot connect to proxy at localhost:' + port);
     console.error('Is the server running? Start with: teamclaude server');

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ switch (command) {
     await accountsCommand();
     process.exit(0);
     break;
+  case 'switch':
+    await switchCommand();
+    process.exit(0);
+    break;
   case 'remove':
     await removeCommand();
     process.exit(0);
@@ -820,6 +824,58 @@ async function statusCommand() {
   }
 }
 
+// ── switch ──────────────────────────────────────────────────
+
+// Manual account switch against a RUNNING server — the headless equivalent of
+// pressing 's' in the TUI, which is unreachable when the proxy runs as a
+// background service. Nothing is written to the config: like the TUI's switch
+// this is a runtime preference that dies with the process, so the server is the
+// only place that can answer or apply it.
+async function switchCommand() {
+  const config = await loadOrCreateConfig();
+  const port = config.proxy.port;
+  const headers = { 'x-api-key': config.proxy.apiKey };
+  const name = args[1] && !args[1].startsWith('-') ? args[1] : null;
+
+  try {
+    if (!name) {
+      const res = await fetch(`http://localhost:${port}/teamclaude/status`, { headers });
+      const data = await res.json();
+      const accounts = data.accounts || [];
+      if (!accounts.length) {
+        console.log('No accounts configured.');
+        return;
+      }
+      for (const a of accounts) {
+        console.log(`${a.name === data.currentAccount ? '*' : ' '} ${a.name}`);
+      }
+      console.log('\nSwitch with: teamclaude switch <name>');
+      return;
+    }
+
+    const res = await fetch(`http://localhost:${port}/teamclaude/switch`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ account: name }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(data.error || `Switch failed (HTTP ${res.status})`);
+      if (data.accounts?.length) {
+        console.error('Known accounts:');
+        for (const n of data.accounts) console.error(`  ${n}`);
+      }
+      process.exit(1);
+    }
+    console.log(`Switched to "${data.account}"`);
+  } catch (err) {
+    console.error('Cannot connect to proxy at localhost:' + port);
+    console.error('Is the server running? Start with: teamclaude server');
+    if (err?.message) console.error(`Details: ${err.message}`);
+    process.exit(1);
+  }
+}
+
 // ── accounts ────────────────────────────────────────────────
 
 async function accountsCommand() {
@@ -1380,6 +1436,8 @@ Commands:
   status [--json]     Show rich proxy/account/probe status (live)
                       Use --color=always|never to control ANSI colors
   accounts            List configured accounts
+  switch [NAME]       Make the running server prefer one account (as 's' in the
+                      TUI does); with no NAME, list accounts and mark the current
   remove <name>       Remove an account (by name or email; --org to disambiguate)
   disable <name>      Temporarily exclude an account from rotation
   enable <name>       Re-enable a disabled account (also clears a stuck error)
@@ -1428,6 +1486,8 @@ launched with and without --no-mitm can share one server.
 
 A running server re-syncs accounts from config on POST /teamclaude/reload
 (local only). add/login/enable/disable/priority trigger it automatically.
+POST /teamclaude/switch {"account": "<name>"} makes one account the preferred
+one, which is what 'teamclaude switch' calls.
 
 Upstream proxy. On a host with no direct route to the internet, set
 "upstreamProxy": "http://user:pass@host:3128" (or just "host:3128") and every

--- a/src/server.js
+++ b/src/server.js
@@ -114,10 +114,13 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
 
       // Switch endpoint — make one account the preferred one, the headless
       // equivalent of picking it with 's' in the TUI. Both do the same single
-      // thing: move currentIndex. It is a preference, not a lock — rotation
-      // still moves off an account that stops being eligible. Body:
-      // {"account": "<name|email|accountUuid|orgUuid>"}. Local control only
-      // (no upstream calls); the auth gate above already applies.
+      // thing: move currentIndex. That is a preference, and a weak one: _select
+      // abandons it as soon as the account is unavailable, and also whenever any
+      // available account carries a strictly lower priority value. So the answer
+      // reports whether the choice will actually take effect rather than only
+      // that it was recorded. Body:
+      // {"account": "<name|email|accountUuid|accountUuid/orgUuid|orgUuid>"}.
+      // Local control only (no upstream calls); the auth gate above applies.
       if (req.method === 'POST' && req.url === '/teamclaude/switch') {
         const names = () => (accountManager.accounts || []).map(a => a.name);
         let target;

--- a/src/server.js
+++ b/src/server.js
@@ -141,6 +141,12 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
           return;
         }
         accountManager.currentIndex = index;
+        // Leave a trace where every other account change already leaves one: the
+        // TUI swaps console.log for its activity pane and headless mode tees it
+        // to the activity log, so this one line covers both. Without it a manual
+        // switch is the only account change that happens invisibly — on exactly
+        // the background-service deployment this endpoint exists for.
+        console.log(`[TeamClaude] Switched to account "${accountManager.accounts[index].name}" (manual)`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: true, account: accountManager.accounts[index].name }));
         return;

--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,40 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
         return;
       }
 
+      // Switch endpoint — make one account the preferred one, the headless
+      // equivalent of picking it with 's' in the TUI. Both do the same single
+      // thing: move currentIndex. It is a preference, not a lock — rotation
+      // still moves off an account that stops being eligible. Body:
+      // {"account": "<name|email|accountUuid|orgUuid>"}. Local control only
+      // (no upstream calls); the auth gate above already applies.
+      if (req.method === 'POST' && req.url === '/teamclaude/switch') {
+        const names = () => (accountManager.accounts || []).map(a => a.name);
+        let target;
+        try {
+          const raw = await readControlBody(req);
+          target = JSON.parse(raw || '{}')?.account;
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: `invalid request body: ${err.message}` }));
+          return;
+        }
+        if (typeof target !== 'string' || !target.trim()) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'missing "account"', accounts: names() }));
+          return;
+        }
+        const index = resolveAccountPin(accountManager, target);
+        if (index == null) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: `no such account "${target}"`, accounts: names() }));
+          return;
+        }
+        accountManager.currentIndex = index;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, account: accountManager.accounts[index].name }));
+        return;
+      }
+
       return forward(req, res);
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
@@ -146,6 +180,20 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   server.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, upstream, sx));
 
   return server;
+}
+
+// Read a control-endpoint body as text. Capped, unlike the proxied request path:
+// these endpoints carry a couple of fields, so anything larger is a mistake or an
+// attack and buffering it whole would be the wrong answer either way.
+async function readControlBody(req, limit = 64 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > limit) throw new Error('body too large');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -125,8 +125,11 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
           const raw = await readControlBody(req);
           target = JSON.parse(raw || '{}')?.account;
         } catch (err) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: false, error: `invalid request body: ${err.message}` }));
+          // Say which of the two it was, but never echo the parser's own message
+          // back to a caller — that is our internals, not their input.
+          const tooLarge = err.message === 'body too large';
+          res.writeHead(tooLarge ? 413 : 400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: tooLarge ? 'request body too large' : 'invalid request body' }));
           return;
         }
         if (typeof target !== 'string' || !target.trim()) {
@@ -141,14 +144,22 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
           return;
         }
         accountManager.currentIndex = index;
+        const name = accountManager.accounts[index].name;
+        // Recording the choice and the choice taking effect are two different
+        // things: selection skips an account it cannot use on the very next
+        // request, so a bare "ok" would be a lie for a disabled or spent target.
+        // The switch still happens (that is the TUI's behaviour) and the answer
+        // says whether traffic will follow it.
+        const { eligible, reason } = accountManager.eligibility(index);
         // Leave a trace where every other account change already leaves one: the
         // TUI swaps console.log for its activity pane and headless mode tees it
         // to the activity log, so this one line covers both. Without it a manual
         // switch is the only account change that happens invisibly — on exactly
         // the background-service deployment this endpoint exists for.
-        console.log(`[TeamClaude] Switched to account "${accountManager.accounts[index].name}" (manual)`);
+        console.log(`[TeamClaude] Switched to account "${name}" (manual)`
+          + (eligible ? '' : ` — ${reason}, so rotation will not use it`));
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, account: accountManager.accounts[index].name }));
+        res.end(JSON.stringify({ ok: true, account: name, eligible, ...(reason ? { reason } : {}) }));
         return;
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -77,6 +77,30 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
         return;
       }
 
+      // Control-plane mutations are refused when the request was issued by a web
+      // page. The gate above exempts loopback from the API key, so without this
+      // any site the operator happens to visit can POST here cross-origin: a
+      // `fetch(..., {mode:'no-cors', body})` with a text/plain content type is a
+      // CORS "simple request", so no preflight is sent and the request lands.
+      // The page cannot read the reply, but the side effect is the point —
+      // forcing the whole fleet onto one named account is a targeted quota
+      // drain, and reload is reachable the same way.
+      //
+      // Origin (and Sec-Fetch-Site) are set by the browser and cannot be
+      // forged from page JavaScript, while curl and the CLI send neither — so
+      // this costs legitimate callers nothing. Deliberately not a content-type
+      // requirement, which would also close the hole but would break the
+      // documented `curl -X POST .../teamclaude/reload` that sends no body.
+      if (req.method === 'POST' && (req.url || '').startsWith('/teamclaude/')
+          && !isSameOriginControlRequest(req)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: false,
+          error: 'cross-origin request refused: the control plane is not reachable from a web page',
+        }));
+        return;
+      }
+
       // Forward-proxy request (HTTP_PROXY): an absolute-form URL is a tool
       // proxying plain HTTP to some host. Account logic is only for hosts we
       // manage (the Anthropic upstream, which is HTTPS-only and never arrives
@@ -200,6 +224,27 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
   server.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, upstream, sx));
 
   return server;
+}
+
+/**
+ * Whether a control-plane POST did NOT come from a web page.
+ *
+ * Both headers are browser-set and unforgeable from page JavaScript:
+ *   - `Sec-Fetch-Site` is the explicit answer where it exists (Chrome, Safari,
+ *     Firefox). Anything but `same-origin` / `none` is a page reaching across.
+ *   - `Origin` is the fallback for browsers that send no Sec-Fetch-Site. Its
+ *     mere presence on a POST to a local control endpoint means a page issued
+ *     it; matching it against our own host would mean guessing which of
+ *     localhost / 127.0.0.1 / [::1] / a LAN address the caller used, and a
+ *     browser-issued same-origin call is not a thing worth supporting here.
+ *
+ * Non-browser callers (curl, the CLI, `teamclaude attach`) send neither and are
+ * unaffected.
+ */
+export function isSameOriginControlRequest(req) {
+  const site = req.headers['sec-fetch-site'];
+  if (site) return site === 'same-origin' || site === 'none';
+  return !req.headers.origin;
 }
 
 // Read a control-endpoint body as text. Capped, unlike the proxied request path:

--- a/test/cli-switch.test.js
+++ b/test/cli-switch.test.js
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// `teamclaude switch` drives the real control endpoint, so these run the CLI
+// against a real proxy server rather than a stubbed one.
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+const ACCTS = [
+  { name: 'alice@example.com', type: 'apikey', apiKey: 'k1' },
+  { name: 'bob@example.com (Acme)', type: 'apikey', apiKey: 'k2' },
+];
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// A port nothing is listening on: bind one, learn its number, give it back.
+function closedPort() {
+  return new Promise(resolve => {
+    const probe = net.createServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+async function writeConfig(port) {
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-switch-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' },
+    upstream: 'https://api.anthropic.com',
+    // Ignore any proxy in the environment: the CLI only ever talks to localhost
+    // here, and an inherited HTTPS_PROXY would make the run machine-dependent.
+    upstreamProxy: false,
+    switchThreshold: 0.98,
+    accounts: ACCTS,
+  }));
+  return path;
+}
+
+function runCli(configPath, cliArgs) {
+  const child = spawn(process.execPath, [cliPath, ...cliArgs], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', c => { stdout += c; });
+  child.stderr.on('data', c => { stderr += c; });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('CLI did not exit')); }, 10_000);
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('exit', code => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+  });
+}
+
+async function withProxy(fn) {
+  const am = new AccountManager(ACCTS, 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com' }, {});
+  const port = await listen(proxy);
+  const configPath = await writeConfig(port);
+  try {
+    await fn(am, configPath);
+  } finally {
+    proxy.close();
+  }
+}
+
+test('switch NAME retargets the running server', async () => {
+  await withProxy(async (am, configPath) => {
+    const res = await runCli(configPath, ['switch', 'bob@example.com (Acme)']);
+    assert.equal(res.code, 0, res.stderr);
+    assert.match(res.stdout, /bob@example\.com \(Acme\)/);
+    assert.equal(am.currentIndex, 1);
+  });
+});
+
+test('switch with no name lists accounts and marks the current one', async () => {
+  await withProxy(async (am, configPath) => {
+    am.currentIndex = 1;
+    const res = await runCli(configPath, ['switch']);
+    assert.equal(res.code, 0, res.stderr);
+    const lines = res.stdout.split('\n');
+    const alice = lines.find(l => l.includes('alice@example.com'));
+    const bob = lines.find(l => l.includes('bob@example.com'));
+    assert.ok(alice && bob, res.stdout);
+    assert.ok(bob.startsWith('*'), `expected the current account marked: ${bob}`);
+    assert.ok(!alice.startsWith('*'), `expected other accounts unmarked: ${alice}`);
+  });
+});
+
+test('an unknown name exits 1 and prints the valid names', async () => {
+  await withProxy(async (am, configPath) => {
+    const res = await runCli(configPath, ['switch', 'nobody@example.com']);
+    assert.equal(res.code, 1);
+    assert.match(res.stderr, /nobody@example\.com/);
+    assert.match(res.stderr, /alice@example\.com/);
+    assert.match(res.stderr, /bob@example\.com \(Acme\)/);
+    assert.equal(am.currentIndex, 0, 'a refused switch must not move the current account');
+  });
+});
+
+test('a down server exits 1 with the same hint as status', async () => {
+  const port = await closedPort();
+  const configPath = await writeConfig(port);
+  for (const cliArgs of [['switch'], ['switch', 'alice@example.com']]) {
+    const res = await runCli(configPath, cliArgs);
+    assert.equal(res.code, 1, cliArgs.join(' '));
+    assert.match(res.stderr, new RegExp(`Cannot connect to proxy at localhost:${port}`));
+    assert.match(res.stderr, /Is the server running\?/);
+  }
+});

--- a/test/cli-switch.test.js
+++ b/test/cli-switch.test.js
@@ -41,8 +41,10 @@ async function writeConfig(port) {
   await writeFile(path, JSON.stringify({
     proxy: { port, apiKey: 'tc-test' },
     upstream: 'https://api.anthropic.com',
-    // Ignore any proxy in the environment: the CLI only ever talks to localhost
-    // here, and an inherited HTTPS_PROXY would make the run machine-dependent.
+    // Belt and braces, not load-bearing: Node's global fetch ignores proxy env
+    // vars unless NODE_USE_ENV_PROXY is set, so an inherited HTTPS_PROXY does not
+    // reach these localhost calls today. Pinned anyway so the test does not start
+    // depending on that default.
     upstreamProxy: false,
     switchThreshold: 0.98,
     accounts: ACCTS,

--- a/test/cli-switch.test.js
+++ b/test/cli-switch.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import net from 'node:net';
+import http from 'node:http';
 import { spawn } from 'node:child_process';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -111,6 +112,105 @@ test('an unknown name exits 1 and prints the valid names', async () => {
     assert.match(res.stderr, /bob@example\.com \(Acme\)/);
     assert.equal(am.currentIndex, 0, 'a refused switch must not move the current account');
   });
+});
+
+// Same rule as the endpoint: the switch is recorded, but a caller must not be
+// told plainly that it worked when no request will ever reach that account.
+async function withDisabled(fn) {
+  const accts = [
+    { name: 'alice@example.com', type: 'apikey', apiKey: 'k1' },
+    { name: 'off@example.com', type: 'apikey', apiKey: 'k2', disabled: true },
+  ];
+  const am = new AccountManager(accts, 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com' }, {});
+  const port = await listen(proxy);
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-switch-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com',
+    upstreamProxy: false, switchThreshold: 0.98, accounts: accts,
+  }));
+  try {
+    await fn(am, path);
+  } finally {
+    proxy.close();
+  }
+}
+
+test('switching to a disabled account warns instead of reporting a clean success', async () => {
+  await withDisabled(async (am, configPath) => {
+    const res = await runCli(configPath, ['switch', 'off@example.com']);
+    assert.equal(res.code, 0, 'the switch is still recorded, so this is not a failure');
+    const all = res.stdout + res.stderr;
+    assert.match(all, /off@example\.com/);
+    assert.match(all, /disabled/i, `expected a warning naming the reason: ${all}`);
+    assert.match(all, /will not route|not be used|until/i, `expected the consequence spelled out: ${all}`);
+  });
+});
+
+test('the listing marks a disabled account', async () => {
+  await withDisabled(async (am, configPath) => {
+    const res = await runCli(configPath, ['switch']);
+    assert.equal(res.code, 0, res.stderr);
+    const off = res.stdout.split('\n').find(l => l.includes('off@example.com'));
+    const alice = res.stdout.split('\n').find(l => l.includes('alice@example.com'));
+    assert.match(off, /disabled/i, `expected the disabled account flagged: ${res.stdout}`);
+    assert.doesNotMatch(alice, /disabled/i, `expected a healthy account left unflagged: ${res.stdout}`);
+  });
+});
+
+// A reply from something that is not our proxy, or from a version that predates
+// the endpoint, must not be reported as "no server" or as an empty account list.
+test('an unexpected reply is reported as such, not as a down server', async () => {
+  const impostor = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<html>not teamclaude</html>');
+  });
+  const port = await listen(impostor);
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-switch-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com',
+    upstreamProxy: false, switchThreshold: 0.98, accounts: ACCTS,
+  }));
+  try {
+    const res = await runCli(path, ['switch']);
+    assert.equal(res.code, 1);
+    assert.doesNotMatch(res.stderr, /Is the server running\?/, 'something answered, so this is not a down server');
+    assert.doesNotMatch(res.stdout, /No accounts configured/, 'an unparseable reply is not an empty fleet');
+    assert.match(res.stderr, /unexpected|not a teamclaude|invalid/i, res.stderr);
+  } finally {
+    impostor.close();
+  }
+});
+
+// An old server has no /teamclaude/switch, so the request falls through to the
+// proxy path and Anthropic answers with an error OBJECT. Printing it raw yields
+// "[object Object]", which tells the user nothing.
+test('a non-string error field does not print as [object Object]', async () => {
+  const oldServer = http.createServer((req, res) => {
+    if (req.url === '/teamclaude/status') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ currentAccount: 'alice@example.com', accounts: [{ name: 'alice@example.com' }] }));
+      return;
+    }
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'nope' } }));
+  });
+  const port = await listen(oldServer);
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-switch-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com',
+    upstreamProxy: false, switchThreshold: 0.98, accounts: ACCTS,
+  }));
+  try {
+    const res = await runCli(path, ['switch', 'alice@example.com']);
+    assert.equal(res.code, 1);
+    assert.doesNotMatch(res.stderr, /\[object Object\]/, res.stderr);
+  } finally {
+    oldServer.close();
+  }
 });
 
 test('a down server exits 1 with the same hint as status', async () => {

--- a/test/control-csrf.test.js
+++ b/test/control-csrf.test.js
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, isSameOriginControlRequest } from '../src/server.js';
+
+// The control plane exempts loopback from the proxy API key, which is what makes
+// it usable from the CLI with no configuration. The cost is that a web page the
+// operator happens to visit is also "loopback": a cross-origin
+// fetch(..., {mode:'no-cors'}) with a text/plain body is a CORS simple request,
+// so it is sent with no preflight and lands on the endpoint. The page cannot
+// read the reply, but for a mutation that does not matter — forcing the fleet
+// onto one named account is a targeted quota drain.
+//
+// Origin and Sec-Fetch-Site are set by the browser and cannot be forged from
+// page JavaScript, so they are what separates a page from curl.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const CONFIG = { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com' };
+const ACCTS = [
+  { name: 'alice@example.com', type: 'apikey', apiKey: 'k1' },
+  { name: 'bob@example.com', type: 'apikey', apiKey: 'k2' },
+];
+
+async function withServer(fn, hooks = {}) {
+  const am = new AccountManager(ACCTS, 0.98);
+  const proxy = createProxyServer(am, CONFIG, hooks);
+  const port = await listen(proxy);
+  try {
+    await fn(am, port);
+  } finally {
+    proxy.close();
+  }
+}
+
+const switchTo = (port, account, headers = {}) =>
+  fetch(`http://127.0.0.1:${port}/teamclaude/switch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({ account }),
+  });
+
+test('a page cannot switch the account cross-origin', async () => {
+  await withServer(async (am, port) => {
+    assert.equal(am.currentIndex, 0);
+
+    const res = await switchTo(port, 'bob@example.com', { Origin: 'https://evil.example' });
+
+    assert.equal(res.status, 403);
+    assert.match((await res.json()).error, /cross-origin/);
+    // The point of the test: refused means nothing moved, not merely that the
+    // caller was told off after the fact.
+    assert.equal(am.currentIndex, 0, 'a refused request must not have switched the account');
+  });
+});
+
+test('Sec-Fetch-Site is honoured when the browser sends it', async () => {
+  await withServer(async (am, port) => {
+    const res = await switchTo(port, 'bob@example.com', { 'Sec-Fetch-Site': 'cross-site' });
+    assert.equal(res.status, 403);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+// reload is reachable by the identical route and predates the switch endpoint,
+// so the guard has to cover it too or the hole is merely moved.
+test('reload is refused cross-origin as well', async () => {
+  let reloads = 0;
+  await withServer(async (_am, port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/reload`, {
+      method: 'POST',
+      headers: { Origin: 'https://evil.example' },
+    });
+    assert.equal(res.status, 403);
+    assert.equal(reloads, 0, 'a refused reload must not have run');
+  }, { reload: async () => { reloads++; return 0; } });
+});
+
+// The guard is worthless if it also blocks the CLI. curl and teamclaude attach
+// send neither header.
+test('a request with no browser headers still works', async () => {
+  await withServer(async (am, port) => {
+    const res = await switchTo(port, 'bob@example.com');
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).ok, true);
+    assert.equal(am.currentIndex, 1);
+  });
+});
+
+test('a same-origin browser request is allowed through', async () => {
+  await withServer(async (am, port) => {
+    const res = await switchTo(port, 'bob@example.com', {
+      'Sec-Fetch-Site': 'same-origin',
+      Origin: `http://127.0.0.1:${port}`,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(am.currentIndex, 1);
+  });
+});
+
+// Reading status cross-origin is already prevented by the same-origin policy —
+// the page issues the request but cannot see the answer — so the guard is
+// deliberately scoped to mutations and does not break anyone polling status.
+test('the guard applies to mutations, not to reads', async () => {
+  await withServer(async (_am, port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/status`, {
+      headers: { Origin: 'https://evil.example' },
+    });
+    assert.equal(res.status, 200);
+  });
+});
+
+test('isSameOriginControlRequest: Sec-Fetch-Site wins, Origin is the fallback', () => {
+  const req = (headers) => ({ headers });
+  // Explicit browser signal.
+  assert.equal(isSameOriginControlRequest(req({ 'sec-fetch-site': 'same-origin' })), true);
+  assert.equal(isSameOriginControlRequest(req({ 'sec-fetch-site': 'none' })), true);       // typed in the URL bar
+  assert.equal(isSameOriginControlRequest(req({ 'sec-fetch-site': 'cross-site' })), false);
+  assert.equal(isSameOriginControlRequest(req({ 'sec-fetch-site': 'same-site' })), false);
+  // A browser that sends Sec-Fetch-Site is trusted over a stale Origin.
+  assert.equal(isSameOriginControlRequest(req({ 'sec-fetch-site': 'same-origin', origin: 'https://evil.example' })), true);
+  // Fallback: any Origin on a control POST means a page issued it.
+  assert.equal(isSameOriginControlRequest(req({ origin: 'https://evil.example' })), false);
+  // curl and the CLI.
+  assert.equal(isSameOriginControlRequest(req({})), true);
+});

--- a/test/server-switch.test.js
+++ b/test/server-switch.test.js
@@ -1,0 +1,150 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// POST /teamclaude/switch is the headless equivalent of picking an account with
+// 's' in the TUI: both only move the manager's currentIndex. The TUI is not
+// reachable when the proxy runs as a background service, which is what this
+// endpoint exists for.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const CONFIG = { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com' };
+const ACCTS = [
+  { name: 'alice@example.com', type: 'apikey', apiKey: 'k1', accountUuid: 'aaaaaaaa-0000-0000-0000-000000000001' },
+  { name: 'bob@example.com (Acme)', type: 'apikey', apiKey: 'k2', accountUuid: 'bbbbbbbb-0000-0000-0000-000000000002' },
+];
+
+async function post(port, body) {
+  const res = await fetch(`http://127.0.0.1:${port}/teamclaude/switch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+async function withServer(fn, hooks = {}) {
+  const am = new AccountManager(ACCTS, 0.98);
+  const proxy = createProxyServer(am, CONFIG, hooks);
+  const port = await listen(proxy);
+  try {
+    await fn(am, port, proxy);
+  } finally {
+    proxy.close();
+  }
+}
+
+test('switch moves currentIndex and answers with the resolved account name', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: 'bob@example.com (Acme)' }));
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.account, 'bob@example.com (Acme)');
+    assert.equal(am.currentIndex, 1);
+  });
+});
+
+test('switch accepts the same account forms as a pin (uuid, bare email)', async () => {
+  await withServer(async (am, port) => {
+    assert.equal((await post(port, JSON.stringify({ account: 'bbbbbbbb-0000-0000-0000-000000000002' }))).status, 200);
+    assert.equal(am.currentIndex, 1);
+    assert.equal((await post(port, JSON.stringify({ account: 'alice@example.com' }))).status, 200);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+test('the status endpoint reports the switched account', async () => {
+  await withServer(async (am, port) => {
+    await post(port, JSON.stringify({ account: 'bob@example.com (Acme)' }));
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/status`);
+    const status = await res.json();
+    assert.equal(status.currentAccount, 'bob@example.com (Acme)');
+    assert.equal(am.currentIndex, 1);
+  });
+});
+
+test('an unknown account is refused with 404 and the valid names', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: 'nobody@example.com' }));
+    assert.equal(res.status, 404);
+    assert.equal(res.body.ok, false);
+    assert.match(res.body.error, /nobody@example\.com/);
+    assert.deepEqual(res.body.accounts, ['alice@example.com', 'bob@example.com (Acme)']);
+    assert.equal(am.currentIndex, 0, 'a refused switch must not move the current account');
+  });
+});
+
+// The rotation index is array position, so accepting it would silently repoint a
+// script at a DIFFERENT account after a removal. resolveAccountPin refuses it and
+// the endpoint inherits that.
+test('a numeric rotation index is not an account name', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: '1' }));
+    assert.equal(res.status, 404);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+test('a missing or blank account field is a 400, not a switch', async () => {
+  await withServer(async (am, port) => {
+    for (const body of ['{}', JSON.stringify({ account: '' }), JSON.stringify({ account: '   ' }), JSON.stringify({ account: 7 })]) {
+      const res = await post(port, body);
+      assert.equal(res.status, 400, body);
+      assert.equal(res.body.ok, false, body);
+    }
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+test('a malformed body is a 400, not a crash', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, 'not json');
+    assert.equal(res.status, 400);
+    assert.equal(res.body.ok, false);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+// Loopback is exempt from the proxy-key gate (that is what makes the fetch-based
+// tests above work), so the gate itself has to be exercised with a remote peer.
+function remoteRequest(server, { headers = {}, body = '{}' } = {}) {
+  const req = Readable.from([Buffer.from(body)]);
+  req.method = 'POST';
+  req.url = '/teamclaude/switch';
+  req.headers = headers;
+  req.socket = { remoteAddress: '203.0.113.9' };
+
+  const res = {
+    status: null,
+    chunks: '',
+    writeHead(status) { this.status = status; return this; },
+    end(chunk) { if (chunk) this.chunks += chunk; this._done(); },
+  };
+  const finished = new Promise(resolve => { res._done = resolve; });
+  server.emit('request', req, res);
+  return finished.then(() => ({ status: res.status, body: JSON.parse(res.chunks || '{}') }));
+}
+
+test('a remote client without the proxy key cannot switch', async () => {
+  await withServer(async (am, port, server) => {
+    const res = await remoteRequest(server, { body: JSON.stringify({ account: 'bob@example.com (Acme)' }) });
+    assert.equal(res.status, 401);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+test('a remote client with the proxy key can switch', async () => {
+  await withServer(async (am, port, server) => {
+    const res = await remoteRequest(server, {
+      headers: { 'x-api-key': 'tc-test' },
+      body: JSON.stringify({ account: 'bob@example.com (Acme)' }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(am.currentIndex, 1);
+  });
+});

--- a/test/server-switch.test.js
+++ b/test/server-switch.test.js
@@ -7,7 +7,9 @@ import { createProxyServer } from '../src/server.js';
 // POST /teamclaude/switch is the headless equivalent of picking an account with
 // 's' in the TUI: both only move the manager's currentIndex. The TUI is not
 // reachable when the proxy runs as a background service, which is what this
-// endpoint exists for.
+// endpoint exists for. currentIndex is a weak preference — selection drops it
+// when the account is unavailable and also when an available account has a
+// lower priority value — so "recorded" and "in effect" are tested separately.
 
 function listen(server) {
   return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));

--- a/test/server-switch.test.js
+++ b/test/server-switch.test.js
@@ -110,6 +110,76 @@ test('a malformed body is a 400, not a crash', async () => {
   });
 });
 
+// A switch that cannot take effect must not report a bare success. currentIndex
+// still moves (that is the TUI's behaviour), but selection skips an unavailable
+// account on the very next request, so the answer says whether traffic will
+// actually follow the choice.
+test('switching to a disabled account succeeds but reports it as ineligible', async () => {
+  const am = new AccountManager([
+    { name: 'live@example.com', type: 'apikey', apiKey: 'k1' },
+    { name: 'off@example.com', type: 'apikey', apiKey: 'k2', disabled: true },
+  ], 0.98);
+  const proxy = createProxyServer(am, CONFIG, {});
+  const port = await listen(proxy);
+  try {
+    const res = await post(port, JSON.stringify({ account: 'off@example.com' }));
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true, 'the switch is still recorded, as in the TUI');
+    assert.equal(res.body.account, 'off@example.com');
+    assert.equal(res.body.eligible, false);
+    assert.match(res.body.reason, /disabled/);
+    assert.equal(am.currentIndex, 1, 'currentIndex moves even when ineligible');
+    // Proof the report is not pedantic: the next selection abandons the choice.
+    assert.equal(am.getActiveAccount().name, 'live@example.com');
+  } finally {
+    proxy.close();
+  }
+});
+
+test('switching to a usable account reports it as eligible', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: 'bob@example.com (Acme)' }));
+    assert.equal(res.body.eligible, true);
+    assert.equal(res.body.reason, undefined, 'no reason when nothing is wrong');
+    assert.equal(am.getActiveAccount().name, 'bob@example.com (Acme)');
+  });
+});
+
+test('an over-limit body is refused as 413 without echoing parser internals', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: 'a'.repeat(70_000) }));
+    assert.equal(res.status, 413);
+    assert.equal(res.body.ok, false);
+    assert.match(res.body.error, /too large/);
+    assert.equal(am.currentIndex, 0);
+  });
+});
+
+// The log line is the only record of a manual switch on a headless server, so a
+// refactor that drops it must fail something.
+test('a successful switch is logged, and says so when the target is ineligible', async () => {
+  const am = new AccountManager([
+    { name: 'live@example.com', type: 'apikey', apiKey: 'k1' },
+    { name: 'off@example.com', type: 'apikey', apiKey: 'k2', disabled: true },
+  ], 0.98);
+  const proxy = createProxyServer(am, CONFIG, {});
+  const port = await listen(proxy);
+  const lines = [];
+  const origLog = console.log;
+  console.log = (...a) => lines.push(a.join(' '));
+  try {
+    await post(port, JSON.stringify({ account: 'live@example.com' }));
+    await post(port, JSON.stringify({ account: 'off@example.com' }));
+  } finally {
+    console.log = origLog;
+    proxy.close();
+  }
+  assert.ok(lines.some(l => l.includes('live@example.com') && /switch/i.test(l)), lines.join(' | '));
+  const offLine = lines.find(l => l.includes('off@example.com'));
+  assert.ok(offLine, lines.join(' | '));
+  assert.match(offLine, /disabled/, 'the log must not claim a clean switch to an unusable account');
+});
+
 // Loopback is exempt from the proxy-key gate (that is what makes the fetch-based
 // tests above work), so the gate itself has to be exercised with a remote peer.
 function remoteRequest(server, { headers = {}, body = '{}' } = {}) {

--- a/test/server-switch.test.js
+++ b/test/server-switch.test.js
@@ -147,6 +147,60 @@ test('switching to a usable account reports it as eligible', async () => {
   });
 });
 
+// Unavailability is not the only way a switch gets undone. A perfectly healthy
+// account is dropped just as fast when another available account outranks it on
+// priority, so "eligible" has to answer the real question — would a request go
+// here — rather than only "is this account usable at all".
+test('a switch that priority will immediately override is reported as ineligible', async () => {
+  const am = new AccountManager([
+    { name: 'high@example.com', type: 'apikey', apiKey: 'k1', priority: 0 },
+    { name: 'low@example.com', type: 'apikey', apiKey: 'k2', priority: 1 },
+  ], 0.98);
+  const proxy = createProxyServer(am, CONFIG, {});
+  const port = await listen(proxy);
+  try {
+    const res = await post(port, JSON.stringify({ account: 'low@example.com' }));
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true, 'the switch is still recorded');
+    assert.equal(res.body.eligible, false, 'a preempted target is not where traffic will go');
+    assert.match(res.body.reason, /priority/i);
+    assert.match(res.body.reason, /high@example\.com/, 'name the account that wins');
+    assert.equal(am.currentIndex, 1, 'currentIndex still moves');
+    // Proof the report is not pedantic: selection hands it straight back.
+    assert.equal(am.getActiveAccount().name, 'high@example.com');
+  } finally {
+    proxy.close();
+  }
+});
+
+test('switching to the highest-priority account is eligible', async () => {
+  const am = new AccountManager([
+    { name: 'high@example.com', type: 'apikey', apiKey: 'k1', priority: 0 },
+    { name: 'low@example.com', type: 'apikey', apiKey: 'k2', priority: 1 },
+  ], 0.98);
+  const proxy = createProxyServer(am, CONFIG, {});
+  const port = await listen(proxy);
+  try {
+    am.currentIndex = 1;
+    const res = await post(port, JSON.stringify({ account: 'high@example.com' }));
+    assert.equal(res.body.eligible, true);
+    assert.equal(res.body.reason, undefined);
+    assert.equal(am.getActiveAccount().name, 'high@example.com');
+  } finally {
+    proxy.close();
+  }
+});
+
+// Equal priority must NOT read as preemption, or every default fleet would
+// report its own current account as ineligible.
+test('accounts at the same priority do not preempt each other', async () => {
+  await withServer(async (am, port) => {
+    const res = await post(port, JSON.stringify({ account: 'bob@example.com (Acme)' }));
+    assert.equal(res.body.eligible, true);
+    assert.equal(am.getActiveAccount().name, 'bob@example.com (Acme)');
+  });
+});
+
 test('an over-limit body is refused as 413 without echoing parser internals', async () => {
   await withServer(async (am, port) => {
     const res = await post(port, JSON.stringify({ account: 'a'.repeat(70_000) }));


### PR DESCRIPTION
Picking an account by hand was only possible through the TUI's `s` key, which a proxy running as a background service never shows. This adds `POST /teamclaude/switch` and a `teamclaude switch [NAME]` command that drives it, so the same choice exists headlessly.

The semantics mirror the TUI: both move the preferred-account index. That preference is weak, so the endpoint and the command report whether the choice will actually take effect, covering both ways selection can drop it: the account cannot serve traffic, or another available account outranks it on priority. Such a switch is still recorded, exactly as in the TUI, but it comes back marked ineligible with a reason and the command warns instead of printing a bare success. The listing marks those accounts using fields the status endpoint already returns.

The target resolves through the existing account-reference forms (display name, bare email, account UUID, org UUID, or the qualified pair). A rotation index is refused, since it is array position and a script pinned to a number would silently follow a different account after a removal. Nothing is written to config, because the choice is runtime state that dies with the process. A successful switch is logged, so it shows up in the TUI activity pane and the headless activity log like every other account change.

Known and pre-existing, noted for follow-up rather than fixed here: the loopback-exempt control plane has no CSRF protection (reload is reachable the same way), a manual switch opens no storm-control ramp window, and a non-matching `/teamclaude/*` path is proxied upstream. All are control-plane-wide, not specific to this endpoint.
