### PR TITLE
fix(proxy): respond on every error path instead of hanging the client

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -193,6 +193,9 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       return forward(req, res);
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
+      // The window above throws for real: `getStatusExtra` is a hook the
+      // application installs, and reload/switch reach the account manager.
+      answerUnhandled(res);
     }
   };
 
@@ -526,8 +529,33 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
+      // The code above the inner try (the egress hold, the pin parsing, body
+      // buffering, the activity hooks) runs outside the 502 that guards
+      // forwardRequest, and the inner `finally` calls onRequestEnd after the
+      // response has streamed.
+      answerUnhandled(res);
     }
   };
+}
+
+/**
+ * The last response an outer catch can send. Three states:
+ *
+ *   - Nothing written yet: send a 502. Guarded on headersSent, because a second
+ *     writeHead raises ERR_HTTP_HEADERS_SENT from inside the catch.
+ *   - Headers sent, body unfinished: destroy. There is no status left to send,
+ *     and end() would present the truncated bytes as a complete reply.
+ *   - Response already ended: leave it alone, the client has its answer.
+ *
+ * `forwardRequest`'s own catch already carries the same pair of arms.
+ */
+function answerUnhandled(res) {
+  if (!res.headersSent && !res.destroyed) {
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
+  } else if (!res.writableEnded) {
+    res.destroy();
+  }
 }
 
 // Per-request https.Agent tunneled through sx.org — one-shot (no keep-alive

--- a/src/server.js
+++ b/src/server.js
@@ -423,14 +423,23 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // The token runs to the next '/', which also begins the real request path.
       const tokenEnd = afterPrefix == null ? -1 : afterPrefix.indexOf('/');
       if (tokenEnd > 0) {
-        const token = decodeURIComponent(afterPrefix.slice(0, tokenEnd));
-        pinnedIndex = resolveAccountPin(accountManager, token);
+        // The escaping of this segment is the CLIENT's, so a malformed one
+        // ("/tc-acct/%/v1/messages") makes decodeURIComponent throw URIError.
+        // That is an ordinary bad request, not an internal error: decode
+        // defensively and fall through to the unknown-pin 404 below, which is
+        // what a pin nobody can resolve already means. An undecodable token is
+        // reported as it arrived, since there is no decoded form to name.
+        const raw = afterPrefix.slice(0, tokenEnd);
+        let token = null;
+        try { token = decodeURIComponent(raw); } catch { token = null; }
+        pinnedIndex = token == null ? null : resolveAccountPin(accountManager, token);
         if (pinnedIndex == null) {
+          const shown = token ?? raw;
           const reqId = ++counter;
           const sessionId = req.headers['x-claude-code-session-id'] || null;
-          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${token}")`, status: 404, model: null, sessionId, pinned: false });
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${shown}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
+          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${shown}"` } }));
           return;
         }
         req.url = afterPrefix.slice(tokenEnd);

--- a/test/account-pin.test.js
+++ b/test/account-pin.test.js
@@ -90,10 +90,11 @@ async function withProxy(run) {
   }
 }
 
-const post = (url) => fetch(url, {
+const post = (url, signal) => fetch(url, {
   method: 'POST',
   headers: { 'content-type': 'application/json' },
   body: JSON.stringify({ model: 'x', messages: [] }),
+  signal,
 });
 
 test('a /tc-acct/<name> request is routed to that exact account, prefix stripped', async () => {
@@ -142,5 +143,38 @@ test('a normal (unpinned) request still rotates as before', async () => {
     assert.equal(res.status, 200);
     assert.equal(seen[0].path, '/v1/messages');
     assert.equal(seen[0].auth, 'Bearer t-alpha'); // default rotation → first account
+  });
+});
+
+// The escaping of a `/tc-acct/` segment is the CLIENT's, so a malformed one is
+// an ordinary bad request rather than something the proxy should choke on:
+// decodeURIComponent throws URIError on '%', '%zz' and a truncated '%E0%A4'.
+// The request is raced against a timer, so "never answered" is a failed
+// assertion rather than a run that never finishes.
+async function postWithin(url, ms = 4000) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  try {
+    const res = await post(url, ac.signal);
+    await res.text();
+    return res.status;
+  } catch (err) {
+    if (err.name === 'AbortError') return 'HUNG';
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test('a /tc-acct/ pin with a malformed escape is answered, not left hanging', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    for (const pin of ['%', '%zz', '%E0%A4']) {
+      assert.equal(await postWithin(`http://127.0.0.1:${proxyPort}/tc-acct/${pin}/v1/messages`), 404,
+        `a pin of "${pin}" left the client waiting on a request nobody will answer`);
+    }
+    // A well-formed but unresolvable pin is the same answer, which is the point:
+    // an undecodable pin is an unusable pin, not an internal error.
+    assert.equal(await postWithin(`http://127.0.0.1:${proxyPort}/tc-acct/%67%68/v1/messages`), 404);
+    assert.equal(seen.length, 0, 'an unresolvable pin reached upstream');
   });
 });

