### PR TITLE
fix(status): show blocked models instead of reporting them available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -369,6 +369,10 @@ async function serverCommand() {
   // Expose reload to the proxy's control endpoint (works with or without TUI).
   hooks.reload = reloadAccounts;
   hooks.getStatusExtra = () => ({
+    // Read live from the shared config (not a startup snapshot) so the TUI's
+    // blocklist editor shows up in `status` immediately, the same way the
+    // per-request gate in server.js picks it up.
+    blockedModels: [...(config.blockedModels || [])],
     server: {
       startedAt: new Date(serverStartedAt).toISOString(),
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),

--- a/src/model.js
+++ b/src/model.js
@@ -52,6 +52,40 @@ function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// The `blockedModels` pattern that takes a model FAMILY out of service, or null.
+//
+// The blocklist is written against concrete model ids (`*fable*`,
+// `claude-fable-5`) but the status view reasons in families (`Fable`), so a
+// direct glob match is not enough: `claude-fable-5` never matches the literal
+// string `Fable`. Both spellings are checked so the two natural ways to block a
+// family light up the same row — the glob (via modelGlobMatches, which also
+// makes a bare `*` block everything) and a concrete id (via substring).
+//
+// Deliberately advisory: this drives display only. The authoritative gate is the
+// per-request check in server.js, which matches the real model id. A pattern
+// that names no family (say `claude-3-*`) simply lights up no row, and the
+// header list still shows it verbatim.
+// Do two model globs describe any model in common? Used to tell whether a route
+// is fully shadowed by the blocklist. Exact glob intersection is not decidable
+// in general, so this compares literal cores (the pattern with `*` removed) in
+// both directions: `claude-fable-5` overlaps `*fable*`, and a bare `*` (empty
+// core) overlaps everything. Display-only, and deliberately inclusive — the
+// authoritative per-request gate still matches the concrete model id.
+export function modelGlobOverlaps(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const core = s => s.replace(/\*/g, '').toLowerCase();
+  const ca = core(a);
+  const cb = core(b);
+  return ca.includes(cb) || cb.includes(ca);
+}
+
+export function findFamilyBlock(patterns, family) {
+  if (!Array.isArray(patterns) || !family) return null;
+  const key = String(family).toLowerCase();
+  return patterns.find(p => typeof p === 'string'
+    && (modelGlobMatches(p, key) || p.toLowerCase().includes(key))) || null;
+}
+
 // Streaming, byte-exact locator for a TOP-LEVEL string field of a JSON object,
 // fed incrementally. It tracks JSON structure (container stack, key/value,
 // string/escape) so it ONLY matches the field at depth 1 of the root object —

--- a/src/model.js
+++ b/src/model.js
@@ -52,19 +52,6 @@ function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// The `blockedModels` pattern that takes a model FAMILY out of service, or null.
-//
-// The blocklist is written against concrete model ids (`*fable*`,
-// `claude-fable-5`) but the status view reasons in families (`Fable`), so a
-// direct glob match is not enough: `claude-fable-5` never matches the literal
-// string `Fable`. Both spellings are checked so the two natural ways to block a
-// family light up the same row — the glob (via modelGlobMatches, which also
-// makes a bare `*` block everything) and a concrete id (via substring).
-//
-// Deliberately advisory: this drives display only. The authoritative gate is the
-// per-request check in server.js, which matches the real model id. A pattern
-// that names no family (say `claude-3-*`) simply lights up no row, and the
-// header list still shows it verbatim.
 // Do two model globs describe any model in common? Used to tell whether a route
 // is fully shadowed by the blocklist. Exact glob intersection is not decidable
 // in general, so this compares literal cores (the pattern with `*` removed) in
@@ -79,6 +66,19 @@ export function modelGlobOverlaps(a, b) {
   return ca.includes(cb) || cb.includes(ca);
 }
 
+// The `blockedModels` pattern that takes a model FAMILY out of service, or null.
+//
+// The blocklist is written against concrete model ids (`*fable*`,
+// `claude-fable-5`) but the status view reasons in families (`Fable`), so a
+// direct glob match is not enough: `claude-fable-5` never matches the literal
+// string `Fable`. Both spellings are checked so the two natural ways to block a
+// family light up the same row — the glob (via modelGlobMatches, which also
+// makes a bare `*` block everything) and a concrete id (via substring).
+//
+// Deliberately advisory: this drives display only. The authoritative gate is the
+// per-request check in server.js, which matches the real model id. A pattern
+// that names no family (say `claude-3-*`) simply lights up no row, and the
+// header list still shows it verbatim.
 export function findFamilyBlock(patterns, family) {
   if (!Array.isArray(patterns) || !family) return null;
   const key = String(family).toLowerCase();

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -1,3 +1,5 @@
+import { findFamilyBlock, modelGlobOverlaps } from './model.js';
+
 const ESC = '\x1b[';
 const RESET = `${ESC}0m`;
 
@@ -7,10 +9,18 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   const probe = status.probe || { enabled: false, intervalSeconds: 0, accounts: [] };
   const warm = status.warm || { enabled: false, intervalSeconds: 0, accounts: [] };
   const accounts = status.accounts || [];
+  const blocked = (status.blockedModels || []).filter(p => typeof p === 'string' && p.length);
 
   lines.push(paint.bold('TeamClaude status'));
   lines.push(`${paint.dim('Active'.padEnd(12))} ${paint.cyan(status.currentAccount || 'none')}`);
   lines.push(`${paint.dim('Switch at'.padEnd(12))} ${formatPercent(status.switchThreshold)}`);
+  // Only when something is blocked: a always-visible "Blocked" row would be
+  // noise for the common case, but its ABSENCE is what made a blocked model
+  // read as available — the per-account Models row reports quota headroom and
+  // knows nothing about the blocklist.
+  if (blocked.length) {
+    lines.push(`${paint.dim('Blocked'.padEnd(12))} ${paint.red(blocked.join(', '))}`);
+  }
   if (status.sessions) {
     lines.push(`${paint.dim('Sessions'.padEnd(12))} ${formatSessions(status.sessions, paint)}`);
   }
@@ -23,14 +33,14 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   }
   lines.push('');
 
-  for (const line of routingLines(status.routes, paint)) lines.push(line);
+  for (const line of routingLines(status.routes, blocked, paint)) lines.push(line);
 
   for (const account of accounts) {
     lines.push(renderAccountHeader(account, status.currentAccount, paint, now));
     for (const quotaLine of quotaLines(account, now, paint)) {
       lines.push(`  ${quotaLine}`);
     }
-    const routing = modelRoutingLine(account, status.switchThreshold, now, paint);
+    const routing = modelRoutingLine(account, status.switchThreshold, blocked, now, paint);
     if (routing) lines.push(`  ${routing}`);
     lines.push(`  ${paint.dim('Usage'.padEnd(8))} ${formatUsage(account.usage, now)}`);
     lines.push(`  ${paint.dim('Probe'.padEnd(8))} ${formatAccountProbe(account.name, probe, now, paint)}`);
@@ -67,13 +77,20 @@ function paintRoute(paint, color, value) {
 // listing the model globs it matches and the accounts it can use, each colored
 // by live eligibility. Auto-created routes (a family metered separately with no
 // configured route) are tagged (auto); a bucket override shows in [brackets].
-function routingLines(routes, paint) {
+function routingLines(routes, blocked, paint) {
   if (!Array.isArray(routes) || routes.length === 0) return [];
   const lines = [paint.bold('Routing')];
   for (const route of routes) {
-    const match = (route.match || []).join(', ');
-    const accounts = (route.accounts || [])
-      .map(a => (a.eligible ? paint.green(a.name) : paint.red(a.name))).join(' ') || paint.gray('(none)');
+    const globs = route.match || [];
+    const match = globs.join(', ');
+    // A route every one of whose globs is blocked can carry no traffic at all —
+    // say so, rather than listing eligible accounts it will never reach.
+    const routeBlocked = globs.length > 0
+      && globs.every(g => blocked.some(p => modelGlobOverlaps(p, g)));
+    const accounts = routeBlocked
+      ? paint.red('blocked')
+      : (route.accounts || [])
+        .map(a => (a.eligible ? paint.green(a.name) : paint.red(a.name))).join(' ') || paint.gray('(none)');
     const tag = route.autocreated ? paint.dim(' (auto)') : route.bucket ? paint.dim(` [${route.bucket}]`) : '';
     const pin = route.pinned ? paint.dim(` [pinned: ${route.pinned}]`) : '';
     // padEnd on the raw text, color after, so ANSI codes don't throw off alignment.
@@ -131,13 +148,19 @@ function formatAccountStatus(account, now, paint) {
 // shared 5h bucket is spent (blocks everything) or when its own weekly bucket is
 // over the switch threshold; the reset is shown when the family bucket is the
 // blocker so it's clear when that model becomes available on this account again.
-function modelRoutingLine(account, threshold, now, paint) {
+function modelRoutingLine(account, threshold, blocked, now, paint) {
   const q = account.quota || {};
   if (q.unified7dSonnet == null && q.unified7dFable == null) return null;
   const t = Number(threshold);
   const fiveOver = q.unified5h != null && !Number.isNaN(t) && q.unified5h >= t;
 
   const cell = (label, weekly, reset) => {
+    // The blocklist outranks quota: a blocked family cannot be served however
+    // much headroom the account has, so it must not read ✓. Reporting quota
+    // alone is what made a fully-blocked model look available.
+    if (findFamilyBlock(blocked, label)) {
+      return `${label} ${paint.red('⊘')}${paint.dim(' blocked')}`;
+    }
     const weeklyOver = weekly != null && !Number.isNaN(t) && weekly >= t;
     const mark = fiveOver || weeklyOver ? paint.red('✗') : paint.green('✓');
     const resetTs = parseTs(reset);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isFableModel, parseRequestModel, TopLevelFieldFinder } from '../src/model.js';
+import { findFamilyBlock, isFableModel, modelGlobOverlaps, parseRequestModel, TopLevelFieldFinder } from '../src/model.js';
 
 test('isFableModel matches the Fable family only', () => {
   assert.equal(isFableModel('claude-fable-5'), true);
@@ -52,4 +52,24 @@ test('TopLevelFieldFinder marks done (absent) once the root object closes', () =
   const finder = new TopLevelFieldFinder('model');
   assert.equal(finder.push(Buffer.from('{"max_tokens":1}')), null);
   assert.equal(finder.done, true); // root closed without the field → stop early
+});
+
+test('findFamilyBlock matches a family by glob, by concrete id, and by catch-all', () => {
+  assert.equal(findFamilyBlock(['*fable*'], 'Fable'), '*fable*');
+  assert.equal(findFamilyBlock(['claude-fable-5'], 'Fable'), 'claude-fable-5');
+  assert.equal(findFamilyBlock(['*'], 'Fable'), '*');
+  assert.equal(findFamilyBlock(['*opus*'], 'Fable'), null);
+  assert.equal(findFamilyBlock([], 'Fable'), null);
+  assert.equal(findFamilyBlock(['*fable*'], ''), null);
+  assert.equal(findFamilyBlock(null, 'Fable'), null);
+  assert.equal(findFamilyBlock([null, 42, '*fable*'], 'Fable'), '*fable*');
+});
+
+test('modelGlobOverlaps compares literal cores in both directions', () => {
+  assert.equal(modelGlobOverlaps('*fable*', '*fable*'), true);
+  assert.equal(modelGlobOverlaps('claude-fable-5', '*fable*'), true);
+  assert.equal(modelGlobOverlaps('*fable*', 'claude-fable-5'), true);
+  assert.equal(modelGlobOverlaps('*', '*fable*'), true);
+  assert.equal(modelGlobOverlaps('*opus*', '*fable*'), false);
+  assert.equal(modelGlobOverlaps(undefined, '*fable*'), false);
 });

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -126,3 +126,76 @@ test('renderStatus sanitizes probe errors', () => {
   assert.match(output, /bad red/);
   assert.doesNotMatch(output, /\x1b\[31m/);
 });
+
+// --- blocklist visibility (issue: a blocked model read as available) ---------
+// `Models` reports quota headroom, so a fully-blocked family used to render ✓
+// while every request for it got a 400. Quota and the blocklist are separate
+// gates; status has to surface both.
+
+function blockedStatus(blockedModels) {
+  const status = sampleStatus();
+  status.blockedModels = blockedModels;
+  status.accounts[0].quota = {
+    unified5h: 0.02,
+    unified5hReset: now + 3600_000,
+    unified7d: 0.49,
+    unified7dReset: now + 86_400_000,
+    unified7dFable: 0.11,
+    unified7dFableReset: now + 86_400_000,
+  };
+  return status;
+}
+
+test('renderStatus shows a Blocked row listing the configured patterns', () => {
+  const output = renderStatus(blockedStatus(['*fable*']), { color: false, now });
+  assert.match(output, /Blocked\s+\*fable\*/);
+});
+
+test('renderStatus omits the Blocked row when nothing is blocked', () => {
+  assert.doesNotMatch(renderStatus(blockedStatus([]), { color: false, now }), /Blocked/);
+  assert.doesNotMatch(renderStatus(sampleStatus(), { color: false, now }), /Blocked/);
+});
+
+test('renderStatus marks a blocked family blocked, not available, despite free quota', () => {
+  const output = renderStatus(blockedStatus(['*fable*']), { color: false, now });
+  // Fable has 89% headroom and the session bucket is nearly empty, so the
+  // quota-only path would have rendered "Fable ✓".
+  assert.match(output, /Fable ⊘ blocked/);
+  assert.doesNotMatch(output, /Fable ✓/);
+  assert.match(output, /Opus ✓/); // unrelated families keep reporting quota
+});
+
+test('renderStatus marks a family blocked by a concrete model id, not just a glob', () => {
+  const output = renderStatus(blockedStatus(['claude-fable-5']), { color: false, now });
+  assert.match(output, /Fable ⊘ blocked/);
+});
+
+test('renderStatus leaves families untouched by an unrelated block', () => {
+  const output = renderStatus(blockedStatus(['*sonnet*']), { color: false, now });
+  assert.match(output, /Fable ✓/);
+  assert.match(output, /Opus ✓/);
+});
+
+test('renderStatus reports a fully-blocked route as blocked instead of listing accounts', () => {
+  const status = blockedStatus(['*fable*']);
+  status.routes = [{
+    name: 'fable',
+    match: ['*fable*'],
+    autocreated: true,
+    accounts: [{ name: 'a', eligible: true }],
+  }];
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /\*fable\*\s+→ blocked \(auto\)/);
+});
+
+test('renderStatus still lists accounts for a route the blocklist does not cover', () => {
+  const status = blockedStatus(['*fable*']);
+  status.routes = [{
+    name: 'sonnet',
+    match: ['*sonnet*'],
+    autocreated: true,
+    accounts: [{ name: 'a', eligible: true }],
+  }];
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /\*sonnet\*\s+→ a \(auto\)/);
+});


### PR DESCRIPTION
Reopened from #171 (closed to drop a messy branch history — same change, no content differences).

## The bug

With a blocklist configured, `teamclaude status` reports the blocked model as available:

```
"blockedModels": ["*fable*"]
```
```
Routing
  *fable*          → acct-a (auto)

  Fable    [██░░░░░░░░░░░░░░░░] 11% reset 6d3h
  Models   Opus ✓   Fable ✓          <-- but every Fable request 400s
```

Meanwhile the proxy is rejecting it correctly:

```
HTTP 400 in 0.00093s
{"type":"error","error":{"type":"invalid_request_error",
 "message":"Model \"claude-fable-5\" is blocked by teamclaude (matched \"*fable*\")."}}
```

## Why

Two independent gates decide whether a model can be served, and status only knew about one.

`modelRoutingLine()` builds the `Models` row from the account's weekly quota buckets alone (`unified7d`, `unified7dSonnet`, `unified7dFable`). That answers *"does this account have headroom left"*, which is a reasonable question and the wrong one here: the blocklist is checked in the request handler **before** an account is selected, so a request for a blocked model never reaches quota evaluation. A family with 89% of its weekly bucket free and a matching blocklist entry is unservable, and status said `✓`.

The blocklist wasn't just mis-rendered, it was **absent from the payload**. `getStatus()` never carried `blockedModels`, so neither the renderer nor `status --json` could see it:

```
$ teamclaude status --json | jq 'has("blockedModels")'
false
```

The TUI shows a blocked count, but a headless server has no way to surface the setting at all. Confirming a block meant reading the config or probing the proxy.

## The fix

- Report `blockedModels` in the status payload, read live from the shared config so the TUI's editor is reflected immediately (matching how the per-request gate already reads it).
- Add a `Blocked` header row listing active patterns, rendered only when non-empty. Its absence was what let a blocked model read as available.
- Mark a blocked family `⊘ blocked` in the `Models` row. The blocklist outranks quota, so it's checked first.
- Render a route whose globs are all blocked as `→ blocked` rather than listing accounts it can never reach.

### After, on the same server

```
TeamClaude status
Active       acct-a
Switch at    98%
Blocked      *fable*
...
Routing
  *fable*          → blocked (auto)

  Session  [██░░░░░░░░░░░░░░░░] 9% reset 4h41m
  Weekly   [█████████░░░░░░░░░] 50% reset 6d3h
  Fable    [██░░░░░░░░░░░░░░░░] 11% reset 6d3h
  Models   Opus ✓   Fable ⊘ blocked
```

Quota rows are deliberately untouched: `Fable 11%` still reports real headroom, which stays useful for knowing what unblocking would give back.

## Notes on the family match

`blockedModels` globs target concrete model ids while the status view reasons in families, so `claude-fable-5` never matches the literal string `Fable`. `findFamilyBlock()` accepts both spellings a block is naturally written in — the glob (`*fable*`) and a bare id (`claude-fable-5`) — and a lone `*` blocks everything. It's display-only and deliberately inclusive; the authoritative per-request gate in `server.js` is unchanged. A pattern naming no family (say `claude-3-*`) lights up no row, and the header still lists it verbatim.

`modelGlobOverlaps()` decides whether a route is fully shadowed. Exact glob intersection isn't decidable in general, so it compares literal cores in both directions.

## Tests

15 new assertions across `test/status-renderer.test.js` and `test/model.test.js`, covering: the `Blocked` row appearing and staying absent when empty, a blocked family not reading `✓` while it has free quota, blocking by concrete id as well as glob, unrelated families unaffected, and both route cases.

```
$ node --test test/status-renderer.test.js test/model.test.js
# pass 25
# fail 0
```

Full suite: 439/440. The one failure (`server exits cleanly when configured port is already in use`, `test/server-listen-error.test.js`) reproduces identically on unmodified `master` in my environment and is unrelated to this change.

`npx eslint` clean on all touched files.