### PR TITLE
feat(tui): attach the dashboard to a running server

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,6 +113,7 @@ teamclaude env               # Print export lines for routing claude yourself
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude status            # Show live proxy status (requires running server)
+teamclaude attach            # Open the live dashboard against a running server
 teamclaude switch [name]     # Prefer an account; no name lists them (needs server)
 teamclaude remove <name>     # Remove an account (by name or email)
 teamclaude disable <name>    # Temporarily exclude an account from rotation
@@ -128,6 +129,8 @@ teamclaude help              # Show all commands
 ```
 
 `teamclaude status` prints the same picture as the TUI, once, as text. Handy over SSH or in a script; `--json` for machine-readable output.
+
+`teamclaude attach` opens the dashboard itself against a server that is already running, which is how you get interactive control back when the proxy runs as a background service. It polls the same status endpoint every second and can do the two things the control plane exposes: `s` switches account, `R` reloads config. Settings editing, quota probing and the request activity stream stay in the server's own TUI — they need state that only that process has. When contact with the server drops, the header marker turns from `▲` to `▼` and what is on screen is the last snapshot, not the current state.
 
 ![teamclaude status output](assets/status-redacted.png)
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -99,6 +99,14 @@ function modelMatches(declared, model) {
   return declared === model || declared.replace(/\[\d+m\]$/, '') === model;
 }
 
+// A representative model for a route's own globs, used to report what that route
+// does right now (which accounts may serve it, and which one it would pick).
+// Taken from the route object rather than looked up by name, so two routes
+// sharing a name are still each described by their own globs.
+function sampleModelFor(route) {
+  return route.match[0].replace(/\*/g, '') || 'model';
+}
+
 export class AccountManager {
   constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
     // How long a just-minted token is trusted against a forced refresh.
@@ -692,7 +700,7 @@ export class AccountManager {
       name: r.name, match: r.match, bucket: r.bucket, color: r.color || null, autocreated: false,
       pinned: this._pinnedName(r.name),
       accounts: this._routeAccountsView(r),
-      target: this._routeTarget(this._routeSample(r.name)),
+      target: this._routeTarget(sampleModelFor(r)),
     }));
 
     const detected = [];
@@ -730,7 +738,7 @@ export class AccountManager {
   /** Accounts a configured route can use (all accounts when it lists none), each
    * with a live eligibility flag for a representative model of the route. */
   _routeAccountsView(route) {
-    const sample = route.match[0].replace(/\*/g, '') || 'model';
+    const sample = sampleModelFor(route);
     const inRoute = a => !route.accounts.length
       || route.accounts.includes(a.name) || route.accounts.includes(String(a.index));
     return this.accounts.filter(inRoute).map(a => ({ name: a.name, eligible: this._isAvailable(a, sample) }));

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -683,13 +683,16 @@ export class AccountManager {
    * own weekly bucket but no configured route already covers. Auto-created routes
    * carry `autocreated: true` and are never persisted — they simply surface the
    * per-model quota the server already respects. Each route lists the accounts it
-   * can use with a live eligibility flag.
+   * can use with a live eligibility flag, plus `target`: the one account it would
+   * pick right now. Everything here is derived for display and thrown away — the
+   * entries are fresh objects, never the stored (persisted) route definitions.
    */
   getRoutes() {
     const out = this.routes.map(r => ({
       name: r.name, match: r.match, bucket: r.bucket, color: r.color || null, autocreated: false,
       pinned: this._pinnedName(r.name),
       accounts: this._routeAccountsView(r),
+      target: this._routeTarget(this._routeSample(r.name)),
     }));
 
     const detected = [];
@@ -705,9 +708,17 @@ export class AccountManager {
         name: d.name, match: d.match, bucket: null, color: null, autocreated: true,
         pinned: this._pinnedName(d.name),
         accounts: this.accounts.map(a => ({ name: a.name, eligible: this._isAvailable(a, d.sample) })),
+        target: this._routeTarget(d.sample),
       });
     }
     return out;
+  }
+
+  /** The name of the account a request for `model` would land on right now, or
+   * null when nothing can serve it (every candidate disabled, spent or excluded). */
+  _routeTarget(model) {
+    const idx = this.previewRouteIndex(model);
+    return idx == null ? null : (this.accounts[idx]?.name ?? null);
   }
 
   /** The name of the account this route is manually pinned to, or null. */

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { ensureCerts } from './mitm.js';
 import { Prober } from './prober.js';
 import { Warmer } from './warmer.js';
 import { TUI } from './tui.js';
+import { RemoteControl, createAttachSession } from './tui-remote.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
@@ -48,6 +49,10 @@ switch (command) {
     break;
   case 'status':
     await statusCommand();
+    process.exit(0);
+    break;
+  case 'attach':
+    await attachCommand();
     process.exit(0);
     break;
   case 'accounts':
@@ -824,6 +829,38 @@ async function statusCommand() {
   }
 }
 
+// ── attach ──────────────────────────────────────────────────
+
+// The interactive dashboard against a server that is ALREADY running. A proxy
+// installed as a background service has no foreground TUI, so this is the only
+// way to watch and steer it live; it renders from polled status and can only do
+// what the control plane exposes (switch, reload).
+async function attachCommand() {
+  const config = await loadOrCreateConfig();
+  const port = config.proxy.port;
+
+  // Checked before connecting: the dashboard needs raw-mode input, and failing
+  // on that after a successful poll would be a confusing order to report it in.
+  if (!process.stdin.isTTY) {
+    console.error('teamclaude attach needs a terminal. For a one-shot readout use: teamclaude status');
+    process.exit(1);
+  }
+
+  const control = new RemoteControl({ port, apiKey: config.proxy.apiKey });
+  try {
+    await control.status(); // fail here, with a usable message, not inside the TUI
+  } catch (err) {
+    console.error('Cannot connect to proxy at localhost:' + port);
+    console.error('Is the server running? Start with: teamclaude server');
+    if (err?.message) console.error(`Details: ${err.message}`);
+    process.exit(1);
+  }
+
+  await new Promise(resolve => {
+    createAttachSession({ control, config, onQuit: resolve }).start();
+  });
+}
+
 // ── switch ──────────────────────────────────────────────────
 
 // Manual account switch against a RUNNING server — the headless equivalent of
@@ -1456,6 +1493,8 @@ Commands:
                       'print' writes the unit to stdout without touching anything)
   status [--json]     Show rich proxy/account/probe status (live)
                       Use --color=always|never to control ANSI colors
+  attach              Open the live dashboard against a running server; s
+                      switches account, R reloads config, q leaves it running
   accounts            List configured accounts
   switch [NAME]       Make the running server prefer one account (as 's' in the
                       TUI does); with no NAME, list accounts and mark the current

--- a/src/index.js
+++ b/src/index.js
@@ -838,6 +838,12 @@ async function statusCommand() {
 async function attachCommand() {
   const config = await loadOrCreateConfig();
   const port = config.proxy.port;
+  // Reach the server where it actually binds (see serverCommand): a host set in
+  // the config or the environment is not reachable as localhost, and reporting
+  // "not running" for a server that is plainly up is the worst of the answers.
+  // A wildcard bind is not an address to dial, so dial this machine instead.
+  const bound = process.env.TEAMCLAUDE_HOST || config.proxy.host || '127.0.0.1';
+  const host = (bound === '0.0.0.0' || bound === '::') ? '127.0.0.1' : bound;
 
   // Checked before connecting: the dashboard needs raw-mode input, and failing
   // on that after a successful poll would be a confusing order to report it in.
@@ -846,18 +852,23 @@ async function attachCommand() {
     process.exit(1);
   }
 
-  const control = new RemoteControl({ port, apiKey: config.proxy.apiKey });
+  const control = new RemoteControl({ port, host, apiKey: config.proxy.apiKey });
+  let first;
   try {
-    await control.status(); // fail here, with a usable message, not inside the TUI
+    first = await control.status(); // fail here, with a usable message, not inside the TUI
   } catch (err) {
-    console.error('Cannot connect to proxy at localhost:' + port);
+    console.error(`Cannot connect to proxy at ${host}:${port}`);
     console.error('Is the server running? Start with: teamclaude server');
     if (err?.message) console.error(`Details: ${err.message}`);
     process.exit(1);
   }
 
   await new Promise(resolve => {
-    createAttachSession({ control, config, onQuit: resolve }).start();
+    const session = createAttachSession({ control, config, onQuit: resolve });
+    // The status just fetched is the first frame: without it the alt-screen opens
+    // on a disconnected, empty dashboard until the first poll lands.
+    session.am.applyStatus(first);
+    session.start();
   });
 }
 

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -18,13 +18,20 @@ export class RemoteControl {
   }
 
   /** The current status payload (the same one `teamclaude status` renders). */
-  status() {
-    return this._call('GET', '/teamclaude/status');
+  async status() {
+    const payload = await this._call('GET', '/teamclaude/status');
+    // A status reply always carries an accounts array, even when it is empty.
+    // Anything else answered on this port is not this control plane, and calling
+    // that "connected with no accounts" would diagnose the wrong problem.
+    if (!Array.isArray(payload?.accounts)) {
+      throw new Error('unexpected reply — this is not a teamclaude status endpoint');
+    }
+    return payload;
   }
 
   /** Re-read config and refresh credentials on the running server. */
   reload() {
-    return this._call('POST', '/teamclaude/reload');
+    return this._action('POST', '/teamclaude/reload');
   }
 
   /**
@@ -39,13 +46,28 @@ export class RemoteControl {
    */
   async switchAccount(name) {
     try {
-      return await this._call('POST', '/teamclaude/switch', { account: name });
+      return await this._action('POST', '/teamclaude/switch', { account: name });
     } catch (err) {
       if (!err.answered && (err.status === 404 || err.status === 501)) {
         throw new Error('this server does not support switching accounts');
       }
       throw err;
     }
+  }
+
+  /**
+   * A call that changes something on the server.
+   *
+   * The control plane confirms an applied action with `ok: true`. A 200 carrying
+   * anything else did not perform it — the configured port may well be answering
+   * from some other service, which will happily 200 an unknown POST — and
+   * reporting success from a bare status code would invent a switch that never
+   * happened.
+   */
+  async _action(method, path, body) {
+    const payload = await this._call(method, path, body);
+    if (payload?.ok !== true) throw new Error('unexpected reply — this is not a teamclaude control endpoint');
+    return payload;
   }
 
   async _call(method, path, body) {
@@ -66,7 +88,12 @@ export class RemoteControl {
       // anything else reached a handler that is not ours (an old server forwards
       // unknown paths upstream, and Anthropic's error body looks nothing like it).
       const answered = payload?.ok === false && typeof payload.error === 'string';
-      const err = new Error(answered ? payload.error : `HTTP ${res.status}`);
+      // A rejected key needs a different fix from an unreachable server, so it is
+      // worth naming: the config's proxy.apiKey does not match the running one.
+      const auth = !answered && (res.status === 401 || res.status === 403);
+      const err = new Error(auth
+        ? `the server rejected the proxy API key (HTTP ${res.status})`
+        : answered ? payload.error : `HTTP ${res.status}`);
       err.status = res.status;
       err.answered = answered;
       throw err;
@@ -99,7 +126,16 @@ export class RemoteAccountManager {
 
   applyStatus(status) {
     const accounts = Array.isArray(status?.accounts) ? status.accounts : [];
-    this.accounts = accounts.map((a, index) => ({ ...a, index, quota: { ...(a.quota || {}) } }));
+    // The payload crosses a process boundary, and the renderer calls string
+    // methods on name/type unguarded: a malformed reply (wrong port, older or
+    // newer server) should read as unknown, not take the dashboard down.
+    this.accounts = accounts.map((a, index) => ({
+      ...a,
+      index,
+      name: a.name || '(unnamed)',
+      type: a.type || '?',
+      quota: { ...(a.quota || {}) },
+    }));
     // -1 when the payload names an account that is no longer listed: nothing is
     // marked current, which is the truth, rather than defaulting to the first row.
     this.currentIndex = this.accounts.findIndex(a => a.name === status?.currentAccount);

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -152,6 +152,7 @@ export class RemoteAccountManager {
 export function createAttachSession({ control, config, onQuit, pollMs = DEFAULT_POLL_MS }) {
   const am = new RemoteAccountManager();
   let timer = null;
+  let polling = false;
 
   const stop = () => {
     if (timer) { clearInterval(timer); timer = null; }
@@ -170,6 +171,10 @@ export function createAttachSession({ control, config, onQuit, pollMs = DEFAULT_
   });
 
   const poll = async () => {
+    // A server that accepts the connection and then never answers would other-
+    // wise collect one pending request per tick, for as long as it stays wedged.
+    if (polling) return;
+    polling = true;
     try {
       const status = await control.status();
       const recovered = !am.connected && am.lastError != null;
@@ -181,6 +186,8 @@ export function createAttachSession({ control, config, onQuit, pollMs = DEFAULT_
         tui._addLog(`Lost contact with the server: ${err.message}`);
       }
       am.markDisconnected(err);
+    } finally {
+      polling = false;
     }
     tui.render();
   };

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -7,13 +7,21 @@ import { modelGlobMatches } from './model.js';
 // to a status snapshot polled over the localhost control plane.
 
 const DEFAULT_POLL_MS = 1000;
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// Addresses that reach this machine. A server bound to one of these exempts
+// loopback clients from the proxy-key gate, which changes what a 401 can mean.
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
 
 /** Client for the server's control endpoints. */
 export class RemoteControl {
-  constructor({ port, apiKey = null, host = '127.0.0.1', fetchImpl = fetch }) {
+  constructor({ port, apiKey = null, host = '127.0.0.1', fetchImpl = fetch, timeoutMs = null }) {
     this.port = port;
     this.apiKey = apiKey;
     this.host = host;
+    // null = unset, so a caller that knows its own cadence (the attach poller)
+    // can derive one; DEFAULT_TIMEOUT_MS covers the one-shot callers.
+    this.timeoutMs = timeoutMs;
     this._fetch = fetchImpl;
   }
 
@@ -71,14 +79,27 @@ export class RemoteControl {
   }
 
   async _call(method, path, body) {
+    const deadline = this.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const headers = {};
     if (this.apiKey) headers['x-api-key'] = this.apiKey;
     if (body !== undefined) headers['content-type'] = 'application/json';
 
-    const res = await this._fetch(`http://${this.host}:${this.port}${path}`, {
-      method, headers,
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
+    let res;
+    try {
+      res = await this._fetch(`http://${this.host}:${this.port}${path}`, {
+        method, headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        // A socket that is open but silent — the server stopped, the laptop
+        // suspended mid-request — would otherwise hold this call for minutes
+        // while the dashboard showed a live marker over a frozen snapshot.
+        signal: AbortSignal.timeout(deadline),
+      });
+    } catch (err) {
+      if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+        throw new Error(`no reply within ${deadline}ms`);
+      }
+      throw err;
+    }
     const text = await res.text();
     let payload = null;
     try { payload = text ? JSON.parse(text) : null; } catch { /* not JSON — the status carries the meaning */ }
