### PR TITLE
Bump to 1.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release 1.1.13.

Merging this triggers `publish.yml`: npm publish via Trusted Publishing, plus a `v1.1.13` tag and GitHub release.

### Security
- Control-plane writes (`/teamclaude/switch`, `/teamclaude/reload`) are now refused when the request carries a browser `Origin` or a cross-site `Sec-Fetch-Site`. Loopback is exempt from the proxy API key so the CLI needs no configuration, but that exemption also covered any web page the operator happened to visit — a cross-origin POST with a `text/plain` body is a CORS simple request, so it was sent without a preflight and the write landed. `curl`, the CLI and `attach` send neither header and are unaffected; reads are untouched, since the same-origin policy already prevents a page reading them.

### Features
- #169 — headless account switching: `POST /teamclaude/switch` and `teamclaude switch [NAME]`, for a proxy running as a background service where the TUI never appears
- #170 — `teamclaude attach`: the dashboard against an already-running server, polling the status endpoint
- #159 — `import` falls back to the macOS Keychain when `~/.claude/.credentials.json` is absent

### Fixes
- #173 — the TUI repainted the whole screen twice a second forever, animating a spinner only drawn next to in-flight requests (refs #134)
- #172 — `status` reported blocked models as available; the per-account Models row knows only about quota headroom
- #160 — progress-bar labels were white on light green/yellow fills

### Test reliability
- #162 — relay tests clean up in `finally`; a failed assertion used to leave servers listening and hang the whole run
- #163 — upstream-proxy e2e tests no longer inherit the shell's `NO_PROXY`/`HTTPS_PROXY`
- #161 — the listen-error test occupies the address the spawned server actually binds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
