### PR TITLE
fix(proxy): close the activity entry a request opened, exactly once

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -193,6 +193,9 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
       return forward(req, res);
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
+      // The window above throws for real: `getStatusExtra` is a hook the
+      // application installs, and reload/switch reach the account manager.
+      answerUnhandled(res);
     }
   };
 
@@ -526,8 +529,33 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       }
     } catch (err) {
       console.error('[TeamClaude] Unhandled error:', err);
+      // The code above the inner try (the egress hold, the pin parsing, body
+      // buffering, the activity hooks) runs outside the 502 that guards
+      // forwardRequest, and the inner `finally` calls onRequestEnd after the
+      // response has streamed.
+      answerUnhandled(res);
     }
   };
+}
+
+/**
+ * The last response an outer catch can send. Three states:
+ *
+ *   - Nothing written yet: send a 502. Guarded on headersSent, because a second
+ *     writeHead raises ERR_HTTP_HEADERS_SENT from inside the catch.
+ *   - Headers sent, body unfinished: destroy. There is no status left to send,
+ *     and end() would present the truncated bytes as a complete reply.
+ *   - Response already ended: leave it alone, the client has its answer.
+ *
+ * `forwardRequest`'s own catch already carries the same pair of arms.
+ */
+function answerUnhandled(res) {
+  if (!res.headersSent && !res.destroyed) {
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
+  } else if (!res.writableEnded) {
+    res.destroy();
+  }
 }
 
 // Per-request https.Agent tunneled through sx.org — one-shot (no keep-alive

--- a/src/server.js
+++ b/src/server.js
@@ -423,14 +423,23 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // The token runs to the next '/', which also begins the real request path.
       const tokenEnd = afterPrefix == null ? -1 : afterPrefix.indexOf('/');
       if (tokenEnd > 0) {
-        const token = decodeURIComponent(afterPrefix.slice(0, tokenEnd));
-        pinnedIndex = resolveAccountPin(accountManager, token);
+        // The escaping of this segment is the CLIENT's, so a malformed one
+        // ("/tc-acct/%/v1/messages") makes decodeURIComponent throw URIError.
+        // That is an ordinary bad request, not an internal error: decode
+        // defensively and fall through to the unknown-pin 404 below, which is
+        // what a pin nobody can resolve already means. An undecodable token is
+        // reported as it arrived, since there is no decoded form to name.
+        const raw = afterPrefix.slice(0, tokenEnd);
+        let token = null;
+        try { token = decodeURIComponent(raw); } catch { token = null; }
+        pinnedIndex = token == null ? null : resolveAccountPin(accountManager, token);
         if (pinnedIndex == null) {
+          const shown = token ?? raw;
           const reqId = ++counter;
           const sessionId = req.headers['x-claude-code-session-id'] || null;
-          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${token}")`, status: 404, model: null, sessionId, pinned: false });
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${shown}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${token}"` } }));
+          res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${shown}"` } }));
           return;
         }
         req.url = afterPrefix.slice(tokenEnd);

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import https from 'node:https';
 import { timingSafeEqual } from 'node:crypto';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, writeSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ensureCerts, createConnectHandler } from './mitm.js';
@@ -192,7 +192,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null)
 
       return forward(req, res);
     } catch (err) {
-      console.error('[TeamClaude] Unhandled error:', err);
+      reportFailure('[TeamClaude] Unhandled error:', err);
       // The window above throws for real: `getStatusExtra` is a hook the
       // application installs, and reload/switch reach the account manager.
       answerUnhandled(res);
@@ -364,6 +364,12 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/files/', '/api/oauth/f
 export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null }) {
   let counter = 0;
   return async (req, res) => {
+    // The activity entry this request opened, while it is still open. Every
+    // consumer holds the row until it is told the request ended, so exactly one
+    // path must close it. Each closing site clears this first, which is how the
+    // outer catch tells an entry it still has to account for from one that is
+    // already closed.
+    let openEntry = null;
     try {
       // Claude Code's telemetry (`/api/event_logging/*`) is high-volume noise in
       // the activity log. `config.eventLogging` (read live so the TUI toggle takes
@@ -471,7 +477,15 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // /v1/messages and count_tokens). Read from headers up front so it drives
       // session-aware routing (issue #109) and colors the TUI activity stream.
       const sessionId = req.headers['x-claude-code-session-id'] || null;
-      if (!hideActivity) hooks.onRequestStart?.(reqId, { method: req.method, path: req.url, sessionId, pinned: pinnedIndex != null });
+      if (!hideActivity) {
+        // Marked open BEFORE the hook runs. The shipped TUI hook registers its
+        // row and then renders, and the render can rethrow, so a hook that
+        // throws part way through has already opened a row that something must
+        // close. The cost of this order is one spurious close if the hook threw
+        // before registering anything, which every consumer already tolerates.
+        openEntry = { reqId, sessionId };
+        hooks.onRequestStart?.(reqId, { method: req.method, path: req.url, sessionId, pinned: pinnedIndex != null });
+      }
 
       // Buffer request body (needed to resend on a different account after a 429).
       // Peek the top-level `model` field incrementally as chunks arrive so the
@@ -505,6 +519,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: `Model "${model}" is blocked by teamclaude (matched "${blockedBy}").` } }));
         }
