### PR TITLE
fix(relay): tear down the client stream when the upstream leg dies mid-response

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -565,6 +565,14 @@ function relayStream(req, res, upstream, sx) {
     }
     res.writeHead(upstreamRes.statusCode, responseHeaders);
     upstreamRes.pipe(res);
+    // pipe() only propagates 'end'. If the upstream leg dies mid-response
+    // (network blip, upstream restart), upstreamRes emits 'aborted'/'error'
+    // and the pipe just stops — the client's long-poll stays open forever and
+    // the CLI keeps waiting on a channel that can no longer deliver events.
+    // Destroying res closes the client socket, which is the one signal its
+    // reconnect logic reacts to.
+    upstreamRes.on('aborted', () => res.destroy());
+    upstreamRes.on('error', () => res.destroy());
   });
 
   upstreamReq.on('error', (err) => {
@@ -572,6 +580,12 @@ function relayStream(req, res, upstream, sx) {
     if (!res.headersSent) {
       res.writeHead(502, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Upstream unreachable' } }));
+    } else {
+      // Headers already went out (the long-poll was live), so a 502 body can't
+      // be written anymore. Close the client socket instead of leaving it
+      // half-dead: seen in production as a `socket hang up` logged here while
+      // the CLI's Remote Control stream silently waited on it for 45+ minutes.
+      res.destroy();
     }
   });
   // Client disconnected (e.g. Claude Code closed the channel): tear down the

--- a/test/remote-control-relay.test.js
+++ b/test/remote-control-relay.test.js
@@ -192,3 +192,46 @@ test('an upstream socket that dies mid-relay tears down the pair instead of cras
     upstream.close();
   }
 });
+
+// Production failure mode (2026-08-30): the upstream leg of a live long-poll
+// died ("socket hang up" logged by the relay), but the client's response was
+// left open — the CLI's Remote Control stream waited on a channel that could
+// never deliver another event, and every message queued silently for 45+
+// minutes. Once headers have gone out, the only way to tell the client is to
+// close its socket; this proves a mid-stream upstream death propagates instead
+// of stranding the client.
+test('destroys the client stream when the upstream leg dies mid-response', async () => {
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: hello\n\n');
+    // Yank the transport mid-stream — an abrupt FIN/RST, not a clean end().
+    setTimeout(() => res.socket.destroy(), 20);
+  });
+
+  const accountManager = { getActiveAccount() { throw new Error('must not rotate'); } };
+  const listener = createProxyRequestListener({
+    accountManager, upstream: `http://127.0.0.1:${upstreamPort}`,
+  });
+  const { server: proxy, port } = await listen(listener);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/code/sessions/abc/worker/events/stream`);
+    assert.equal(res.status, 200);
+    const reader = res.body.getReader();
+    const { value } = await reader.read();
+    assert.match(Buffer.from(value).toString(), /event: hello/);
+
+    // Without the fix this read never settles: the proxy keeps the client
+    // socket open after the upstream is gone. The race makes the regression
+    // fail fast instead of hanging the whole test run.
+    const outcome = await Promise.race([
+      reader.read().then(({ done }) => (done ? 'closed' : 'data'), () => 'closed'),
+      new Promise((resolve) => setTimeout(() => resolve('stranded'), 2000)),
+    ]);
+    assert.equal(outcome, 'closed');
+  } finally {
+    proxy.close();
+    upstream.close();
+    upstream.closeAllConnections();
+  }
+});


### PR DESCRIPTION
## What

When a Remote Control long-poll (`/v1/code/*`, relayed by `relayStream`) loses its upstream leg **after** response headers have been sent, the proxy logged `Remote Control relay error: <message>` but left the client's response open. `pipe()` only propagates `'end'` — an upstream `'aborted'`/`'error'` just stops the flow, and the client socket stays open indefinitely.

## Impact seen in production

2026-08-30: a quota outage killed the upstream leg of a session's event stream (`socket hang up` logged by this handler). The Claude Code session kept waiting on the half-dead long-poll — it never reconnected, and every message sent to it from the app queued silently for 45+ minutes until the process was killed by hand.

## Fix

- `upstreamReq 'error'` after `headersSent`: destroy `res` instead of doing nothing — closing the client socket is the one signal its reconnect logic reacts to (the existing `!headersSent` 502 path is unchanged).
- `upstreamRes 'aborted'`/`'error'`: destroy `res` for mid-body deaths that never fire the request-level error.

## Test

New regression test in `test/remote-control-relay.test.js`: upstream sends headers plus one event, then destroys its socket mid-stream; the client's read must settle (connection closed) instead of hanging. Without the fix the client strands forever (the race in the test fails with `stranded`). Full suite: 527 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)