### PR TITLE
feat(oauth): Add support for copy/paste authentication

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { installCrashHandlers } from './crash-log.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
-import { importCredentials, loginOAuth, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
+import { importCredentials, loginOAuth, loginOAuthWithPastedCode, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
 import { sameIdentity, orgKey, matchAccounts, findUpsertTarget } from './identity.js';
 import { resolveAccounts } from './resolve-accounts.js';
 import * as alias from './alias.js';
@@ -564,6 +564,10 @@ async function loginCommand() {
     await loginApiCommand();
     return;
   }
+  if (args.includes('--token')) {
+    await loginOAuthCommand({ pasteOnly: true });
+    return;
+  }
   if (args.includes('--oauth')) {
     await loginOAuthCommand();
     return;
@@ -617,14 +621,14 @@ async function loginApiCommand() {
   console.log(`Saved to ${getConfigPath()}`);
 }
 
-async function loginOAuthCommand() {
+async function loginOAuthCommand({ pasteOnly = false } = {}) {
   const config = await loadOrCreateConfig();
   let name = argValue('--name');
 
   console.log('Starting OAuth login...');
   let creds;
   try {
-    creds = await loginOAuth();
+    creds = pasteOnly ? await loginOAuthWithPastedCode() : await loginOAuth();
   } catch (err) {
     console.error(`OAuth login failed: ${err.message}`);
     console.error('');
@@ -1488,6 +1492,7 @@ Commands:
   server              Start the proxy server (default; --headless to skip the TUI)
   import              Import credentials from Claude Code
   login               OAuth login via browser
+  login --token       OAuth login via copy/paste (no local callback; for headless/remote)
   login --api         Add an API key account
   env [--no-mitm]     Print export lines to point Claude Code at the proxy, for
                       'eval "$(teamclaude env)"' (MITM forward-proxy by default;

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -282,6 +282,81 @@ export async function fetchUsage(accessToken) {
 // shared with the refresh path — see DEFAULT_CLIENT_ID / DEFAULT_TOKEN_ENDPOINT.
 const OAUTH_AUTHORIZE = 'https://claude.ai/oauth/authorize';
 const OAUTH_SCOPES = 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload';
+const MANUAL_LOGIN_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
+
+/**
+ * Exchange an OAuth authorization code for access/refresh tokens.
+ * Shared by both browser-callback and manual/paste login paths.
+ */
+async function exchangeCodeForTokens(code, state, codeVerifier, redirectUri, tokenEndpoint = DEFAULT_TOKEN_ENDPOINT) {
+  const tokenRes = await proxyFetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      code,
+      state,
+      grant_type: 'authorization_code',
+      client_id: DEFAULT_CLIENT_ID,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    const text = await tokenRes.text();
+    throw new Error(`Token exchange failed (${tokenRes.status}): ${text}`);
+  }
+
+  const tokens = await tokenRes.json();
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresAt: normalizeExpiresAt(tokens.expires_at) || (Date.now() + (tokens.expires_in || 3600) * 1000),
+  };
+}
+
+/**
+ * Parse an authorization code from user input.
+ * Accepts either:
+ * 1. A full callback URL with ?code= and ?state= parameters
+ * 2. A code#state format (manual login success page)
+ * 3. A raw authorization code (falls back to using expectedState if provided)
+ */
+function parseAuthCode(input, expectedState) {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Try to parse as a URL with ?code= parameter
+  try {
+    const url = new URL(trimmed);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    if (code) {
+      if (expectedState && state && state !== expectedState) {
+        throw new Error('OAuth state mismatch');
+      }
+      return { code, state: state || expectedState };
+    }
+  } catch (e) {
+    if (e.message === 'OAuth state mismatch') throw e;
+  }
+
+  // Try to parse as code#state format (manual login)
+  if (trimmed.includes('#')) {
+    const parts = trimmed.split('#');
+    const code = parts[0].trim();
+    const state = parts[1]?.trim();
+    if (code) {
+      if (expectedState && state && state !== expectedState) {
+        throw new Error('OAuth state mismatch');
+      }
+      return { code, state: state || expectedState };
+    }
+  }
+
+  // Treat as raw authorization code
+  return { code: trimmed, state: expectedState };
+}
 
 /**
  * Perform OAuth login via browser with PKCE flow.
@@ -323,30 +398,58 @@ export async function loginOAuth() {
 
   // Exchange code for tokens
   console.log('Exchanging authorization code for tokens...');
-  const tokenRes = await proxyFetch(DEFAULT_TOKEN_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      code,
-      state,
-      grant_type: 'authorization_code',
-      client_id: DEFAULT_CLIENT_ID,
-      redirect_uri: redirectUri,
-      code_verifier: codeVerifier,
-    }),
-  });
+  return exchangeCodeForTokens(code, state, codeVerifier, redirectUri);
+}
 
-  if (!tokenRes.ok) {
-    const text = await tokenRes.text();
-    throw new Error(`Token exchange failed (${tokenRes.status}): ${text}`);
+/**
+ * Perform OAuth login via manual copy/paste (no local callback server).
+ * User opens the authorization URL on any device, logs in, and pastes back
+ * the authorization code shown on the success page. Useful for headless
+ * machines, remote servers, or when localhost callbacks are unavailable.
+ */
+export async function loginOAuthWithPastedCode() {
+  // Generate PKCE
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const state = randomBytes(32).toString('base64url');
+  const redirectUri = MANUAL_LOGIN_REDIRECT_URI;
+
+  // Build authorization URL
+  const authUrl = new URL(OAUTH_AUTHORIZE);
+  authUrl.searchParams.set('code', 'true');
+  authUrl.searchParams.set('client_id', DEFAULT_CLIENT_ID);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', OAUTH_SCOPES);
+  authUrl.searchParams.set('code_challenge', codeChallenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+  authUrl.searchParams.set('state', state);
+
+  // Display the authorization URL
+  console.log('Authorization URL:');
+  console.log(`  ${authUrl.toString()}\n`);
+  console.log('Steps:');
+  console.log('  1. Open the URL above in a browser (on any device)');
+  console.log('  2. Log in to your Claude account');
+  console.log('  3. Copy the authorization code shown on the success page');
+  console.log('  4. Paste it below\n');
+
+  // Prompt for manual paste
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const input = await new Promise(resolve => {
+    rl.question('Paste authorization code (or full callback URL): ', resolve);
+  });
+  rl.close();
+
+  // Parse the input
+  const parsed = parseAuthCode(input, state);
+  if (!parsed || !parsed.code) {
+    throw new Error('No authorization code provided');
   }
 
-  const tokens = await tokenRes.json();
-  return {
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    expiresAt: normalizeExpiresAt(tokens.expires_at) || (Date.now() + (tokens.expires_in || 3600) * 1000),
-  };
+  // Exchange code for tokens
+  console.log('Exchanging authorization code for tokens...');
+  return exchangeCodeForTokens(parsed.code, parsed.state, codeVerifier, redirectUri);
 }
 
 /**
@@ -368,26 +471,16 @@ function raceWithStdinCode(callbackPromise, expectedState) {
     };
 
     rl.question('Paste authorization code here (or wait for browser callback): ', answer => {
-      const trimmed = answer.trim();
-      if (!trimmed) return; // empty input, keep waiting for callback
+      if (!answer.trim()) return; // empty input, keep waiting for callback
 
-      // Try to parse as a URL with ?code= parameter
       try {
-        const url = new URL(trimmed);
-        const code = url.searchParams.get('code');
-        const state = url.searchParams.get('state');
-        if (code) {
-          if (expectedState && state && state !== expectedState) {
-            settle(reject, new Error('OAuth state mismatch'));
-          } else {
-            settle(resolve, code);
-          }
-          return;
+        const parsed = parseAuthCode(answer, expectedState);
+        if (parsed?.code) {
+          settle(resolve, parsed.code);
         }
-      } catch {}
-
-      // Treat raw input as the authorization code
-      settle(resolve, trimmed);
+      } catch (err) {
+        settle(reject, err);
+      }
     });
 
     callbackPromise.then(


### PR DESCRIPTION
Current `login` authentication flow spins up a local callback server, which only works if the browser and teamclaude are on the same box. On a remote server or in a container that's a dead end you end up logging in elsewhere and copying the credentials file over by hand.

This adds `login --token`: prints the auth URL, you log in from whatever browser you have, paste the code back. No listener, no localhost.

Along the way the token exchange and code parsing got pulled out into shared helpers, so the browser flow's existing paste fallback now handles the `code#state` format too.