### PR TITLE
fix(routing): track the selection cursor per route

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -128,6 +128,13 @@ export class AccountManager {
     // bias selection for a route's models and reset on restart. A pinned account
     // that becomes ineligible is skipped — routing falls back to best-available.
     this.routePins = new Map();
+    // Selection cursor per route (routeName → account index; '' when no route
+    // matches). A single global cursor reads traffic that alternates between
+    // routes as a rotation: the cursor sits on the other route's account, that
+    // account fails this model's route check, and selection "switches" away from
+    // it. Each such switch arms the ramp below, so steady interleaved traffic
+    // holds both accounts at the ramp floor while nothing has failed over.
+    this.routeCursors = new Map();
     this.switchThreshold = switchThreshold;
     this.setRoutes(routes);
     // Storm control: when rotation switches to a fresh account, a burst of
@@ -242,6 +249,16 @@ export class AccountManager {
    * request keeps flowing (upstream then fails just the advisor call).
    */
   getActiveAccount(exclude = null, model = null, advisorModel = null, sessionId = null) {
+    const account = this._pickActiveAccount(exclude, model, advisorModel, sessionId);
+    // Record where this route now sits, whatever path chose it — the steady-state
+    // path returns the account the cursor already names and never reaches the
+    // rotation code, so recording there alone would leave the cursor unset and
+    // the next real failover unpaced.
+    if (account) this.routeCursors.set(this._cursorKey(model), account.index);
+    return account;
+  }
+
+  _pickActiveAccount(exclude, model, advisorModel, sessionId) {
     // Clear expired quotas across all accounts and switch proactively if a
     // session reset made a sooner-expiring account the better choice. This runs
     // on every request so the behaviour holds without the TUI render loop.
@@ -646,6 +663,29 @@ export class AccountManager {
         if (name !== 'fable' && name !== 'sonnet' && !names.has(name)) this.routePins.delete(name);
       }
     }
+    // A reload can rename or drop a route, stranding its cursor under a key
+    // nothing resolves to. Clearing them costs one extra best-available walk per
+    // route and keeps no state that outlives the table it belonged to.
+    this.routeCursors?.clear();
+  }
+
+  /** Cursor key for a model: its route's name, or '' when no route matches. */
+  _cursorKey(model) {
+    return this._routeForModel(model)?.name || '';
+  }
+
+  /** The account this route was serving from before the current selection, or
+   * null when it has none — used to tell a rotation from ordinary routing.
+   *
+   * Before a route has its own cursor, the global one stands in, but only when
+   * it names an account the route could have used: a cursor left on another
+   * route's account was never this route's position, so moving off it is not a
+   * rotation. */
+  _previousCursor(model) {
+    const recorded = this.routeCursors.get(this._cursorKey(model));
+    if (recorded != null) return recorded;
+    const current = this.accounts[this.currentIndex];
+    return current && this._routeAllows(current, model) ? current.index : null;
   }
 
   /** The first configured route whose globs match `model`, or null. */
@@ -1005,7 +1045,8 @@ export class AccountManager {
   _selectNext(exclude = null, model = null, advisorModel = null) {
     const best = this._pickBestAvailable(exclude, model, advisorModel);
     if (best) {
-      const switched = best.index !== this.currentIndex;
+      const previous = this._previousCursor(model);
+      const switched = previous != null && previous !== best.index;
       this.currentIndex = best.index;
       // If we switched to an account whose weekly quota is still unknown, flag
       // it so we re-evaluate once that quota is learned (see updateQuota).
@@ -1325,6 +1366,12 @@ export class AccountManager {
     for (const [name, idx] of [...this.routePins.entries()]) {
       if (idx === index) this.routePins.delete(name);
       else if (idx > index) this.routePins.set(name, idx - 1);
+    }
+    // Same for the selection cursors: a cursor on the removed account is dropped
+    // so the route re-picks, and one above it follows the shift.
+    for (const [name, idx] of [...this.routeCursors.entries()]) {
+      if (idx === index) this.routeCursors.delete(name);
+      else if (idx > index) this.routeCursors.set(name, idx - 1);
     }
   }
 

--- a/test/route-cursor.test.js
+++ b/test/route-cursor.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// Account selection keeps one cursor per route rather than a single global one.
+// Traffic that alternates between routes (a third-party backend serving its own
+// models while Claude accounts serve everything else) would otherwise register
+// every request as a rotation: the cursor points at the other route's account,
+// that account fails the route check, and selection "switches" away from it. The
+// switch arms the storm-control ramp, which caps concurrency to the account it
+// lands on — so steady interleaved traffic pins both accounts near the ramp
+// floor even though nothing failed over.
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+function apikey(name, extra = {}) {
+  return { name, type: 'apikey', apiKey: 'k-' + name, ...extra };
+}
+
+const SPLIT_ROUTES = [
+  { name: 'backend', match: ['k3*'], accounts: ['backend'] },
+  { name: 'claude', match: ['*'], accounts: ['a', 'b'] },
+];
+
+function split() {
+  return new AccountManager([oauth('a'), oauth('b'), apikey('backend', { priority: 100 })], 0.98, {
+    routes: SPLIT_ROUTES,
+  });
+}
+
+/** Run fn with console.log captured; returns the lines it emitted. */
+function captureLog(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try { fn(); } finally { console.log = original; }
+  return lines;
+}
+
+test('alternating between routes neither arms the ramp nor logs a rotation', () => {
+  const am = split();
+
+  const lines = captureLog(() => {
+    for (let i = 0; i < 4; i++) {
+      assert.equal(am.getActiveAccount(null, 'k3').name, 'backend');
+      assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'a');
+    }
+  });
+
+  for (const account of am.accounts) {
+    assert.equal(account.rampStartedAt, null, `interleaving must not ramp "${account.name}"`);
+  }
+  assert.deepEqual(lines.filter(l => /Switched to account/.test(l)), []);
+});
+
+test('a route keeps serving from its own account while another route moves', () => {
+  const am = split();
+
+  assert.equal(am.getActiveAccount(null, 'k3').name, 'backend');
+  assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'a');
+
+  // The Claude route fails over to its second account; the backend route's
+  // cursor is independent and must not follow.
+  am.setDisabled(0, true);
+  assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'b');
+  assert.equal(am.getActiveAccount(null, 'k3').name, 'backend');
+});
+
+test('failover inside one route still arms the ramp on the account it lands on', () => {
+  const am = split();
+
+  assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'a');
+  am.setDisabled(0, true);
+
+  const lines = captureLog(() => {
+    assert.equal(am.getActiveAccount(null, 'claude-opus-5').name, 'b');
+  });
+
+  assert.equal(am.accounts[1].rampStartedAt !== null, true, 'a real failover must ramp its target');
+  assert.equal(lines.some(l => /Switched to account "b"/.test(l)), true);
+});
+
+test('the first request on a route is not a rotation', () => {
+  const am = split();
+
+  const lines = captureLog(() => {
+    assert.equal(am.getActiveAccount(null, 'k3').name, 'backend');
+  });
+
+  assert.equal(am.accounts[2].rampStartedAt, null, 'nothing failed over — no ramp');
+  assert.deepEqual(lines.filter(l => /Switched to account/.test(l)), []);
+});


