### PR TITLE
fix(run): bootstrap client auth through proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ teamclaude run       # in another terminal: Claude Code through the proxy
 
 Already logged into Claude Code? `teamclaude import` takes its credentials instead of a fresh OAuth round. API keys, and one email holding accounts in several orgs, are covered in [docs/accounts.md](docs/accounts.md).
 
+`teamclaude run` does not require a separate Claude Code login for normal API
+requests. When local Claude OAuth is unavailable or expired, proxy credential
+mode supplies a local-only bootstrap key; the proxy replaces that placeholder
+with the selected TeamClaude account credential before forwarding.
+
 ## What it does
 
 - Rotates to the next account when the 5h session or 7d weekly bucket reaches the threshold (98% by default), preferring the account whose weekly quota resets soonest.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,7 +117,9 @@ eval "$(teamclaude env --no-mitm)" # base-URL: ANTHROPIC_BASE_URL only
 claude
 ```
 
-Only the export lines go to stdout (so `eval` is safe); a short summary and any hints go to stderr. No `ANTHROPIC_API_KEY` is emitted — loopback clients are exempt from the proxy key gate, and setting it would drop Claude Code out of subscription mode. A remote (non-loopback) client must add the proxy key itself.
+Only the export lines go to stdout (so `eval` is safe); a short summary and any hints go to stderr. When local Claude OAuth is valid, no `ANTHROPIC_API_KEY` is emitted and Claude Code stays in subscription mode. When local OAuth is missing or expired, TeamClaude switches to proxy credential mode and emits a harmless local bootstrap key so Claude Code can start; the proxy replaces it with the selected account credential for normal API requests.
+
+The bootstrap mode does not authenticate the passthrough endpoints used by Remote Control and claude.ai file transfers, which intentionally retain the client's own headers. Run `claude /login` if those features are needed. A remote (non-loopback) client must override the bootstrap key with the real proxy key.
 
 **Using an agent multiplexer or a tool that spawns `claude` itself?** Export this environment in the process that launches those `claude` instances — e.g. `eval "$(teamclaude env)"` in the shell you start the multiplexer from. Every spawned `claude` then gets the same routing (and MITM interception of hardcoded endpoints) without going through `teamclaude run`. The trade-off: `run`'s proxy-up/down guard only applies when you launch via `run`, so start the server before the multiplexer.
 

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -8,6 +8,10 @@ export function encodePinComponent(s) {
   return encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+}
+
 // Build the shell `export` lines that point Claude Code — or any tool that
 // spawns it, e.g. an agent multiplexer — at the proxy. This is the same
 // environment `teamclaude run` sets up, but emitted for `eval "$(teamclaude
