### PR TITLE
fix(oauth): scope the Keychain lookup to the current user's item

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { homedir, userInfo } from 'node:os';
 import { randomBytes, createHash } from 'node:crypto';
 import { exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -12,13 +12,57 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_CREDENTIALS_PATH = '~/.claude/.credentials.json';
 const KEYCHAIN_SERVICE = 'Claude Code-credentials';
 
+/** The login name whose Keychain item to prefer, or null where there isn't one. */
+function currentUsername() {
+  try { return userInfo().username || null; } catch { return null; }
+}
+
+/** Whether a Keychain payload actually carries a usable token. */
+function hasToken(raw) {
+  return Boolean(raw?.claudeAiOauth?.accessToken || raw?.accessToken);
+}
+
 /**
  * Read Claude Code credentials from the macOS Keychain, where Claude Code
  * stores them on darwin (there is no ~/.claude/.credentials.json on macOS).
+ *
+ * The service name is not unique. Claude Code has been observed leaving a stray
+ * `acct="unknown"` item that holds only `mcpOAuth` alongside the real
+ * `acct="<login name>"` one, and `find-generic-password -s NAME -w` returns
+ * whichever the Keychain yields first. Reading the stray item makes a machine
+ * with a perfectly good login look like it has no credentials at all, and the
+ * import fails with a "Keychain lookup failed" that sends people off to
+ * re-authenticate something that was never broken.
+ *
+ * So ask for the current user's item first, fall back to the service-only
+ * lookup, and take the first payload that actually carries a token — a present
+ * but blank `claudeAiOauth` (left behind by a logout) is skipped the same way.
  */
-async function readKeychainCredentials() {
-  const { stdout } = await execFileAsync('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w']);
-  return JSON.parse(stdout.trim());
+export async function readKeychainCredentials({ exec = execFileAsync, username = currentUsername() } = {}) {
+  const base = ['find-generic-password', '-s', KEYCHAIN_SERVICE];
+  const lookups = username ? [[...base, '-a', username, '-w'], [...base, '-w']] : [[...base, '-w']];
+
+  let firstParsed = null;
+  let firstErr = null;
+
+  for (const args of lookups) {
+    let parsed;
+    try {
+      const { stdout } = await exec('security', args);
+      parsed = JSON.parse(stdout.trim());
+    } catch (err) {
+      firstErr ??= err;
+      continue;
+    }
+    if (hasToken(parsed)) return parsed;
+    firstParsed ??= parsed;
+  }
+
+  // Nothing had a token. Hand back whatever parsed so the caller's own
+  // "no credentials" reporting stays in charge, and only throw if every
+  // lookup failed outright.
+  if (firstParsed) return firstParsed;
+  throw firstErr ?? new Error(`no "${KEYCHAIN_SERVICE}" item found in the Keychain`);
 }
 
 /**

--- a/test/import-credentials.test.js
+++ b/test/import-credentials.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { importCredentials } from '../src/oauth.js';
+import { importCredentials, readKeychainCredentials } from '../src/oauth.js';
 
 const CREDS = { accessToken: 'at', refreshToken: 'rt', expiresAt: 1754500000000 };
 
@@ -71,5 +71,75 @@ test('reports both file and Keychain failure when fallback fails', async () => {
   await assert.rejects(
     importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain }),
     /Keychain.*item not found in keychain/,
+  );
+});
+
+// The Keychain service name is not unique — a stray acct="unknown" item can sit
+// alongside the real one, and a service-only lookup may return either.
+
+test('keychain lookup asks for the current user\'s item first', async () => {
+  const calls = [];
+  const exec = async (_bin, args) => {
+    calls.push(args);
+    return { stdout: JSON.stringify({ claudeAiOauth: CREDS }) };
+  };
+
+  const raw = await readKeychainCredentials({ exec, username: 'ada' });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], ['find-generic-password', '-s', 'Claude Code-credentials', '-a', 'ada', '-w']);
+  assert.equal(raw.claudeAiOauth.accessToken, 'at');
+});
+
+test('skips an item that carries no credentials', async () => {
+  const exec = async (_bin, args) => ({
+    stdout: JSON.stringify(args.includes('-a') ? { claudeAiOauth: CREDS } : { mcpOAuth: {} }),
+  });
+
+  const raw = await readKeychainCredentials({ exec, username: 'ada' });
+  assert.equal(raw.claudeAiOauth.accessToken, 'at');
+});
+
+test('skips an item whose credentials are blank', async () => {
+  const exec = async (_bin, args) => ({
+    stdout: JSON.stringify(args.includes('-a')
+      ? { claudeAiOauth: { accessToken: '', refreshToken: '' } }
+      : { claudeAiOauth: CREDS }),
+  });
+
+  const raw = await readKeychainCredentials({ exec, username: 'ada' });
+  assert.equal(raw.claudeAiOauth.accessToken, 'at');
+});
+
+test('falls back to the service-only lookup when the account-scoped one misses', async () => {
+  const tried = [];
+  const exec = async (_bin, args) => {
+    const scoped = args.includes('-a');
+    tried.push(scoped ? 'scoped' : 'service');
+    if (scoped) throw new Error('SecKeychainSearchCopyNext: The specified item could not be found');
+    return { stdout: JSON.stringify({ claudeAiOauth: CREDS }) };
+  };
+
+  const raw = await readKeychainCredentials({ exec, username: 'ada' });
+  assert.deepEqual(tried, ['scoped', 'service']);
+  assert.equal(raw.claudeAiOauth.accessToken, 'at');
+});
+
+test('uses the service-only lookup when there is no username to scope to', async () => {
+  const calls = [];
+  const exec = async (_bin, args) => {
+    calls.push(args);
+    return { stdout: JSON.stringify({ claudeAiOauth: CREDS }) };
+  };
+
+  await readKeychainCredentials({ exec, username: null });
+  assert.deepEqual(calls, [['find-generic-password', '-s', 'Claude Code-credentials', '-w']]);
+});
+
+test('surfaces the Keychain error when every lookup fails', async () => {
+  const exec = async () => { throw new Error('item not found in keychain'); };
+
+  await assert.rejects(
+    readKeychainCredentials({ exec, username: 'ada' }),
+    /item not found in keychain/,
   );
 });


### PR DESCRIPTION
`find-generic-password -s "Claude Code-credentials" -w` returns whichever item the Keychain yields first, and the service name is not unique.

On this machine Claude Code has left a stray `acct="unknown"` item holding only `mcpOAuth` next to the real `acct="<login name>"` one. `importCredentials` reads the stray item, finds no `claudeAiOauth`, and reports no credentials — while a valid login sits in the item beside it.

Reproduced against the real Keychain, before and after:

```
before (master) : keys=[mcpOAuth]                 token=MISSING
after  (patch)  : keys=[mcpOAuth, claudeAiOauth]  token=PRESENT
```

## The fix

Ask for the current user's item first, fall back to the existing service-only lookup, and take the first payload that actually carries a token. That also skips a present-but-blank `claudeAiOauth` left behind by a logout.

Behaviour is unchanged on machines with a single item: the scoped lookup hits it, and if the account name doesn't match, the fallback is the exact call master makes today.

## Tests

`readKeychainCredentials` is now exported and takes `{ exec, username }`, so it can be injected the way `importCredentials` already is. Six cases added to `test/import-credentials.test.js` covering lookup order, the stray-item case, the blank-token case, fallback, the no-username path, and error propagation.

531 tests pass, `eslint` clean.
