### PR TITLE
fix: stop re-sending a refresh token upstream already rejected

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1145,6 +1145,10 @@ export class AccountManager {
     if (!disabled && account.status === 'error') {
       account.status = 'active';
       account.rateLimitedUntil = null;
+      // Operator escape hatch: re-enabling is an explicit "try this again", so
+      // drop the dead-token guard too — otherwise the account would come back
+      // active but never attempt a refresh (see ensureTokenFresh).
+      account._deadRefreshToken = null;
       console.log(`[TeamClaude] Account "${account.name}" re-enabled — clearing error state`);
     }
   }
@@ -1222,6 +1226,17 @@ export class AccountManager {
     const account = this.accounts[accountIndex];
     if (!account || account.type !== 'oauth' || !account.refreshToken) return;
 
+    // Dead-token guard: a refresh token upstream already rejected (invalid_grant)
+    // will be rejected every time, so retrying it only floods the OAuth endpoint
+    // — observed live: 287 identical invalid_grant calls after two accounts' tokens
+    // were invalidated (a `/login` elsewhere rotates the token and kills the copy
+    // teamclaude holds). Paths that bypass availability checks keep calling this
+    // (warmup/probe pin an account by name via /tc-acct, skipping _isAvailable),
+    // so marking the account 'error' alone does not stop the retries. Keyed on the
+    // token VALUE, not the status: the moment a DIFFERENT refresh token arrives
+    // (re-login, config reload, updateAccountTokens) the guard lifts on its own.
+    if (account._deadRefreshToken && account._deadRefreshToken === account.refreshToken) return;
+
     if (!force && !isTokenExpiringSoon(account.expiresAt)) return;
 
     // A forced refresh answers a 401, but 401s arrive in bursts: every request
@@ -1250,6 +1265,7 @@ export class AccountManager {
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
         account._lastRefreshAt = Date.now();
+        account._deadRefreshToken = null; // this token works; clear any stale guard
         console.log(`[TeamClaude] Token refreshed for account "${account.name}"`);
         this._onTokenRefresh?.(accountIndex, newTokens);
       } catch (err) {
@@ -1263,6 +1279,10 @@ export class AccountManager {
         const isAuthRejection = err.status === 400 || err.status === 401 || err.status === 403;
         if (isAuthRejection) {
           account.status = 'error';
+          // Remember WHICH token was rejected so we stop re-sending it (see the
+          // dead-token guard above). A transient failure deliberately does not
+          // arm this — that token may still be good.
+          account._deadRefreshToken = account.refreshToken;
           console.error(`[TeamClaude] Account "${account.name}" needs re-login (refresh token rejected) — run: teamclaude login`);
         }
       } finally {

--- a/test/dead-refresh-token.test.js
+++ b/test/dead-refresh-token.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { AccountManager } from '../src/account-manager.js';
+
+// An account whose token is already expiring, so ensureTokenFresh always tries.
+function mgr(refreshFn) {
+  return new AccountManager([{
+    name: 'a', type: 'oauth',
+    accessToken: 'at-old', refreshToken: 'rt-dead', expiresAt: Date.now() - 1000,
+  }], 0.98, { refreshFn });
+}
+
+function authError(status = 400) {
+  const e = new Error(`Token refresh failed (${status}): {"error":"invalid_grant"}`);
+  e.status = status;
+  return e;
+}
+
+test('a rejected refresh token is not re-sent (no OAuth flood)', async () => {
+  let calls = 0;
+  const m = mgr(async () => { calls++; throw authError(400); });
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 1);
+  assert.strictEqual(m.accounts[0].status, 'error');
+  // warmer/prober keep calling this for every account regardless of availability
+  for (let i = 0; i < 25; i++) await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 1, 'dead token must be sent exactly once, not once per call');
+});
+
+test('force=true does not bypass the dead-token guard', async () => {
+  let calls = 0;
+  const m = mgr(async () => { calls++; throw authError(401); });
+  await m.ensureTokenFresh(0);
+  await m.ensureTokenFresh(0, true);
+  assert.strictEqual(calls, 1, 'a known-dead token stays dead even under force');
+});
+
+test('a TRANSIENT failure is not guarded — it retries', async () => {
+  let calls = 0;
+  const m = mgr(async () => { calls++; const e = new Error('socket hang up'); e.status = 500; throw e; });
+  await m.ensureTokenFresh(0);
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 2, 'network/5xx must keep retrying (token may still be good)');
+  assert.notStrictEqual(m.accounts[0].status, 'error', 'transient failure must not sideline the account');
+});
+
+test('guard lifts automatically when a NEW refresh token arrives (re-login)', async () => {
+  let calls = 0;
+  const m = mgr(async (rt) => {
+    calls++;
+    if (rt === 'rt-dead') throw authError(400);
+    return { accessToken: 'at-new', refreshToken: 'rt-fresh2', expiresAt: Date.now() + 3600_000 };
+  });
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 1);
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 1, 'still guarded while the token is unchanged');
+
+  // re-login / config reload hands the account a fresh token
+  m.updateAccountTokens(0, { accessToken: 'at-x', refreshToken: 'rt-fresh', expiresAt: Date.now() - 1000 });
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 2, 'a different refresh token must be attempted');
+  assert.strictEqual(m.accounts[0].status, 'active');
+});
+
+test('re-enabling a disabled account clears the guard (operator escape hatch)', async () => {
+  let calls = 0;
+  const m = mgr(async () => { calls++; throw authError(403); });
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 1);
+  m.setDisabled(0, true);
+  m.setDisabled(0, false);
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(calls, 2, 'explicit re-enable means "try again"');
+});
+
+test('a successful refresh clears any stale guard', async () => {
+  let mode = 'fail';
+  let calls = 0;
+  const m = mgr(async () => {
+    calls++;
+    if (mode === 'fail') throw authError(400);
+    return { accessToken: 'at2', refreshToken: 'rt2', expiresAt: Date.now() - 1000 };
+  });
+  await m.ensureTokenFresh(0);            // dead → guard armed on 'rt-dead'
+  m.accounts[0].refreshToken = 'rt-other'; // a different token arrives
+  mode = 'ok';
+  await m.ensureTokenFresh(0);            // succeeds → guard cleared
+  assert.strictEqual(m.accounts[0]._deadRefreshToken, null);
+  const before = calls;
+  await m.ensureTokenFresh(0);            // token still expiring → tries again freely
+  assert.strictEqual(calls, before + 1, 'no lingering guard after a success');
+});