@@ -88,11 +109,15 @@ export class RemoteControl {
       // anything else reached a handler that is not ours (an old server forwards
       // unknown paths upstream, and Anthropic's error body looks nothing like it).
       const answered = payload?.ok === false && typeof payload.error === 'string';
-      // A rejected key needs a different fix from an unreachable server, so it is
-      // worth naming: the config's proxy.apiKey does not match the running one.
+      // 401/403 needs a different fix from an unreachable server — but which fix
+      // depends on where we are pointed. A teamclaude server exempts loopback
+      // clients from the key gate, so a 401 from there cannot be about the key
+      // and blaming it would send the operator to edit a config that is fine.
       const auth = !answered && (res.status === 401 || res.status === 403);
       const err = new Error(auth
-        ? `the server rejected the proxy API key (HTTP ${res.status})`
+        ? (LOOPBACK_HOSTS.has(this.host)
+          ? `something other than teamclaude is answering on port ${this.port} (HTTP ${res.status})`
+          : `the server rejected the proxy API key (HTTP ${res.status})`)
         : answered ? payload.error : `HTTP ${res.status}`);
       err.status = res.status;
       err.answered = answered;
@@ -148,7 +173,14 @@ export class RemoteAccountManager {
       perAccount: sessions.perAccount || {},
     };
     this.distributeSessions = !!sessions.distribute;
-    this.routes = Array.isArray(status?.routes) ? status.routes : [];
+    // Same rule as the accounts above, and for the same reason: the renderer
+    // walks route.accounts and route.match directly, so a route the payload
+    // leaves half-specified would take the whole dashboard down mid-frame.
+    this.routes = (Array.isArray(status?.routes) ? status.routes : []).map(r => ({
+      ...r,
+      match: Array.isArray(r?.match) ? r.match : [],
+      accounts: Array.isArray(r?.accounts) ? r.accounts : [],
+    }));
     this.status = status;
     this.connected = true;
     this.lastError = null;
@@ -189,6 +221,10 @@ export function createAttachSession({ control, config, onQuit, pollMs = DEFAULT_
   const am = new RemoteAccountManager();
   let timer = null;
   let polling = false;
+  // A poll still outstanding after a few intervals is not going to arrive, and
+  // holding it hides an outage behind the last good frame. An explicitly
+  // configured deadline wins.
+  control.timeoutMs ??= Math.max(2000, pollMs * 3);
 
   const stop = () => {
     if (timer) { clearInterval(timer); timer = null; }

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -28,16 +28,20 @@ export class RemoteControl {
   }
 
   /**
-   * Point the running server's default route at `name`.
+   * Make the running server prefer `name`.
    *
-   * A server predating the endpoint answers 404 — reported as such rather than
-   * swallowed, so the dashboard never shows a switch that did not happen.
+   * The endpoint answers 404 for an account it cannot resolve, and a server
+   * predating the endpoint has no handler for the path at all — two different
+   * failures behind one status code. The control endpoints always answer with
+   * `ok: false` plus a reason, so a 404 without that came from somewhere else
+   * and means the feature is missing. Either way it is reported, never swallowed:
+   * the dashboard must not show a switch that did not happen.
    */
   async switchAccount(name) {
     try {
       return await this._call('POST', '/teamclaude/switch', { account: name });
     } catch (err) {
-      if (err.status === 404 || err.status === 501) {
+      if (!err.answered && (err.status === 404 || err.status === 501)) {
         throw new Error('this server does not support switching accounts');
       }
       throw err;
@@ -58,8 +62,13 @@ export class RemoteControl {
     try { payload = text ? JSON.parse(text) : null; } catch { /* not JSON — the status carries the meaning */ }
 
     if (!res.ok) {
-      const err = new Error(payload?.error ? `HTTP ${res.status}: ${payload.error}` : `HTTP ${res.status}`);
+      // `ok: false` + a string reason is this control plane's own error shape;
+      // anything else reached a handler that is not ours (an old server forwards
+      // unknown paths upstream, and Anthropic's error body looks nothing like it).
+      const answered = payload?.ok === false && typeof payload.error === 'string';
+      const err = new Error(answered ? payload.error : `HTTP ${res.status}`);
       err.status = res.status;
+      err.answered = answered;
       throw err;
     }
     // A 200 body can still report failure (the reload endpoint does this).

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -1,0 +1,186 @@
+import { TUI } from './tui.js';
+import { modelGlobMatches } from './model.js';
+
+// Attach mode — the dashboard against a server running somewhere else (a
+// background service, another terminal). The renderer is the same one the
+// in-process TUI uses; only its data source changes, from a live AccountManager
+// to a status snapshot polled over the localhost control plane.
+
+const DEFAULT_POLL_MS = 1000;
+
+/** Client for the server's control endpoints. */
+export class RemoteControl {
+  constructor({ port, apiKey = null, host = '127.0.0.1', fetchImpl = fetch }) {
+    this.port = port;
+    this.apiKey = apiKey;
+    this.host = host;
+    this._fetch = fetchImpl;
+  }
+
+  /** The current status payload (the same one `teamclaude status` renders). */
+  status() {
+    return this._call('GET', '/teamclaude/status');
+  }
+
+  /** Re-read config and refresh credentials on the running server. */
+  reload() {
+    return this._call('POST', '/teamclaude/reload');
+  }
+
+  /**
+   * Point the running server's default route at `name`.
+   *
+   * A server predating the endpoint answers 404 — reported as such rather than
+   * swallowed, so the dashboard never shows a switch that did not happen.
+   */
+  async switchAccount(name) {
+    try {
+      return await this._call('POST', '/teamclaude/switch', { account: name });
+    } catch (err) {
+      if (err.status === 404 || err.status === 501) {
+        throw new Error('this server does not support switching accounts');
+      }
+      throw err;
+    }
+  }
+
+  async _call(method, path, body) {
+    const headers = {};
+    if (this.apiKey) headers['x-api-key'] = this.apiKey;
+    if (body !== undefined) headers['content-type'] = 'application/json';
+
+    const res = await this._fetch(`http://${this.host}:${this.port}${path}`, {
+      method, headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let payload = null;
+    try { payload = text ? JSON.parse(text) : null; } catch { /* not JSON — the status carries the meaning */ }
+
+    if (!res.ok) {
+      const err = new Error(payload?.error ? `HTTP ${res.status}: ${payload.error}` : `HTTP ${res.status}`);
+      err.status = res.status;
+      throw err;
+    }
+    // A 200 body can still report failure (the reload endpoint does this).
+    if (payload && payload.ok === false) throw new Error(payload.error || 'request rejected');
+    return payload;
+  }
+}
+
+/**
+ * The read surface the dashboard renders from, filled from a status payload.
+ *
+ * Deliberately not an AccountManager: attach mode has no rotation state of its
+ * own, and anything the payload does not carry stays absent rather than being
+ * guessed at.
+ */
+export class RemoteAccountManager {
+  constructor() {
+    this.accounts = [];
+    this.currentIndex = -1;
+    this.switchThreshold = 0.98;
+    this.distributeSessions = false;
+    this.routes = [];
+    this.sessions = { active: 0, known: 0, perAccount: {} };
+    this.connected = false;   // false ⇒ the view is a stale snapshot
+    this.lastError = null;
+    this.status = null;
+  }
+
+  applyStatus(status) {
+    const accounts = Array.isArray(status?.accounts) ? status.accounts : [];
+    this.accounts = accounts.map((a, index) => ({ ...a, index, quota: { ...(a.quota || {}) } }));
+    // -1 when the payload names an account that is no longer listed: nothing is
+    // marked current, which is the truth, rather than defaulting to the first row.
+    this.currentIndex = this.accounts.findIndex(a => a.name === status?.currentAccount);
+    if (status?.switchThreshold != null) this.switchThreshold = status.switchThreshold;
+
+    const sessions = status?.sessions || {};
+    this.sessions = {
+      active: sessions.active || 0,
+      known: sessions.known || 0,
+      perAccount: sessions.perAccount || {},
+    };
+    this.distributeSessions = !!sessions.distribute;
+    this.routes = Array.isArray(status?.routes) ? status.routes : [];
+    this.status = status;
+    this.connected = true;
+    this.lastError = null;
+  }
+
+  markDisconnected(err) {
+    this.connected = false;
+    this.lastError = err?.message || String(err);
+  }
+
+  sessionStats() {
+    return { ...this.sessions };
+  }
+
+  getRoutes() {
+    return this.routes;
+  }
+
+  /** The account index a request for `model` would land on, from the route
+   * target the server published, or null when no route matches or none can
+   * serve it. */
+  previewRouteIndex(model) {
+    const route = this.routes.find(r => (r.match || []).some(g => modelGlobMatches(g, model)));
+    if (!route?.target) return null;
+    const idx = this.accounts.findIndex(a => a.name === route.target);
+    return idx >= 0 ? idx : null;
+  }
+
+  /** Quota windows expire on the server, which re-reports them; nothing to do. */
+  refreshExpiredQuotas() {}
+}
+
+/**
+ * Wire a dashboard to a remote server: polling, control actions and quit.
+ * Returns the pieces so a caller (or a test) can drive the poll itself.
+ */
+export function createAttachSession({ control, config, onQuit, pollMs = DEFAULT_POLL_MS }) {
+  const am = new RemoteAccountManager();
+  let timer = null;
+
+  const stop = () => {
+    if (timer) { clearInterval(timer); timer = null; }
+  };
+
+  const tui = new TUI({
+    accountManager: am,
+    config,
+    remote: true,
+    // Every screen that writes config is unreachable in attach mode; if one ever
+    // becomes reachable, this fails loudly instead of silently dropping a save.
+    saveConfig: async () => { throw new Error('attach mode cannot write config'); },
+    syncAccounts: async () => (await control.reload())?.added || 0,
+    applySwitch: name => control.switchAccount(name),
+    onQuit: () => { stop(); onQuit?.(); },
+  });
+
+  const poll = async () => {
+    try {
+      const status = await control.status();
+      const recovered = !am.connected && am.lastError != null;
+      am.applyStatus(status);
+      if (recovered) tui._addLog('Reconnected to the server');
+    } catch (err) {
+      // One line per outage, not one per second.
+      if (am.connected || am.lastError == null) {
+        tui._addLog(`Lost contact with the server: ${err.message}`);
+      }
+      am.markDisconnected(err);
+    }
+    tui.render();
+  };
+
+  const start = () => {
+    tui.start();
+    poll();
+    timer = setInterval(poll, pollMs);
+  };
+
+  return { tui, am, poll, start, stop };
+}

--- a/src/tui.js
+++ b/src/tui.js
@@ -192,10 +192,16 @@ function timestamp() {
 
 export class TUI {
   constructor({ accountManager, config, saveConfig, syncAccounts, onQuit, sx = null, probeQuota = null, activityLogPath = null,
+    // Attach mode: the accounts belong to a server in another process, reached
+    // over its control plane. Everything that would mutate local state is off,
+    // and a switch becomes a request (applySwitch) instead of an assignment.
+    remote = false, applySwitch = null,
     // Injectable so the import path can be exercised without a real credentials
     // file or a live profile call.
     readCredentials = importCredentials, readProfile = fetchProfile }) {
     this.am = accountManager;
+    this.remote = remote;
+    this.applySwitch = applySwitch;
     this.config = config;
     this.saveConfig = saveConfig;
     this.syncAccounts = syncAccounts;
@@ -379,13 +385,18 @@ export class TUI {
   _keyNormal(k) {
     if (k === 'q') { this.stop(); this.onQuit?.(); }
     else if (k === 's' && this.am.accounts.length > 0) {
-      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = this.am.currentIndex; this.selRoute = null; this.selReturn = 'normal';
+      // currentIndex is -1 when nothing is marked current (attach mode, when the
+      // server names an account that has since gone); start at the top instead.
+      this.mode = 'select'; this.selAction = 'switch'; this.selIdx = Math.max(0, this.am.currentIndex); this.selRoute = null; this.selReturn = 'normal';
     }
+    else if (k === 'R') { this._doSync(); }
+    // The keys below all edit local state or call out to Anthropic, neither of
+    // which attach mode can do — the server owns both.
+    else if (this.remote) { /* nothing else is available here */ }
     else if (k === 'd' && this.am.accounts.length > 0) {
       this.mode = 'select'; this.selAction = 'toggle'; this.selIdx = this.am.currentIndex; this.selReturn = 'normal';
     }
     else if (k === 'p' && this.am.accounts.length > 0) { this._doProbe(); }
-    else if (k === 'R') { this._doSync(); }
     else if (k === 'g') { this.mode = 'settings'; this.setIdx = 0; this._loadSxBalance(); }
   }
 
@@ -611,8 +622,10 @@ export class TUI {
     // Tab / ←→ (switch only): cycle which route the pick applies to. null = the
     // global default account; each getRoutes() entry = a per-route manual pin.
     // ↑↓ move within the account list, so ←→ are free to move across targets.
-    else if ((k === 'tab' || k === 'right') && this.selAction === 'switch') this._cycleSelRoute(+1);
-    else if (k === 'left' && this.selAction === 'switch') this._cycleSelRoute(-1);
+    // Pins are runtime state of the server's rotation, so attach mode — which
+    // can only ask for the default account — leaves these keys alone.
+    else if ((k === 'tab' || k === 'right') && this.selAction === 'switch' && !this.remote) this._cycleSelRoute(+1);
+    else if (k === 'left' && this.selAction === 'switch' && !this.remote) this._cycleSelRoute(-1);
     else if (k === 'enter') {
       if (this.selAction === 'switch') {
         this._doSwitchSelection();
@@ -644,6 +657,11 @@ export class TUI {
   // retry, rather than silently returning to normal.
   _doSwitchSelection() {
     const acct = this.am.accounts[this.selIdx];
+    // The list can shrink under the cursor between polls in attach mode.
+    if (!acct) return;
+    // Attach mode: the rotation lives in another process, so this is a request
+    // whose result the next poll reflects, not a local assignment.
+    if (this.applySwitch) { this.mode = 'normal'; this._doSwitchRemote(acct); return; }
     if (this.selRoute === null) {
       this.am.currentIndex = this.selIdx;
       this._addLog(`Switched to "${acct.name}"`);
@@ -664,6 +682,18 @@ export class TUI {
     } else {
       this._addLog(`Can't pin: ${res.reason}`); // stay in select mode to retry
     }
+  }
+
+  // Ask the running server to switch. A failure is reported as one, so the
+  // dashboard never implies a switch that the server refused.
+  async _doSwitchRemote(acct) {
+    try {
+      await this.applySwitch(acct.name);
+      this._addLog(`Switched to "${acct.name}"`);
+    } catch (e) {
+      this._addLog(`Switch failed: ${e.message}`);
+    }
+    if (this.running) this.render();
   }
 
   // The add chooser is opened from the settings screen (g → Add account), so
@@ -980,7 +1010,10 @@ export class TUI {
     const sessStr = (sess.active || sess.known)
       ? `${sess.active} sess${this.am.distributeSessions ? green(' dist') : ''}  `
       : '';
-    const right = `${sessStr}Port ${port} ${green('▲')} `;
+    // ▼ marks a dashboard that lost contact with the server it polls (attach
+    // mode): what is on screen is the last snapshot, not the current state.
+    const live = this.am.connected === false ? red('▼') : green('▲');
+    const right = `${sessStr}Port ${port} ${live} `;
     lines.push(left + ' '.repeat(Math.max(1, W - vw(left) - vw(right))) + right);
     lines.push(' ' + dim('─'.repeat(W - 2)));
 
@@ -1036,11 +1069,13 @@ export class TUI {
     // ► marks a route the account serves — next to the F7/S7 bar for a Fable/Sonnet
     // route, at the row start for a general route — bold when it's the route's pin.
 
-    // ── Activity header
+    // ── Activity header. Attach mode sees no request traffic — the server logs
+    // that in its own process — so the pane is named for what it does hold:
+    // messages from the actions taken here.
     lines.push('');
     const ac = this.active.size;
     const acTag = ac > 0 ? `  ${cyan(ac + ' active')}` : '';
-    const aHdr = ` Activity${acTag} `;
+    const aHdr = this.remote ? ' Messages ' : ` Activity${acTag} `;
     lines.push(aHdr + dim('─'.repeat(Math.max(1, W - vw(aHdr)))));
 
     // Active requests
@@ -1541,7 +1576,9 @@ export class TUI {
   _renderFooter() {
     switch (this.mode) {
       case 'normal':
-        return ` ${bold('s')}witch  ${bold('d')}isable  ${bold('p')}robe quota  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
+        return this.remote
+          ? ` ${bold('s')}witch  ${bold('R')}eload  ${bold('q')}uit`
+          : ` ${bold('s')}witch  ${bold('d')}isable  ${bold('p')}robe quota  ${bold('R')}eload  ${bold('g')} settings  ${bold('q')}uit`;
       case 'settings':
         return ` ${dim('↑↓')} navigate  ${dim('←→')} change  ${bold('Enter')} edit  ${bold('Esc')} back`;
       case 'routes':
@@ -1553,6 +1590,9 @@ export class TUI {
       case 'blocklist':
         return ` ${dim('↑↓')} select  ${bold('a')}dd  ${bold('d')}elete  ${bold('Esc')} back`;
       case 'select': {
+        if (this.selAction === 'switch' && this.remote) {
+          return ` ${dim('↑↓')} select  ${bold('Enter')} switch  ${bold('Esc')} cancel`;
+        }
         if (this.selAction === 'switch') {
           const target = this.selRoute
             ? routeColorFn(this.selRoute.color)(`route ${this.selRoute.name}`)

--- a/src/tui.js
+++ b/src/tui.js
@@ -695,9 +695,18 @@ export class TUI {
       // switch applied to an account that cannot currently serve requests, which
       // the row already shows but is worth stating at the moment it is chosen.
       const name = res?.account || acct.name;
-      this._addLog(res?.eligible === false
-        ? `Switched to "${name}" — it cannot serve requests right now`
-        : `Switched to "${name}"`);
+      if (res?.eligible === false) {
+        // The server knows WHY — disabled, out of quota, outranked by a
+        // higher-priority account — so quote it rather than restating the
+        // generic case. Control characters and length are clamped: this string
+        // arrives over the wire and is drawn into a fixed-width frame.
+        // The server's reasons are phrased to follow "<name> is ...", so they are
+        // composed that way here too.
+        const given = typeof res.reason === 'string' ? res.reason.replace(/\p{C}/gu, ' ').trim().slice(0, 60) : '';
+        this._addLog(`Switched to "${name}" — ${given ? `it is ${given}` : 'it cannot serve requests right now'}`);
+      } else {
+        this._addLog(`Switched to "${name}"`);
+      }
     } catch (e) {
       this._addLog(`Switch failed: ${e.message}`);
     }

--- a/src/tui.js
+++ b/src/tui.js
@@ -657,8 +657,9 @@ export class TUI {
   // retry, rather than silently returning to normal.
   _doSwitchSelection() {
     const acct = this.am.accounts[this.selIdx];
-    // The list can shrink under the cursor between polls in attach mode.
-    if (!acct) return;
+    // The list can shrink under the cursor between polls in attach mode. Say so
+    // rather than swallowing the keypress.
+    if (!acct) { this.mode = 'normal'; this._addLog('That account is no longer listed'); return; }
     // Attach mode: the rotation lives in another process, so this is a request
     // whose result the next poll reflects, not a local assignment.
     if (this.applySwitch) { this.mode = 'normal'; this._doSwitchRemote(acct); return; }
@@ -1039,7 +1040,11 @@ export class TUI {
     // ── Accounts
     if (this.am.accounts.length === 0) {
       lines.push('');
-      lines.push(yellow('  No accounts configured. Press [g] → Add account.'));
+      // Attach mode cannot add an account, and pointing at a key that does
+      // nothing here would be worse than saying only what is known.
+      lines.push(yellow(this.remote
+        ? '  The server reports no accounts.'
+        : '  No accounts configured. Press [g] → Add account.'));
     } else {
       lines.push('');
       const showBoth = W >= 70;

--- a/src/tui.js
+++ b/src/tui.js
@@ -689,8 +689,15 @@ export class TUI {
   // dashboard never implies a switch that the server refused.
   async _doSwitchRemote(acct) {
     try {
-      await this.applySwitch(acct.name);
-      this._addLog(`Switched to "${acct.name}"`);
+      const res = await this.applySwitch(acct.name);
+      // The server resolves the name it was given and echoes what it settled on;
+      // prefer that over what was highlighted here. `eligible: false` means the
+      // switch applied to an account that cannot currently serve requests, which
+      // the row already shows but is worth stating at the moment it is chosen.
+      const name = res?.account || acct.name;
+      this._addLog(res?.eligible === false
+        ? `Switched to "${name}" — it cannot serve requests right now`
+        : `Switched to "${name}"`);
     } catch (e) {
       this._addLog(`Switch failed: ${e.message}`);
     }

--- a/test/route-target.test.js
+++ b/test/route-target.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// The `target` field on a getRoutes() entry: the account that route would pick
+// for a request right now. The dashboard draws one marker per route from it, so
+// it has to track live eligibility rather than route membership.
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+const byName = (routes, name) => routes.find(r => r.name === name);
+
+test('a route names the account it currently resolves to', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'] }],
+  });
+  assert.equal(byName(am.getRoutes(), 'bulk').target, 'a');
+
+  am.setRoutePin('bulk', 1);
+  assert.equal(byName(am.getRoutes(), 'bulk').target, 'b'); // pin moves the target
+});
+
+test('an auto-detected family route names its live target', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  for (const acc of am.accounts) {
+    acc.quota.unified7dFable = 0.1;
+    acc.quota.unified7dFableReset = Date.now() + 3600_000;
+  }
+  assert.equal(byName(am.getRoutes(), 'fable').target, 'a');
+
+  // a's Fable bucket crosses the switch threshold — the bucket, not the account,
+  // is what moves the marker.
+  am.accounts[0].quota.unified7dFable = 0.999;
+  assert.equal(byName(am.getRoutes(), 'fable').target, 'b');
+});
+
+test('target is null when no account can serve the route', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98, {
+    routes: [{ name: 'bulk', match: ['*opus*'], accounts: ['a'] }], // only a may serve it
+  });
+  am.setDisabled(0, true);
+  assert.equal(byName(am.getRoutes(), 'bulk').target, null);
+});
+
+test('target stays null-safe with no accounts and no quota data', () => {
+  const empty = new AccountManager([], 0.98, { routes: [{ name: 'bulk', match: ['*opus*'] }] });
+  const emptyRoutes = empty.getRoutes();
+  assert.equal(byName(emptyRoutes, 'bulk').target, null);
+  assert.deepEqual(emptyRoutes.filter(r => r.autocreated), []); // no quota → no family routes
+
+  // Accounts present but never probed: no family buckets, configured route still resolves.
+  const unprobed = new AccountManager([oauth('a')], 0.98, { routes: [{ name: 'bulk', match: ['*opus*'] }] });
+  const routes = unprobed.getRoutes();
+  assert.equal(byName(routes, 'bulk').target, 'a');
+  assert.deepEqual(routes.filter(r => r.autocreated), []);
+});
+
+test('target is derived for display only and never reaches the stored routing table', () => {
+  const configured = [{ name: 'bulk', match: ['*opus*'] }];
+  const am = new AccountManager([oauth('a')], 0.98, { routes: configured });
+  am.getRoutes();
+
+  // The config array the caller handed in — the object that gets written back to
+  // disk — must be untouched, as must the manager's normalized copy.
+  assert.equal('target' in configured[0], false);
+  assert.equal('target' in am.routes[0], false);
+});

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -141,6 +141,33 @@ test('an unresolvable account is reported by reason, not as a missing feature', 
   await assert.rejects(() => control.switchAccount('ghost'), /no such account "ghost"/);
 });
 
+// Something else listening on the configured port answers 200 to anything. A
+// bare 200 is not evidence that an account was switched.
+test('a 200 from something that is not this control plane is not a switch', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html>hello</html>');
+      },
+    },
+  });
+  await assert.rejects(() => control.switchAccount('alpha'), /not a teamclaude control endpoint/);
+});
+
+test('a rejected proxy API key is named, not reported as an outage', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': (req, res) => {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'Invalid proxy API key' } }));
+      },
+    },
+  });
+  await assert.rejects(() => control.status(), /API key/);
+});
+
 test('a rejection reported with 200 is still a rejection', async (t) => {
   const { control } = await makeSession(t, {
     routes: {
@@ -197,6 +224,39 @@ test('a status payload with no routes and no quota data renders nothing rather t
   assert.deepEqual(am.accounts[0].quota, {});
   assert.deepEqual(am.sessionStats(), { active: 0, known: 0, perAccount: {} });
   am.refreshExpiredQuotas(); // server-side concern; must be a harmless no-op here
+});
+
+// The payload comes from another process over a port the user configured, so a
+// reply can be JSON and still not be the status this dashboard expects.
+test('a payload missing the fields the renderer formats reads as unknown, not a crash', async (t) => {
+  const { am, tui } = await makeSession(t);
+  am.applyStatus({ accounts: [{ status: 'active' }, {}] });
+  assert.deepEqual(am.accounts.map(a => [a.name, a.type]), [['(unnamed)', '?'], ['(unnamed)', '?']]);
+  const out = renderToString(tui);
+  assert.match(out, /\(unnamed\)/);
+});
+
+// "Connected, no accounts" would send the user looking at their account list;
+// the actual problem is that the port answers from something else entirely.
+test('a reply that is not a status payload is a connection problem, not an empty fleet', async (t) => {
+  const { session, am, tui } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json({ hello: 'this is some other service' }) },
+  });
+  await session.poll();
+  assert.equal(am.connected, false);
+  assert.match(tui.log[0].msg, /not a teamclaude status endpoint/);
+  assert.deepEqual(am.accounts, []);
+});
+
+test('an empty but genuine fleet is reported as such, without pointing at dead keys', async (t) => {
+  const { session, am, tui } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json({ accounts: [], switchThreshold: 0.98 }) },
+  });
+  await session.poll();
+  assert.equal(am.connected, true);
+  const out = renderToString(tui);
+  assert.match(out, /server reports no accounts/);
+  assert.doesNotMatch(out, /\[g\]/); // never point at a key attach mode ignores
 });
 
 test('a lost connection keeps the last snapshot and says it is stale', async (t) => {
@@ -320,6 +380,20 @@ test('a rejected switch is reported and leaves the view alone', async (t) => {
   await settle();
   assert.equal(tui.mode, 'normal');
   assert.match(tui.log[0].msg, /switch failed/i);
+});
+
+test('a row that vanished between polls reports that nothing happened', async (t) => {
+  const { tui, am, seen } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('down'); // cursor on the second account
+  am.applyStatus(statusFixture({ accounts: [statusFixture().accounts[0]] })); // it goes away
+  tui._key('enter');
+  await settle();
+
+  assert.equal(tui.mode, 'normal');
+  assert.match(tui.log[0].msg, /no longer listed/i);
+  assert.deepEqual(seen, []); // and nothing was asked of the server
 });
 
 test('route pinning is not offered in attach mode', async (t) => {

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -8,7 +8,24 @@ import { RemoteControl, createAttachSession } from '../src/tui-remote.js';
 // status payloads, so the client is exercised over the wire it actually uses.
 
 const stripAnsi = s => s.replace(/\x1b\[[0-9;]*m/g, '');
-const settle = () => new Promise(r => setTimeout(r, 5));
+
+// Every action here crosses a real socket, so wait for the thing to have
+// happened rather than for a duration: a fixed sleep is a race that a loaded
+// machine loses, and these tests run alongside the rest of the suite.
+async function waitFor(predicate, what, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise(r => setTimeout(r, 2));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+const logged = tui => waitFor(() => tui.log.length > 0, 'a message in the pane');
+const reached = seen => waitFor(() => seen.length > 0, 'a request to reach the server');
+// Only for asserting that nothing happens: there is no condition to wait on, so
+// this has to be a duration, and it is generous on purpose.
+const nothingHappens = () => new Promise(r => setTimeout(r, 50));
 
 const HOUR = 3600_000;
 
@@ -316,7 +333,7 @@ test('a wedged server does not collect one pending request per tick', async (t) 
   });
 
   const first = session.poll();
-  await settle(); // let that one reach the server, where it now hangs
+  await reached(seen); // let that one reach the server, where it now hangs
   await session.poll(); // a tick landing while the first is still in flight
   await session.poll();
   assert.equal(seen.length, 1);
@@ -334,7 +351,7 @@ test('keys that would need write endpoints are inert in attach mode', async (t) 
   const { tui, am, seen } = await makeSession(t);
   am.applyStatus(statusFixture());
   for (const k of ['g', 'd', 'p', 'a', 'r']) tui._key(k);
-  await settle();
+  await nothingHappens();
   assert.equal(tui.mode, 'normal');
   assert.deepEqual(tui.log, []);
   assert.deepEqual(seen, []); // nothing was sent to the server
@@ -343,7 +360,7 @@ test('keys that would need write endpoints are inert in attach mode', async (t) 
 test('R reloads the running server and reports the outcome', async (t) => {
   const { tui, seen } = await makeSession(t);
   tui._key('R');
-  await settle();
+  await logged(tui);
   assert.deepEqual(seen.map(r => [r.method, r.url]), [['POST', '/teamclaude/reload']]);
   assert.equal(tui.log.length, 1);
   assert.match(tui.log[0].msg, /reload/i);
@@ -354,7 +371,7 @@ test('R reports a failed reload instead of pretending it worked', async (t) => {
     routes: { 'GET /teamclaude/status': json(statusFixture()) }, // no reload route
   });
   tui._key('R');
-  await settle();
+  await logged(tui);
   assert.match(tui.log[0].msg, /failed/i);
 });
 
@@ -366,7 +383,7 @@ test('s switches the running server to the selected account', async (t) => {
   assert.equal(tui.mode, 'select');
   tui._key('up'); // from "bravo" (current) to "alpha"
   tui._key('enter');
-  await settle();
+  await logged(tui);
 
   assert.equal(tui.mode, 'normal');
   assert.deepEqual(JSON.parse(seen.at(-1).body), { account: 'alpha' });
@@ -386,8 +403,48 @@ test('switching to an account that cannot serve says so', async (t) => {
   am.applyStatus(statusFixture());
   tui._key('s');
   tui._key('enter');
-  await settle();
+  await logged(tui);
   assert.match(tui.log[0].msg, /cannot serve requests/);
+});
+
+test('the server\'s own reason for ineligibility is what gets shown', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': json({
+        ok: true, account: 'alpha', eligible: false,
+        reason: 'outranked by higher-priority account "bravo"',
+      }),
+    },
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await logged(tui);
+  assert.match(tui.log[0].msg, /it is outranked by higher-priority account "bravo"/);
+});
+
+// The reason crosses the wire and is drawn into a fixed-width frame.
+test('a reason carrying control characters cannot corrupt the frame', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': json({
+        ok: true, account: 'alpha', eligible: false,
+        reason: `disabled\x1b[2J\r\n${'x'.repeat(200)}`,
+      }),
+    },
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await logged(tui);
+
+  const msg = tui.log[0].msg;
+  assert.doesNotMatch(msg, /\x1b/);
+  assert.doesNotMatch(msg, /[\r\n]/);
+  assert.ok(msg.length < 120, `reason should be clamped, got ${msg.length} chars`);
+  assert.match(msg, /disabled/);
 });
 
 test('a switch reports the name the server settled on', async (t) => {
@@ -401,7 +458,7 @@ test('a switch reports the name the server settled on', async (t) => {
   am.applyStatus(statusFixture());
   tui._key('s');
   tui._key('enter');
-  await settle();
+  await logged(tui);
   assert.match(tui.log[0].msg, /Switched to "bravo \(Acme\)"/);
 });
 
@@ -412,7 +469,7 @@ test('a rejected switch is reported and leaves the view alone', async (t) => {
   am.applyStatus(statusFixture());
   tui._key('s');
   tui._key('enter');
-  await settle();
+  await logged(tui);
   assert.equal(tui.mode, 'normal');
   assert.match(tui.log[0].msg, /switch failed/i);
 });
@@ -424,7 +481,7 @@ test('a row that vanished between polls reports that nothing happened', async (t
   tui._key('down'); // cursor on the second account
   am.applyStatus(statusFixture({ accounts: [statusFixture().accounts[0]] })); // it goes away
   tui._key('enter');
-  await settle();
+  await logged(tui);
 
   assert.equal(tui.mode, 'normal');
   assert.match(tui.log[0].msg, /no longer listed/i);
@@ -445,7 +502,7 @@ test('switching with nothing marked current starts at the first account', async 
   am.applyStatus(statusFixture({ currentAccount: 'gone' }));
   tui._key('s');
   tui._key('enter');
-  await settle();
+  await logged(tui);
   assert.deepEqual(JSON.parse(seen.at(-1).body), { account: 'alpha' });
 });
 

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -1,0 +1,338 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { RemoteControl, RemoteAccountManager, createAttachSession } from '../src/tui-remote.js';
+
+// Attach mode: a dashboard driven by polled /teamclaude/status instead of a live
+// AccountManager. The control plane here is a real HTTP server serving canned
+// status payloads, so the client is exercised over the wire it actually uses.
+
+const stripAnsi = s => s.replace(/\x1b\[[0-9;]*m/g, '');
+const settle = () => new Promise(r => setTimeout(r, 5));
+
+const HOUR = 3600_000;
+
+function statusFixture(over = {}) {
+  const reset = Date.now() + HOUR;
+  return {
+    server: { startedAt: new Date().toISOString(), uptimeSeconds: 42, port: 3456 },
+    probe: { enabled: false, intervalSeconds: 0, running: false, accounts: [] },
+    warm: { enabled: false, intervalSeconds: 0, running: false, accounts: [] },
+    currentAccount: 'bravo',
+    switchThreshold: 0.98,
+    sessions: { active: 2, known: 3, distribute: true, perAccount: { 0: 1, 1: 1 } },
+    routes: [{
+      name: 'fable', match: ['*fable*'], bucket: null, color: null, autocreated: true,
+      pinned: null, target: 'alpha',
+      accounts: [{ name: 'alpha', eligible: true }, { name: 'bravo', eligible: true }],
+    }],
+    accounts: [
+      {
+        name: 'alpha', type: 'oauth', orgName: null, priority: 0, disabled: false,
+        status: 'active', sessions: 1,
+        quota: { unified5h: 0.4, unified5hReset: reset, unified7d: 0.2, unified7dReset: reset, unified7dFable: 0.1, unified7dFableReset: reset },
+        usage: { totalRequests: 5 }, rateLimitedUntil: null, pausedUntil: null,
+      },
+      {
+        name: 'bravo', type: 'apikey', orgName: null, priority: 0, disabled: false,
+        status: 'active', sessions: 1,
+        quota: { unified5h: 0.1, unified5hReset: reset, unified7d: 0.1, unified7dReset: reset },
+        usage: { totalRequests: 2 }, rateLimitedUntil: null, pausedUntil: null,
+      },
+    ],
+    ...over,
+  };
+}
+
+// A stand-in control plane. `routes` maps "METHOD /path" to a handler; anything
+// unmapped answers 404, which is how an older server without the switch endpoint
+// behaves.
+async function fakeServer(t, routes = {}) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      seen.push({ method: req.method, url: req.url, key: req.headers['x-api-key'], body });
+      const handler = routes[`${req.method} ${req.url}`];
+      if (!handler) { res.writeHead(404, { 'Content-Type': 'application/json' }); res.end('{"error":"not found"}'); return; }
+      handler(req, res);
+    });
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise(resolve => server.close(resolve)));
+  return { server, seen, port: server.address().port };
+}
+
+const json = payload => (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+};
+
+async function makeSession(t, { routes, status = statusFixture() } = {}) {
+  const fake = await fakeServer(t, routes || {
+    'GET /teamclaude/status': json(status),
+    'POST /teamclaude/reload': json({ ok: true, added: 0 }),
+    'POST /teamclaude/switch': json({ ok: true }),
+  });
+  const control = new RemoteControl({ port: fake.port, apiKey: 'secret' });
+  const quits = [];
+  const session = createAttachSession({
+    control,
+    config: { proxy: { port: fake.port, apiKey: 'secret' } },
+    onQuit: () => quits.push(true),
+  });
+  session.tui.render = () => {}; // bypass the terminal, as the other TUI tests do
+  return { ...fake, control, session, tui: session.tui, am: session.am, quits };
+}
+
+// ── control client ───────────────────────────────────────────
+
+test('the status call carries the proxy API key and returns the payload', async (t) => {
+  const { control, seen } = await makeSession(t);
+  const status = await control.status();
+  assert.equal(status.currentAccount, 'bravo');
+  assert.deepEqual(
+    seen.map(r => [r.method, r.url, r.key]),
+    [['GET', '/teamclaude/status', 'secret']],
+  );
+});
+
+test('a non-2xx status reply is an error, not a half-empty dashboard', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': (req, res) => { res.writeHead(500); res.end('boom'); } },
+  });
+  await assert.rejects(() => control.status(), /500/);
+});
+
+test('reload posts to the existing control endpoint', async (t) => {
+  const { control, seen } = await makeSession(t);
+  assert.deepEqual(await control.reload(), { ok: true, added: 0 });
+  assert.deepEqual(seen.map(r => [r.method, r.url]), [['POST', '/teamclaude/reload']]);
+});
+
+test('switching names the account in the request body', async (t) => {
+  const { control, seen } = await makeSession(t);
+  await control.switchAccount('alpha');
+  assert.deepEqual(seen.map(r => [r.method, r.url]), [['POST', '/teamclaude/switch']]);
+  assert.deepEqual(JSON.parse(seen[0].body), { account: 'alpha' });
+});
+
+test('a server without the switch endpoint says so instead of reporting success', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json(statusFixture()) }, // no switch route
+  });
+  await assert.rejects(() => control.switchAccount('alpha'), /does not support/i);
+});
+
+// ── status → account-manager adapter ─────────────────────────
+
+test('a status payload fills the read surface the dashboard renders from', async (t) => {
+  const { am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+
+  assert.deepEqual(am.accounts.map(a => a.name), ['alpha', 'bravo']);
+  assert.deepEqual(am.accounts.map(a => a.index), [0, 1]);
+  assert.equal(am.accounts[0].quota.unified7dFable, 0.1);
+  assert.equal(am.currentIndex, 1); // "bravo"
+  assert.equal(am.switchThreshold, 0.98);
+  assert.equal(am.distributeSessions, true);
+  assert.deepEqual(am.sessionStats(), { active: 2, known: 3, perAccount: { 0: 1, 1: 1 } });
+  assert.equal(am.getRoutes()[0].name, 'fable');
+  assert.equal(am.connected, true);
+});
+
+test('an unknown current account marks nothing current rather than guessing', async (t) => {
+  const { am } = await makeSession(t);
+  am.applyStatus(statusFixture({ currentAccount: 'gone' }));
+  assert.equal(am.currentIndex, -1);
+});
+
+test('previewRouteIndex resolves a route target by glob', async (t) => {
+  const { am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  assert.equal(am.previewRouteIndex('claude-fable-5'), 0); // route target "alpha"
+  assert.equal(am.previewRouteIndex('claude-opus-4'), null); // no route matches
+});
+
+test('a route with no serving account yields no marker', async (t) => {
+  const { am } = await makeSession(t);
+  const status = statusFixture();
+  status.routes[0].target = null;
+  am.applyStatus(status);
+  assert.equal(am.previewRouteIndex('claude-fable-5'), null);
+});
+
+test('a status payload with no routes and no quota data renders nothing rather than throwing', async (t) => {
+  const { am } = await makeSession(t);
+  am.applyStatus({ accounts: [{ name: 'alpha', type: 'oauth', status: 'active' }] });
+  assert.deepEqual(am.getRoutes(), []);
+  assert.equal(am.previewRouteIndex('claude-fable-5'), null);
+  assert.deepEqual(am.accounts[0].quota, {});
+  assert.deepEqual(am.sessionStats(), { active: 0, known: 0, perAccount: {} });
+  am.refreshExpiredQuotas(); // server-side concern; must be a harmless no-op here
+});
+
+test('a lost connection keeps the last snapshot and says it is stale', async (t) => {
+  const { am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  am.markDisconnected(new Error('ECONNREFUSED'));
+
+  assert.equal(am.connected, false);
+  assert.match(am.lastError, /ECONNREFUSED/);
+  assert.deepEqual(am.accounts.map(a => a.name), ['alpha', 'bravo']); // last known state kept
+
+  am.applyStatus(statusFixture());
+  assert.equal(am.connected, true);
+  assert.equal(am.lastError, null);
+});
+
+// ── polling ──────────────────────────────────────────────────
+
+test('a poll applies the payload; a failing poll flags the header and logs once', async (t) => {
+  let fail = false;
+  const { session, am, tui } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': (req, res) => {
+        if (fail) { res.writeHead(503); res.end('down'); return; }
+        json(statusFixture())(req, res);
+      },
+    },
+  });
+
+  await session.poll();
+  assert.equal(am.connected, true);
+  assert.equal(am.accounts.length, 2);
+
+  fail = true;
+  await session.poll();
+  assert.equal(am.connected, false);
+  const dropped = tui.log.filter(l => /lost|503/i.test(l.msg));
+  assert.equal(dropped.length, 1);
+
+  await session.poll(); // still down — do not repeat the message every second
+  assert.equal(tui.log.filter(l => /lost|503/i.test(l.msg)).length, 1);
+});
+
+// ── keys ─────────────────────────────────────────────────────
+
+test('keys that would need write endpoints are inert in attach mode', async (t) => {
+  const { tui, am, seen } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  for (const k of ['g', 'd', 'p', 'a', 'r']) tui._key(k);
+  await settle();
+  assert.equal(tui.mode, 'normal');
+  assert.deepEqual(tui.log, []);
+  assert.deepEqual(seen, []); // nothing was sent to the server
+});
+
+test('R reloads the running server and reports the outcome', async (t) => {
+  const { tui, seen } = await makeSession(t);
+  tui._key('R');
+  await settle();
+  assert.deepEqual(seen.map(r => [r.method, r.url]), [['POST', '/teamclaude/reload']]);
+  assert.equal(tui.log.length, 1);
+  assert.match(tui.log[0].msg, /reload/i);
+});
+
+test('R reports a failed reload instead of pretending it worked', async (t) => {
+  const { tui } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json(statusFixture()) }, // no reload route
+  });
+  tui._key('R');
+  await settle();
+  assert.match(tui.log[0].msg, /failed/i);
+});
+
+test('s switches the running server to the selected account', async (t) => {
+  const { tui, am, seen } = await makeSession(t);
+  am.applyStatus(statusFixture());
+
+  tui._key('s');
+  assert.equal(tui.mode, 'select');
+  tui._key('up'); // from "bravo" (current) to "alpha"
+  tui._key('enter');
+  await settle();
+
+  assert.equal(tui.mode, 'normal');
+  assert.deepEqual(JSON.parse(seen.at(-1).body), { account: 'alpha' });
+  assert.match(tui.log[0].msg, /alpha/);
+});
+
+test('a rejected switch is reported and leaves the view alone', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json(statusFixture()) }, // no switch route
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await settle();
+  assert.equal(tui.mode, 'normal');
+  assert.match(tui.log[0].msg, /switch failed/i);
+});
+
+test('route pinning is not offered in attach mode', async (t) => {
+  const { tui, am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('right');
+  tui._key('tab');
+  assert.equal(tui.selRoute, null); // no per-route pin target to cycle to
+});
+
+test('switching with nothing marked current starts at the first account', async (t) => {
+  const { tui, am, seen } = await makeSession(t);
+  am.applyStatus(statusFixture({ currentAccount: 'gone' }));
+  tui._key('s');
+  tui._key('enter');
+  await settle();
+  assert.deepEqual(JSON.parse(seen.at(-1).body), { account: 'alpha' });
+});
+
+test('q leaves attach mode without touching the server', async (t) => {
+  const { tui, quits, seen } = await makeSession(t);
+  tui.stop = () => {}; // no terminal to restore in a test
+  tui._key('q');
+  assert.deepEqual(quits, [true]);
+  assert.deepEqual(seen, []);
+});
+
+// ── rendering ────────────────────────────────────────────────
+
+function renderToString(tui) {
+  const chunks = [];
+  const orig = process.stdout.write;
+  process.stdout.write = chunk => { chunks.push(chunk); return true; };
+  try { tui.running = true; tui._render(); } finally { process.stdout.write = orig; }
+  return stripAnsi(chunks.join(''));
+}
+
+test('the dashboard renders accounts from a status payload alone', async (t) => {
+  const { tui, am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  const out = renderToString(tui);
+
+  assert.match(out, /alpha/);
+  assert.match(out, /bravo/);
+  assert.match(out, /oauth/);
+  assert.match(out, /▲/); // connected
+  assert.match(out, /switch/); // attach footer
+  assert.doesNotMatch(out, /settings/); // settings screen is not reachable here
+});
+
+test('a stale dashboard says so instead of looking live', async (t) => {
+  const { tui, am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  am.markDisconnected(new Error('ECONNREFUSED'));
+  const out = renderToString(tui);
+
+  assert.match(out, /▼/); // disconnected marker in the header
+  assert.doesNotMatch(out, /▲/);
+});
+
+test('attach mode does not present an activity stream it cannot see', async (t) => {
+  const { tui, am } = await makeSession(t);
+  am.applyStatus(statusFixture());
+  const out = renderToString(tui);
+  assert.doesNotMatch(out, /Activity/);
+});

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -125,6 +125,32 @@ test('a server without the switch endpoint says so instead of reporting success'
   await assert.rejects(() => control.switchAccount('alpha'), /does not support/i);
 });
 
+// The endpoint answers 404 for an account it cannot resolve, which is a
+// different failure from the path not existing at all — and the only thing
+// separating them is the control plane's own { ok: false, error } shape.
+test('an unresolvable account is reported by reason, not as a missing feature', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': (req, res) => {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'no such account "ghost"', accounts: ['alpha', 'bravo'] }));
+      },
+    },
+  });
+  await assert.rejects(() => control.switchAccount('ghost'), /no such account "ghost"/);
+});
+
+test('a rejection reported with 200 is still a rejection', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/reload': json({ ok: false, error: 'reload not supported' }),
+    },
+  });
+  await assert.rejects(() => control.reload(), /reload not supported/);
+});
+
 // ── status → account-manager adapter ─────────────────────────
 
 test('a status payload fills the read surface the dashboard renders from', async (t) => {

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -370,6 +370,38 @@ test('s switches the running server to the selected account', async (t) => {
   assert.match(tui.log[0].msg, /alpha/);
 });
 
+// The server applies a switch to a disabled account and says so with
+// eligible:false. The row already carries the disabled marker, but the moment of
+// choosing is where it matters.
+test('switching to an account that cannot serve says so', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': json({ ok: true, account: 'alpha', eligible: false }),
+    },
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await settle();
+  assert.match(tui.log[0].msg, /cannot serve requests/);
+});
+
+test('a switch reports the name the server settled on', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      // resolveAccountPin canonicalises what it is given; the echo is the truth.
+      'POST /teamclaude/switch': json({ ok: true, account: 'bravo (Acme)' }),
+    },
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await settle();
+  assert.match(tui.log[0].msg, /Switched to "bravo \(Acme\)"/);
+});
+
 test('a rejected switch is reported and leaves the view alone', async (t) => {
   const { tui, am } = await makeSession(t, {
     routes: { 'GET /teamclaude/status': json(statusFixture()) }, // no switch route

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
-import { RemoteControl, RemoteAccountManager, createAttachSession } from '../src/tui-remote.js';
+import { RemoteControl, createAttachSession } from '../src/tui-remote.js';
 
 // Attach mode: a dashboard driven by polled /teamclaude/status instead of a live
 // AccountManager. The control plane here is a real HTTP server serving canned
@@ -238,6 +238,31 @@ test('a poll applies the payload; a failing poll flags the header and logs once'
 
   await session.poll(); // still down — do not repeat the message every second
   assert.equal(tui.log.filter(l => /lost|503/i.test(l.msg)).length, 1);
+});
+
+test('a wedged server does not collect one pending request per tick', async (t) => {
+  let release;
+  const held = new Promise(resolve => { release = resolve; });
+  const { session, seen } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': async (req, res) => {
+        await held; // accepted, answered only when the test lets go
+        json(statusFixture())(req, res);
+      },
+    },
+  });
+
+  const first = session.poll();
+  await settle(); // let that one reach the server, where it now hangs
+  await session.poll(); // a tick landing while the first is still in flight
+  await session.poll();
+  assert.equal(seen.length, 1);
+
+  release();
+  await first;
+  assert.equal(seen.length, 1);
+  await session.poll(); // the door reopens once the outstanding call finishes
+  assert.equal(seen.length, 2);
 });
 
 // ── keys ─────────────────────────────────────────────────────

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -60,7 +60,10 @@ async function fakeServer(t, routes = {}) {
     });
   });
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-  t.after(() => new Promise(resolve => server.close(resolve)));
+  // fetch() pools keep-alive sockets, and server.close() waits for them: without
+  // dropping them explicitly the teardown lingers and leaves sockets behind for
+  // whatever runs next.
+  t.after(() => new Promise(resolve => { server.closeAllConnections(); server.close(resolve); }));
   return { server, seen, port: server.address().port };
 }
 

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -84,6 +84,10 @@ async function fakeServer(t, routes = {}) {
   return { server, seen, port: server.address().port };
 }
 
+// The three members _call reads off a fetch reply. Cheaper than a real Response,
+// and it keeps these tests free of fetch globals.
+const reply = (status, body) => ({ ok: status >= 200 && status < 300, status, text: async () => body });
+
 const json = payload => (req, res) => {
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(payload));
@@ -174,18 +178,6 @@ test('a 200 from something that is not this control plane is not a switch', asyn
     },
   });
   await assert.rejects(() => control.switchAccount('alpha'), /not a teamclaude control endpoint/);
-});
-
-test('a rejected proxy API key is named, not reported as an outage', async (t) => {
-  const { control } = await makeSession(t, {
-    routes: {
-      'GET /teamclaude/status': (req, res) => {
-        res.writeHead(401, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'Invalid proxy API key' } }));
-      },
-    },
-  });
-  await assert.rejects(() => control.status(), /API key/);
 });
 
 test('a rejection reported with 200 is still a rejection', async (t) => {
@@ -343,6 +335,82 @@ test('a wedged server does not collect one pending request per tick', async (t) 
   assert.equal(seen.length, 1);
   await session.poll(); // the door reopens once the outstanding call finishes
   assert.equal(seen.length, 2);
+});
+
+// A server that accepts the connection and then goes silent — SIGSTOPped, or the
+// laptop suspended mid-request — must read as lost contact. Without a deadline the
+// dashboard sits on a frozen snapshot under a green marker for minutes.
+test('a poll that never gets an answer becomes a lost connection, not a live view', async (t) => {
+  const never = new Promise(() => {});
+  const fake = await fakeServer(t, { 'GET /teamclaude/status': async () => { await never; } });
+  const control = new RemoteControl({ port: fake.port, apiKey: 'secret', timeoutMs: 60 });
+  const session = createAttachSession({ control, config: { proxy: { port: fake.port } }, onQuit: () => {} });
+  session.tui.render = () => {};
+
+  await session.am.applyStatus(statusFixture()); // start from a good snapshot
+  await session.poll();
+
+  assert.equal(session.am.connected, false);
+  assert.match(session.tui.log[0].msg, /no reply within/);
+  assert.deepEqual(session.am.accounts.map(a => a.name), ['alpha', 'bravo']); // snapshot kept, marked stale
+  session.stop();
+});
+
+test('the poll deadline is derived from the poll interval', async (t) => {
+  const fake = await fakeServer(t, { 'GET /teamclaude/status': json(statusFixture()) });
+  const control = new RemoteControl({ port: fake.port });
+  const session = createAttachSession({ control, config: { proxy: { port: fake.port } }, onQuit: () => {}, pollMs: 4000 });
+  assert.equal(control.timeoutMs, 12_000);
+  session.stop();
+
+  const fixed = new RemoteControl({ port: fake.port, timeoutMs: 250 });
+  createAttachSession({ control: fixed, config: {}, onQuit: () => {}, pollMs: 4000 }).stop();
+  assert.equal(fixed.timeoutMs, 250); // an explicit deadline is not overridden
+});
+
+// A general (non-family) route is drawn as a marker column on every account row,
+// which reaches into route.accounts. The payload is not ours to trust.
+test('a general route renders, and a half-specified one does not take the dashboard down', async (t) => {
+  const { tui, am } = await makeSession(t);
+  const status = statusFixture();
+  status.routes = [
+    { name: 'bulk', match: ['*opus*'], color: 'green', autocreated: false, pinned: 'alpha', target: 'alpha',
+      accounts: [{ name: 'alpha', eligible: true }] },
+    { name: 'broken' }, // no match, no accounts, no target
+  ];
+  am.applyStatus(status);
+
+  assert.deepEqual(am.getRoutes().map(r => r.accounts), [[{ name: 'alpha', eligible: true }], []]);
+  assert.deepEqual(am.getRoutes()[1].match, []);
+  const out = renderToString(tui);
+  assert.match(out, /alpha/);
+  assert.match(out, /bravo/);
+  assert.equal(am.previewRouteIndex('claude-opus-4'), 0); // the general route still resolves
+});
+
+test('the control client talks to the host it was given', async () => {
+  const calls = [];
+  const control = new RemoteControl({
+    port: 3456, host: '192.0.2.10',
+    fetchImpl: async url => { calls.push(url); return reply(200, '{"accounts":[]}'); },
+  });
+  await control.status();
+  assert.deepEqual(calls, ['http://192.0.2.10:3456/teamclaude/status']);
+});
+
+test('on loopback a 401 blames the port, not the key the server never checks', async (t) => {
+  const unauthorized = (req, res) => { res.writeHead(401); res.end('nope'); };
+  const local = await fakeServer(t, { 'GET /teamclaude/status': unauthorized });
+  await assert.rejects(
+    () => new RemoteControl({ port: local.port, host: '127.0.0.1', apiKey: 'k' }).status(),
+    /something other than teamclaude/i,
+  );
+  // A non-loopback server DOES gate on the key, so there the key is the suspect.
+  const remote = new RemoteControl({
+    port: 3456, host: '192.0.2.10', apiKey: 'k',
+    fetchImpl: async () => reply(401, 'nope'),
+  });
+  await assert.rejects(() => remote.status(), /rejected the proxy API key/i);
 });
 
 // ── keys ─────────────────────────────────────────────────────


### PR DESCRIPTION
The dashboard only existed inside a foreground `teamclaude server` process. Installed as a background service the proxy has no terminal, so switching an account or reloading config meant one-shot CLI calls with no live picture of quota or routing while doing it. `teamclaude attach` opens the same dashboard against a server that is already running.

It renders from the existing status endpoint, polled once a second, through an adapter that fills the narrow read surface the renderer previously wanted from a live account manager. Two keys act: `s` switches account, `R` reloads config. Nothing else is offered, because the rest of the settings screens write local state or call Anthropic, which only the server process can do. The one thing the renderer needed and status did not carry is the account each route currently resolves to, so the routing table now reports it.

Failures are surfaced rather than smoothed over. Losing contact flips the header marker and what is on screen is the last snapshot, not the current state. An action counts as done only when the control plane confirms it with its own reply shape, so a stale port answering 200 to an unknown POST cannot produce a switch that never happened, and a rejected API key is named separately from an unreachable server. A switch onto an account that cannot take traffic is reported with the server's own reason for it.

The routing table's `target` field is derived per call and is never written to config. The attach test waits on conditions rather than fixed sleeps, since a fixed sleep raced a real socket round trip and lost it under a parallel suite.

Stacked on #169, whose switch endpoint the `s` key calls. Until that merges this branch contains its commits, so review the last few commits here for the attach-specific change.
