### PR TITLE
feat(quota): run the quota probe by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Step-by-step lifecycle: [docs/routing.md](docs/routing.md#request-lifecycle).
 | [Accounts](docs/accounts.md) | OAuth login, import, API keys, multiple orgs, third-party backends |
 | [Usage](docs/usage.md) | Server and TUI, running Claude Code, shell alias, command reference, logging |
 | [Routing](docs/routing.md) | Rotation, the two kinds of 429, storm control, model routes, session spreading, pinning, prompt cache |
-| [Quota](docs/quota.md) | Quota probe, keep-warm, holding on exhaustion |
+| [Quota](docs/quota.md) | Quota probe (on by default), keep-warm, holding on exhaustion |
 | [Configuration](docs/configuration.md) | Config format, every field, environment variables, network tuning |
 | [Proxy modes](docs/proxy-modes.md) | MITM forward proxy, sx.org residential egress |
 | [Compliance](docs/compliance.md) | Terms of service notes |

--- a/docs/quota.md
+++ b/docs/quota.md
@@ -10,17 +10,17 @@ Observed quota is persisted to `teamclaude.state.json` next to the config, so ro
 
 ## Quota probe
 
-If you'd rather keep idle accounts' quota fresh, enable the background probe:
+The background probe keeps idle accounts' quota fresh. It is **on by default**, every 300s:
 
 ```bash
-teamclaude probe 300    # refresh every 300s
-teamclaude probe off    # back to passive (default)
+teamclaude probe 300    # refresh every 300s (the default)
+teamclaude probe off    # passive only
 teamclaude probe        # show current setting
 ```
 
 The **Quota probe** row on the TUI settings screen (`g`) does the same thing, and `p` on the main screen is a one-shot refresh of every account.
 
-It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota**. API-key and third-party accounts are skipped. Minimum interval is 30s. Changing it takes effect on a running server immediately.
+It reads each OAuth account's utilization from Anthropic's usage endpoint (`/api/oauth/usage`), which reports quota **without consuming any message quota** — which is why it is on by default while [keep-warm](#keep-warm), which does spend a little, is not. API-key and third-party accounts are skipped. Minimum interval is 30s. Changing it takes effect on a running server immediately.
 
 The probe is also the only source for the **Sonnet 7-day** bucket, when your plan exposes it. The Fable weekly bucket arrives passively in the response headers (`anthropic-ratelimit-unified-7d_oi-*`), so Fable-aware routing works without turning the probe on.
 

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,20 @@ export async function saveState(state) {
   await chmod(path, 0o600).catch(() => {});
 }
 
+// Default background quota-probe interval, in seconds. The probe reads the
+// zero-spend /api/oauth/usage endpoint, so unlike keep-warm it costs no message
+// quota — and it is the only path that can refresh a family (Fable/Sonnet)
+// weekly bucket without sending a request of that family, or read a bucket that
+// has no response header at all (Sonnet). An explicit 0 in the config still
+// turns it off; only an ABSENT setting takes this default.
+export const DEFAULT_QUOTA_PROBE_SECONDS = 300;
+
+/** The probe interval a config asks for: an explicit value (0 = off) wins, an
+ * absent one takes the default. */
+export function quotaProbeSeconds(config) {
+  return config?.quotaProbeSeconds ?? DEFAULT_QUOTA_PROBE_SECONDS;
+}
+
 export function createDefaultConfig() {
   return {
     proxy: {
@@ -56,6 +70,7 @@ export function createDefaultConfig() {
     },
     upstream: 'https://api.anthropic.com',
     switchThreshold: 0.98,
+    quotaProbeSeconds: DEFAULT_QUOTA_PROBE_SECONDS,
     holdSeconds: 0,
     distributeSessions: false,
     eventLogging: 'hide',

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { createWriteStream } from 'node:fs';
 import net from 'node:net';
-import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, getCrashLogPath, loadState, saveState } from './config.js';
+import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, getCrashLogPath, loadState, saveState, quotaProbeSeconds } from './config.js';
 import { installCrashHandlers } from './crash-log.js';
 import { AccountManager } from './account-manager.js';
 import { createProxyServer } from './server.js';
@@ -263,7 +263,7 @@ async function serverCommand() {
   const headless = args.includes('--headless') || args.includes('--no-tui');
   const useTUI = !headless && process.stdout.isTTY && process.stdin.isTTY;
 
-  // Opt-in background quota probe (config.quotaProbeSeconds, default 0 = off).
+  // Background quota probe (config.quotaProbeSeconds; on by default, 0 = off).
   let prober = null;
   // Opt-in keep-warm scheduler (config.warmupSeconds, default 0 = off).
   let warmer = null;
@@ -303,9 +303,9 @@ async function serverCommand() {
       else { sx.disable(); await sx.setMode(diskSxMode); }
     }
     if (prober) {
-      const ms = (diskConfig.quotaProbeSeconds || 0) * 1000;
+      const ms = quotaProbeSeconds(diskConfig) * 1000;
       if (ms !== prober.intervalMs) {
-        config.quotaProbeSeconds = diskConfig.quotaProbeSeconds || 0;
+        config.quotaProbeSeconds = quotaProbeSeconds(diskConfig);
         prober.reschedule(ms);
       }
     }
@@ -424,7 +424,7 @@ async function serverCommand() {
     },
     probe: prober?.getStatus() || {
       enabled: false,
-      intervalSeconds: config.quotaProbeSeconds || 0,
+      intervalSeconds: quotaProbeSeconds(config),
       running: false,
       accounts: accountManager.accounts.map(account => ({
         name: account.name,
@@ -503,8 +503,8 @@ async function serverCommand() {
   quotaSaveInterval = setInterval(persistQuotaState, 60_000);
   quotaSaveInterval.unref?.();
 
-  // Start the opt-in quota probe (no-op when quotaProbeSeconds is 0).
-  prober = new Prober(accountManager, { intervalMs: (config.quotaProbeSeconds || 0) * 1000 });
+  // Start the quota probe (no-op when quotaProbeSeconds is an explicit 0).
+  prober = new Prober(accountManager, { intervalMs: quotaProbeSeconds(config) * 1000 });
   prober.start();
 
   // Start the opt-in keep-warm scheduler (no-op when warmupSeconds is 0). It
@@ -1220,7 +1220,7 @@ async function probeCommand() {
   const arg = args[1];
 
   if (arg === undefined) {
-    const cur = config.quotaProbeSeconds || 0;
+    const cur = quotaProbeSeconds(config);
     console.log(cur > 0 ? `Quota probe: every ${cur}s` : 'Quota probe: off (passive only)');
     console.log('Set with: teamclaude probe <off|seconds>   e.g. teamclaude probe 300');
     return;

--- a/src/tui.js
+++ b/src/tui.js
@@ -8,6 +8,7 @@ import {
 } from './identity.js';
 import { formatPercent } from './status-renderer.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
+import { quotaProbeSeconds } from './config.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -494,7 +495,7 @@ export class TUI {
       label: 'Quota probe',
       hint: '←→ ±30s',
       value: () => {
-        const probe = this.config.quotaProbeSeconds || 0;
+        const probe = quotaProbeSeconds(this.config);
         return probe > 0 ? green(`${probe}s`) : gray('off (passive)');
       },
       left: () => this._nudgeProbe(-30),
@@ -649,7 +650,7 @@ export class TUI {
   }
 
   _nudgeProbe(deltaSec) {
-    const cur = this.config.quotaProbeSeconds || 0;
+    const cur = quotaProbeSeconds(this.config);
     const next = Math.max(0, cur + deltaSec);
     if (next !== cur) this._doSetProbe(String(next));
   }

--- a/test/quota-probe-default.test.js
+++ b/test/quota-probe-default.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDefaultConfig, quotaProbeSeconds, DEFAULT_QUOTA_PROBE_SECONDS } from '../src/config.js';
+
+// The probe reads the zero-spend usage endpoint, and it is the only path that
+// can refresh a family (Fable/Sonnet) weekly bucket without sending a request of
+// that family — so it is on unless the operator turns it off. The distinction
+// that matters is absent (take the default) vs. an explicit 0 (stay off).
+
+test('an absent setting takes the default interval', () => {
+  assert.equal(quotaProbeSeconds({}), DEFAULT_QUOTA_PROBE_SECONDS);
+  assert.equal(quotaProbeSeconds({ switchThreshold: 0.9 }), DEFAULT_QUOTA_PROBE_SECONDS);
+  assert.equal(quotaProbeSeconds(undefined), DEFAULT_QUOTA_PROBE_SECONDS);
+  assert.ok(DEFAULT_QUOTA_PROBE_SECONDS >= 30, 'must respect the documented 30s floor');
+});
+
+test('an explicit 0 keeps the probe off — `teamclaude probe off` must stick', () => {
+  assert.equal(quotaProbeSeconds({ quotaProbeSeconds: 0 }), 0);
+});
+
+test('an explicit interval wins over the default', () => {
+  assert.equal(quotaProbeSeconds({ quotaProbeSeconds: 60 }), 60);
+  assert.equal(quotaProbeSeconds({ quotaProbeSeconds: 3600 }), 3600);
+});
+
+test('a fresh config writes the default out explicitly', () => {
+  assert.equal(createDefaultConfig().quotaProbeSeconds, DEFAULT_QUOTA_PROBE_SECONDS);
+});


### PR DESCRIPTION
The quota probe reads `/api/oauth/usage`, which reports utilization **without consuming message quota**. Being opt-in made sense when it looked like one more way to learn the same numbers the response headers already carry. It isn't — it is the only path to two things.

**The Sonnet weekly bucket has no response header at all.** `unified7dSonnet` is populated exclusively by `applyUsageData`. With the probe off it stays `null` forever, the S7 bar never appears, and Sonnet requests are gated by the shared weekly bucket alone.

**A spent family bucket can only be refreshed by a request of that family.** The `7d_oi` headers ride on Fable responses and appear on no other model's response — verified on a Max account, same account seconds apart:

```
claude-fable-5-1 → 200   anthropic-ratelimit-unified-7d_oi-utilization = 0.0
claude-opus-5    → 200   (no 7d_oi header at all)
```

So once the bucket reads spent, selection stops sending the one thing that could correct it. Observed live on a six-account fleet: five accounts pinned at the switch threshold for Fable with cached resets days out, while `/api/oauth/usage` reported `{"kind":"weekly_scoped","percent":0,"scope":{"model":{"display_name":"Fable"}}}` on those same accounts. Passive-only mode has no way to see that. (#226 adds a staleness escape for that case; this PR removes the need to rely on it.)

## The change

Default to 300s. The distinction that matters is **absent** (take the default) vs. an **explicit 0** (stay off), so `teamclaude probe off` sticks, and any config that already set an interval keeps it.

That distinction is why this isn't a one-line diff: `config.quotaProbeSeconds || 0` appeared in four places and cannot tell "off" from "unset". The default now lives in `config.js` as `DEFAULT_QUOTA_PROBE_SECONDS`, and every reader goes through `quotaProbeSeconds(config)`.

Keep-warm stays opt-in. That's the line this draws: the probe spends nothing, keep-warm spends real quota.

## Cost

One `GET /api/oauth/usage` per OAuth account per interval — on a six-account fleet, 72 requests/hour against an endpoint that exists to be polled. API-key and third-party accounts are skipped. The 30s floor is unchanged.

## Tests

`test/quota-probe-default.test.js` pins the absent/explicit-0/explicit-value cases and that a fresh config writes the default out. Suite 546/546, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FgVD2djKUuKWr4maN34H9
