### PR TITLE
fix(proxy): a DNS failure closes the connection instead of walking the fleet

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -722,6 +722,72 @@ function formatHeaders(headers) {
   return Object.entries(headers).map(([k, v]) => `  ${k}: ${v}`).join('\n');
 }
 
+// Failures that say nothing about the ACCOUNT, only about the socket. Retrying
+// can succeed where failing over cannot, and closing fast lets Node evict the
+// dead socket so the client's retry reconnects cleanly. EPIPE joins the set as
+// the write-side sibling of ECONNRESET.
+//
+// ECONNREFUSED sits here despite being arguably a property of the host. It is
+// already unconditionally transient, so making it conditional converts every gap
+// in that condition into a regression instead of leaving an unfixed case. One
+// such gap is measurable: a disabled account carrying its own `upstream` is
+// never selected, so it never enters `ctx.tried`, and the condition below then
+// reads as satisfied indefinitely. Wired that way, a four-account fleet spent
+// three accounts on a refused connection and answered rate_limit_error.
+const SOCKET_TRANSIENT = new Set([
+  'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT',
+  'TEAMCLAUDE_HEADERS_TIMEOUT', 'TEAMCLAUDE_BODY_TIMEOUT',
+]);
+
+// Failures that are a property of the HOST being dialled: name resolution and
+// routing. The hostname has no per-account component, so every account produces
+// the same failure, and walking the fleet spends an upstream call per account to
+// learn the same thing. The client is then told its quota is exhausted because a
+// name would not resolve.
+//
+// Conditional, because an account may name its own `upstream` for a third-party
+// backend. Where an untried account would dial a different host, this failure
+// says nothing about that one, and failing over is correct.
+const HOST_TRANSIENT = new Set(['ENOTFOUND', 'EAI_AGAIN', 'EHOSTUNREACH', 'ENETUNREACH', 'ENETDOWN']);
+
+/**
+ * Every error code a failure carries: its own, its `cause`'s, and its
+ * children's. Node's global fetch puts the real error on `cause`, and the
+ * happy-eyeballs dialer reports an all-addresses-failed connect as an
+ * AggregateError that may carry no top-level code at all, with the reason
+ * recorded once per address.
+ */
+function errorCodes(err) {
+  const codes = [err?.code, err?.cause?.code];
+  for (const child of err?.errors || []) codes.push(child?.code);
+  for (const child of err?.cause?.errors || []) codes.push(child?.code);
+  return codes.filter(Boolean);
+}
+
+/**
+ * Should this upstream failure close the connection for the client to retry,
+ * instead of being failed over to the next account?
+ *
+ * `otherHostAvailable` states whether an untried account would dial a different
+ * host, which is what makes a host-scoped failure worth failing over. Exported
+ * for its own tests.
+ */
+export function isTransientUpstreamError(err, { otherHostAvailable = false } = {}) {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'TimeoutError' || err.name === 'AbortError') return true;
+  const codes = errorCodes(err);
+  if (codes.some(c => SOCKET_TRANSIENT.has(c))) return true;
+  if (codes.some(c => HOST_TRANSIENT.has(c))) return !otherHostAvailable;
+  // Read last, and only once no code has been found. Node's global fetch, which
+  // `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH` selects, reports every failure with this
+  // message and the real error on `.cause`; checking it earlier would answer for
+  // the whole transport before the codes above were consulted, so a host-scoped
+  // failure there would never reach its conditional arm.
+  if (typeof err.message === 'string' && err.message.includes('fetch failed')) return true;
+  return false;
+}
+
 export async function forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, useSx) {
   const maxRetries = accountManager.accounts.length;
   // This function is exported, so a caller may hand us a ctx built elsewhere.
@@ -1110,13 +1176,13 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     const l = getLog();
     if (l) { l.write(`\n\n=== ERROR ===\n${err.stack || err.message}`); l.end(); }
 
-    const isTransient = err instanceof Error &&
-      (err.code === 'TEAMCLAUDE_HEADERS_TIMEOUT' || err.code === 'TEAMCLAUDE_BODY_TIMEOUT' ||
-        err.name === 'TimeoutError' || err.name === 'AbortError' ||
-        err.message.includes('fetch failed') ||
-        err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
-        err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT' ||
-        err.code === 'UND_ERR_HEADERS_TIMEOUT' || err.code === 'UND_ERR_BODY_TIMEOUT');
+    // Would failing over dial anywhere else? Only an untried account pointing at
+    // a different `upstream` makes that true, and it is what decides whether a
+    // name-resolution failure is worth retrying elsewhere.
+    const thisHost = account.upstream || upstream;
+    const otherHostAvailable = accountManager.accounts.some(a =>
+      a.index !== account.index && !ctx.tried.has(a.index) && (a.upstream || upstream) !== thisHost);
+    const isTransient = isTransientUpstreamError(err, { otherHostAvailable });
 
     // Transient network errors (including a stale-socket headers/body timeout):
     // close the connection and let the client retry. Failing over to another

--- a/test/unreachable-upstream.test.js
+++ b/test/unreachable-upstream.test.js
@@ -1,0 +1,167 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+import { setUpstreamProxy, resolveUpstreamProxy, resetUpstreamProxy } from '../src/upstream-proxy.js';
+
+// What one unreachable upstream costs a fleet. These drive the real server and
+// import nothing this change adds, so they run against the tree as it was and
+// report the behaviour, not a missing symbol.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const accounts = (names) => names.map(n => ({ name: n, type: 'apikey', apiKey: `k-${n}` }));
+
+// A fresh name per run, so no resolver cache can answer it from a previous one.
+const unresolvable = () => `http://nx-${Date.now()}-${Math.random().toString(36).slice(2)}-teamclaude.invalid`;
+
+// Behind an ambient proxy a DNS failure never reaches the classification: the
+// proxy resolves the name and reports its own refusal, leaving no resolution
+// code to read. Disable it through the seam upstream-proxy.test.js already uses.
+function withoutAmbientProxy() {
+  setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: false }, {}));
+  return resetUpstreamProxy;
+}
+
+// Drive one request through a proxy and collect the upstream failures it logged.
+async function oneRequest(proxyPort) {
+  const lines = [];
+  const realErr = console.error;
+  const realLog = console.log;
+  console.error = (...a) => lines.push(a.map(x => (x instanceof Error ? x.message : String(x))).join(' '));
+  console.log = () => {};
+  let outcome;
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+    });
+    outcome = `${res.status} ${await res.text()}`;
+  } catch {
+    outcome = 'connection closed';        // the transient path, by design
+  } finally {
+    console.error = realErr;
+    console.log = realLog;
+  }
+  return { outcome, attempts: lines.filter(l => l.includes('Upstream error')) };
+}
+
+const sawResolutionFailure = (got) => got.attempts.some(l => /ENOTFOUND|EAI_AGAIN/.test(l));
+const nothingMeasured = (got) =>
+  `this environment did not produce a resolution failure, so nothing here was measured: ${got.attempts.join(' | ') || '(no attempts logged)'}`;
+
+test('an unresolvable upstream is not walked through the whole fleet', async () => {
+  const am = new AccountManager(accounts(['a', 'b', 'c', 'd']), 0.98);
+  const restore = withoutAmbientProxy();
+  const proxy = createProxyServer(am, { proxy: {}, upstream: unresolvable() });
+  const port = await listen(proxy);
+  let got;
+  try {
+    got = await oneRequest(port);
+  } finally {
+    restore();
+    proxy.close();
+  }
+  assert.ok(sawResolutionFailure(got), nothingMeasured(got));
+  assert.equal(got.attempts.length, 1,
+    `one unresolvable host spent ${got.attempts.length} of ${am.accounts.length} accounts`);
+  assert.ok(!/rate_limit_error/.test(got.outcome),
+    `a name that would not resolve was reported to the client as exhausted quota: ${got.outcome}`);
+});
+
+test('an unresolvable upstream still fails over to an account on a different host', async () => {
+  const am = new AccountManager(accounts(['a', 'b']), 0.98);
+  const reached = [];
+  const good = http.createServer((req, res) => {
+    reached.push(req.headers['x-api-key'] || 'none');
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  const goodPort = await listen(good);
+  am.accounts[1].upstream = `http://127.0.0.1:${goodPort}`;   // 'b' has its own backend
+
+  const restore = withoutAmbientProxy();
+  const proxy = createProxyServer(am, { proxy: {}, upstream: unresolvable() });
+  const port = await listen(proxy);
+  let got;
+  try {
+    got = await oneRequest(port);
+  } finally {
+    restore();
+    proxy.close();
+    good.close();
+  }
+  assert.ok(sawResolutionFailure(got), nothingMeasured(got));
+  assert.match(got.outcome, /^200 /,
+    `the request did not reach the account whose host was up: ${got.outcome}`);
+  assert.equal(reached.length, 1, 'the account on the reachable host was not the one that served');
+});
+
+// Once an account has been tried, its host is no longer somewhere else to go.
+// Without that term the last failure still counts the accounts already spent, so
+// the fleet runs out of untried accounts and the client is told its quota is
+// exhausted, for two hosts that would not resolve.
+test('a fleet whose hosts are all unresolvable closes rather than reporting exhaustion', async () => {
+  const am = new AccountManager(accounts(['a', 'b']), 0.98);
+  am.accounts[1].upstream = unresolvable();          // a different host, equally unresolvable
+
+  const restore = withoutAmbientProxy();
+  const proxy = createProxyServer(am, { proxy: {}, upstream: unresolvable() });
+  const port = await listen(proxy);
+  let got;
+  try {
+    got = await oneRequest(port);
+  } finally {
+    restore();
+    proxy.close();
+  }
+  assert.ok(sawResolutionFailure(got), nothingMeasured(got));
+  assert.equal(got.attempts.length, 2,
+    `two accounts on two dead hosts produced ${got.attempts.length} attempts`);
+  assert.ok(!/rate_limit_error/.test(got.outcome),
+    `two names that would not resolve were reported to the client as exhausted quota: ${got.outcome}`);
+});
+
+// The shape that makes ECONNREFUSED unsafe to route through the condition.
+// `otherHostAvailable` scans the raw account list, while selection goes through
+// its own availability check, so an account selection can never choose still
+// counts toward "another host is available", and nothing removes it: it is never
+// selected, so it never enters the tried set. A disabled account carrying its
+// own upstream is the cheapest instance.
+//
+// A refused port here on purpose. This is about a code that must stay
+// unconditional, so the test has to use one.
+test('a refused connection is not walked through the fleet by an unselectable account', async () => {
+  const am = new AccountManager(accounts(['a', 'b', 'c', 'd']), 0.98);
+  const good = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  const goodPort = await listen(good);
+  am.accounts[3].upstream = `http://127.0.0.1:${goodPort}`;
+  am.accounts[3].disabled = true;
+
+  // Same determinism guard as the tests above. A configured proxy without a
+  // loopback bypass changes the error shape, and this test would then be
+  // measuring that instead.
+  const restore = withoutAmbientProxy();
+  const proxy = createProxyServer(am, { proxy: {}, upstream: 'http://127.0.0.1:1' });
+  const port = await listen(proxy);
+  let got;
+  try {
+    got = await oneRequest(port);
+  } finally {
+    restore();
+    proxy.close();
+    good.close();
+  }
+  assert.ok(got.attempts.length > 0, 'the request never reached the upstream error path');
+  assert.equal(got.attempts.length, 1,
+    `one refused connection spent ${got.attempts.length} accounts, because an account selection cannot choose counted toward a failover that could never be taken`);
+  assert.ok(!/rate_limit_error/.test(got.outcome),
+    `a network failure was reported to the client as exhausted quota: ${got.outcome}`);
+});

--- a/test/upstream-error-classification.test.js
+++ b/test/upstream-error-classification.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isTransientUpstreamError } from '../src/server.js';
+
+// An upstream failure is either about the socket or about the host, and the
+// difference decides whether the fleet gets walked. A socket failure is about
+// this connection, so another account cannot mend it. A host failure would
+// reach every account identically, unless one of them dials somewhere else.
+//
+// The fleet-level consequence of getting this wrong is in
+// test/unreachable-upstream.test.js.
+
+const withCode = (code) => Object.assign(new Error(code), { code });
+
+test('a socket failure is transient whatever else the fleet could dial', () => {
+  for (const code of ['ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT',
+    'TEAMCLAUDE_HEADERS_TIMEOUT', 'TEAMCLAUDE_BODY_TIMEOUT']) {
+    assert.equal(isTransientUpstreamError(withCode(code)), true, code);
+    assert.equal(isTransientUpstreamError(withCode(code), { otherHostAvailable: true }), true,
+      `${code} is about this connection, and another host cannot mend a broken one`);
+  }
+});
+
+test('a host failure is transient only when no other host could be dialled', () => {
+  for (const code of ['ENOTFOUND', 'EAI_AGAIN', 'EHOSTUNREACH', 'ENETUNREACH', 'ENETDOWN']) {
+    assert.equal(isTransientUpstreamError(withCode(code)), true, code);
+    assert.equal(isTransientUpstreamError(withCode(code), { otherHostAvailable: true }), false,
+      `${code} says nothing about an account that dials somewhere else`);
+  }
+});
+
+// Stated as an assertion so a later edit cannot quietly move this code into the
+// host set. What that move costs is measured in unreachable-upstream.test.js.
+test('a refused connection stays transient even when another host is available', () => {
+  assert.equal(isTransientUpstreamError(withCode('ECONNREFUSED')), true);
+  assert.equal(isTransientUpstreamError(withCode('ECONNREFUSED'), { otherHostAvailable: true }), true,
+    'a refused connection became conditional, which reopens every gap in the condition');
+});
+
+test('the timeout and abort names are transient without a code', () => {
+  assert.equal(isTransientUpstreamError(Object.assign(new Error('x'), { name: 'TimeoutError' })), true);
+  assert.equal(isTransientUpstreamError(Object.assign(new Error('x'), { name: 'AbortError' })), true);
+});
+
+// The shape the global-fetch transport really produces, which is every failure
+// on that path: a TypeError saying "fetch failed" with the code on `cause`. The
+// message is enough on its own to call a failure transient, so it has to be read
+// after the codes; read first, it answers for the whole transport and the
+// host-scoped arm never runs there.
+test('a global-fetch wrapper is classified by the code it carries, not by its message', () => {
+  const wrapped = Object.assign(new TypeError('fetch failed'), { cause: withCode('ENOTFOUND') });
+  assert.equal(isTransientUpstreamError(wrapped), true);
+  assert.equal(isTransientUpstreamError(wrapped, { otherHostAvailable: true }), false,
+    'the message decided this before the code was read, so the conditional arm never ran');
+  // And the fallback the message check exists for: a wrapper carrying nothing.
+  assert.equal(isTransientUpstreamError(new TypeError('fetch failed')), true);
+});
+
+// Asserted in the direction where reading the children changes the answer. The
+// other direction returns false whether the children were read or not, since an
+// error carrying no recognised code is not transient either, so it would be
+// satisfied by a version that never looked.
+test('the code is read from a wrapper and from an aggregate', () => {
+  const child = withCode('ENOTFOUND');
+  assert.equal(isTransientUpstreamError(Object.assign(new Error('boom'), { cause: child })), true,
+    'the real error sits on `cause` when global fetch is the transport');
+
+  const aggregate = new AggregateError([child]);
+  assert.equal(isTransientUpstreamError(aggregate), true,
+    'an aggregate carries no top-level code, so the children have to be read');
+  assert.equal(isTransientUpstreamError(aggregate, { otherHostAvailable: true }), false,
+    'and once read, the code is host-scoped like any other');
+
+  const wrappedAggregate = Object.assign(new Error('boom'), { cause: new AggregateError([child]) });
+  assert.equal(isTransientUpstreamError(wrappedAggregate), true,
+    'global fetch wraps the aggregate, so the children sit two levels down');
+});
+
+test('an unrecognised failure is not transient, and neither is a non-Error', () => {
+  assert.equal(isTransientUpstreamError(withCode('EACCES')), false);
+  assert.equal(isTransientUpstreamError(new Error('something else')), false);
+  assert.equal(isTransientUpstreamError({ code: 'ENOTFOUND' }), false, 'not an Error');
+  assert.equal(isTransientUpstreamError(undefined), false);
+});


### PR DESCRIPTION
teamclaude answers `rate_limit_error` when DNS is down.

A hostname has no per-account component, so an upstream name that will not resolve fails identically for every account. The failover path treated it as an account failure and tried the whole fleet:

```
before  4 of 4 accounts spent, 429 rate_limit_error "All 4 accounts exhausted"
after   1 of 4, connection closed
```

Both runs observed `getaddrinfo ENOTFOUND`, with the ambient outbound proxy disabled (behind one, the proxy resolves the name and the failure never arrives as a resolution error). Each walked account is a real upstream call charged to its bucket, and the log gets one line per account, so an outage also reads as several times its actual traffic.

## The classification

**Socket-scoped** codes describe this connection: `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`, and the five timeout codes (three undici, two of the proxy's own watchdogs). These stay unconditionally transient; the connection closes and the client retries. `EPIPE` is new to the set, the write-side sibling of `ECONNRESET`.

**Host-scoped** codes describe the host being dialled: `ENOTFOUND`, `EAI_AGAIN`, `EHOSTUNREACH`, `ENETUNREACH`, `ENETDOWN`. These are transient only while no untried account would dial a *different* host. An account may carry its own `upstream` for a third-party backend, and a name failure on the default host says nothing about that one, so that failover still works and is tested.

Codes are read from the error, its `cause` (global fetch puts the real error there), and its children (the happy-eyeballs dialer reports an all-addresses-failed connect as an `AggregateError` that can carry no top-level code).

## Why `ECONNREFUSED` is not in the host set

Nothing listening at `host:port` is arguably a property of the host, and an earlier version classified it that way. It was reverted. `ECONNREFUSED` was already unconditionally transient, so the conditional could only subtract: every gap in the condition becomes a live regression instead of an unfixed case. One gap is measurable today, since the condition scans the raw account list while selection applies its own availability check:

```
ECONNREFUSED unconditional   1 account spent, connection closed
ECONNREFUSED conditional     3 accounts spent, 429 rate_limit_error
```

(A disabled account carrying its own `upstream` is never selected, never enters the tried set, and satisfies "another host is available" for the whole request.) A test holds this at both levels: the unit assertion, and the fleet behaviour with a disabled account on its own backend.

## What this does not fix

The condition is a heuristic for whether failing over would reach somewhere new, and it is wrong in six known ways. None is introduced here.

<details>
<summary>Six limitations</summary>

1. **Accounts selection cannot choose still count.** Disabled, spent or excluded accounts never enter the tried set and satisfy the condition for the whole request. Measured above.

2. **A shared outbound proxy is invisible.** Accounts routed through one egress proxy reach the same real host whatever their `upstream` says.

3. **Hosts are compared as raw strings.** `http://localhost:1` and `http://127.0.0.1:1` read as two hosts.

4. **A pinned request counts accounts it cannot use**, so a host failure on it fails over into a path with nowhere to go and the client gets the 429 this change is meant to prevent.

5. **Behind an outbound proxy the code is gone before classification.** The proxy resolves the name and reports its own refusal, with no resolution code left to match.

6. **Disagreeing children are decided by evaluation order.** One `ECONNRESET` child makes an aggregate unconditionally transient where an `ENOTFOUND` sibling alone would have been conditional. Measured both ways.

</details>

The first four leave a host failure classified as worth failing over; the cost ranges from a fleet walk down to one wasted retry. The last two stop the condition being reached at all. Each costs less than the defect fixed here, and for `ECONNREFUSED` each would have been a new regression.

Separately: the flag chooses between closing and failing over, and does not reorder selection. On a mixed fleet the failover still walks same-host accounts in priority order before reaching one that dials somewhere new, so a mixed fleet saves less than the homogeneous `1 of 4` above.

## Tests

Eleven, in two files.

`test/upstream-error-classification.test.js` covers the predicate: socket codes stay transient with another host available, host codes do not, and codes are read from `cause` and from children. The aggregate case is asserted in the direction where reading the children changes the answer; the other direction is satisfied even by a version that never looks.

`test/unreachable-upstream.test.js` drives the real server and imports nothing this change adds, so it runs against the unfixed tree:

```
✖ an unresolvable upstream is not walked through the whole fleet
    one unresolvable host spent 4 of 4 accounts
✔ an unresolvable upstream still fails over to an account on a different host
✖ a fleet whose hosts are all unresolvable closes rather than reporting exhaustion
    two names that would not resolve were reported to the client as exhausted quota:
    429 {"type":"error","error":{"type":"rate_limit_error","message":"All 2 accounts exhausted. Retry in 60s."}}
✔ a refused connection is not walked through the fleet by an unselectable account
```

The two passing tests pin behaviour this change must preserve: failover across genuinely different hosts, and a refused connection staying unconditional. Each fleet test uses a fresh unresolvable name (no resolver cache), disables the ambient proxy through the existing test seam, and asserts it actually observed a resolution failure, so a resolver that hijacks unknown names fails loudly.

```
$ node --test --test-timeout=120000
ℹ tests 536
ℹ pass 536
ℹ fail 0
```

525 before, 536 after. `npx eslint .` clean.

## Compatibility

Classification only. Nothing changes for successful requests, upstream 429s or 401s, or the codes already socket-scoped. `EPIPE` is the exception: a broken-pipe failure now closes the connection instead of falling through to failover.

One deliberate client-visible change: a host-scoped failure closes after one attempt instead of returning a 429 that blames quota for a network fault. A retrying client sees the same outcome sooner; a client honoring the 429's retry interval no longer waits on a quota state that was never real.