--- a/test/server-error-paths.test.js
+++ b/test/server-error-paths.test.js
@@ -1,0 +1,184 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// Every error path responds on the socket.
+//
+// Both of the server's outer catches sit above the 502 that guards
+// forwardRequest: one around the control plane (the auth gate, the CSRF gate,
+// status/reload/switch), one around the proxied request (pin parsing, body
+// buffering, the activity hooks). A throw in either is the last chance to
+// respond at all.
+//
+// Every request here races a timer, so a hang is a failed assertion rather
+// than a run that never finishes.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const ACCTS = [{ name: 'alice@example.com', type: 'apikey', apiKey: 'k1' }];
+// Port 1 is never listening, so nothing here can reach a real upstream: these
+// tests are about what happens before forwardRequest gets that far.
+const NO_UPSTREAM = { proxy: {}, upstream: 'http://127.0.0.1:1' };
+
+// What the client got, as one of three distinguishable outcomes: `{ status }`
+// for a reply it could read to the end, `{ hung: true }` if nothing arrived
+// before the timer, `{ closed: err }` if the connection was torn down under it.
+// The last two are separate on purpose: a torn-down connection is an answer,
+// and it is the only one that tells the client its reply is incomplete.
+async function outcomeWithin(url, init = {}, ms = 4000) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  try {
+    const res = await fetch(url, { ...init, signal: ac.signal });
+    await res.text();
+    return { status: res.status };
+  } catch (err) {
+    return err.name === 'AbortError' ? { hung: true } : { closed: err };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const postMessages = (port) => outcomeWithin(`http://127.0.0.1:${port}/v1/messages`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+});
+
+// Run `fn` with console.error muted: these tests deliberately provoke the
+// "[TeamClaude] Unhandled error" log, and the stack traces would drown the run.
+async function quietly(fn) {
+  const realErr = console.error;
+  console.error = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.error = realErr;
+  }
+}
+
+// ── the proxied request path ─────────────────────────────────────────────────
+
+// Held at the seam rather than through one input that happens to reach it:
+// anything that throws in the window above forwardRequest is answered.
+// `onRequestStart` fires there.
+test('a throw above forwardRequest is answered rather than hanging the client', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    onRequestStart: () => { reached = true; throw new Error('injected failure above forwardRequest'); },
+  });
+  const port = await listen(proxy);
+  try {
+    assert.deepEqual(await quietly(() => postMessages(port)), { status: 502 },
+      'a throw above forwardRequest left the client waiting forever');
+  } finally {
+    proxy.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+});
+
+// The other half of that catch: it must not respond a second time. The inner
+// `finally` runs `onRequestEnd` after the response has streamed, so a throw
+// there reaches the catch with the headers long sent, and a second writeHead
+// raises ERR_HTTP_HEADERS_SENT from inside the recovery. The client already has
+// its answer in full, and neither arm may take it away.
+test('a throw after the response is streamed does not answer a second time', async () => {
+  // SSE in several frames, so the reply really goes through streamResponse and
+  // the headers are long gone by the time the throw below lands. A buffered
+  // JSON reply never reaches that path.
+  const upstream = http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    res.write('event: message_start\ndata: {"type":"message_start"}\n\n');
+    await new Promise(r => setTimeout(r, 10));
+    res.write('event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n');
+    await new Promise(r => setTimeout(r, 10));
+    res.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    res.end();
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` }, {
+    onRequestEnd: () => { reached = true; throw new Error('injected failure after the response'); },
+  });
+  const port = await listen(proxy);
+
+  // Narrowed to the one rejection this test is about, and attached only for the
+  // length of its own request: `unhandledRejection` is process-wide, so a
+  // catch-all here would report a stray rejection from anywhere else in the run
+  // as this test's failure.
+  const rejections = [];
+  const onRejection = (err) => { if (err?.code === 'ERR_HTTP_HEADERS_SENT') rejections.push(err); };
+  process.on('unhandledRejection', onRejection);
+  try {
+    assert.deepEqual(await quietly(() => postMessages(port)), { status: 200 },
+      'the client did not get the response the upstream already sent');
+    // Give a rejection a turn of the loop to surface before we judge.
+    await new Promise(r => setTimeout(r, 50));
+  } finally {
+    process.off('unhandledRejection', onRejection);
+    proxy.close();
+    upstream.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+  assert.deepEqual(rejections.map(e => e.code), [],
+    'the outer catch tried to answer an already-answered request and threw doing it');
+});
+
+// ── the control-plane path ───────────────────────────────────────────────────
+
+// `getStatusExtra` is a hook the application installs, so this throw surface is
+// real rather than hypothetical.
+test('a throwing status hook is answered, not left hanging', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    getStatusExtra: () => { reached = true; throw new Error('status hook blew up'); },
+  });
+  const port = await listen(proxy);
+  try {
+    assert.deepEqual(await quietly(() => outcomeWithin(`http://127.0.0.1:${port}/teamclaude/status`)), { status: 502 },
+      'a throwing status hook left the client waiting forever');
+  } finally {
+    proxy.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+});
+
+// The half that a before-headers guard alone does not cover. The status
+// endpoint serializes the hook's value after writeHead, so a value JSON cannot
+// represent (a cycle, a BigInt) throws with the 200 already sent, and nothing
+// else ends the response.
+//
+// Not answering at all and ending the response gracefully are both wrong here,
+// and only one of them looks wrong: an end() delivers the 200 the client asked
+// for, with a body that was never written, and the client has no way to tell it
+// from a real one. So this asserts the connection was destroyed, not merely
+// that something came back.
+test('a status hook returning an unserializable value closes the connection', async () => {
+  const cyclic = {}; cyclic.self = cyclic;
+  for (const [label, extra] of [['a cycle', { cyclic }], ['a BigInt', { big: 1n }]]) {
+    const am = new AccountManager(ACCTS, 0.98);
+    let reached = false;
+    const proxy = createProxyServer(am, NO_UPSTREAM, {
+      getStatusExtra: () => { reached = true; return extra; },
+    });
+    const port = await listen(proxy);
+    let outcome;
+    try {
+      outcome = await quietly(() => outcomeWithin(`http://127.0.0.1:${port}/teamclaude/status`));
+    } finally {
+      proxy.close();
+    }
+    assert.ok(reached, `the request never reached the hook returning ${label}`);
+    assert.ok(!outcome.hung, `${label}: the client waited forever for a response nobody sent`);
+    assert.ok(outcome.closed,
+      `${label}: the client read a complete ${outcome.status} whose body was never written`);
+  }
+});


