### PR TITLE
feat(proxy): attribute usage by configured request headers

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,12 @@
     "clientKeys": [
       { "name": "alice", "key": "tc-alice-own-secret" },
       { "name": "bob", "key": "tc-bob-own-secret" }
-    ]
+    ],
+    "usageDimensions": [
+      { "name": "project", "header": "x-teamclaude-project" },
+      { "name": "ref", "header": "x-teamclaude-ref" }
+    ],
+    "sessionDetail": false
   },
   "upstream": "https://api.anthropic.com",
   "switchThreshold": 0.98,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,8 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `proxy.host` | Interface to bind. Defaults to `127.0.0.1` (localhost only). Set to `0.0.0.0` (or override with env `TEAMCLAUDE_HOST`) to accept off-box clients — in which case **set `proxy.apiKey`**, since remote clients must present it (via `x-api-key`, or `Proxy-Authorization` for CONNECT/HTTPS-proxy usage); loopback is always exempt |
 | `proxy.apiKey` | API key clients use to authenticate with the proxy (required for any non-loopback client; the proxy injects real account tokens, so an unauthenticated open port would leak them) |
 | `proxy.clientKeys` | Optional per-client keys: `[{ "name": "alice", "key": "tc-…" }, …]`. Each entry authenticates exactly like `proxy.apiKey`, and the tokens its responses report are booked against `name` — per-client usage shows up under `clients` in `/teamclaude/status`, in `teamclaude status`, and (with `--activity-log`) as a `[name]` prefix on each request line. Counters persist in the state file. Traffic on the shared `proxy.apiKey` or the loopback exemption stays unattributed, so give every consumer their own entry when you want complete stats. Edits apply live via `POST /teamclaude/reload` |