### PR DESCRIPTION
Rotation state is a single global cursor, so traffic that alternates between routes reads as a rotation on every request.

The setup that triggers it: a third-party backend account serving its own models through a route, Claude accounts serving everything else. A request for the backend's model finds the cursor parked on a Claude account, that account fails the route check, and selection moves off it — recorded as a switch. The next Claude request finds the cursor on the backend account and switches back. Nothing failed over; the two routes are just taking turns.

The cost isn't only the log line. `_beginRamp` sits in the same `if (switched)` branch, and the ramp caps concurrency on the account it lands on: `1 + floor(elapsed/250ms)`, unbounded only after the 30s window. Steady interleaved traffic re-arms it on both accounts continuously, so both sit near the floor while quota is untouched. Pacing a herd onto a freshly failed-over account is what the ramp is for, and route alternation isn't that.

Each route now keeps its own cursor, and a switch means moving off the account that route was serving from. Where a route has no cursor yet the global one stands in, but only when it names an account that route could have used — a cursor left on another route's account was never this route's position, so leaving it isn't a rotation.

Selection itself is deliberately unchanged: the walk still starts from the global cursor, so a manual account switch steers routing exactly as before. I first had it start from the per-route cursor and two existing tests caught that — manual switching and the Fable-bucket case both depend on the global start — so this is narrowed to the cursor bookkeeping only.

Four new cases in `test/route-cursor.test.js`: interleaving arms no ramp and logs no rotation, routes don't drag each other's cursor, a real failover inside a route still ramps its target, and a route's first request isn't a rotation. Full suite and lint pass.