### PR DESCRIPTION
Three error paths in `server.js` catch a throw, log it, and return without writing anything to the socket. The client never gets a response and waits until its own timeout expires. One of the three is reachable from an ordinary request line, no hooks involved.

## 1. Malformed percent-escape in a `/tc-acct/` pin

The pin segment is percent-encoded by the client, and `decodeURIComponent` throws `URIError` on a malformed escape. The throw lands in the outer catch, which logs and returns:

```
$ curl -sS -m 6 -o /dev/null -w 'HTTP %{http_code} in %{time_total}s\n' \
    -X POST -H 'content-type: application/json' -d '{"model":"claude-opus-5","messages":[]}' \
    'http://127.0.0.1:8787/tc-acct/%/v1/messages'
curl: (28) Operation timed out after 6002 milliseconds with 0 bytes received
HTTP 000 in 6.002430s
```

`%zz` and a truncated `%E0%A4` behave the same way, while a well-formed unknown pin (`/tc-acct/ghost/...`) answers 404 in a few milliseconds.

The decode is now wrapped in a try/catch, and an undecodable pin falls through to the existing unknown-pin 404, since an undecodable pin and an unknown pin mean the same thing to the caller. The error message quotes the token as it arrived, because there is no decoded form to show. All the inputs above answer 404 in under 10 ms after the change.