+| `proxy.usageDimensions` | Optional request-header usage dimensions: `[{ "name": "project", "header": "x-teamclaude-project" }, …]`. For each request the proxy reads the configured headers and books the response tokens against their sanitized values, shown under `usageDimensions` in `/teamclaude/status`, `teamclaude status`, and the dashboard. A request that omits a header is simply unattributed for that dimension. Counters persist in the state file, and each dimension is capped at 500 distinct values — further values are summed into `(other)` rather than evicting existing rows. Edits apply live via `POST /teamclaude/reload` |
+| `proxy.sessionDetail` | Adds a per-session breakdown (`sessions.items`) to `/teamclaude/status` and the dashboard: one row per session with its id, client, dimension values, pinned accounts, and the tokens it spent per weekly bucket. **Off by default** — any holder of any proxy key can read status, so on a shared proxy this shows every consumer what every other consumer is working on. The aggregate `sessions` counts are unaffected and always present |
 | `upstream` | Upstream API base URL |
 | `switchThreshold` | Quota utilization (0–1) at which to switch accounts (`teamclaude threshold <1-100>`, or the TUI settings screen: **Switch threshold**). The screen accepts tenths of a percent, e.g. `99.5`, which is stored as `0.995`. Reported OAuth utilization arrives on a whole-percent grid, so a fraction only changes the outcome for an API-key account, whose used share is continuous |
 | `quotaProbeSeconds` | Background [quota-probe](quota.md#quota-probe) interval in seconds (`0` = off, the default; CLI `probe`, or the **Quota probe** row on the TUI settings screen) |
@@ -84,6 +86,49 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 ```bash
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 ```
+
+## Usage Dimensions
+
+Usage dimensions answer which project, branch, pull request, or CI job spent the tokens, without a TeamClaude change for every new grouping. `proxy.clientKeys` names WHO spent them; a dimension names what they were spent ON, which one shared CI key cannot express on its own.
+
+Configure the dimensions once on the proxy:
+
+```json
+{
+  "proxy": {
+    "usageDimensions": [
+      { "name": "project", "header": "x-teamclaude-project" },
+      { "name": "ref", "header": "x-teamclaude-ref" }
+    ]
+  }
+}
+```
+
+Developers set a project identity per repository in `.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_CUSTOM_HEADERS": "X-Teamclaude-Project: KarpelesLab/teamclaude"
+  }
+}
+```
+
+CI can set several dimensions with newline-separated custom headers:
+
+```bash
+export ANTHROPIC_CUSTOM_HEADERS=$'X-Teamclaude-Project: KarpelesLab/teamclaude\nX-Teamclaude-Ref: pull/123'
+```
+
+Use stable, low-cardinality values such as `org/repo`, `pull/123`, or a branch name — a dimension is capped at 500 distinct values, and everything past the cap is summed into an `(other)` row. Header values are client-supplied: they are sanitized on ingest and length-capped before they reach any status output.
+
+A configured dimension header is **consumed by the proxy and not forwarded upstream** — it labels traffic for this proxy, so your internal project and branch names stay on your own infrastructure. It is still not a place for secrets: the values are persisted to the state file and readable by any proxy-key holder.
+
+Header names the proxy refuses to use as a dimension, because it or the client already relies on them: `authorization`, `proxy-authorization`, `cookie`, `x-api-key`, `x-app`, `x-claude-code-session-id`, `x-claude-code-agent-id`, `x-claude-code-parent-agent-id`, `x-anthropic-additional-protection`.
+
+### Per-session cost
+
+Per-session token cost is **not** a usage dimension. The session tracker already meters what each session's responses reported — cache reads and cache creation included — per weekly bucket, and that is the number that matters: a sum of `input_tokens` and `output_tokens` understates a cached Claude Code session by orders of magnitude. Set `proxy.sessionDetail` to surface it per session.
 
 ## Network resilience
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -170,7 +170,9 @@ teamclaude help              # Show all commands
 
 ## Status dashboard (browser)
 
-`GET /teamclaude/dashboard` serves a self-contained HTML page rendering the same data as `teamclaude status`: per-account quota bars (session/weekly, plus Sonnet/Fable buckets where present), rotation state, active sessions — refreshed every few seconds.
+`GET /teamclaude/dashboard` serves a self-contained HTML page rendering the same data as `teamclaude status`: per-account quota bars (session and weekly, plus one bar per model-scoped weekly bucket upstream reports), rotation state, and active sessions — refreshed every few seconds.
+
+With `proxy.usageDimensions` configured, each dimension gets its own sortable table. With `proxy.sessionDetail` on, a per-session table shows each session's client, project, serving accounts, and what it actually spent per weekly bucket — cache reads and cache creation included — filterable by project or client. That table is off by default; see [Configuration](configuration.md#usage-dimensions).
 
 ```
 http://localhost:3456/teamclaude/dashboard

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -601,8 +601,8 @@ export class AccountManager {
   /** Mark a session request as in flight / finished. Paired around the whole
    * client request (including retries) so a long streaming completion keeps the
    * session counted as active for its full duration. */
-  beginSession(sessionId) {
-    if (sessionId) this.sessionTracker.beginRequest(sessionId);
+  beginSession(sessionId, metadata = null) {
+    if (sessionId) this.sessionTracker.beginRequest(sessionId, undefined, metadata);
   }
 
   endSession(sessionId) {
@@ -2048,8 +2048,12 @@ export class AccountManager {
   /**
    * Return a status summary of all accounts (safe to expose, no credentials).
    */
-  getStatus() {
-    const sessions = this.sessionTracker.stats();
+  // `sessionDetail` adds the per-session `sessions.items` array. Off unless the
+  // operator turns on proxy.sessionDetail: the rows name every session id,
+  // client and dimension value to anyone who can read status, and on a shared
+  // proxy that is every key holder.
+  getStatus({ sessionDetail = false } = {}) {
+    const sessions = this.sessionTracker.stats(undefined, { detail: sessionDetail });
     return {
       currentAccount: this.accounts[this.currentIndex]?.name,
       switchThreshold: this.effectiveThreshold,

--- a/src/client-usage.js
+++ b/src/client-usage.js
@@ -17,15 +17,49 @@
 // single shared proxy.apiKey. Deployments that want complete per-client stats
 // give every consumer a clientKeys entry and treat the shared key as legacy.
 
+export const DEFAULT_USAGE_DIMENSION_MAX_KEYS = 500;
+export const USAGE_DIMENSION_VALUE_MAX_LENGTH = 200;
+
+// Where usage lands once a tracker is at its key cap. The counters are
+// persisted and cumulative, so the cap must never delete a row: evicting the
+// least-recently-used one means a burst of distinct values silently erases
+// lifetime totals for the values that matter, and the periodic save makes that
+// permanent. Folding into one bucket keeps the sum honest and says so in the
+// output. A caller whose value is literally `(other)` merges with it — harmless,
+// and preferable to a sentinel that no value could ever collide with but that
+// also could not be typed by an operator reading the docs.
+export const OVERFLOW_KEY = '(other)';
+
+const RESERVED_CUSTOM_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'x-api-key',
+  'x-app',
+  'x-claude-code-session-id',
+  'x-claude-code-agent-id',
+  'x-claude-code-parent-agent-id',
+  'x-anthropic-additional-protection',
+]);
+
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9a-z]+$/i;
+const DIMENSION_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
 export class ClientUsageTracker {
-  constructor({ now = () => Date.now() } = {}) {
+  // `maxKeys` stays unbounded for per-client accounting — clientKeys is
+  // operator-configured, so the key space is bounded by the config file. It is
+  // set only for the header-derived dimension trackers, whose values come from
+  // callers and are therefore unbounded.
+  constructor({ now = () => Date.now(), maxKeys = Infinity } = {}) {
     this.clients = new Map(); // name → { requests, inputTokens, outputTokens, lastUsed(ms) }
     this._now = now;
+    this.maxKeys = maxKeys;
   }
 
   _ensure(name) {
     let c = this.clients.get(name);
     if (!c) {
+      if (this.clients.size >= this.maxKeys && name !== OVERFLOW_KEY) return this._ensure(OVERFLOW_KEY);
       c = { requests: 0, inputTokens: 0, outputTokens: 0, lastUsed: null };
       this.clients.set(name, c);
     }
@@ -82,4 +116,157 @@ export class ClientUsageTracker {
       if (!Number.isNaN(t) && (c.lastUsed == null || t > c.lastUsed)) c.lastUsed = t;
     }
   }
+}
+
+/**
+ * The same accounting, one tracker per operator-configured dimension.
+ *
+ * `proxy.clientKeys` answers "who spent this" for a consumer that holds a key.
+ * It cannot answer "on what" — one CI key covers every repository it builds.
+ * A dimension maps a request header to a counter set, so a caller can label its
+ * own traffic (project, ref, team) through ANTHROPIC_CUSTOM_HEADERS without the
+ * operator issuing a key per label.
+ *
+ * Only configured dimensions exist. Per-session cost is NOT a dimension here:
+ * SessionTracker already meters it from the response usage, cache tokens
+ * included, which is the number that matters — an `input_tokens` sum
+ * understates a cached session by orders of magnitude.
+ */
+export class UsageDimensionTracker {
+  constructor({ now = () => Date.now(), maxKeys = DEFAULT_USAGE_DIMENSION_MAX_KEYS } = {}) {
+    this._now = now;
+    this._dimensions = new Map();
+    this._maxKeys = maxKeys;
+  }
+
+  _tracker(name) {
+    const key = normalizeDimensionName(name);
+    if (!key) return null;
+    let tracker = this._dimensions.get(key);
+    if (!tracker) {
+      tracker = new ClientUsageTracker({ now: this._now, maxKeys: this._maxKeys });
+      this._dimensions.set(key, tracker);
+    }
+    return tracker;
+  }
+
+  record(dimension, key, usage) {
+    const tracker = this._tracker(dimension);
+    if (!tracker || !key) return;
+    tracker.record(key, usage);
+  }
+
+  export() {
+    // Null prototype for the same reason ClientUsageTracker.export() uses one:
+    // a dimension named `__proto__` must land as an own key, not silently
+    // vanish onto the prototype.
+    const out = Object.create(null);
+    for (const [name, tracker] of this._dimensions) {
+      const entries = tracker.export();
+      if (Object.keys(entries).length) out[name] = entries;
+    }
+    return Object.fromEntries(Object.entries(out));
+  }
+
+  restore(saved) {
+    if (!saved || typeof saved !== 'object') return;
+    for (const [name, entries] of Object.entries(saved)) {
+      const tracker = this._tracker(name);
+      if (tracker) tracker.restore(entries);
+    }
+  }
+}
+
+/**
+ * The dimensions one request contributes to: `[{ name, key }]`, empty when
+ * nothing is configured or no configured header was sent. Read from
+ * `proxy.usageDimensions` live per request, so a config reload applies to a
+ * running server the way clientKeys does.
+ */
+export function resolveUsageDimensions(proxyConfig, headers = {}) {
+  const out = [];
+  const configured = Array.isArray(proxyConfig?.usageDimensions) ? proxyConfig.usageDimensions : [];
+  for (const entry of configured) {
+    const name = normalizeDimensionName(entry?.name);
+    const header = normalizeUsageHeaderName(entry?.header);
+    if (!name || !header) continue;
+    const value = sanitizeUsageDimensionValue(headers[header]);
+    if (value) out.push({ name, key: value });
+  }
+  return out;
+}
+
+/**
+ * The header names configured as dimensions, lowercased — what to strip before
+ * forwarding upstream. An entry is only counted when BOTH its name and header
+ * are valid, so this stays exactly the set resolveUsageDimensions() reads: a
+ * header the proxy does not consume is not the proxy's to remove.
+ */
+export function usageDimensionHeaderNames(proxyConfig) {
+  const out = new Set();
+  const configured = Array.isArray(proxyConfig?.usageDimensions) ? proxyConfig.usageDimensions : [];
+  for (const entry of configured) {
+    const header = normalizeUsageHeaderName(entry?.header);
+    if (header && normalizeDimensionName(entry?.name)) out.add(header);
+  }
+  return out;
+}
+
+export function createUsageRecorder({ client, clientUsage, dimensions, dimensionUsage }) {
+  const targets = [];
+  if (client && clientUsage) targets.push({ tracker: clientUsage, key: client });
+  if (dimensionUsage) {
+    for (const dimension of dimensions || []) {
+      targets.push({ tracker: dimensionUsage, dimension: dimension.name, key: dimension.key });
+    }
+  }
+  if (!targets.length) return { recordRequest: () => {}, onUsage: null };
+  return {
+    recordRequest() {
+      for (const target of targets) {
+        if (target.dimension) target.tracker.record(target.dimension, target.key, { requests: 1 });
+        else target.tracker.record(target.key, { requests: 1 });
+      }
+    },
+    onUsage(inputTokens, outputTokens) {
+      for (const target of targets) {
+        if (target.dimension) target.tracker.record(target.dimension, target.key, { inputTokens, outputTokens });
+        else target.tracker.record(target.key, { inputTokens, outputTokens });
+      }
+    },
+  };
+}
+
+function normalizeDimensionName(value) {
+  if (typeof value !== 'string') return null;
+  const name = value.trim();
+  return DIMENSION_NAME_RE.test(name) ? name : null;
+}
+
+// A configured header must be a valid token, and must not be one the proxy or
+// the client already relies on: a dimension is operator config, but pointing one
+// at `authorization` or `cookie` would copy a credential into a persisted,
+// status-visible counter name.
+function normalizeUsageHeaderName(value) {
+  if (typeof value !== 'string') return null;
+  const header = value.trim().toLowerCase();
+  if (!header || !HEADER_NAME_RE.test(header)) return null;
+  if (RESERVED_CUSTOM_HEADER_NAMES.has(header)) return null;
+  return header;
+}
+
+/**
+ * Header values reach a terminal renderer and a JSON status payload, so control
+ * characters and escape sequences are stripped at ingest rather than at every
+ * point of display, and the result is length-capped.
+ */
+export function sanitizeUsageDimensionValue(value, { maxLength = USAGE_DIMENSION_VALUE_MAX_LENGTH } = {}) {
+  if (Array.isArray(value)) value = value.join(', ');
+  if (typeof value !== 'string') return null;
+  const sanitized = value
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]|\p{C}/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!sanitized) return null;
+  return sanitized.length > maxLength ? sanitized.slice(0, maxLength) : sanitized;
 }

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -54,7 +54,69 @@ export function accountTokens(usage) {
     + (u.totalCacheReadTokens || 0) + (u.totalCacheCreationTokens || 0);
 }
 
-const SHARED_HELPERS = [scopedWeeklyRows, accountTokens].map(fn => fn.toString()).join('\n\n');
+// One row per session, from `sessions.items` (proxy.sessionDetail). The token
+// columns are #192's numbers — what each response actually reported, cache
+// included — summed across the weekly buckets the session touched. `pins` is a
+// bucket→account map rather than one index, because a session spending two
+// model families is served by two accounts at the same time.
+export function sessionRows(sessions) {
+  var items = (sessions && sessions.items) || [];
+  return items.map(function (s) {
+    var buckets = s.tokens || {};
+    var row = {
+      id: s.id,
+      client: s.client || '',
+      project: (s.dimensions || {}).project || '',
+      active: !!s.active,
+      requests: s.requests || 0,
+      cacheRead: 0, cacheCreation: 0, input: 0, output: 0, context: 0,
+      accounts: Object.keys(s.pins || {}).map(function (b) { return s.pins[b]; }).join(', '),
+      lastSeen: s.lastSeen || 0,
+    };
+    Object.keys(buckets).forEach(function (b) {
+      var t = buckets[b] || {};
+      row.cacheRead += t.cacheRead || 0;
+      row.cacheCreation += t.cacheCreation || 0;
+      row.input += t.input || 0;
+      row.output += t.output || 0;
+      row.context += t.context || 0;
+    });
+    row.total = row.cacheRead + row.cacheCreation + row.input + row.output;
+    return row;
+  });
+}
+
+export function filterSessionRows(rows, filters) {
+  var f = filters || {};
+  return (rows || []).filter(function (r) {
+    if (f.project && r.project !== f.project) return false;
+    if (f.client && r.client !== f.client) return false;
+    return true;
+  });
+}
+
+// Text sorts alphabetically, numbers numerically. A missing value sorts as
+// empty/zero rather than dropping the row.
+export function sortRows(rows, key, dir) {
+  var sign = dir === 'asc' ? 1 : -1;
+  return (rows || []).slice().sort(function (a, b) {
+    var x = a[key], y = b[key];
+    if (typeof x === 'string' || typeof y === 'string') {
+      return sign * String(x == null ? '' : x).localeCompare(String(y == null ? '' : y));
+    }
+    return sign * ((x || 0) - (y || 0));
+  });
+}
+
+export function uniqSorted(values) {
+  var seen = Object.create(null);
+  (values || []).forEach(function (v) { if (v) seen[v] = true; });
+  return Object.keys(seen).sort();
+}
+
+const SHARED_HELPERS = [
+  scopedWeeklyRows, accountTokens, sessionRows, filterSessionRows, sortRows, uniqSorted,
+].map(fn => fn.toString()).join('\n\n');
 
 const PAGE = `<!doctype html>
 <html lang="en">
@@ -99,6 +161,13 @@ const PAGE = `<!doctype html>
   td.num, th.num { text-align: right; }
   .usage { color: var(--dim); font-size: 12px; margin-top: 6px; }
   .blocked { color: var(--warn); font-size: 12px; margin-top: 6px; }
+  .filters { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; padding: 8px 10px; border-bottom: 1px solid var(--line); }
+  .filters label { color: var(--dim); font-size: 12px; display: flex; align-items: center; gap: 6px; }
+  .filters select { background: var(--bg); border: 1px solid var(--line); border-radius: 6px; color: var(--text); font: inherit; font-size: 12px; padding: 4px 8px; }
+  .hint { color: var(--dim); font-size: 12px; margin-left: auto; }
+  th.sortable { cursor: pointer; user-select: none; }
+  th.sortable:hover { color: var(--text); }
+  td.dim { color: var(--dim); }
   #err { color: var(--bad); margin: 12px 0; display: none; }
   #keybox { display: none; margin: 40px auto; max-width: 420px; text-align: center; }
   #keybox input { width: 100%; padding: 10px 12px; margin: 12px 0; background: var(--panel); border: 1px solid var(--line); border-radius: 6px; color: var(--text); font: inherit; }
@@ -124,6 +193,18 @@ const PAGE = `<!doctype html>
       <h2>Clients</h2>
       <div class="card" style="padding:4px 6px"><table id="clients"></table></div>
     </div>
+    <div id="dimensionsWrap"></div>
+    <div id="sessionsWrap" style="display:none">
+      <h2>Sessions</h2>
+      <div class="card" style="padding:0">
+        <div class="filters">
+          <label>Project <select id="fProject"></select></label>
+          <label>Client <select id="fClient"></select></label>
+          <span class="hint" id="sessionCount"></span>
+        </div>
+        <div style="padding:4px 6px"><table id="sessions"></table></div>
+      </div>
+    </div>
     <footer id="foot"></footer>
   </div>
 </main>
@@ -133,6 +214,9 @@ const PAGE = `<!doctype html>
   var KEY = 'teamclaude-dashboard-key';
   var POLL_MS = 5000;
   var timer = null;
+  var lastStatus = null;
+  var sessionFilters = { project: '', client: '' };
+  var sortState = { sessions: { key: 'lastSeen', dir: 'desc' } };
   var UNAVAILABLE_TEXT = ${JSON.stringify(UNAVAILABLE_TEXT)};
 
 ${SHARED_HELPERS}
@@ -266,7 +350,132 @@ ${SHARED_HELPERS}
     });
   }
 
+  // Header cells that re-sort in place. The sort is state, not a re-fetch, so
+  // it survives the 5s poll: re-rendering re-reads sortState below.
+  function addSortableHeader(tr, table, label, key, numeric) {
+    var th = el('th', (numeric ? 'num ' : '') + 'sortable', label + (sortState[table].key === key ? (sortState[table].dir === 'asc' ? ' ▲' : ' ▼') : ''));
+    th.addEventListener('click', function () {
+      var st = sortState[table];
+      if (st.key === key) st.dir = st.dir === 'asc' ? 'desc' : 'asc';
+      else { st.key = key; st.dir = numeric ? 'desc' : 'asc'; }
+      if (lastStatus) render(lastStatus);
+    });
+    tr.appendChild(th);
+  }
+
+  var SESSION_COLUMNS = [
+    { key: 'id', label: 'Session' },
+    { key: 'client', label: 'Client' },
+    { key: 'project', label: 'Project' },
+    { key: 'accounts', label: 'Accounts' },
+    { key: 'requests', label: 'Req', num: true },
+    { key: 'cacheRead', label: 'Cache read', num: true },
+    { key: 'cacheCreation', label: 'Cache write', num: true },
+    { key: 'input', label: 'Input', num: true },
+    { key: 'output', label: 'Output', num: true },
+    { key: 'context', label: 'Context', num: true },
+    { key: 'lastSeen', label: 'Last seen', num: true },
+  ];
+
+  function renderSessions(sessions) {
+    var wrap = document.getElementById('sessionsWrap');
+    // Absent unless proxy.sessionDetail is on — the aggregate counts in the
+    // summary line stay either way.
+    if (!sessions || !sessions.items) { wrap.style.display = 'none'; return; }
+    wrap.style.display = '';
+
+    var all = sessionRows(sessions);
+    var projectSel = document.getElementById('fProject');
+    var clientSel = document.getElementById('fClient');
+    fillFilter(projectSel, uniqSorted(all.map(function (r) { return r.project; })), sessionFilters.project);
+    fillFilter(clientSel, uniqSorted(all.map(function (r) { return r.client; })), sessionFilters.client);
+    sessionFilters.project = projectSel.value;
+    sessionFilters.client = clientSel.value;
+
+    var rows = sortRows(filterSessionRows(all, sessionFilters), sortState.sessions.key, sortState.sessions.dir);
+    document.getElementById('sessionCount').textContent = rows.length + ' of ' + all.length + ' sessions';
+
+    var table = document.getElementById('sessions');
+    table.textContent = '';
+    var hr = el('tr');
+    SESSION_COLUMNS.forEach(function (c) { addSortableHeader(hr, 'sessions', c.label, c.key, !!c.num); });
+    table.appendChild(hr);
+    rows.forEach(function (r) {
+      var tr = el('tr');
+      tr.appendChild(el('td', r.active ? '' : 'dim', r.id));
+      tr.appendChild(el('td', '', r.client || '—'));
+      tr.appendChild(el('td', '', r.project || '—'));
+      tr.appendChild(el('td', '', r.accounts || '—'));
+      ['requests', 'cacheRead', 'cacheCreation', 'input', 'output', 'context'].forEach(function (k) {
+        tr.appendChild(el('td', 'num', fmtNum(r[k])));
+      });
+      tr.appendChild(el('td', 'num', r.lastSeen ? fmtAgo(r.lastSeen) : '—'));
+      table.appendChild(tr);
+    });
+  }
+
+  function fillFilter(select, values, value) {
+    select.textContent = '';
+    var all = el('option', '', 'All');
+    all.value = '';
+    select.appendChild(all);
+    values.forEach(function (v) {
+      var option = el('option', '', v);
+      option.value = v;
+      select.appendChild(option);
+    });
+    select.value = values.indexOf(value) === -1 ? '' : value;
+  }
+
+  // One table per configured usage dimension (proxy.usageDimensions).
+  function renderDimensions(dimensions) {
+    var wrap = document.getElementById('dimensionsWrap');
+    wrap.textContent = '';
+    Object.keys(dimensions || {}).forEach(function (name) {
+      var entries = dimensions[name] || {};
+      var rows = Object.keys(entries).map(function (key) {
+        var e = entries[key] || {};
+        return {
+          name: key,
+          requests: e.requests || 0,
+          inputTokens: e.inputTokens || 0,
+          outputTokens: e.outputTokens || 0,
+          lastUsed: e.lastUsed ? Date.parse(e.lastUsed) : 0,
+        };
+      });
+      if (!rows.length) return;
+      sortState[name] = sortState[name] || { key: 'inputTokens', dir: 'desc' };
+      rows = sortRows(rows, sortState[name].key, sortState[name].dir);
+
+      wrap.appendChild(el('h2', '', name.charAt(0).toUpperCase() + name.slice(1)));
+      var card = el('div', 'card');
+      card.style.padding = '4px 6px';
+      var table = el('table');
+      var hr = el('tr');
+      [{ key: 'name', label: name.charAt(0).toUpperCase() + name.slice(1) },
+        { key: 'requests', label: 'Req', num: true },
+        { key: 'inputTokens', label: 'Input tok', num: true },
+        { key: 'outputTokens', label: 'Output tok', num: true },
+        { key: 'lastUsed', label: 'Last used', num: true }].forEach(function (c) {
+        addSortableHeader(hr, name, c.label, c.key, !!c.num);
+      });
+      table.appendChild(hr);
+      rows.forEach(function (r) {
+        var tr = el('tr');
+        tr.appendChild(el('td', '', r.name));
+        tr.appendChild(el('td', 'num', fmtNum(r.requests)));
+        tr.appendChild(el('td', 'num', fmtNum(r.inputTokens)));
+        tr.appendChild(el('td', 'num', fmtNum(r.outputTokens)));
+        tr.appendChild(el('td', 'num', r.lastUsed ? fmtAgo(r.lastUsed) : '—'));
+        table.appendChild(tr);
+      });
+      card.appendChild(table);
+      wrap.appendChild(card);
+    });
+  }
+
   function render(s) {
+    lastStatus = s;
     var sess = s.sessions || {};
     var up = s.server && s.server.uptimeSeconds != null ? 'up ' + fmtIn(s.server.uptimeSeconds) : '';
     var sum = document.getElementById('summary');
@@ -278,6 +487,8 @@ ${SHARED_HELPERS}
     acc.textContent = '';
     (s.accounts || []).forEach(function (a) { acc.appendChild(renderAccount(a, s.currentAccount)); });
     renderClients(s.clients);
+    renderDimensions(s.usageDimensions);
+    renderSessions(s.sessions);
     document.getElementById('foot').textContent = 'refreshes every ' + (POLL_MS / 1000) + 's · ' + new Date().toLocaleTimeString();
   }
 
@@ -322,6 +533,13 @@ ${SHARED_HELPERS}
   });
   document.getElementById('key').addEventListener('keydown', function (e) {
     if (e.key === 'Enter') document.getElementById('go').click();
+  });
+
+  ['fProject', 'fClient'].forEach(function (id) {
+    document.getElementById(id).addEventListener('change', function () {
+      sessionFilters[id === 'fProject' ? 'project' : 'client'] = this.value;
+      if (lastStatus) render(lastStatus);
+    });
   });
 
   if (localStorage.getItem(KEY)) start(); else showKeybox();

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus, formatPercent } from './status-renderer.js';
 import { sanitizeText } from './safe-text.js';
-import { ClientUsageTracker } from './client-usage.js';
+import { ClientUsageTracker, UsageDimensionTracker } from './client-usage.js';
 import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
@@ -265,6 +265,8 @@ async function serverCommand() {
   // per-client counters survive a restart the same way rotation state does.
   const clientUsage = new ClientUsageTracker();
   if (savedState?.clients) clientUsage.restore(savedState.clients);
+  const dimensionUsage = new UsageDimensionTracker();
+  if (savedState?.usageDimensions) dimensionUsage.restore(savedState.usageDimensions);
 
   // With quota restored, pick the best account up front (highest priority /
   // soonest-resetting weekly window) instead of defaulting to the first one.
@@ -272,7 +274,7 @@ async function serverCommand() {
 
   // Periodically persist quota (and once more on shutdown) to the state file.
   const persistQuotaState = () =>
-    saveState({ quota: accountManager.exportQuotaState(), clients: clientUsage.export() })
+    saveState({ quota: accountManager.exportQuotaState(), clients: clientUsage.export(), usageDimensions: dimensionUsage.export() })
       .catch(err => console.error(`[TeamClaude] Failed to save quota state: ${err.message}`));
   let quotaSaveInterval = null;
 
@@ -347,6 +349,10 @@ async function serverCommand() {
     // key add/rotate/revoke needs — no restart).
     if (config.proxy && diskConfig.proxy) {
       config.proxy.clientKeys = diskConfig.proxy.clientKeys;
+      // Dimensions are resolved per request from this same object, so a
+      // reload adds or drops one without a restart.
+      config.proxy.usageDimensions = diskConfig.proxy.usageDimensions;
+      config.proxy.sessionDetail = diskConfig.proxy.sessionDetail;
       // The shared key is read per request too, so a rotated key on disk
       // takes effect on reload the same way.
       config.proxy.apiKey = diskConfig.proxy.apiKey;
@@ -484,6 +490,8 @@ async function serverCommand() {
     blockedModels: [...(config.blockedModels || [])],
     // Per-client usage (proxy.clientKeys) — empty object when unconfigured.
     clients: clientUsage.export(),
+    // Per-dimension usage (proxy.usageDimensions) — empty when unconfigured.
+    usageDimensions: dimensionUsage.export(),
     server: {
       startedAt: new Date(serverStartedAt).toISOString(),
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),
@@ -518,7 +526,7 @@ async function serverCommand() {
     },
   });
 
-  const server = createProxyServer(accountManager, config, hooks, sx, clientUsage);
+  const server = createProxyServer(accountManager, config, hooks, sx, clientUsage, dimensionUsage);
   // Catch bind-time errors (e.g. EADDRINUSE) only. Once the socket is bound we
   // remove this handler so a later runtime 'error' isn't misreported as a
   // listen failure and exit the whole proxy.

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -110,7 +110,7 @@ export function hostMode(host, config) {
  * the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null, clientUsage = null }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null, clientUsage = null, dimensionUsage = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
 
@@ -138,7 +138,7 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     p = (async () => {
     const { key, cert } = await ensureLeaf();
     const srv = http2.createSecureServer({ key, cert, allowHTTP1: true });
-    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null, egress, clientUsage, forcedClient: client }));
+    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null, egress, clientUsage, forcedClient: client, dimensionUsage }));
     // Remote Control's real-time channel is a WebSocket (Upgrade handshake),
     // which never fires 'request' — only 'upgrade', with a raw socket instead
     // of a response object (h1-only; falls back to blind h2 passthrough is not

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,7 @@ import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
 import { renderDashboardHtml } from './dashboard.js';
+import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -144,7 +145,7 @@ export function resolveClientAuth(proxyConfig, presented) {
   return { ok: false, client: null };
 }
 
-export function createProxyServer(accountManager, config, hooks = {}, sx = null, clientUsage = null) {
+export function createProxyServer(accountManager, config, hooks = {}, sx = null, clientUsage = null, dimensionUsage = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
 
@@ -230,7 +231,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
 
       // Status endpoint
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
-        const status = accountManager.getStatus();
+        const status = accountManager.getStatus({ sessionDetail: config.proxy?.sessionDetail === true });
         const extra = hooks.getStatusExtra?.() || {};
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ...extra, ...status }, null, 2));
@@ -323,7 +324,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
   // Opt-in egress pin: null unless config.egress.pin is set, and then shared by
   // the base listener and the MITM one so both honour the same hold.
   const egress = createEgressGuard(config, console.error);
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, egress, clientUsage });
+  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, egress, clientUsage, dimensionUsage });
   const server = http.createServer(requestHandler);
 
   // What bounds a directory of one-shot dumps is deleting the expired ones, not
@@ -361,7 +362,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx, egress, clientUsage }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx, egress, clientUsage, dimensionUsage }));
   // Remote Control's real-time channel is a WebSocket, not a request/response
   // call — Node fires 'upgrade' for that handshake, never 'request', so it
   // needs its own listener (base-URL routing path; the MITM path wires the
@@ -539,7 +540,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/'];
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
-export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null }) {
+export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null, dimensionUsage = null }) {
   let counter = 0;
   return async (req, res) => {
     // The activity entry this request opened, while it is still open. Every
@@ -710,17 +711,29 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // instead — the same split as the account pin. onUsage lets the usage
       // extraction deep in the response path book tokens against the client
       // without threading the name through every layer.
+      //
+      // Usage dimensions (proxy.usageDimensions) ride the same hook: each
+      // configured header the caller sent becomes one more counter the response
+      // tokens are booked against, so one CI key can still be split by project.
       const client = req.tcClient ?? forcedClient ?? null;
-      const onUsage = (client && clientUsage)
-        ? (inputTokens, outputTokens) => clientUsage.record(client, { inputTokens, outputTokens })
-        : null;
-      if (client && clientUsage) clientUsage.record(client, { requests: 1 });
+      const usageDimensions = resolveUsageDimensions(config.proxy, req.headers);
+      const usageRecorder = createUsageRecorder({ client, clientUsage, dimensions: usageDimensions, dimensionUsage });
+      usageRecorder.recordRequest();
 
-      const ctx = { account: null, status: null, tried: new Set(), reauthed: new Set(), model, advisorModel, pinnedIndex, provider: providerForPath(req.url), holdBudgetMs: holdMs, sessionId, client, onUsage, logLevel: resolveLogLevel(config), logMaxBodyBytes: resolveLogMaxBodyBytes(config) };
+      // The dimension headers are ours, not upstream's: they exist to label
+      // traffic for this proxy. Forwarding them would leak an operator's
+      // internal project and branch names to Anthropic for no benefit, so they
+      // are dropped with the other proxy-control headers.
+      const stripHeaders = usageDimensionHeaderNames(config.proxy);
+
+      const ctx = { account: null, status: null, tried: new Set(), reauthed: new Set(), model, advisorModel, pinnedIndex, provider: providerForPath(req.url), holdBudgetMs: holdMs, sessionId, client, onUsage: usageRecorder.onUsage, stripHeaders, logLevel: resolveLogLevel(config), logMaxBodyBytes: resolveLogMaxBodyBytes(config) };
       // Hold the session "in flight" across the WHOLE request (incl. retries and
       // a multi-minute streaming completion) so it stays counted as active and
       // never expires mid-request.
-      accountManager.beginSession(sessionId);
+      accountManager.beginSession(sessionId, {
+        client,
+        dimensions: Object.fromEntries(usageDimensions.map(d => [d.name, d.key])),
+      });
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -1448,6 +1461,10 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // Strip accept-encoding: Node fetch auto-decompresses, which would
     // mismatch the Content-Encoding header we forward to the client
     if (lk === 'accept-encoding') continue;
+    // Headers configured as usage dimensions are addressed to this proxy and
+    // carry the operator's own labels (project, branch, team). They are
+    // consumed here, so they do not travel upstream.
+    if (ctx.stripHeaders?.has(lk)) continue;
     headers[key] = value;
   }
 

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -107,11 +107,18 @@ export class SessionTracker {
   // flight counts as active (and non-expirable) for the whole request, however
   // long it streams — a 5-minute completion must not drop out of "active" or the
   // load balancer would under-count that account. Paired with endRequest.
-  beginRequest(sessionId, now = this._now()) {
+  //
+  // `metadata` (`{ client, dimensions }`) labels the session with who asked and
+  // under which usage dimensions, for the per-session readout. It is attached
+  // here rather than in touch() or recordSession() because this is the one call
+  // that runs once per CLIENT request, with the request headers still in scope;
+  // the other two run per forward attempt and per route decision.
+  beginRequest(sessionId, now = this._now(), metadata = null) {
     if (!sessionId) return null;
     const s = this._ensure(sessionId, now);
     s.inFlight += 1;
     s.lastSeen = now;
+    applyMetadata(s, metadata);
     return s;
   }
 
@@ -211,6 +218,9 @@ export class SessionTracker {
         // The same key space as `pins`, so a family's spend and the account it
         // is pinned to are looked up by one bucket key.
         tokens: new Map(),
+        // Labels from the request that opened the session (see beginRequest).
+        client: null,
+        dimensions: null,
       };
       this.sessions.set(sessionId, s);
     }
@@ -345,13 +355,18 @@ export class SessionTracker {
   // fleet has spent, and what it is carrying now. `byBucket` is the same pair
   // per weekly family, which is the only view in which a fleet spending its Opus
   // and its Fable windows at different rates is visible at all.
-  stats(now = this._now()) {
+  //
+  // `items` is the same walk, per session instead of summed — off unless the
+  // operator asks for it (see `stats({ detail: true })`), because it names every
+  // session id, client and project value to whoever reads status.
+  stats(now = this._now(), { detail = false } = {}) {
     this._lastSweep = now;
     let known = 0;
     let active = 0;
     const perAccount = {};
     const tokens = emptyAggregate();
     const byBucket = {};
+    const items = detail ? [] : null;
     let activeContext = 0;
     for (const [id, s] of this.sessions) {
       if (this._isExpired(s, now)) {
@@ -359,6 +374,7 @@ export class SessionTracker {
         continue;
       }
       known += 1;
+      if (items) items.push(sessionItem(id, s, this._isActive(s, now)));
       for (const [bucket, t] of s.tokens) {
         const per = byBucket[bucket] || (byBucket[bucket] = emptyAggregate());
         for (const k of COUNTERS) {
@@ -384,6 +400,43 @@ export class SessionTracker {
     }
     tokens.activeContext = activeContext;
     tokens.byBucket = byBucket;
-    return { known, active, perAccount, tokens };
+    // Newest first: a per-session table is read top-down for what is happening
+    // now, and the list is capped by the same TTLs as the map behind it.
+    if (items) items.sort((a, b) => b.lastSeen - a.lastSeen);
+    return items ? { known, active, perAccount, tokens, items } : { known, active, perAccount, tokens };
+  }
+}
+
+// One row of the per-session readout. `pins` replaces what used to be a single
+// accountIndex: a session holds one pin per weekly bucket, so a session
+// spending two families is served by two accounts at once and naming only one
+// of them would be wrong rather than merely incomplete.
+function sessionItem(id, s, active) {
+  return {
+    id,
+    active,
+    inFlight: s.inFlight,
+    requests: s.count,
+    firstSeen: s.firstSeen,
+    lastSeen: s.lastSeen,
+    client: s.client,
+    dimensions: s.dimensions ? { ...s.dimensions } : null,
+    pins: Object.fromEntries([...s.pins].map(([bucket, p]) => [bucket, p.idx])),
+    // #192's numbers, per weekly bucket: what the responses actually reported,
+    // cache included. An input+output sum understates a cached session by
+    // orders of magnitude, which is why this is not counted from request headers.
+    tokens: Object.fromEntries([...s.tokens].map(([bucket, t]) => [bucket, { ...t }])),
+  };
+}
+
+// Labels are last-write-wins: a session is one client's, and a caller that
+// changes the project mid-session means the new one. Absent fields leave the
+// existing label alone, so a request without the header does not erase it.
+function applyMetadata(s, metadata) {
+  if (!metadata || typeof metadata !== 'object') return;
+  if (typeof metadata.client === 'string' && metadata.client) s.client = metadata.client;
+  const dims = metadata.dimensions;
+  if (dims && typeof dims === 'object' && Object.keys(dims).length) {
+    s.dimensions = { ...(s.dimensions || {}), ...dims };
   }
 }

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -58,17 +58,37 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   const clients = Object.entries(status.clients || {});
   if (clients.length) {
     lines.push(paint.bold('Clients'));
-    clients.sort(([, a], [, b]) => ((b.inputTokens || 0) + (b.outputTokens || 0)) - ((a.inputTokens || 0) + (a.outputTokens || 0)));
-    for (const [name, c] of clients) {
-      const tokens = `${formatNumber(c.inputTokens)} in / ${formatNumber(c.outputTokens)} out`;
-      const last = parseTs(c.lastUsed);
-      const lastText = last ? `, last ${formatAgo(last, now)}` : '';
-      lines.push(`  ${paint.cyan(safeLine(name).padEnd(20))} ${c.requests || 0} req, ${tokens}${lastText}`);
-    }
+    renderUsageEntries(lines, clients, paint, now);
+    lines.push('');
+  }
+
+  // One section per configured usage dimension (proxy.usageDimensions). The
+  // dimension list is operator config and each tracker is key-capped, so the
+  // size of this output is bounded by the config file, not by caller traffic.
+  for (const [dimension, entries] of Object.entries(status.usageDimensions || {})) {
+    const rows = Object.entries(entries || {});
+    if (!rows.length) continue;
+    lines.push(paint.bold(usageDimensionTitle(dimension)));
+    renderUsageEntries(lines, rows, paint, now);
     lines.push('');
   }
 
   return lines.join('\n').trimEnd();
+}
+
+function renderUsageEntries(lines, entries, paint, now) {
+  entries.sort(([, a], [, b]) => ((b.inputTokens || 0) + (b.outputTokens || 0)) - ((a.inputTokens || 0) + (a.outputTokens || 0)));
+  for (const [name, c] of entries) {
+    const tokens = `${formatNumber(c.inputTokens)} in / ${formatNumber(c.outputTokens)} out`;
+    const last = parseTs(c.lastUsed);
+    const lastText = last ? `, last ${formatAgo(last, now)}` : '';
+    lines.push(`  ${paint.cyan(safeLine(name).padEnd(20))} ${c.requests || 0} req, ${tokens}${lastText}`);
+  }
+}
+
+function usageDimensionTitle(name) {
+  const safe = safeLine(name);
+  return `${safe.charAt(0).toUpperCase()}${safe.slice(1)} usage`;
 }
 
 // Why an account is out of rotation, in the operator's terms. Reading

--- a/test/client-usage.test.js
+++ b/test/client-usage.test.js
@@ -4,7 +4,16 @@ import http from 'node:http';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer, resolveClientAuth } from '../src/server.js';
 import { resolveConnectAuth, resolveConnectPin } from '../src/mitm.js';
-import { ClientUsageTracker } from '../src/client-usage.js';
+import {
+  ClientUsageTracker,
+  UsageDimensionTracker,
+  OVERFLOW_KEY,
+  DEFAULT_USAGE_DIMENSION_MAX_KEYS,
+  resolveUsageDimensions,
+  usageDimensionHeaderNames,
+  sanitizeUsageDimensionValue,
+  createUsageRecorder,
+} from '../src/client-usage.js';
 
 function listen(server) {
   return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
@@ -193,4 +202,162 @@ test('export() keeps a hostile client name as a plain key', () => {
   assert.ok(Object.hasOwn(out, '__proto__'), 'an own key, not the prototype');
   assert.equal(out['__proto__'].requests, 1);
   assert.equal(Object.getPrototypeOf(out), Object.prototype, 'still a plain object for deepEqual/JSON');
+});
+
+// --- usage dimensions (proxy.usageDimensions) -------------------------------
+
+test('per-client accounting stays uncapped: clientKeys is bounded by the config', () => {
+  const t = new ClientUsageTracker();
+  for (let i = 0; i < DEFAULT_USAGE_DIMENSION_MAX_KEYS + 50; i++) t.record(`c${i}`, { requests: 1 });
+  assert.equal(Object.keys(t.export()).length, DEFAULT_USAGE_DIMENSION_MAX_KEYS + 50);
+});
+
+test('an over-cap dimension value folds into (other) and never evicts a row', () => {
+  const t = new ClientUsageTracker({ maxKeys: 3 });
+  t.record('a', { requests: 1, inputTokens: 10 });
+  t.record('b', { requests: 1 });
+  t.record('c', { requests: 1 });
+  // Three more distinct values arrive. Eviction would delete `a` — whose
+  // counters are cumulative and persisted — making the loss permanent at the
+  // next save. The fold must leave every existing row untouched.
+  t.record('d', { requests: 1, inputTokens: 5 });
+  t.record('e', { requests: 1, inputTokens: 5 });
+  t.record('f', { requests: 1, inputTokens: 5 });
+
+  const out = t.export();
+  assert.deepEqual(Object.keys(out).sort(), ['(other)', 'a', 'b', 'c']);
+  assert.equal(out.a.inputTokens, 10, 'the first value keeps its lifetime total');
+  assert.equal(out[OVERFLOW_KEY].requests, 3, 'the overflow is summed, not dropped');
+  assert.equal(out[OVERFLOW_KEY].inputTokens, 15);
+
+  // A value already known is still booked to itself, cap or no cap.
+  t.record('a', { requests: 1 });
+  assert.equal(t.export().a.requests, 2);
+});
+
+test('a restored snapshot cannot be evicted by later traffic either', () => {
+  const t = new ClientUsageTracker({ maxKeys: 2 });
+  t.restore({ old: { requests: 7, inputTokens: 70, lastUsed: '2020-01-01T00:00:00.000Z' } });
+  t.record('new', { requests: 1 });
+  t.record('newer', { requests: 1 });
+  const out = t.export();
+  assert.equal(out.old.requests, 7, 'the least-recently-used row survives');
+  assert.equal(out[OVERFLOW_KEY].requests, 1);
+});
+
+test('a caller-supplied dimension value of __proto__ lands as an own key', () => {
+  // Dimension NAMES are operator config and validated, but VALUES come from a
+  // request header: `X-Teamclaude-Project: __proto__` passes sanitization, so
+  // the row must survive the export rather than vanish onto the prototype.
+  const t = new UsageDimensionTracker();
+  assert.equal(sanitizeUsageDimensionValue('__proto__'), '__proto__', 'the value is not filtered');
+  t.record('project', '__proto__', { requests: 1 });
+  const project = t.export().project;
+  assert.ok(Object.hasOwn(project, '__proto__'), 'an own key, not the prototype');
+  assert.equal(project['__proto__'].requests, 1);
+  assert.equal(Object.getPrototypeOf(t.export()), Object.prototype, 'plain object for JSON');
+});
+
+test('a dimension name that is not a valid identifier is refused', () => {
+  const t = new UsageDimensionTracker();
+  t.record('__proto__', 'v', { requests: 1 });
+  t.record('bad name!', 'v', { requests: 1 });
+  assert.deepEqual(t.export(), {});
+});
+
+test('dimensions are resolved from configured headers only', () => {
+  const proxy = {
+    usageDimensions: [
+      { name: 'project', header: 'X-Teamclaude-Project' },
+      { name: 'ref', header: 'x-teamclaude-ref' },
+      { name: 'bad name!', header: 'x-ignored' },
+      { name: 'creds', header: 'authorization' },
+      { name: 'creds2', header: 'cookie' },
+    ],
+  };
+  const headers = {
+    'x-teamclaude-project': 'skaile-dev',
+    'x-claude-code-session-id': 'sess-1',
+    authorization: 'Bearer secret',
+    cookie: 'a=b',
+  };
+  // No session dimension: per-session cost comes from SessionTracker, which
+  // meters the response usage including cache tokens.
+  assert.deepEqual(resolveUsageDimensions(proxy, headers), [{ name: 'project', key: 'skaile-dev' }]);
+  // A dimension pointed at a credential header is refused outright, so the
+  // credential can never become a persisted counter name.
+  assert.deepEqual(
+    [...usageDimensionHeaderNames(proxy)].sort(),
+    ['x-teamclaude-project', 'x-teamclaude-ref'],
+  );
+  assert.deepEqual(resolveUsageDimensions({}, headers), []);
+  assert.deepEqual(resolveUsageDimensions(null, headers), []);
+});
+
+test('dimension values are sanitized at ingest and length-capped', () => {
+  assert.equal(sanitizeUsageDimensionValue('  my [31mproject\n '), 'my project');
+  assert.equal(sanitizeUsageDimensionValue('x'.repeat(500)).length, 200);
+  assert.equal(sanitizeUsageDimensionValue(['a', 'b']), 'a, b');
+  assert.equal(sanitizeUsageDimensionValue('   '), null);
+  assert.equal(sanitizeUsageDimensionValue(undefined), null);
+});
+
+test('the recorder books one request and its tokens to every target', () => {
+  const clientUsage = new ClientUsageTracker();
+  const dimensionUsage = new UsageDimensionTracker();
+  const rec = createUsageRecorder({
+    client: 'ci',
+    clientUsage,
+    dimensions: [{ name: 'project', key: 'skaile-dev' }],
+    dimensionUsage,
+  });
+  rec.recordRequest();
+  rec.onUsage(100, 20);
+  assert.equal(clientUsage.export().ci.requests, 1);
+  assert.equal(clientUsage.export().ci.inputTokens, 100);
+  assert.equal(dimensionUsage.export().project['skaile-dev'].outputTokens, 20);
+
+  // Nothing to attribute means no work and no onUsage hook to install.
+  const none = createUsageRecorder({ client: null, clientUsage, dimensions: [], dimensionUsage });
+  assert.equal(none.onUsage, null);
+});
+
+test('a dimension header is booked here and NOT forwarded upstream', async () => {
+  let seen = null;
+  const upstream = http.createServer((req, res) => {
+    seen = req.headers;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, usage: { input_tokens: 7, output_tokens: 3 } }));
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'acct', type: 'api_key', apiKey: 'sk-a' }], 0.98);
+  const dimensionUsage = new UsageDimensionTracker();
+  const proxy = createProxyServer(am, {
+    proxy: { ...PROXY, usageDimensions: [{ name: 'project', header: 'x-teamclaude-project' }] },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  }, {}, null, new ClientUsageTracker(), dimensionUsage);
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-teamclaude-project': 'skaile-dev',
+        'x-teamclaude-other': 'kept',
+      },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    await res.text();
+
+    assert.equal(dimensionUsage.export().project['skaile-dev'].inputTokens, 7);
+    // The header labels traffic for THIS proxy. Forwarding it would hand the
+    // operator's internal project names to the upstream vendor for no benefit.
+    assert.equal(seen['x-teamclaude-project'], undefined, 'dimension header must not reach upstream');
+    // Only the configured ones are stripped — this is not a general filter.
+    assert.equal(seen['x-teamclaude-other'], 'kept');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
 });

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer } from '../src/server.js';
-import { renderDashboardHtml, scopedWeeklyRows, accountTokens } from '../src/dashboard.js';
+import {
+  renderDashboardHtml, scopedWeeklyRows, accountTokens,
+  sessionRows, filterSessionRows, sortRows, uniqSorted,
+} from '../src/dashboard.js';
 
 function listen(server) {
   return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
@@ -53,11 +56,82 @@ test('account token total includes the cache fields', () => {
   assert.equal(accountTokens(null), 0);
 });
 
+const SESSIONS = {
+  items: [
+    {
+      id: 's-old', client: 'bob', dimensions: { project: 'p2' }, active: false,
+      requests: 2, lastSeen: 200, pins: { unified7d: 1 },
+      tokens: { unified7d: { cacheRead: 5, cacheCreation: 1, input: 2, output: 1, context: 8 } },
+    },
+    {
+      id: 's-new', client: 'alice', dimensions: { project: 'p1' }, active: true,
+      requests: 1, lastSeen: 100, pins: { unified7d: 0, unified7dFable: 1 },
+      tokens: {
+        unified7d: { cacheRead: 900, cacheCreation: 50, input: 10, output: 5, context: 960 },
+        unified7dFable: { cacheRead: 0, cacheCreation: 0, input: 4, output: 2, context: 4 },
+      },
+    },
+  ],
+};
+
+test('a session row totals what the responses reported, cache included', () => {
+  const rows = sessionRows(SESSIONS);
+  const row = rows.find(r => r.id === 's-new');
+  // input+output alone would say 21 for a session that actually cost 971.
+  assert.equal(row.input + row.output, 21);
+  assert.equal(row.total, 971);
+  assert.equal(row.cacheRead, 900);
+  // Summed across every weekly bucket the session touched.
+  assert.equal(row.context, 964);
+  // A session spending two model families is served by two accounts at once,
+  // which is why this is a pin map and not one index.
+  assert.equal(row.accounts, '0, 1');
+  assert.equal(row.client, 'alice');
+  assert.equal(row.project, 'p1');
+});
+
+test('session rows tolerate a payload with nothing in it', () => {
+  assert.deepEqual(sessionRows({}), []);
+  assert.deepEqual(sessionRows(null), []);
+  const [bare] = sessionRows({ items: [{ id: 'x' }] });
+  assert.deepEqual(
+    { id: bare.id, client: bare.client, project: bare.project, total: bare.total, accounts: bare.accounts },
+    { id: 'x', client: '', project: '', total: 0, accounts: '' },
+  );
+});
+
+test('filters narrow by project and client, and combine', () => {
+  const rows = sessionRows(SESSIONS);
+  assert.deepEqual(filterSessionRows(rows, { project: 'p1' }).map(r => r.id), ['s-new']);
+  assert.deepEqual(filterSessionRows(rows, { client: 'bob' }).map(r => r.id), ['s-old']);
+  assert.deepEqual(filterSessionRows(rows, { project: 'p1', client: 'bob' }), []);
+  // An empty filter is "All", not a match against the empty string.
+  assert.equal(filterSessionRows(rows, { project: '', client: '' }).length, 2);
+  assert.equal(filterSessionRows(rows, {}).length, 2);
+});
+
+test('sorting handles both text and number columns, and does not mutate', () => {
+  const rows = sessionRows(SESSIONS);
+  const before = rows.map(r => r.id);
+  assert.deepEqual(sortRows(rows, 'total', 'desc').map(r => r.id), ['s-new', 's-old']);
+  assert.deepEqual(sortRows(rows, 'total', 'asc').map(r => r.id), ['s-old', 's-new']);
+  assert.deepEqual(sortRows(rows, 'client', 'asc').map(r => r.id), ['s-new', 's-old']);
+  assert.deepEqual(sortRows(rows, 'client', 'desc').map(r => r.id), ['s-old', 's-new']);
+  assert.deepEqual(rows.map(r => r.id), before, 'the caller\'s array is untouched');
+  assert.deepEqual(sortRows(null, 'total', 'desc'), []);
+});
+
+test('filter options are unique, sorted, and drop the unlabelled', () => {
+  assert.deepEqual(uniqSorted(['b', 'a', '', 'a', null, undefined]), ['a', 'b']);
+  assert.deepEqual(uniqSorted([]), []);
+  assert.deepEqual(uniqSorted(null), []);
+});
+
 test('the page ships the same helper implementations it is tested against', () => {
   // The serialization is the contract: if a helper stops being self-contained
   // (closes over module scope), the page would silently ReferenceError.
   const html = renderDashboardHtml();
-  for (const fn of [scopedWeeklyRows, accountTokens]) {
+  for (const fn of [scopedWeeklyRows, accountTokens, sessionRows, filterSessionRows, sortRows, uniqSorted]) {
     assert.ok(html.includes(fn.toString()), `${fn.name} not serialized into the page`);
   }
   const script = html.slice(html.indexOf('<script>') + 8, html.indexOf('</script>'));

--- a/test/session-tracker.test.js
+++ b/test/session-tracker.test.js
@@ -309,3 +309,66 @@ test('pinnedSessionIds drops forgotten sessions as it reads', () => {
   assert.deepEqual(st.pinnedSessionIds(clock.t), ['fresh']);
   assert.equal(st.sessions.has('old'), false);
 });
+
+// --- per-session detail (proxy.sessionDetail) -------------------------------
+
+test('stats() carries no per-session rows unless detail is asked for', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t, { client: 'alice', dimensions: { project: 'skaile-dev' } });
+  // Any holder of any proxy key can read status, so the default must not name
+  // sessions, clients, or project values.
+  assert.equal('items' in st.stats(clock.t), false);
+  assert.equal(Array.isArray(st.stats(clock.t, { detail: true }).items), true);
+  // The aggregate counts are unaffected either way.
+  assert.equal(st.stats(clock.t).known, st.stats(clock.t, { detail: true }).known);
+});
+
+test('a detail row carries the labels and the per-bucket tokens the responses reported', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t, { client: 'alice', dimensions: { project: 'skaile-dev' } });
+  st.touch('s1', 0, SHARED, clock.t);
+  st.touch('s1', 1, FABLE, clock.t);
+  st.recordTokens('s1', SHARED, {
+    cache_read_input_tokens: 900, cache_creation_input_tokens: 50,
+    input_tokens: 10, output_tokens: 5,
+  }, clock.t);
+
+  const [row] = st.stats(clock.t, { detail: true }).items;
+  assert.equal(row.id, 's1');
+  assert.equal(row.client, 'alice');
+  assert.deepEqual(row.dimensions, { project: 'skaile-dev' });
+  // A session holds one pin per weekly bucket and can be served by two accounts
+  // at once, which a single accountIndex could not express.
+  assert.deepEqual(row.pins, { [SHARED]: 0, [FABLE]: 1 });
+  // Cost comes from the response usage, cache included: input+output alone
+  // would report 15 for a turn that actually read 965 tokens of context.
+  assert.equal(row.tokens[SHARED].cacheRead, 900);
+  assert.equal(row.tokens[SHARED].context, 960);
+  assert.equal(row.inFlight, 1);
+  assert.equal(row.active, true);
+});
+
+test('detail rows are newest-first, and a forgotten session is absent', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.touch('old', 0, SHARED, clock.t);
+  clock.t += 1000;
+  st.touch('new', 0, SHARED, clock.t);
+  assert.deepEqual(st.stats(clock.t, { detail: true }).items.map(r => r.id), ['new', 'old']);
+  clock.t += SESSION_KNOWN_TTL_MS + 1;
+  st.touch('newest', 0, SHARED, clock.t);
+  assert.deepEqual(st.stats(clock.t, { detail: true }).items.map(r => r.id), ['newest']);
+});
+
+test('a request without labels does not erase the ones the session already has', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t, { client: 'alice', dimensions: { project: 'p1' } });
+  st.beginRequest('s1', clock.t, null);
+  st.beginRequest('s1', clock.t, { dimensions: {} });
+  const [row] = st.stats(clock.t, { detail: true }).items;
+  assert.equal(row.client, 'alice');
+  assert.deepEqual(row.dimensions, { project: 'p1' });
+});

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -149,6 +149,42 @@ test('renderStatus sanitizes probe errors', () => {
   assert.doesNotMatch(output, /\x1b\[31m/);
 });
 
+test('renderStatus prints configured usage dimensions and sanitizes their labels', () => {
+  const status = sampleStatus();
+  status.usageDimensions = {
+    project: {
+      'KarpelesLab/teamclaude': { requests: 2, inputTokens: 1000, outputTokens: 250, lastUsed: '2026-07-03T11:59:00Z' },
+    },
+    'bad\x1b[31mname': {
+      'value\nred': { requests: 1, inputTokens: 1, outputTokens: 1 },
+    },
+  };
+
+  const output = renderStatus(status, { color: false, now });
+  assert.match(output, /Project usage/);
+  assert.match(output, /KarpelesLab\/teamclaude\s+2 req, 1.0k in \/ 250 out, last 1m ago/);
+  assert.match(output, /Bad name usage/);
+  assert.match(output, /value red/);
+  assert.doesNotMatch(output, /\x1b\[31m/);
+});
+
+test('renderStatus never grows a per-session section', () => {
+  // Sessions are unbounded caller-supplied ids: a terminal renderer that
+  // printed one line each would bury the whole status readout. The per-session
+  // view is the dashboard's (behind proxy.sessionDetail), not the CLI's.
+  const status = sampleStatus();
+  status.sessions = {
+    known: 3, active: 2, perAccount: {},
+    items: Array.from({ length: 300 }, (_, i) => ({
+      id: `session-${i}`, client: 'alice', dimensions: { project: 'p' },
+      requests: 1, lastSeen: 0, firstSeen: 0, active: true, inFlight: 0, pins: {}, tokens: {},
+    })),
+  };
+  const output = renderStatus(status, { color: false, now });
+  assert.doesNotMatch(output, /Session usage|Sessions usage/);
+  assert.doesNotMatch(output, /session-0/);
+});
+
 // --- blocklist visibility (issue: a blocked model read as available) ---------
 // `Models` reports quota headroom, so a fully-blocked family used to render ✓
 // while every request for it got a 400. Quota and the blocklist are separate


### PR DESCRIPTION
Rebased onto master (1.1.14). #186 has merged, so the stale copy of it that used to sit in this branch is gone; what remains is #188 plus this change. Stacked on #188.

## Summary
- add configurable request-header usage dimensions under `proxy.usageDimensions`, fed by `ANTHROPIC_CUSTOM_HEADERS`
- expose dimension counters in `teamclaude status`, `/teamclaude/status`, and the dashboard, alongside the existing `clients` payload
- add a per-session table built on #192's numbers — the tokens each response reported, cache included, per weekly bucket — behind `proxy.sessionDetail` (default off)
- make the dashboard usage tables sortable, and the session table filterable by project or client
- persist configured dimensions in the state file
- document local and CI setup

There is no longer a `session` usage dimension. #192 already meters per-session cost from the response usage; counting `input_tokens` + `output_tokens` a second time would have been the wrong number by orders of magnitude on a cached session.

Closes #196.

## Testing
- `npm run lint`
- `npm test` (884 tests)

Also verified end to end against a stub upstream: a configured dimension header is booked here and absent from the forwarded request, `teamclaude status` grows a `Project usage` section and no session section, and `sessions.items` appears only with `proxy.sessionDetail` on.