+        openEntry = null;   // this path owns the close below; the outer catch must not repeat it
         hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: '(blocked)', status: 400, model, sessionId });
         return;
       }
@@ -518,17 +533,53 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
         ctx.status = ctx.status || 502;
-        console.error('[TeamClaude] Unhandled error:', err);
+        // Same rule as the two outer catches: a recovery path does not report
+        // through a console that may be the thing that failed. Here it also
+        // decides which error gets reported at all, since a throw from the
+        // report would carry the render failure outward in place of this one.
+        reportFailure('[TeamClaude] Unhandled error:', err);
         if (!res.headersSent) {
           res.writeHead(502, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
         }
       } finally {
         accountManager.endSession(sessionId);
+        // Cleared BEFORE the hook, because the hook can throw: leaving the entry
+        // marked open would send the outer catch to call that same throwing hook
+        // a second time for one request.
+        openEntry = null;
         if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId, pinned: ctx.pinnedIndex != null });
       }
     } catch (err) {
-      console.error('[TeamClaude] Unhandled error:', err);
+      reportFailure('[TeamClaude] Unhandled error:', err);
+      // Close the activity entry. Only the inner path has a `finally`, so a
+      // throw above it opens a row that nothing else will ever close, and every
+      // consumer holds an open row indefinitely: the TUI keeps it in `active`
+      // and never idles its animation, a headless consumer's in-flight count
+      // grows by one. `for await (const chunk of req)` rejects when a client
+      // cancels mid-body, which Ctrl+C in Claude Code does, on a daemon that
+      // runs for weeks.
+      if (openEntry) {
+        // 499 when nothing was sent and nothing will be, either because the
+        // client is gone or because the response is past the point of saying
+        // anything; 502 is what the answer below is about to write.
+        const status = res.headersSent || res.destroyed ? 499 : 502;
+        const entry = openEntry;
+        openEntry = null;
+        // Guarded, because the throw that landed here may be this hook. Escaping
+        // this catch means escaping an async request listener with nothing above
+        // it, which is an unhandled rejection, and crash-log.js turns that into
+        // exit(1). A broken activity hook must not take the daemon down, and it
+        // must not cost the socket its answer below either.
+        try {
+          hooks.onRequestEnd?.(entry.reqId, {
+            method: req.method, path: req.url, account: null, status,
+            model: null, sessionId: entry.sessionId, pinned: false,
+          });
+        } catch (hookErr) {
+          reportFailure('[TeamClaude] activity hook failed while closing a request:', hookErr);
+        }
+      }
       // The code above the inner try (the egress hold, the pin parsing, body
       // buffering, the activity hooks) runs outside the 502 that guards
       // forwardRequest, and the inner `finally` calls onRequestEnd after the
@@ -536,6 +587,34 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       answerUnhandled(res);
     }
   };