## 2. Neither outer catch answers the socket

The 502 in `forwardRequest` covers the inner try only. The code above it (the egress hold, pin parsing, body buffering, the activity hooks) runs under a catch that logs and returns, and `createProxyServer`'s request handler has the same catch around the auth gate, the CSRF gate, the forward-proxy relay, and the status/reload/switch endpoints.

`getStatusExtra` is a hook the application installs, so this is reachable from a plain `GET`:

```
$ curl -sS -m 6 -o /dev/null -w 'HTTP %{http_code} in %{time_total}s\n' \
    http://127.0.0.1:8787/teamclaude/status        # with a status hook that throws
curl: (28) Operation timed out after 6002 milliseconds with 0 bytes received
HTTP 000 in 6.002208s
```

Both catches now send the same 502 that `forwardRequest` sends, when nothing has been written yet.

## 3. Throw after the headers are sent

The status endpoint serializes the hook's value after `writeHead`. If the hook returns something `JSON.stringify` rejects (a cycle, a `BigInt`), the throw happens with the 200 already sent. A 502 can no longer be written, nothing else ends the response, and the client hangs exactly as in the previous case. Measured on `master`, both inputs do.

For this case the catch destroys the response instead. `end()` would be wrong: it delivers truncated bytes as an apparently complete reply, and the client has no reason to retry. `forwardRequest` already handles its own errors with this writeHead-or-destroy pair; both outer catches now go through one shared `answerUnhandled` helper that does the same.

After the change, with the same three hooks:

```
  getStatusExtra throw   -> HTTP 502 in 0.003629s
  getStatusExtra cycle   -> curl: (52) Empty reply from server, 0.003077s
  getStatusExtra bigint  -> curl: (52) Empty reply from server, 0.003141s
```

The `headersSent` check matters in the other direction too: the inner `finally` calls `onRequestEnd` after the response has streamed, so a throw from that hook reaches the catch with the headers long sent, and an unguarded `writeHead` would raise `ERR_HTTP_HEADERS_SENT` from inside the catch.

## Tests

Five new tests: one in `test/account-pin.test.js`, four in a new `test/server-error-paths.test.js`. Each races its request against a 4 s timer, so a hang shows up as a failed assertion instead of a stuck run.

Four of the five fail on unmodified `master`, each by timing out:

```
✖ a /tc-acct/ pin with a malformed escape is answered, not left hanging (4002.770875ms)
✖ a throw above forwardRequest is answered rather than hanging the client (4007.947542ms)
✖ a throwing status hook is answered, not left hanging (4001.618458ms)
✖ a status hook returning an unserializable value closes the connection (4002.195959ms)
```

That last one asserts the connection was destroyed rather than merely that something came back, so an implementation that ended the response gracefully fails it too: swapping `destroy()` for `end()` in `answerUnhandled` turns it red with `the client read a complete 200 whose body was never written`.

The fifth test, `a throw after the response is streamed does not answer a second time`, passes on `master` and pins the new guard: it streams a real SSE response through `streamResponse`, throws from `onRequestEnd` afterwards, and fails if the recovery either answers twice or destroys the client's completed 200. Removing the `headersSent` check turns it red with `ERR_HTTP_HEADERS_SENT` as an unhandled rejection.

```
$ node --test --test-timeout=120000
ℹ tests 530
ℹ pass 530
ℹ fail 0
```

525 tests before, 530 after. `npx eslint .` clean.

## Compatibility

Error paths only. Successful requests, resolvable pins, unknown pins, blocked models, 429s and upstream failures all take exactly the path they took before.

The new recovery does run after a response that completed: a throw from `onRequestEnd` reaches the catch with the reply already delivered. There it does nothing, because the response has ended and both arms decline, and the fifth test pins that. What a client can observe changing is a response that was still incomplete when the throw happened: it now gets a 502, or a closed connection if the headers were already out, instead of waiting for its own timeout.