### PR DESCRIPTION
Once a refresh token is rejected with `invalid_grant`, the current code keeps sending that same dead token on every subsequent `ensureTokenFresh` call.

Marking the account `error` does not stop this, because **warmer.js and prober.js call `ensureTokenFresh` for every account regardless of availability** — they pin accounts via `/tc-acct` and so bypass `_isAvailable`. On a fleet where one account had been re-authenticated elsewhere (a `/login` in Claude Code rotates the token family and orphans the copy the proxy holds), this produced **287 identical rejected refresh calls** and grew `teamclaude-server.err.log` to 338 KB. Beyond the noise, hammering the OAuth endpoint with a known-dead credential risks the client being flagged upstream.

**The fix** remembers the auth-rejected token *by value* and skips the refresh while it is unchanged:

- a **different** token (re-login, config reload, `updateAccountTokens`) lifts the guard automatically — no manual reset, no stale-guard trap
- a **successful** refresh clears it
- `setDisabled(idx, false)` clears it too, as an operator escape hatch
- **transient** failures (network, 5xx, timeout) deliberately do **not** arm it — that token may still be good, and sidelining a healthy account on a blip is the bug this must not reintroduce

Keying on the value rather than on `account.status` is the point: status can be changed by other paths, but the token itself is the thing that is known-dead.

Composes with #136 (re-auth and retry on 401): that handles a 401 in flight, this prevents flooding the token endpoint with a credential already known to be rejected.

6 tests. Full suite green on this branch (531/531).
