### PR TITLE
fix(tui): stop repainting twice a second while idle

### DIFF
--- a/src/tui.js
+++ b/src/tui.js
@@ -221,6 +221,9 @@ export class TUI {
     this.frame = 0;
     this.running = false;
     this.timer = null;
+    // Injectable so a test can drive the repaint tick by hand instead of
+    // sleeping through real 500ms/5s intervals.
+    this._setTimeout = setTimeout;
     this._origLog = null;
     this._origErr = null;
   }
@@ -264,7 +267,7 @@ export class TUI {
 
   _scheduleTick() {
     if (!this.running) return;
-    this.timer = setTimeout(() => {
+    this.timer = this._setTimeout(() => {
       if (!this.running) return;
       // Only advance the spinner when it is actually on screen; otherwise the
       // frame counter would change every tick and defeat the repaint dedupe.

--- a/src/tui.js
+++ b/src/tui.js
@@ -6,6 +6,21 @@ import { parseProxyUrl, proxyToUrl, describeProxy, resolveUpstreamProxy, setUpst
 // ── ANSI helpers ─────────────────────────────────────────────
 
 const SPINNER = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'.split('');
+
+// Repaint cadence.
+//
+// The spinner is drawn only alongside in-flight requests, so animating it while
+// the proxy is idle wakes the process twice a second to redraw a frame nobody
+// can tell apart from the last one. On a laptop that is enough to keep the
+// machine from going to sleep (#134), which is a poor trade for animating
+// nothing. Tick fast only while there is something to animate; otherwise tick
+// slowly, just often enough that elapsed times and quota countdowns stay honest.
+const SPIN_MS = 500;
+const IDLE_TICK_MS = 5_000;
+// Even when the composed frame is unchanged, repaint occasionally: the terminal
+// is shared state, and anything that writes over it (a stray warning, a resumed
+// job) would otherwise leave the screen corrupted until the next real change.
+const FORCE_REPAINT_MS = 60_000;
 const ESC = '\x1b[';
 const RESET = `${ESC}0m`;
 const BOLD = `${ESC}1m`;
@@ -227,7 +242,9 @@ export class TUI {
     process.stdin.resume();
     process.stdin.setEncoding('utf8');
     this._dataHandler = d => this._onData(d);
-    this._resizeHandler = () => this.render();
+    // A resize reflows the terminal itself, so the cached frame says nothing
+    // about what is on screen — always repaint.
+    this._resizeHandler = () => this.render({ force: true });
     process.stdin.on('data', this._dataHandler);
     process.stdout.on('resize', this._resizeHandler);
 
@@ -237,16 +254,41 @@ export class TUI {
     console.log = (...a) => this._addLog(a.join(' '));
     console.error = (...a) => this._addLog(a.join(' '));
 
+    this._lastFrame = null;   // entering the alt screen always paints
     this.render();
-    this.timer = setInterval(() => {
-      this.frame = (this.frame + 1) % SPINNER.length;
+    this._scheduleTick();
+  }
+
+  /** Fast while something is animating, slow when there is nothing to animate. */
+  _tickDelay() { return this.active.size > 0 ? SPIN_MS : IDLE_TICK_MS; }
+
+  _scheduleTick() {
+    if (!this.running) return;
+    this.timer = setTimeout(() => {
+      if (!this.running) return;
+      // Only advance the spinner when it is actually on screen; otherwise the
+      // frame counter would change every tick and defeat the repaint dedupe.
+      if (this.active.size > 0) this.frame = (this.frame + 1) % SPINNER.length;
       this.render();
-    }, 500);
+      this._scheduleTick();
+    }, this._tickDelay());
+    this.timer.unref?.();
+  }
+
+  /**
+   * Re-arm the tick after the animating/idle state changes, so a request
+   * arriving during an idle tick starts animating now rather than up to
+   * IDLE_TICK_MS later.
+   */
+  _retick() {
+    if (!this.running) return;
+    if (this.timer) clearTimeout(this.timer);
+    this._scheduleTick();
   }
 
   stop() {
     this.running = false;
-    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
     if (this._origLog) { console.log = this._origLog; console.error = this._origErr; }
     if (this._activityStream) { this._activityStream.end(); this._activityStream = null; }
     process.stdin.removeListener('data', this._dataHandler);
@@ -261,6 +303,7 @@ export class TUI {
   onRequestStart(id, info) {
     this.active.set(id, { ...info, t: timestamp(), started: Date.now(), account: null });
     this.render();
+    if (this.active.size === 1) this._retick();   // idle → animating
   }
 
   onRequestModel(id, info) {
@@ -282,6 +325,7 @@ export class TUI {
     const sid = info.sessionId || r?.sessionId || null;
     const pin = (info.pinned || r?.pinned) ? dim(' [pin]') : '';
     this._addLog(`${sessionTag(sid)} ${info.method} ${info.path}${model} → ${acct}${pin} (${info.status}, ${dur}s)`);
+    if (this.active.size === 0) this._retick();   // animating → idle
   }
 
   _addLog(msg) {
@@ -881,20 +925,33 @@ export class TUI {
 
   // ── rendering ──────────────────────────────────────
 
-  render() {
+  render({ force = false } = {}) {
     if (!this.running) return;
     // Guard against re-entry: clearing an expired quota logs, and _addLog calls
     // render() again — without this the nested call would render twice.
     if (this._rendering) return;
     this._rendering = true;
     try {
-      this._render();
+      this._render(force);
     } finally {
       this._rendering = false;
     }
   }
 
-  _render() {
+  /**
+   * Write `buf` to the terminal unless it is byte-identical to what is already
+   * there. An idle proxy composes the same screen every tick, and writing it
+   * again costs a wake-up and a terminal round trip to change nothing.
+   */
+  _paint(buf, force) {
+    const stale = Date.now() - (this._lastPaintAt || 0) >= FORCE_REPAINT_MS;
+    if (!force && !stale && buf === this._lastFrame) return;
+    this._lastFrame = buf;
+    this._lastPaintAt = Date.now();
+    process.stdout.write(buf);
+  }
+
+  _render(force = false) {
     // Reset the display the instant a quota window (e.g. 5-hour session) expires,
     // instead of waiting for the next request to clear it.
     this.am.refreshExpiredQuotas();
@@ -902,7 +959,7 @@ export class TUI {
     const H = process.stdout.rows || 24;
 
     if (W < 40 || H < 8) {
-      process.stdout.write(`${ESC}H${ESC}2JTerminal too small (need 40x8+)\r\n`);
+      this._paint(`${ESC}H${ESC}2JTerminal too small (need 40x8+)\r\n`, force);
       return;
     }
 
@@ -1011,7 +1068,7 @@ export class TUI {
     }
     // Show cursor only in input mode
     buf += this.mode === 'input' ? `${ESC}?25h` : `${ESC}?25l`;
-    process.stdout.write(buf);
+    this._paint(buf, force);
   }
 
   _renderAcct(idx, bw, showBoth, routes = this.am.getRoutes(), genRoutes = routes.filter(r => routeFamily(r) === null), familyTarget = {}) {

--- a/test/tui-repaint.test.js
+++ b/test/tui-repaint.test.js
@@ -44,16 +44,12 @@ test('the tick is slow while idle and fast only while something is animating', (
   assert.equal(tui._tickDelay(), idle, 'falls back to the idle cadence once nothing is in flight');
 });
 
-// Run exactly one real tick by capturing the callback _scheduleTick arms.
+// Run exactly one real tick, driving the scheduler's own callback rather than a
+// hand-rolled copy of its body.
 function runOneTick(tui) {
-  const realSetTimeout = global.setTimeout;
   let captured = null;
-  global.setTimeout = (fn) => { captured = fn; return { unref() {} }; };
-  try {
-    tui._scheduleTick();
-  } finally {
-    global.setTimeout = realSetTimeout;
-  }
+  tui._setTimeout = (fn) => { captured = fn; return { unref() {} }; };
+  tui._scheduleTick();
   assert.ok(captured, '_scheduleTick armed no timer');
   // Stop it re-arming forever when we invoke it.
   const rearm = tui._scheduleTick;

--- a/test/tui-repaint.test.js
+++ b/test/tui-repaint.test.js
@@ -1,0 +1,144 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TUI } from '../src/tui.js';
+
+// The TUI used to repaint the whole screen every 500ms for as long as the proxy
+// ran. The spinner it was animating is drawn only next to in-flight requests, so
+// while idle each tick redrew a frame indistinguishable from the last — enough
+// wake-ups to keep a laptop from sleeping (issue #134).
+//
+// Two properties keep that from coming back: the tick slows down when there is
+// nothing to animate, and an unchanged frame is not written to the terminal at
+// all.
+
+function makeTUI() {
+  const am = {
+    accounts: [{ name: 'a', index: 0, type: 'oauth', credential: 't' }],
+    currentIndex: 0,
+    switchThreshold: 0.98,
+    getRoutes: () => [],
+    sessionStats: () => ({ active: 0, total: 0 }),
+    getStatus: () => ({ accounts: [] }),
+    refreshExpiredQuotas: () => {},
+  };
+  const config = { proxy: { port: 1 }, accounts: [{ name: 'a', type: 'oauth' }], routes: [], blockedModels: [] };
+  return new TUI({
+    accountManager: am, config, sx: null,
+    saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {},
+  });
+}
+
+test('the tick is slow while idle and fast only while something is animating', () => {
+  const tui = makeTUI();
+  assert.equal(tui.active.size, 0);
+  const idle = tui._tickDelay();
+
+  tui.active.set('r1', { started: Date.now() });
+  const busy = tui._tickDelay();
+
+  assert.ok(busy < idle, `animating tick (${busy}ms) must be faster than idle (${idle}ms)`);
+  // The point of the issue: idling must not mean waking twice a second.
+  assert.ok(idle >= 5000, `idle tick is ${idle}ms — too chatty to let a laptop sleep`);
+
+  tui.active.delete('r1');
+  assert.equal(tui._tickDelay(), idle, 'falls back to the idle cadence once nothing is in flight');
+});
+
+// Run exactly one real tick by capturing the callback _scheduleTick arms.
+function runOneTick(tui) {
+  const realSetTimeout = global.setTimeout;
+  let captured = null;
+  global.setTimeout = (fn) => { captured = fn; return { unref() {} }; };
+  try {
+    tui._scheduleTick();
+  } finally {
+    global.setTimeout = realSetTimeout;
+  }
+  assert.ok(captured, '_scheduleTick armed no timer');
+  // Stop it re-arming forever when we invoke it.
+  const rearm = tui._scheduleTick;
+  tui._scheduleTick = () => {};
+  try { captured(); } finally { tui._scheduleTick = rearm; }
+}
+
+test('the spinner frame only advances when the spinner is on screen', () => {
+  const tui = makeTUI();
+  tui.running = true;
+  tui.render = () => {};
+
+  const before = tui.frame;
+  runOneTick(tui);
+  assert.equal(tui.frame, before, 'an idle tick must not change what would be drawn');
+
+  tui.active.set('r1', { started: Date.now() });
+  runOneTick(tui);
+  assert.notEqual(tui.frame, before, 'the spinner still animates while a request is in flight');
+});
+
+// An unchanged screen must not be rewritten: that write is the wake-up.
+test('an identical frame is not written to the terminal twice', () => {
+  const tui = makeTUI();
+  tui.running = true;
+
+  const writes = [];
+  const orig = process.stdout.write;
+  process.stdout.write = (chunk) => { writes.push(String(chunk)); return true; };
+  try {
+    tui._paint('SAME', false);
+    tui._paint('SAME', false);
+    tui._paint('SAME', false);
+    assert.equal(writes.length, 1, 'repeated identical frames collapse to one write');
+
+    tui._paint('DIFFERENT', false);
+    assert.equal(writes.length, 2, 'a changed frame is written');
+
+    // force is how a resize gets through: the terminal reflowed, so the cached
+    // frame says nothing about what is actually on screen.
+    tui._paint('DIFFERENT', true);
+    assert.equal(writes.length, 3, 'a forced repaint is written even when unchanged');
+  } finally {
+    process.stdout.write = orig;
+  }
+});
+
+// The terminal is shared state. If something else scribbles on it, an unchanged
+// frame would otherwise leave the screen corrupted indefinitely.
+test('an unchanged frame is still repainted eventually', () => {
+  const tui = makeTUI();
+  tui.running = true;
+
+  const writes = [];
+  const orig = process.stdout.write;
+  process.stdout.write = (chunk) => { writes.push(String(chunk)); return true; };
+  try {
+    tui._paint('SAME', false);
+    assert.equal(writes.length, 1);
+    tui._paint('SAME', false);
+    assert.equal(writes.length, 1);
+
+    // Pretend the last paint was long enough ago to be considered stale.
+    tui._lastPaintAt = Date.now() - 120_000;
+    tui._paint('SAME', false);
+    assert.equal(writes.length, 2, 'a stale screen is refreshed even when the frame matches');
+  } finally {
+    process.stdout.write = orig;
+  }
+});
+
+// A request arriving mid-idle-tick must start animating immediately rather than
+// waiting out the remainder of the slow tick.
+test('a request arriving while idle re-arms the tick at once', () => {
+  const tui = makeTUI();
+  tui.running = true;
+  tui.render = () => {};
+
+  let scheduled = 0;
+  tui._scheduleTick = () => { scheduled++; };
+
+  tui.onRequestStart('r1', { method: 'POST', path: '/v1/messages' });
+  assert.equal(scheduled, 1, 'going from idle to animating re-arms the tick');
+
+  // A second concurrent request is already animating — no need to re-arm again.
+  tui.onRequestStart('r2', { method: 'POST', path: '/v1/messages' });
+  assert.equal(scheduled, 1);
+});


### PR DESCRIPTION
Refs #134.

## What I found

The TUI armed a 500ms `setInterval` for the entire lifetime of the server:

```js
this.timer = setInterval(() => {
  this.frame = (this.frame + 1) % SPINNER.length;
  this.render();
}, 500);
```

`SPINNER[this.frame]` is drawn in exactly one place — inside `_render`'s loop over in-flight requests. So with nothing in flight, every tick advanced a counter nothing displayed and then wrote a full screen to the terminal to produce a frame indistinguishable from the previous one. Twice a second, forever, for as long as `teamclaude server` was open.

That is a credible mechanism for #134 ("prevents Mac OS sleep"): it is a sustained timer wake plus a tty write, it exists only while the proxy is running, and it stops entirely under `--headless`. I have not reproduced it on macOS myself, so I am not claiming it as *the* cause — but it is worth not doing regardless.

## The change

**Adaptive cadence.** 500ms while something is animating, 5s otherwise. The tick re-arms when the in-flight count crosses zero in either direction, so a request arriving during a slow tick starts animating immediately rather than waiting out the remainder.

**The frame counter only advances when the spinner is on screen.** Besides being correct, this keeps the idle frame byte-stable, which the next part depends on.

**Unchanged frames are not written.** `_paint` compares the composed buffer against what was last written and skips the write when they match. Idle now costs a compose and no terminal I/O.

Two escape hatches, because the terminal is shared state and the cache is only a claim about what *we* last wrote:
- a resize forces a repaint — the terminal reflowed, so the cached frame says nothing about what is on screen;
- an unchanged frame is repainted once a minute anyway, so anything that scribbles over the screen (a stray warning, a resumed job) is cleaned up rather than persisting until the next real change.

## Tests

`test/tui-repaint.test.js` — the idle cadence is slower than the animating one and at least 5s; the frame advances during a real tick only when a request is in flight (driven through the actual `_scheduleTick` callback, not a hand-rolled copy of its body); identical frames collapse to a single write while changed and forced ones get through; a stale screen is refreshed even when the frame matches; and going idle → animating re-arms the tick exactly once.

## Not claimed

This does not prove #134 is fixed. I am leaving that issue open for the reporter to confirm against a build with this in — the useful check is whether `pmset -g assertions` still shows something holding the machine awake, and whether `teamclaude server --headless` behaves differently from the TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