+}
+
+/**
+ * Report a failure without depending on the console to survive it.
+ *
+ * Under the TUI the console is the TUI: `console.error` appends to the activity
+ * log and repaints, so a render that throws makes `console.error` throw. That
+ * matters because these reports are the FIRST statement of the paths that
+ * recover from a throw, and the throw being recovered from is often the same
+ * broken render. An unguarded report there skips the whole recovery.
+ *
+ * Falls back to stderr rather than swallowing, so a render bug still leaves a
+ * diagnostic. The TUI already does this when its own activity stream fails.
+ *
+ * `writeSync` rather than `process.stderr.write`, because the fallback has to
+ * fail the way this function promises to. A closed stderr makes the stream
+ * surface EPIPE asynchronously, as an error event no `try` around the call can
+ * see, and this daemon treats an uncaught EPIPE as fatal. `writeSync` throws
+ * where it is called, so the catch below is real.
+ */
+function reportFailure(...args) {
+  try {
+    console.error(...args);
+  } catch {
+    try {
+      writeSync(2, `${args.map(a => a?.stack || String(a)).join(' ')}\n`);
+    } catch { /* nothing left to report with */ }
+  }
 }
 
 /**

--- a/test/account-pin.test.js
+++ b/test/account-pin.test.js
@@ -90,10 +90,11 @@ async function withProxy(run) {
   }
 }
 
-const post = (url) => fetch(url, {
+const post = (url, signal) => fetch(url, {
   method: 'POST',
   headers: { 'content-type': 'application/json' },
   body: JSON.stringify({ model: 'x', messages: [] }),
+  signal,
 });
 
 test('a /tc-acct/<name> request is routed to that exact account, prefix stripped', async () => {
@@ -142,5 +143,38 @@ test('a normal (unpinned) request still rotates as before', async () => {
     assert.equal(res.status, 200);
     assert.equal(seen[0].path, '/v1/messages');
     assert.equal(seen[0].auth, 'Bearer t-alpha'); // default rotation → first account
+  });
+});
+
+// The escaping of a `/tc-acct/` segment is the CLIENT's, so a malformed one is
+// an ordinary bad request rather than something the proxy should choke on:
+// decodeURIComponent throws URIError on '%', '%zz' and a truncated '%E0%A4'.
+// The request is raced against a timer, so "never answered" is a failed
+// assertion rather than a run that never finishes.
+async function postWithin(url, ms = 4000) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  try {
+    const res = await post(url, ac.signal);
+    await res.text();
+    return res.status;
+  } catch (err) {
+    if (err.name === 'AbortError') return 'HUNG';
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test('a /tc-acct/ pin with a malformed escape is answered, not left hanging', async () => {
+  await withProxy(async ({ proxyPort, seen }) => {
+    for (const pin of ['%', '%zz', '%E0%A4']) {
+      assert.equal(await postWithin(`http://127.0.0.1:${proxyPort}/tc-acct/${pin}/v1/messages`), 404,
+        `a pin of "${pin}" left the client waiting on a request nobody will answer`);
+    }
+    // A well-formed but unresolvable pin is the same answer, which is the point:
+    // an undecodable pin is an unusable pin, not an internal error.
+    assert.equal(await postWithin(`http://127.0.0.1:${proxyPort}/tc-acct/%67%68/v1/messages`), 404);
+    assert.equal(seen.length, 0, 'an unresolvable pin reached upstream');
   });
 });

--- a/test/activity-entries.test.js
+++ b/test/activity-entries.test.js
@@ -1,0 +1,332 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// One request opens one activity entry, and exactly one path closes it.
+//
+// The entry is a promise to every consumer of the activity hooks: the TUI holds
+// the row in `active` and keeps its animation running while one is open, a
+// headless consumer counts it as in flight. Nothing reclaims a row that is
+// never closed, so on a daemon that runs for weeks a leak is permanent.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const ACCTS = [{ name: 'alice@example.com', type: 'apikey', apiKey: 'k1' }];
+// Port 1 is never listening. Where a test does not care what upstream says, a
+// failed forward is the shortest way to the paths under test.
+const NO_UPSTREAM = { proxy: {}, upstream: 'http://127.0.0.1:1' };
+
+const BODY = JSON.stringify({ model: 'claude-opus-5', messages: [] });
+
+// An upstream that answers every request with a small JSON 200, so the inner
+// path runs to completion and its `finally` is the site that closes the entry.
+function okUpstream() {
+  return http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => { res.writeHead(200, { 'content-type': 'application/json' }); res.end('{}'); });
+  });
+}
+
+async function postMessages(port, body = BODY) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body,
+  }).catch(() => null);
+  await res?.text().catch(() => {});
+  return res;
+}
+
+// These tests provoke throws the server logs. Mute that so the stack traces do
+// not drown the run.
+async function quietly(fn) {
+  const realErr = console.error;
+  console.error = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.error = realErr;
+  }
+}
+
+// A client that announces a body, sends part of it, and hangs up. This is what
+// Ctrl+C in Claude Code does to a request that is still uploading, and it makes
+// the server's `for await (const chunk of req)` reject above the inner try.
+function abortMidBody(port) {
+  return new Promise((resolve) => {
+    const req = http.request({
+      host: '127.0.0.1', port, method: 'POST', path: '/v1/messages',
+      headers: { 'content-type': 'application/json', 'content-length': String(BODY.length + 64) },
+    });
+    req.on('error', () => {});
+    req.write(BODY.slice(0, 24));
+    setTimeout(() => { req.destroy(); resolve(); }, 50);
+  });
+}
+
+test('a request aborted mid-body closes its activity entry', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  const started = [];
+  const ended = [];
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    onRequestStart: (id) => started.push(id),
+    onRequestEnd: (id, info) => ended.push({ id, status: info.status }),
+  });
+  const port = await listen(proxy);
+  try {
+    await quietly(async () => {
+      await abortMidBody(port);
+      await new Promise(r => setTimeout(r, 200));   // let the server-side rejection land
+    });
+  } finally {
+    proxy.close();
+  }
+  assert.ok(started.length > 0, 'no activity entry was opened, so this proves nothing');
+  assert.deepEqual(ended.map(e => e.id), started,
+    `an aborted request left ${started.length - ended.length} activity entry(s) open forever`);
+  assert.deepEqual(ended.map(e => e.status), [499],
+    'an entry closed for a client that went away should say so');
+});
+
+// The shipped TUI start hook has exactly this shape: it registers the row and
+// then renders, and the render can rethrow. Whether the row survives depends on
+// whether the entry was marked open before the hook ran or after it returned.
+test('a start hook that registers its row and then throws does not orphan it', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  const open = new Set();
+  const closed = [];
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    onRequestStart: (id) => { open.add(id); throw new Error('render() rethrew'); },
+    onRequestEnd: (id, info) => { open.delete(id); closed.push(info.status); },
+  });
+  const port = await listen(proxy);
+  let status;
+  try {
+    status = (await quietly(() => postMessages(port)))?.status;
+  } finally {
+    proxy.close();
+  }
+  assert.deepEqual([...open], [],
+    'a start hook that threw after registering its row left the row open forever');
+  // 502, not 499. This client is still connected and still waiting, and the
+  // recovery is about to send it exactly that. 499 is for a row closed on
+  // behalf of a client that will never read anything.
+  assert.equal(status, 502, 'the client did not get the answer the row is reporting');
+  assert.deepEqual(closed, [502],
+    'the row was closed with a status the client was never sent');
+});
+
+// The mirror of the rule above, on the closing side. The inner path owns the
+// entry from the moment it starts closing it, so it must give up its claim
+// before calling the hook; otherwise a hook that throws still looks open to the
+// outer catch, which calls that same hook again for the same request.
+test('a throwing end hook is not called twice for one request', async () => {
+  const upstream = okUpstream();
+  const upPort = await listen(upstream);
+  const am = new AccountManager(ACCTS, 0.98);
+  const calls = [];
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upPort}` }, {
+    onRequestEnd: (id, info) => { calls.push(info.status); throw new Error('the activity pane rethrew'); },
+  });
+  const port = await listen(proxy);
+  try {
+    const res = await quietly(() => postMessages(port));
+    assert.equal(res?.status, 200, 'the request did not complete normally, so this proves nothing');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+  assert.equal(calls.length, 1,
+    `one request closed its activity entry ${calls.length} times (statuses ${calls.join(', ')})`);
+});
+
+// The recovery calls a hook, and the throw that sent it there may be that same
+// hook. Unguarded, the second throw leaves an async request listener with
+// nothing above it to catch it: an unhandled rejection, which src/crash-log.js
+// treats as fatal and turns into exit(1). A broken activity hook must not take
+// the daemon down with it, and the socket must still get its answer.
+//
+// Reaching the guarded call needs BOTH hooks to throw: the start hook, so the
+// entry is still open when the catch runs, and the end hook, so the call the
+// catch makes to close it throws too.
+test('a hook that throws on every call cannot bring the process down', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  const SENTINEL = 'the activity pane rethrew, every time';
+  let ends = 0;
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    onRequestStart: () => { throw new Error('render() rethrew on open'); },
+    onRequestEnd: () => { ends += 1; throw new Error(SENTINEL); },
+  });
+  const port = await listen(proxy);
+
+  // Scoped to this test's own errors: `unhandledRejection` and
+  // `uncaughtException` are process-wide, so a catch-all here would report a
+  // stray failure from anywhere else in the run as this test's.
+  const escaped = [];
+  const mine = (e) => e?.message === SENTINEL || e?.message === 'render() rethrew on open';
+  const onRejection = (e) => { if (mine(e)) escaped.push(`unhandledRejection: ${e.message}`); };
+  const onUncaught = (e) => { if (mine(e)) escaped.push(`uncaughtException: ${e.message}`); };
+  process.on('unhandledRejection', onRejection);
+  process.on('uncaughtException', onUncaught);
+  let status;
+  try {
+    await quietly(async () => {
+      status = (await postMessages(port))?.status;
+      await new Promise(r => setTimeout(r, 150));   // let any escape surface
+    });
+  } finally {
+    process.off('unhandledRejection', onRejection);
+    process.off('uncaughtException', onUncaught);
+    proxy.close();
+  }
+  assert.ok(ends > 0, 'the recovery never tried to close the entry, so this proves nothing');
+  assert.deepEqual(escaped, [],
+    'a throwing activity hook escaped the request listener, where crash-log turns it into exit(1)');
+  assert.equal(status, 502, 'the broken hook cost the client its answer');
+});
+
+// ── the recovery has to survive its own logging ──────────────────────────────
+//
+// Under the TUI, `console.error` is the TUI: it appends to the activity log and
+// repaints. So the render that made the start hook throw makes the console throw
+// too, and the first statement of every recovery path here is a report.
+// Everything after it only runs if that report returns.
+//
+// Its fallback is `writeSync(2, ...)` rather than `process.stderr.write`, and
+// the difference is load-bearing: a stderr whose reader is gone makes the stream
+// surface EPIPE asynchronously, as an error event that no `try` around the call
+// can catch, and crash-log.js treats an uncaught EPIPE as fatal. The helper
+// written to keep a broken render from killing the daemon would kill it instead.
+// Nothing before this had that exposure, because the global `console.error`
+// swallows its own write errors.
+//
+// These run in a child for two reasons. A raw fd-2 write goes around any stub a
+// test could install, so reading the child's stderr is the only honest way to
+// assert the report arrived; and taking stderr away, which is the whole point of
+// the third one, is not something a test can do to its own runner.
+
+const SERVER_PATH = fileURLToPath(new URL('../src/server.js', import.meta.url));
+const AM_PATH = fileURLToPath(new URL('../src/account-manager.js', import.meta.url));
+
+// Run a proxy in a child whose console throws, drive one request at `path`, and
+// report back over stdout. `stderr: 'destroy'` removes the reader before the
+// request, which is what turns a fallback write into EPIPE.
+//
+// `hooks` is source, not a value, since it crosses a process boundary.
+function recoverInChild({ path = '/v1/messages', method = 'POST', hooks, stderr = 'pipe' }) {
+  const source = `
+    import http from 'node:http';
+    import { AccountManager } from ${JSON.stringify(AM_PATH)};
+    import { createProxyServer } from ${JSON.stringify(SERVER_PATH)};
+    const say = (s) => process.stdout.write(s + '\\n');
+    // Bounded, because whatever escapes ends up inside an assertion message,
+    // and an unbounded one is unreadable at the moment someone has to read it.
+    const why = (e) => String(e?.code || e?.message).slice(0, 80);
+    process.on('uncaughtException', (e) => { say('ESCAPED:uncaughtException:' + why(e)); process.exit(9); });
+    process.on('unhandledRejection', (e) => { say('ESCAPED:unhandledRejection:' + why(e)); process.exit(9); });
+
+    const open = new Set();
+    const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k' }], 0.98);
+    const proxy = createProxyServer(am, { proxy: {}, upstream: 'http://127.0.0.1:1' }, ${hooks});
+    proxy.listen(0, '127.0.0.1', () => {
+      const port = proxy.address().port;
+      console.error = () => { throw new Error('TUI render failed'); };
+      const req = http.request({ host: '127.0.0.1', port, method: ${JSON.stringify(method)}, path: ${JSON.stringify(path)},
+        headers: { 'content-type': 'application/json' } }, (res) => {
+        res.resume();
+        res.on('end', () => {
+          say('answered=' + res.statusCode);
+          setTimeout(() => { say('rowsStillOpen=' + open.size); say('STILL-ALIVE'); process.exit(0); }, 300);
+        });
+      });
+      req.on('error', (e) => { say('client-error=' + e.code); process.exit(8); });
+      req.end(${JSON.stringify(method)} === 'POST' ? JSON.stringify({ model: 'claude-opus-5', messages: [] }) : undefined);
+    });
+  `;
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', source],
+      { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = [];
+    const errChunks = [];
+    child.stdout.on('data', (d) => out.push(...String(d).trim().split('\n').filter(Boolean)));
+    child.stderr.on('error', () => {});
+    if (stderr === 'destroy') child.stderr.destroy();
+    else child.stderr.on('data', (d) => errChunks.push(String(d)));
+    child.on('close', (code) => resolve({ code, out, reported: errChunks.join('') }));
+  });
+}
+
+const LISTENER_HOOKS = `{
+  onRequestStart: (id) => { open.add(id); throw new Error('TUI render failed'); },
+  // Closes its row and THEN throws, the same way the start hook does. This is
+  // what carries the failure into the recovery's own guarded hook call, whose
+  // report is the second place a throwing console can stop everything.
+  onRequestEnd: (id) => { open.delete(id); throw new Error('TUI render failed'); },
+}`;
+
+test('a console that throws does not defeat the recovery', async () => {
+  const { out, reported } = await recoverInChild({ hooks: LISTENER_HOOKS });
+  assert.ok(!out.some(l => l.startsWith('ESCAPED:')),
+    `a throwing console escaped the request listener, where crash-log turns it into exit(1): ${out.join(', ')}`);
+  assert.ok(out.includes('rowsStillOpen=0'), `a throwing console left the activity row open forever: ${out.join(', ')}`);
+  assert.ok(out.includes('answered=502'), `a throwing console cost the client its answer: ${out.join(', ')}`);
+  // Recovering quietly is not the same as recovering. Both reports on this path
+  // have to reach somewhere a person can read them, or a render bug is invisible
+  // for as long as the TUI is up.
+  assert.match(reported, /\[TeamClaude\] Unhandled error:/,
+    'the failure that started the recovery was never reported anywhere');
+  assert.match(reported, /\[TeamClaude\] activity hook failed while closing a request:/,
+    'the hook failure inside the recovery was never reported anywhere');
+});
+
+// The same hazard on the control plane, where the report is likewise the first
+// statement of the catch.
+test('a console that throws does not defeat the control-plane recovery', async () => {
+  const { out, reported } = await recoverInChild({
+    path: '/teamclaude/status', method: 'GET',
+    hooks: `{ getStatusExtra: () => { throw new Error('TUI render failed'); } }`,
+  });
+  assert.ok(!out.some(l => l.startsWith('ESCAPED:')),
+    `a throwing console escaped the control-plane handler, where crash-log turns it into exit(1): ${out.join(', ')}`);
+  assert.ok(out.includes('answered=502'), `a throwing console cost the status request its answer: ${out.join(', ')}`);
+  assert.match(reported, /\[TeamClaude\] Unhandled error:/,
+    'the failure that started the recovery was never reported anywhere');
+});
+
+// And the fallback itself, with nobody left to read what it writes.
+test('a report to a closed stderr does not kill the process', async () => {
+  const { code, out } = await recoverInChild({ hooks: LISTENER_HOOKS, stderr: 'destroy' });
+  assert.ok(!out.some(l => l.startsWith('ESCAPED:')),
+    `the fallback report escaped and killed the daemon: ${out.join(', ')}`);
+  assert.ok(out.includes('answered=502'), `the client was not answered: ${out.join(', ')}`);
+  assert.ok(out.includes('STILL-ALIVE'), `the process did not survive the report: ${out.join(', ')}`);
+  assert.equal(code, 0, 'the child exited non-zero');
+});
+
+
+// The blocklist answers and returns on its own, so it owns the entry it closes.
+// Leaving it marked open means the outer catch closes it a second time, which
+// is reachable the moment the hook itself throws.
+test('a blocked model closes its activity entry exactly once', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  const ends = [];
+  const proxy = createProxyServer(am, { ...NO_UPSTREAM, blockedModels: ['*fable*'] }, {
+    onRequestEnd: (id, info) => {
+      ends.push(info.status);
+      if (ends.length === 1) throw new Error('the activity pane rethrew');
+    },
+  });
+  const port = await listen(proxy);
+  try {
+    const res = await quietly(() => postMessages(port, JSON.stringify({ model: 'claude-fable-5', messages: [] })));
+    assert.equal(res?.status, 400, 'the blocklist did not answer, so this proves nothing');
+  } finally {
+    proxy.close();
+  }
+  assert.equal(ends.length, 1,
+    `one blocked request closed its activity entry ${ends.length} times (statuses ${ends.join(', ')})`);
+});

--- a/test/server-error-paths.test.js
+++ b/test/server-error-paths.test.js
@@ -1,0 +1,184 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// Every error path responds on the socket.
+//
+// Both of the server's outer catches sit above the 502 that guards
+// forwardRequest: one around the control plane (the auth gate, the CSRF gate,
+// status/reload/switch), one around the proxied request (pin parsing, body
+// buffering, the activity hooks). A throw in either is the last chance to
+// respond at all.
+//
+// Every request here races a timer, so a hang is a failed assertion rather
+// than a run that never finishes.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const ACCTS = [{ name: 'alice@example.com', type: 'apikey', apiKey: 'k1' }];
+// Port 1 is never listening, so nothing here can reach a real upstream: these
+// tests are about what happens before forwardRequest gets that far.
+const NO_UPSTREAM = { proxy: {}, upstream: 'http://127.0.0.1:1' };
+
+// What the client got, as one of three distinguishable outcomes: `{ status }`
+// for a reply it could read to the end, `{ hung: true }` if nothing arrived
+// before the timer, `{ closed: err }` if the connection was torn down under it.
+// The last two are separate on purpose: a torn-down connection is an answer,
+// and it is the only one that tells the client its reply is incomplete.
+async function outcomeWithin(url, init = {}, ms = 4000) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  try {
+    const res = await fetch(url, { ...init, signal: ac.signal });
+    await res.text();
+    return { status: res.status };
+  } catch (err) {
+    return err.name === 'AbortError' ? { hung: true } : { closed: err };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const postMessages = (port) => outcomeWithin(`http://127.0.0.1:${port}/v1/messages`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+});
+
+// Run `fn` with console.error muted: these tests deliberately provoke the
+// "[TeamClaude] Unhandled error" log, and the stack traces would drown the run.
+async function quietly(fn) {
+  const realErr = console.error;
+  console.error = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.error = realErr;
+  }
+}
+
+// ── the proxied request path ─────────────────────────────────────────────────
+
+// Held at the seam rather than through one input that happens to reach it:
+// anything that throws in the window above forwardRequest is answered.
+// `onRequestStart` fires there.
+test('a throw above forwardRequest is answered rather than hanging the client', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    onRequestStart: () => { reached = true; throw new Error('injected failure above forwardRequest'); },
+  });
+  const port = await listen(proxy);
+  try {
+    assert.deepEqual(await quietly(() => postMessages(port)), { status: 502 },
+      'a throw above forwardRequest left the client waiting forever');
+  } finally {
+    proxy.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+});
+
+// The other half of that catch: it must not respond a second time. The inner
+// `finally` runs `onRequestEnd` after the response has streamed, so a throw
+// there reaches the catch with the headers long sent, and a second writeHead
+// raises ERR_HTTP_HEADERS_SENT from inside the recovery. The client already has
+// its answer in full, and neither arm may take it away.
+test('a throw after the response is streamed does not answer a second time', async () => {
+  // SSE in several frames, so the reply really goes through streamResponse and
+  // the headers are long gone by the time the throw below lands. A buffered
+  // JSON reply never reaches that path.
+  const upstream = http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    res.write('event: message_start\ndata: {"type":"message_start"}\n\n');
+    await new Promise(r => setTimeout(r, 10));
+    res.write('event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n');
+    await new Promise(r => setTimeout(r, 10));
+    res.write('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+    res.end();
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` }, {
+    onRequestEnd: () => { reached = true; throw new Error('injected failure after the response'); },
+  });
+  const port = await listen(proxy);
+
+  // Narrowed to the one rejection this test is about, and attached only for the
+  // length of its own request: `unhandledRejection` is process-wide, so a
+  // catch-all here would report a stray rejection from anywhere else in the run
+  // as this test's failure.
+  const rejections = [];
+  const onRejection = (err) => { if (err?.code === 'ERR_HTTP_HEADERS_SENT') rejections.push(err); };
+  process.on('unhandledRejection', onRejection);
+  try {
+    assert.deepEqual(await quietly(() => postMessages(port)), { status: 200 },
+      'the client did not get the response the upstream already sent');
+    // Give a rejection a turn of the loop to surface before we judge.
+    await new Promise(r => setTimeout(r, 50));
+  } finally {
+    process.off('unhandledRejection', onRejection);
+    proxy.close();
+    upstream.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+  assert.deepEqual(rejections.map(e => e.code), [],
+    'the outer catch tried to answer an already-answered request and threw doing it');
+});
+
+// ── the control-plane path ───────────────────────────────────────────────────
+
+// `getStatusExtra` is a hook the application installs, so this throw surface is
+// real rather than hypothetical.
+test('a throwing status hook is answered, not left hanging', async () => {
+  const am = new AccountManager(ACCTS, 0.98);
+  let reached = false;
+  const proxy = createProxyServer(am, NO_UPSTREAM, {
+    getStatusExtra: () => { reached = true; throw new Error('status hook blew up'); },
+  });
+  const port = await listen(proxy);
+  try {
+    assert.deepEqual(await quietly(() => outcomeWithin(`http://127.0.0.1:${port}/teamclaude/status`)), { status: 502 },
+      'a throwing status hook left the client waiting forever');
+  } finally {
+    proxy.close();
+  }
+  assert.ok(reached, 'the request never reached the injected throw, so this proves nothing');
+});
+
+// The half that a before-headers guard alone does not cover. The status
+// endpoint serializes the hook's value after writeHead, so a value JSON cannot
+// represent (a cycle, a BigInt) throws with the 200 already sent, and nothing
+// else ends the response.
+//
+// Not answering at all and ending the response gracefully are both wrong here,
+// and only one of them looks wrong: an end() delivers the 200 the client asked
+// for, with a body that was never written, and the client has no way to tell it
+// from a real one. So this asserts the connection was destroyed, not merely
+// that something came back.
+test('a status hook returning an unserializable value closes the connection', async () => {
+  const cyclic = {}; cyclic.self = cyclic;
+  for (const [label, extra] of [['a cycle', { cyclic }], ['a BigInt', { big: 1n }]]) {
+    const am = new AccountManager(ACCTS, 0.98);
+    let reached = false;
+    const proxy = createProxyServer(am, NO_UPSTREAM, {
+      getStatusExtra: () => { reached = true; return extra; },
+    });
+    const port = await listen(proxy);
+    let outcome;
+    try {
+      outcome = await quietly(() => outcomeWithin(`http://127.0.0.1:${port}/teamclaude/status`));
+    } finally {
+      proxy.close();
+    }
+    assert.ok(reached, `the request never reached the hook returning ${label}`);
+    assert.ok(!outcome.hung, `${label}: the client waited forever for a response nobody sent`);
+    assert.ok(outcome.closed,
+      `${label}: the client read a complete ${outcome.status} whose body was never written`);
+  }
+});


### PR DESCRIPTION
Builds on #180, which added the outer catch this uses. Review that one first; the diff here is the last commit only.

Cancel a request in Claude Code with Ctrl+C and the proxy never learns it ended: the TUI's activity row spins forever, and a headless consumer's in-flight count grows by one, permanently, per cancelled upload.

```
$ node repro-leak.mjs . 5
5 cancelled uploads -> 5 activity rows still open      (0 after this change)
```

<details>
<summary><code>repro-leak.mjs</code></summary>

```js
// Count the activity rows left open after N cancelled uploads.
// usage: node repro-leak.mjs <repo-dir> <n>
import http from 'node:http';
const [, , repo, nArg] = process.argv;
const { AccountManager } = await import(`${repo}/src/account-manager.js`);
const { createProxyServer } = await import(`${repo}/src/server.js`);

const active = new Map();                       // the TUI's `active`, in miniature
const am = new AccountManager([{ name: 'alice', type: 'apikey', apiKey: 'k1' }], 0.98);
const server = createProxyServer(am, { proxy: {}, upstream: 'http://127.0.0.1:1' }, {
  onRequestStart: (id, info) => active.set(id, info),
  onRequestEnd: (id) => active.delete(id),
});
const realErr = console.error;
console.error = () => {};

const port = await new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port)));
const body = JSON.stringify({ model: 'claude-opus-5', messages: [] });

for (let i = 0; i < Number(nArg); i++) {
  await new Promise((resolve) => {
    const req = http.request({
      host: '127.0.0.1', port, method: 'POST', path: '/v1/messages',
      headers: { 'content-type': 'application/json', 'content-length': String(body.length + 64) },
    });
    req.on('error', () => {});
    req.write(body.slice(0, 24));               // partial upload, then Ctrl+C
    setTimeout(() => { req.destroy(); resolve(); }, 30);
  });
}
await new Promise(r => setTimeout(r, 300));
console.error = realErr;
console.log(`${nArg} cancelled uploads -> ${active.size} activity rows still open`);
server.close();
```

</details>

## Why

The entry is opened by `onRequestStart` but only closed by the `finally` around `forwardRequest`, so anything that throws above the inner try leaves it open forever. Two ordinary things do: a client cancelling mid-upload (`for await (const chunk of req)` rejects above the inner try), and a start hook that registers its row and then throws, which is the shipped TUI hook's shape (`active.set(id, ...)`, then a render that can rethrow).

## The fix

The listener tracks the open entry in one marker: set before the start hook, cleared before the end hook at every closing site, and the outer catch closes whatever is left (499 if the client is gone or the response is past answering, 502 when that is what it is about to write). Each ordering trades a spurious close, which every shipped consumer tolerates, against a permanent leak. The outer catch's own hook call is guarded, because the throw that sent it there may be that hook; unguarded, it escapes as an unhandled rejection, which `crash-log.js` turns into `exit(1)`.

## The recovery has to survive its own logging

Under the TUI the console **is** the TUI: `console.error` renders, so a broken render makes the first line of every recovery throw. That half exists on plain `master` today. `onRequestRouted` is called inside `forwardRequest`, whose catch answers 502; run the same request twice and vary only the console:

```
working console  -> { clientGot: "HTTP 502", escaped: [] }
throwing console -> { clientGot: "HUNG (no response in 3s)", escaped: ["TUI render failed"] }
```

<details>
<summary><code>probe-master-logging.mjs</code></summary>

```js
// Isolate the logging defect on plain upstream master, away from the ledger
// leak and the unanswered-socket defect.
//
// `onRequestRouted` is called INSIDE forwardRequest, so a throwing one lands in
// the inner catch, which is the one recovery master already has: it writes a
// 502. Run it twice, once with a working console and once with a TUI-shaped
// console that throws. The only difference between the runs is the console.
//
// usage: node probe-master-logging.mjs <repo-dir>
import http from 'node:http';
const [, , repo] = process.argv;
const { AccountManager } = await import(`${repo}/src/account-manager.js`);
const { createProxyServer } = await import(`${repo}/src/server.js`);

async function run(consoleThrows) {
  const am = new AccountManager([{ name: 'alice', type: 'apikey', apiKey: 'k1' }], 0.98);
  const escaped = [];
  const onRej = (e) => escaped.push(e?.message);
  process.on('unhandledRejection', onRej);

  const server = createProxyServer(am, { proxy: {}, upstream: 'http://127.0.0.1:1' }, {
    onRequestRouted: () => { throw new Error('routed hook failed'); },
  });
  const port = await new Promise(r => server.listen(0, '127.0.0.1', () => r(server.address().port)));

  const realErr = console.error;
  console.error = consoleThrows
    ? () => { throw new Error('TUI render failed'); }
    : () => {};

  const answer = await new Promise((resolve) => {
    const req = http.request({
      host: '127.0.0.1', port, method: 'POST', path: '/v1/messages',
      headers: { 'content-type': 'application/json' },
    }, (res) => { res.resume(); res.on('end', () => resolve(`HTTP ${res.statusCode}`)); });
    req.on('error', (e) => resolve(`no answer (${e.code})`));
    setTimeout(() => resolve('HUNG (no response in 3s)'), 3000);
    req.end(JSON.stringify({ model: 'claude-opus-5', messages: [] }));
  });

  await new Promise(r => setTimeout(r, 200));
  console.error = realErr;
  process.off('unhandledRejection', onRej);
  server.close();
  return { consoleThrows, clientGot: answer, escaped };
}

console.log(JSON.stringify(await run(false), null, 2));
console.log(JSON.stringify(await run(true), null, 2));
process.exit(0);
```

</details>

Inside this change, one broken render causes both throws at once. Measured before this part was added: `{ rowsStillOpen: 1, clientGot: "HUNG", escaped: ["TUI render failed"] }`. After: `{ rowsStillOpen: 0, clientGot: "HTTP 502", escaped: [] }`.

So every recovery-path report goes through one `reportFailure` helper that falls back to stderr with the full stack, as `tui.js` already does when its own activity stream fails. The fallback writes with `writeSync`, not `process.stderr.write`: a closed stderr surfaces EPIPE asynchronously where no `try` can catch it, and this daemon treats an uncaught EPIPE as fatal.

```
process.stderr.write -> { code: 9, out: ["after=none", "UNCAUGHT:EPIPE"] }
writeSync(2, ...)    -> { code: 0, out: ["after=CAUGHT:EPIPE", "STILL-ALIVE"] }
```

Three of the four converted sites are each held by a test; the fourth, the inner catch around `forwardRequest`, is converted for consistency and carries no claim.

## Tests

Eight in `test/activity-entries.test.js`. Six fail on this PR's base:

```
✖ a request aborted mid-body closes its activity entry
✖ a start hook that registers its row and then throws does not orphan it
✖ a hook that throws on every call cannot bring the process down
✖ a console that throws does not defeat the recovery
✖ a console that throws does not defeat the control-plane recovery
✖ a report to a closed stderr does not kill the process
```

The three console tests run the proxy in a child with a throwing (not muted) `console.error`, since a raw fd-2 write bypasses any in-process stub. The other two pass on the base and pin the clear-before-call orderings; moving either clear turns its test red.

538/538 (530 on the base), #180's five tests unmodified, `npx eslint .` clean.

## Compatibility

Accounting and hooks only; no routing, selection, retry or upstream changes. Clients see a difference in two places, neither a loss: an abandoned request's entry now closes as 499 where the client previously got nothing, and under a throwing TUI render, requests that used to hang now get their 502. `onRequestEnd` consumers can now see `account: null, model: null` with a 499 or 502 for a request that never reached selection, the same shape an early failure already produced.