@@ -20,17 +24,25 @@ export function encodePinComponent(s) {
 // NODE_EXTRA_CA_CERTS. base-URL mode only redirects the Anthropic base URL and
 // leaves other hosts alone.
 //
-// No ANTHROPIC_API_KEY is emitted: loopback clients are exempt from the proxy's
-// key gate, and setting it would drop Claude Code out of subscription mode (and
-// its full model access). Remote clients that aren't on loopback must add the
-// proxy key themselves.
+// A client bootstrap key is emitted only when the caller determined that local
+// Claude OAuth is unavailable. It gets Claude Code past its startup auth check;
+// the proxy replaces it for normal API requests. Remote clients that are not on
+// loopback must replace it with the real proxy key.
 // `account` pins the session to one account (TC_ACCT), exactly as `teamclaude
 // run` does: in MITM mode it rides in the proxy URL's userinfo and reaches the
 // proxy as the CONNECT's Basic username; in base-URL mode it becomes a
 // `/tc-acct/` prefix. TC_ACCT itself is then unset, so the pin does not leak
 // into claude or anything it spawns — same reasoning as `run` deleting it from
 // the child environment.
-export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '' }) {
+export function buildClaudeEnvLines({
+  port,
+  useMitm = true,
+  caPath = null,
+  holdSeconds = 0,
+  account = null,
+  proxyApiKey = '',
+  clientApiKey = null,
+}) {
   const lines = [];
   const pin = (account || '').trim();
 
@@ -55,6 +67,10 @@ export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdS
 
   // The pin is now carried by the routing itself; keep it out of the child.
   if (pin) lines.push('unset TC_ACCT');
+  if (clientApiKey) {
+    lines.push('unset ANTHROPIC_AUTH_TOKEN');
+    lines.push(`export ANTHROPIC_API_KEY=${shellQuote(clientApiKey)}`);
+  }
 
   // Parity with `run`: if the proxy may hold the connection on exhaustion, raise
   // the client-side timeout so it doesn't give up mid-hold.

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,16 @@ import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConf
 import { installCrashHandlers } from './crash-log.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
-import { importCredentials, loginOAuth, loginOAuthWithPastedCode, fetchProfile, refreshAccessToken, isTokenExpiringSoon } from './oauth.js';
+import {
+  DEFAULT_CREDENTIALS_PATH,
+  importCredentials,
+  loginOAuth,
+  loginOAuthWithPastedCode,
+  fetchProfile,
+  refreshAccessToken,
+  isTokenExpiringSoon,
+  needsProxyClientCredential,
+} from './oauth.js';
 import {
   sameIdentity,
   orgKey,
@@ -58,6 +67,7 @@ const ROUTE_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
 
 const args = process.argv.slice(2);
 const command = args[0];
+const LOCAL_PROXY_API_KEY = 'teamclaude-local';
 
 switch (command) {
   case 'server':
@@ -727,14 +737,21 @@ async function envCommand() {
 
   // Same pin as `teamclaude run`, so `eval "$(teamclaude env)"` and `run` agree.
   const account = (process.env.TC_ACCT || '').trim();
+  const clientApiKey = (
+    !process.env.ANTHROPIC_AUTH_TOKEN
+    && await needsLocalProxyClientCredential()
+  ) ? LOCAL_PROXY_API_KEY : null;
   const lines = buildClaudeEnvLines({
     port, useMitm, caPath, holdSeconds: config.holdSeconds,
-    account, proxyApiKey: config.proxy?.apiKey || '',
+    account, proxyApiKey: config.proxy?.apiKey || '', clientApiKey,
   });
   process.stdout.write(`${lines.join('\n')}\n`);
 
   const mode = useMitm ? 'MITM forward-proxy' : 'base-URL';
   process.stderr.write(`# TeamClaude env: ${mode} mode, localhost:${port}\n`);
+  if (clientApiKey) {
+    process.stderr.write('# local Claude OAuth unavailable; using proxy credential mode\n');
+  }
   if (account) {
     process.stderr.write(`# pinned to account "${account}" (TC_ACCT)\n`);
     // Warn, don't fail: the account list can change before the shell is used,
@@ -788,6 +805,11 @@ async function runCommand() {
   // MITM mode too, and keeps the pin out of the API path.
   const pinnedBase = isLocalAccountPin(process.env.ANTHROPIC_BASE_URL, port);
   if (await isProxyUp(port)) {
+    if (!env.ANTHROPIC_AUTH_TOKEN && await needsLocalProxyClientCredential()) {
+      delete env.ANTHROPIC_AUTH_TOKEN;
+      env.ANTHROPIC_API_KEY = LOCAL_PROXY_API_KEY;
+      console.error('[TeamClaude] Local Claude OAuth unavailable — using proxy credential mode');
+    }
     if (useMitm) {
       // Route ALL of claude's traffic through us as an HTTPS forward proxy, so
       // even hardcoded api.anthropic.com endpoints (e.g. the design MCP) get the
@@ -813,9 +835,10 @@ async function runCommand() {
       }
       delete env.ANTHROPIC_BASE_URL;
     } else {
-      // Only set ANTHROPIC_BASE_URL — Claude Code keeps its own OAuth token
-      // which the proxy accepts from localhost. Not setting ANTHROPIC_API_KEY
-      // lets Claude Code stay in subscription mode (full model access).
+      // Set ANTHROPIC_BASE_URL and preserve subscription mode while local OAuth
+      // is usable. When it is unavailable, the harmless bootstrap key above
+      // gets Claude Code past its startup auth check; the proxy replaces it
+      // with the selected account credential before forwarding.
       // TC_ACCT wins; teamclaude builds the pinned URL itself rather than making
       // the caller hand-write one. Otherwise an existing /tc-acct/ base URL
       // pointing at this proxy is preserved for configs written against 1.1.10.
@@ -870,6 +893,17 @@ async function runCommand() {
   await autoUpdate({ config }).catch(() => {});
 
   process.exit(result.status ?? 1);
+}
+
+async function needsLocalProxyClientCredential() {
+  try {
+    return needsProxyClientCredential(await importCredentials(DEFAULT_CREDENTIALS_PATH));
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      console.error(`[TeamClaude] Could not read local Claude OAuth — using proxy credential mode: ${error.message}`);
+    }
+    return true;
+  }
 }
 
 // ── status ──────────────────────────────────────────────────

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -9,7 +9,7 @@ import { proxyFetch } from './upstream-fetch.js';
 
 const execFileAsync = promisify(execFile);
 
-const DEFAULT_CREDENTIALS_PATH = '~/.claude/.credentials.json';
+export const DEFAULT_CREDENTIALS_PATH = '~/.claude/.credentials.json';
 const KEYCHAIN_SERVICE = 'Claude Code-credentials';
 
 /** The login name whose Keychain item to prefer, or null where there isn't one. */
@@ -202,6 +202,12 @@ export function isTokenExpiringSoon(expiresAt, thresholdMs = 5 * 60 * 1000) {
 export function isTokenExpired(expiresAt) {
   if (!expiresAt) return false;
   return Date.now() >= normalizeExpiresAt(expiresAt);
+}
+
+export function needsProxyClientCredential(credentials, now = Date.now()) {
+  if (!credentials?.accessToken) return true;
+  if (!credentials.expiresAt) return false;
+  return normalizeExpiresAt(credentials.expiresAt) <= now;
 }
 
 /**

--- a/test/claude-env.test.js
+++ b/test/claude-env.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { buildClaudeEnvLines } from '../src/claude-env.js';
 
 test('MITM mode (default) emits proxy vars + CA cert, and clears ANTHROPIC_BASE_URL', () => {
@@ -27,7 +28,7 @@ test('--no-mitm (base-URL) mode emits only ANTHROPIC_BASE_URL, no proxy/cert var
   assert.deepEqual(lines, ['export ANTHROPIC_BASE_URL=http://localhost:8080']);
 });
 
-test('no ANTHROPIC_API_KEY is ever emitted (loopback is auth-exempt; keeps subscription mode)', () => {
+test('client bootstrap key remains absent unless requested', () => {
   const mitm = buildClaudeEnvLines({ port: 3456, useMitm: true, caPath: '/x' });
   const base = buildClaudeEnvLines({ port: 3456, useMitm: false });
   for (const l of [...mitm, ...base]) assert.ok(!l.includes('ANTHROPIC_API_KEY'), l);
@@ -90,4 +91,26 @@ test('a pinned line is shell-safe: no unquoted metacharacters survive', () => {
       for (const l of lines) assert.ok(!/[()'!*]/.test(l), `${l} (from ${name})`);
     }
   }
+});
+
+test('emits a client bootstrap key when requested', () => {
+  const lines = buildClaudeEnvLines({
+    port: 3456,
+    useMitm: false,
+    clientApiKey: 'teamclaude-local',
+  });
+
+  assert.ok(lines.includes('unset ANTHROPIC_AUTH_TOKEN'));
+  assert.ok(lines.includes("export ANTHROPIC_API_KEY='teamclaude-local'"));
+});
+
+test('client bootstrap key is shell-quoted for eval safety', () => {
+  const clientApiKey = "key'; printf injected; #";
+  const lines = buildClaudeEnvLines({ port: 3456, useMitm: false, clientApiKey });
+  const result = spawnSync('/bin/sh', ['-c', `${lines.join('\n')}\nprintf %s "$ANTHROPIC_API_KEY"`], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, clientApiKey);
 });

--- a/test/client-auth-cli.test.js
+++ b/test/client-auth-cli.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const cli = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+async function runEnvCommand(credentials, extraEnv = {}) {
+  const home = await mkdtemp(join(tmpdir(), 'teamclaude-client-auth-'));
+  const configPath = join(home, 'teamclaude.json');
+  await writeFile(configPath, JSON.stringify({
+    autoUpdate: false,
+    proxy: { port: 3456 },
+    accounts: [],
+  }));
+
+  if (credentials) {
+    const claudeDir = join(home, '.claude');
+    await mkdir(claudeDir);
+    await writeFile(join(claudeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: credentials,
+    }));
+  }
+
+  try {
+    return spawnSync(process.execPath, [cli, 'env', '--no-mitm'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: home,
+        TEAMCLAUDE_CONFIG: configPath,
+        ...extraEnv,
+      },
+    });
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+test('env emits proxy client auth when local Claude OAuth is absent', async () => {
+  const result = await runEnvCommand(null);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /unset ANTHROPIC_AUTH_TOKEN/);
+  assert.match(result.stdout, /export ANTHROPIC_API_KEY='teamclaude-local'/);
+});
+
+test('env preserves subscription mode for valid local Claude OAuth', async () => {
+  const result = await runEnvCommand({
+    accessToken: 'local-test-token',
+    refreshToken: 'local-test-refresh',
+    expiresAt: Date.now() + 60_000,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /ANTHROPIC_API_KEY/);
+  assert.doesNotMatch(result.stdout, /ANTHROPIC_AUTH_TOKEN/);
+});
+
+test('env preserves an existing client auth token without local OAuth', async () => {
+  const result = await runEnvCommand(null, { ANTHROPIC_AUTH_TOKEN: 'existing-client-token' });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /ANTHROPIC_API_KEY/);
+  assert.doesNotMatch(result.stdout, /ANTHROPIC_AUTH_TOKEN/);
+});

--- a/test/client-auth.test.js
+++ b/test/client-auth.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { needsProxyClientCredential } from '../src/oauth.js';
+
+test('proxy client credential is needed without a local access token', () => {
+  assert.equal(needsProxyClientCredential(null, 2_000_000_000_000), true);
+  assert.equal(needsProxyClientCredential({}, 2_000_000_000_000), true);
+});
+
+test('proxy client credential is needed for an expired local access token', () => {
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    expiresAt: 1_999_999_999_999,
+  }, 2_000_000_000_000), true);
+});
+
+test('valid local OAuth keeps Claude Code in subscription mode', () => {
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    expiresAt: 2_000_000_000_001,
+  }, 2_000_000_000_000), false);
+  assert.equal(needsProxyClientCredential({ accessToken: 'token' }, 2_000_000_000_000), false);
+});


### PR DESCRIPTION
## Summary
- bootstrap Claude Code through the proxy when local OAuth is missing or expired
- preserve valid local OAuth and existing `ANTHROPIC_AUTH_TOKEN` flows
- keep `--auto-fallback` semantics unchanged
- shell-quote emitted credentials for eval safety

## Limitations
Remote Control and claude.ai file-transfer passthrough endpoints still require client-side authentication.

## Verification
- `npm test`: 533/533 passed
- `npm run lint`: clean
- isolated HOME end-to-end invocation passed