### PR TITLE
feat(usage): record what a request cost, per session and per weekly family (#192, rebased)

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -62,6 +62,14 @@ function emptyQuota() {
   };
 }
 
+// One level deeper than a spread, for the per-bucket usage split. Each bucket's
+// counters are a flat object, so this is the whole depth of the structure.
+function copyBuckets(byBucket) {
+  const out = {};
+  for (const [bucket, counters] of Object.entries(byBucket)) out[bucket] = { ...counters };
+  return out;
+}
+
 // Build a fresh in-memory account record from a config/disk account object.
 // Shared by the constructor and addAccount() so the field set can never drift
 // between startup accounts and runtime-added ones (a divergence here once left
@@ -90,6 +98,18 @@ function makeAccount(acct, index) {
     usage: {
       totalInputTokens: 0,
       totalOutputTokens: 0,
+      // The two cache fields upstream reports alongside `input_tokens` and that
+      // nothing read until now. `totalInputTokens` counts uncached input only,
+      // so on its own it understates what a request cost this account by
+      // whatever the cache served, which on a Claude Code turn is nearly all of
+      // it: across 873012 sampled usage objects these two carry 99.95% of the
+      // input side.
+      totalCacheReadTokens: 0,
+      totalCacheCreationTokens: 0,
+      // The same two totals split by weekly bucket. Fable meters into its own
+      // weekly, so what a point there costs is its own question, and a sum
+      // across families cannot be taken apart afterwards.
+      byBucket: {},
       totalRequests: 0,
       lastUsed: null,
     },
@@ -1315,6 +1335,47 @@ export class AccountManager {
   }
 
   /**
+   * Record one upstream usage report against the account that served it and the
+   * session that asked for it.
+   *
+   * Separate from `updateUsage` rather than folded into it: that one is on the
+   * path every existing caller and test already drives, and this adds a second
+   * scope (the session) whose lifetime is not the account's. Keeping them apart
+   * means nothing that reads the account totals changes behaviour here.
+   *
+   * Nothing routes on any of this. Both the account totals and the per-session
+   * ones are published for an operator to read and are not consulted by
+   * selection.
+   */
+  recordTokenUsage(accountIndex, sessionId, model, usage) {
+    if (!usage) return;
+    // The same resolver routing uses, so a token total and a routing decision
+    // agree about which family a request belonged to. Resolved here rather than
+    // at the call sites: they parse a wire format and have no business knowing
+    // about quota buckets.
+    //
+    // It follows that `unified7d` is not "Opus": it is the shared weekly bucket,
+    // so Opus, Haiku and any model this cannot classify (absent, empty or
+    // unrecognised) all land there together, exactly as they are all gated
+    // there. A per-family figure is only as separable as the quota is.
+    const bucket = this._weeklyBucketFor(model);
+    const account = this.accounts[accountIndex];
+    if (account) {
+      const read = Number.isFinite(usage.cache_read_input_tokens) ? usage.cache_read_input_tokens : 0;
+      const creation = Number.isFinite(usage.cache_creation_input_tokens) ? usage.cache_creation_input_tokens : 0;
+      account.usage.totalCacheReadTokens += read;
+      account.usage.totalCacheCreationTokens += creation;
+      const per = account.usage.byBucket[bucket]
+        || (account.usage.byBucket[bucket] = { cacheReadTokens: 0, cacheCreationTokens: 0 });
+      per.cacheReadTokens += read;
+      per.cacheCreationTokens += creation;
+    }
+    // A request with no session id (or one the tracker has forgotten) is still a
+    // real spend by the account, so the two scopes are recorded independently.
+    this.sessionTracker.recordTokens(sessionId, bucket, usage);
+  }
+
+  /**
    * Enable or disable an account. A disabled account is skipped by rotation
    * until re-enabled. Re-enabling also clears a stuck 'error' state (and any
    * lingering rate-limit hold) so the account is retried immediately.
@@ -1612,7 +1673,14 @@ export class AccountManager {
         status: a.status,
         sessions: sessions.perAccount[a.index] || 0,
         quota: { ...a.quota },
-        usage: { ...a.usage },
+        // `byBucket` is the one nested value under `usage`, so the shallow copy
+        // that covers every flat counter beside it would hand the caller a live
+        // reference into the account, leaving the payload half snapshot and half
+        // window: its per-family figures would keep moving while every other
+        // number on the same object stayed put. Every in-process reader today
+        // serialises it straight away, so this holds a property rather than
+        // fixing a live defect.
+        usage: { ...a.usage, byBucket: copyBuckets(a.usage.byBucket) },
         rateLimitedUntil: a.rateLimitedUntil
           ? new Date(a.rateLimitedUntil).toISOString()
           : null,

--- a/src/server.js
+++ b/src/server.js
@@ -1689,7 +1689,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       const l = getLog();
       const bw = l ? l.bodyWriter('RESPONSE BODY (streamed)', contentType) : null;
       try {
-        await streamResponse(upstreamRes.body, res, account.index, accountManager, bw, ctx.onUsage);
+        await streamResponse(upstreamRes.body, res, account.index, accountManager, bw, ctx.onUsage, ctx.sessionId, ctx.model);
       } finally {
         // Also on the failure path: without the note a capped body reads as a
         // stream that simply stopped, which is the other thing that happens here.
@@ -1698,7 +1698,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       l?.end();
     } else {
       const buf = Buffer.from(await upstreamRes.arrayBuffer());
-      extractUsageFromBody(buf, account.index, accountManager, ctx.onUsage);
+      extractUsageFromBody(buf, account.index, accountManager, ctx.onUsage, ctx.sessionId, ctx.model);
       const l = getLog();
       if (l) { l.body('RESPONSE BODY', buf, contentType); l.end(); }
       res.end(buf);
@@ -1823,12 +1823,14 @@ export function readWithIdleTimeout(reader, ms) {
 /**
  * Stream an SSE response to the client, parsing usage data along the way.
  */
-async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, onUsage = null) {
+async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, onUsage = null, sessionId = null, model = null) {
   const reader = webStream.getReader();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
   let sseBuffer = '';
   let errored = false;
+  // The message's usage, merged across its two reports and recorded once below.
+  const merged = {};
 
   try {
     while (true) {
@@ -1857,7 +1859,7 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
       sseBuffer = events.pop(); // keep incomplete event
 
       for (const event of events) {
-        parseSSEUsage(event, accountIndex, accountManager, onUsage);
+        parseSSEUsage(event, accountIndex, accountManager, onUsage, merged);
       }
 
       // Handle backpressure — also bail out if client disconnects,
@@ -1877,7 +1879,7 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
 
     // Parse any remaining buffer
     if (sseBuffer.trim()) {
-      parseSSEUsage(sseBuffer, accountIndex, accountManager, onUsage);
+      parseSSEUsage(sseBuffer, accountIndex, accountManager, onUsage, merged);
     }
   } catch (err) {
     // A mid-stream idle timeout (or any read error) means the upstream went
@@ -1888,6 +1890,15 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
     errored = true;
     throw err;
   } finally {
+    // Record the message once, on every exit path. A stream that died after
+    // `message_start` still spent the input it reported, so the merge is written
+    // even when no `message_delta` ever arrived. An empty merge is written
+    // nowhere rather than written as zeroes: plenty of streams carry no usage at
+    // all (a ping and some text deltas, or an upstream error after the headers),
+    // and recording those would report an observation that never happened.
+    if (Object.keys(merged).length) {
+      accountManager.recordTokenUsage(accountIndex, sessionId, model, merged);
+    }
     // Cancel upstream reader to stop consuming data nobody needs (and, on the
     // timeout path, to destroy the dead socket so the pool drops it).
     reader.cancel().catch(() => {});
@@ -1895,7 +1906,19 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
   }
 }
 
-function parseSSEUsage(event, accountIndex, accountManager, onUsage = null) {
+// A streaming response reports its usage twice. `message_start` carries the
+// input side, including the two cache fields, with an output figure that is only
+// a placeholder. `message_delta` then reports figures that are cumulative for
+// the whole message, so every field it carries supersedes the earlier one rather
+// than adding to it.
+//
+// The two counters therefore consume the stream differently. `updateUsage` is
+// incremental, so it takes each side at the event that settles it: input at
+// `message_start`, output at `message_delta`. `merged` instead accumulates the
+// message's final figures for a single `recordTokenUsage` once the stream is
+// over. One record per message is what makes double counting unrepresentable
+// rather than merely avoided.
+function parseSSEUsage(event, accountIndex, accountManager, onUsage = null, merged = null) {
   const dataLine = event.split('\n').find(l => l.startsWith('data: '));
   if (!dataLine) return;
 
@@ -1904,21 +1927,24 @@ function parseSSEUsage(event, accountIndex, accountManager, onUsage = null) {
     if (data.type === 'message_start' && data.message?.usage) {
       accountManager.updateUsage(accountIndex, data.message.usage.input_tokens, 0);
       onUsage?.(data.message.usage.input_tokens || 0, 0);
+      if (merged) Object.assign(merged, data.message.usage);
     } else if (data.type === 'message_delta' && data.usage) {
       accountManager.updateUsage(accountIndex, 0, data.usage.output_tokens);
       onUsage?.(0, data.usage.output_tokens || 0);
+      if (merged) Object.assign(merged, data.usage);
     }
   } catch {
     // not valid JSON, skip
   }
 }
 
-function extractUsageFromBody(buffer, accountIndex, accountManager, onUsage = null) {
+function extractUsageFromBody(buffer, accountIndex, accountManager, onUsage = null, sessionId = null, model = null) {
   try {
     const json = JSON.parse(buffer.toString());
     if (json.usage) {
       accountManager.updateUsage(accountIndex, json.usage.input_tokens, json.usage.output_tokens);
       onUsage?.(json.usage.input_tokens || 0, json.usage.output_tokens || 0);
+      accountManager.recordTokenUsage(accountIndex, sessionId, model, json.usage);
     }
   } catch {
     // not JSON or no usage

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -24,9 +24,54 @@ export const SESSION_ACTIVE_TTL_MS = 2 * 60 * 1000; // 2min idle → no longer "
 
 const SWEEP_INTERVAL_MS = 60 * 1000; // bound growth without an external timer
 
+// Per-session token totals, kept per weekly bucket rather than once per session.
+// Fable meters into its own weekly bucket, so how much capacity a point there
+// costs is a per-family quantity by construction; totals summed across families
+// cannot be taken apart again afterwards, and the distinction is gone before
+// anything can use it.
+//
+// The names map one-to-one onto the fields upstream reports in its `usage`
+// object, so a reader can line them up with the wire:
+// `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_tokens`,
+// `output_tokens`.
+//
+// `context` is the odd one out and is not a sum. It is the size of the last
+// context upstream reported reading, which is what one request on this session
+// costs to serve; summing it would answer a question nobody asks. The sums,
+// read against `firstSeen` and `lastSeen`, give the session's burn rate.
+//
+// `reports` counts the usage objects that contributed, so a reader can tell "no
+// tokens because the session is idle" from "no tokens because nothing was ever
+// observed": two states that otherwise look identical at zero.
+function emptyTokens() {
+  return { cacheRead: 0, cacheCreation: 0, input: 0, output: 0, context: 0, reports: 0 };
+}
+
+// The counters in an aggregate sum over KNOWN sessions; the cached footprint
+// only over ACTIVE ones. Two populations in one object, so the footprint is
+// named for its scope. `context / reports` would otherwise read as an average
+// and be a ratio of different denominators.
+const COUNTERS = ['cacheRead', 'cacheCreation', 'input', 'output', 'reports'];
+function emptyAggregate() {
+  return { cacheRead: 0, cacheCreation: 0, input: 0, output: 0, reports: 0, activeContext: 0 };
+}
+
+// Upstream omits a field it has nothing to say about, and has been seen to send
+// null. Anything that is not a finite number contributes zero, so one malformed
+// report cannot turn a running total into NaN and keep it there.
+function num(v) {
+  return Number.isFinite(v) ? v : 0;
+}
+
+function setAndReturn(map, key, value) {
+  map.set(key, value);
+  return value;
+}
+
 export class SessionTracker {
   constructor({ knownTtlMs, activeTtlMs, now } = {}) {
-    // id -> { pins: Map<bucketKey, { idx, at }>, firstSeen, lastSeen, count, inFlight }
+    // id -> { pins: Map<bucketKey, { idx, at }>, firstSeen, lastSeen, count,
+    //         inFlight, tokens: Map<bucketKey, ...> }
     this.sessions = new Map();
     this.knownTtlMs = knownTtlMs ?? SESSION_KNOWN_TTL_MS;
     this.activeTtlMs = activeTtlMs ?? SESSION_ACTIVE_TTL_MS;
@@ -97,10 +142,76 @@ export class SessionTracker {
     s.lastSeen = now;
   }
 
+  /**
+   * Add one upstream usage report to a session's running totals, under the
+   * weekly quota bucket the request was governed by.
+   *
+   * Records only what the report carries. A streaming response splits its usage
+   * across two events, and the caller merges those into one object before
+   * getting here, so this is called once per upstream message however many
+   * events that message took to arrive.
+   *
+   * Four cases this deliberately does NOT special-case, because the tokens were
+   * spent upstream whether or not the request finished:
+   *
+   *   - a stream that fails after `message_start`: the context read happened and
+   *     was charged, so it stays counted;
+   *   - a request the client abandoned: same, the client leaving does not refund
+   *     anything;
+   *   - an advisor request: one report covers the whole request, and the
+   *     advisor's sub-inference is not separable from the executor's inside it,
+   *     so it lands on the executing model's bucket. Splitting it across the two
+   *     buckets a request can touch would be inventing a division upstream did
+   *     not report;
+   *   - a session the tracker has already forgotten: its totals went with its
+   *     record, and this will NOT resurrect one. The id is a client-supplied
+   *     header, so creating records here would let usage reports repopulate a
+   *     map the idle window exists to drain. A report for a session that is gone
+   *     is dropped.
+   */
+  recordTokens(sessionId, bucket, usage, now = this._now()) {
+    const s = this._live(sessionId, now);
+    if (!s || !usage || !bucket) return null;
+    const t = s.tokens.get(bucket) || setAndReturn(s.tokens, bucket, emptyTokens());
+    const read = num(usage.cache_read_input_tokens);
+    const creation = num(usage.cache_creation_input_tokens);
+    const input = num(usage.input_tokens);
+    t.cacheRead += read;
+    t.cacheCreation += creation;
+    t.input += input;
+    t.output += num(usage.output_tokens);
+    // Only a report that carries the input side describes a context. A
+    // `message_delta` carries output alone and would otherwise reset this to 0.
+    if (read || creation || input) t.context = read + creation + input;
+    t.reports += 1;
+    return t;
+  }
+
+  // A known, non-expired session's record, or null. Never creates one, and
+  // drops an expired one on read like pinnedAccount does.
+  _live(sessionId, now) {
+    const s = sessionId && this.sessions.get(sessionId);
+    if (!s) return null;
+    if (this._isExpired(s, now)) {
+      this.sessions.delete(sessionId);
+      return null;
+    }
+    return s;
+  }
+
   _ensure(sessionId, now) {
     let s = this.sessions.get(sessionId);
     if (!s) {
-      s = { pins: new Map(), firstSeen: now, lastSeen: now, count: 0, inFlight: 0 };
+      s = {
+        pins: new Map(), firstSeen: now, lastSeen: now, count: 0, inFlight: 0,
+        // bucket -> emptyTokens(). On the session's own record rather than in a
+        // map beside it, so there is one lifetime and one eviction policy for
+        // everything scoped to a session: a second map keyed by session id would
+        // need its own bound and its own sweep to stay in step with this one.
+        // The same key space as `pins`, so a family's spend and the account it
+        // is pinned to are looked up by one bucket key.
+        tokens: new Map(),
+      };
       this.sessions.set(sessionId, s);
     }
     return s;
@@ -211,19 +322,37 @@ export class SessionTracker {
     }
   }
 
-  // { known, active, perAccount: { [index]: activeCount } } — for status/TUI.
-  // Sweeps as it goes so a long-lived headless server stays bounded.
+  // { known, active, perAccount: { [index]: activeCount }, tokens } — for
+  // status/TUI. Sweeps as it goes so a long-lived headless server stays bounded.
+  // The token totals come out of the walk this already does: the status endpoint
+  // is read on every TUI frame, so nothing here may add a second pass.
+  //
+  // `tokens` sums the sessions still KNOWN, while `activeContext` beside it sums
+  // only the ACTIVE ones, because the two answer different questions: what this
+  // fleet has spent, and what it is carrying now. `byBucket` is the same pair
+  // per weekly family, which is the only view in which a fleet spending its Opus
+  // and its Fable windows at different rates is visible at all.
   stats(now = this._now()) {
     this._lastSweep = now;
     let known = 0;
     let active = 0;
     const perAccount = {};
+    const tokens = emptyAggregate();
+    const byBucket = {};
+    let activeContext = 0;
     for (const [id, s] of this.sessions) {
       if (this._isExpired(s, now)) {
         this.sessions.delete(id);
         continue;
       }
       known += 1;
+      for (const [bucket, t] of s.tokens) {
+        const per = byBucket[bucket] || (byBucket[bucket] = emptyAggregate());
+        for (const k of COUNTERS) {
+          tokens[k] += t[k];
+          per[k] += t[k];
+        }
+      }
       if (this._isActive(s, now)) {
         active += 1;
         // Once per account, on every account this session is currently
@@ -231,8 +360,17 @@ export class SessionTracker {
         for (const idx of this._loadedAccounts(s, now)) {
           perAccount[idx] = (perAccount[idx] || 0) + 1;
         }
+        // The live cached footprint, per family and in total. A session holding
+        // a big Opus context and a small Fable one contributes to both.
+        for (const [bucket, t] of s.tokens) {
+          const per = byBucket[bucket] || (byBucket[bucket] = emptyAggregate());
+          per.activeContext += t.context;
+          activeContext += t.context;
+        }
       }
     }
-    return { known, active, perAccount };
+    tokens.activeContext = activeContext;
+    tokens.byBucket = byBucket;
+    return { known, active, perAccount, tokens };
   }
 }

--- a/test/session-token-accounting.test.js
+++ b/test/session-token-accounting.test.js
@@ -1,0 +1,375 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SessionTracker } from '../src/session-tracker.js';
+import { AccountManager } from '../src/account-manager.js';
+
+// Per-session token accounting. Upstream reports what a request cost in a
+// `usage` object, and until now only `input_tokens` and `output_tokens` were
+// read off it: the two cache fields were discarded, and nothing was attributed
+// to the session that caused the spend.
+//
+// Nothing routes on any of this. These tests pin what is recorded and, just as
+// importantly, what is not: the counters are a measurement, and a measurement
+// that quietly double counts or resurrects forgotten state is worse than none.
+
+const SID = 'sess-a';
+const accounts = (names) => names.map(n => ({ name: n, type: 'apikey', apiKey: `k-${n}` }));
+
+// Totals are per weekly bucket, so every assertion has to name one. These are
+// the two families that meter separately, which is the whole reason for the
+// split: an Opus point and a Fable point are not the same thing.
+const OPUS = 'claude-opus-5';
+const FABLE = 'claude-fable-5';
+const OPUS_BUCKET = 'unified7d';
+const FABLE_BUCKET = 'unified7dFable';
+const tokensFor = (t, id, bucket = OPUS_BUCKET) => t.sessions.get(id).tokens.get(bucket);
+
+// The shape upstream sends at `message_start`: the input side, including both
+// cache fields, with output present but not yet meaningful.
+const startUsage = (over = {}) => ({
+  input_tokens: 12,
+  cache_read_input_tokens: 4000,
+  cache_creation_input_tokens: 300,
+  output_tokens: 1,
+  ...over,
+});
+
+// The shape at `message_delta`: output only.
+const deltaUsage = (over = {}) => ({ output_tokens: 500, ...over });
+
+function trackerWith(sessionId = SID) {
+  const t = new SessionTracker();
+  t.touch(sessionId);
+  return t;
+}
+
+test('a usage report is attributed to the session that caused it', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  const got = tokensFor(t, SID);
+  assert.equal(got.cacheRead, 4000);
+  assert.equal(got.cacheCreation, 300);
+  assert.equal(got.input, 12);
+  assert.equal(got.output, 1);
+  assert.equal(got.reports, 1);
+});
+
+// The tracker sums every report it is handed: that is what makes a session total
+// a total across the turns of a conversation. It follows that the streaming path
+// must hand it one report per message rather than one per SSE event, which is
+// asserted end to end in streaming-usage-merge.test.js.
+test('successive reports accumulate into the session total', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  const got = tokensFor(t, SID);
+  assert.equal(got.input, 24, 'a second turn adds to the running total');
+  assert.equal(got.cacheRead, 8000);
+  assert.equal(got.reports, 2);
+});
+
+// `context` is the size of the last context read, not a running total. Summing
+// it across a conversation answers a question nobody asks, and a delta report
+// carries no input side at all, so it must not reset it either.
+test('context tracks the latest input side and survives an output-only report', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  assert.equal(tokensFor(t, SID).context, 4312);
+  t.recordTokens(SID, OPUS_BUCKET, deltaUsage());
+  assert.equal(tokensFor(t, SID).context, 4312,
+    'an output-only report has nothing to say about context size');
+  t.recordTokens(SID, OPUS_BUCKET, startUsage({ cache_read_input_tokens: 9000 }));
+  assert.equal(tokensFor(t, SID).context, 9312,
+    'the next turn read a bigger context, and that is the current one');
+});
+
+// The id is a client-supplied header, so a report for a session the tracker is
+// not carrying must not create a record: that would let usage reports repopulate
+// a map the idle window exists to drain.
+test('a report for an untracked session is dropped, not resurrected', () => {
+  const t = new SessionTracker();
+  assert.equal(t.recordTokens('never-seen', OPUS_BUCKET, startUsage()), null);
+  assert.equal(t.sessions.size, 0, 'a usage report created a session record');
+  assert.equal(t.recordTokens(null, OPUS_BUCKET, startUsage()), null);
+  assert.equal(t.sessions.size, 0);
+});
+
+// The totals ride the session record, so they end when it does. This is the read
+// path: a report arriving for a session that has idled past the known window
+// finds nothing to add to, and takes the dead record out on its way through.
+// (A `touch` arriving first revives the record instead, tokens and all — see the
+// limitation in the PR body. That is the pre-existing lifecycle and not
+// something this change either introduces or repairs.)
+test('a report for a session idled past the known window is dropped with it', () => {
+  let now = 1000;
+  const t = new SessionTracker({ knownTtlMs: 100, now: () => now });
+  t.touch(SID);
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  assert.equal(tokensFor(t, SID).cacheRead, 4000);
+  now += 500;
+  assert.equal(t.recordTokens(SID, OPUS_BUCKET, startUsage()), null,
+    'a report landed on a session the tracker had already forgotten');
+  assert.equal(t.sessions.has(SID), false, 'the expired record was left behind');
+});
+
+// A stream that fails after the first report keeps what was observed: the
+// context was read upstream and charged, and the client leaving refunds nothing.
+test('a stream that stops after its first report keeps what it spent', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  const got = tokensFor(t, SID);
+  assert.equal(got.cacheRead, 4000);
+  assert.equal(got.output, 1, 'only what was reported');
+  assert.equal(got.reports, 1);
+});
+
+test('a malformed report contributes zero rather than poisoning the totals', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  t.recordTokens(SID, OPUS_BUCKET, { input_tokens: null, cache_read_input_tokens: 'lots', output_tokens: undefined });
+  const got = tokensFor(t, SID);
+  for (const [k, v] of Object.entries(got)) {
+    assert.ok(Number.isFinite(v), `${k} is ${v}`);
+  }
+  assert.equal(got.cacheRead, 4000, 'a non-numeric field added nothing');
+});
+
+// ── the families meter separately ────────────────────────────────────────────
+
+// The point of keying by bucket. A session that talks to both families holds two
+// contexts and two burn rates, and pooling them destroys a distinction nothing
+// downstream can rebuild.
+test('a session that spans two families keeps their totals apart', () => {
+  const t = trackerWith();
+  t.recordTokens(SID, OPUS_BUCKET, startUsage());
+  t.recordTokens(SID, FABLE_BUCKET, startUsage({ cache_read_input_tokens: 90, input_tokens: 3 }));
+  assert.equal(tokensFor(t, SID, OPUS_BUCKET).cacheRead, 4000);
+  assert.equal(tokensFor(t, SID, FABLE_BUCKET).cacheRead, 90);
+  assert.equal(tokensFor(t, SID, OPUS_BUCKET).context, 4312);
+  assert.equal(tokensFor(t, SID, FABLE_BUCKET).context, 393,
+    'the two families reported different context sizes and one overwrote the other');
+});
+
+test('a report with no bucket is dropped rather than pooled', () => {
+  const t = trackerWith();
+  assert.equal(t.recordTokens(SID, null, startUsage()), null);
+  assert.equal(t.sessions.get(SID).tokens.size, 0,
+    'a report that named no family landed somewhere anyway');
+});
+
+// ── the account side ─────────────────────────────────────────────────────────
+
+test('the cache fields are totalled against the account that served them', () => {
+  const am = new AccountManager(accounts(['a', 'b']), 0.98);
+  am.sessionTracker.touch(SID);
+  am.recordTokenUsage(0, SID, OPUS, startUsage());
+  am.recordTokenUsage(0, SID, OPUS, startUsage());
+  assert.equal(am.accounts[0].usage.totalCacheReadTokens, 8000);
+  assert.equal(am.accounts[0].usage.totalCacheCreationTokens, 600);
+  assert.equal(am.accounts[1].usage.totalCacheReadTokens, 0, 'the other account was charged');
+});
+
+test('an account report with no session still lands on the account', () => {
+  const am = new AccountManager(accounts(['a']), 0.98);
+  am.recordTokenUsage(0, null, OPUS, startUsage());
+  assert.equal(am.accounts[0].usage.totalCacheReadTokens, 4000,
+    'a request without a session id is still a real spend by this account');
+});
+
+test('recordTokenUsage leaves the existing account totals alone', () => {
+  const am = new AccountManager(accounts(['a']), 0.98);
+  am.recordTokenUsage(0, null, OPUS, startUsage());
+  assert.equal(am.accounts[0].usage.totalInputTokens, 0,
+    'the uncached-input total is updateUsage\'s to keep, and this must not touch it');
+  assert.equal(am.accounts[0].usage.totalOutputTokens, 0);
+});
+
+test('the account totals are split by family and still sum', () => {
+  const am = new AccountManager(accounts(['a']), 0.98);
+  am.sessionTracker.touch(SID);
+  am.recordTokenUsage(0, SID, OPUS, startUsage());
+  am.recordTokenUsage(0, SID, FABLE, startUsage({ cache_read_input_tokens: 90 }));
+  const u = am.accounts[0].usage;
+  assert.equal(u.byBucket[OPUS_BUCKET].cacheReadTokens, 4000);
+  assert.equal(u.byBucket[FABLE_BUCKET].cacheReadTokens, 90);
+  assert.equal(u.totalCacheReadTokens, 4090, 'the flat total no longer agrees with the split');
+});
+
+// An advisor request reports once, and the two inferences inside it are not
+// separable in that report. It lands on the executing model's family, and this
+// pins that rather than leaving it to be discovered.
+test('an advisor request lands on the executing model\'s family', () => {
+  const am = new AccountManager(accounts(['a']), 0.98);
+  am.sessionTracker.touch(SID);
+  am.recordTokenUsage(0, SID, OPUS, startUsage());   // executor Opus, advisor elsewhere
+  assert.equal(am.sessionTracker.sessions.get(SID).tokens.get(FABLE_BUCKET), undefined,
+    'a bucket the request did not execute on was charged');
+  assert.equal(am.sessionTracker.sessions.get(SID).tokens.get(OPUS_BUCKET).cacheRead, 4000);
+});
+
+// A `bucket` override on a route is how an operator redirects a model's quota
+// accounting, and the totals follow it for the same reason routing does: a
+// figure filed under a bucket the request was not gated by describes nothing.
+test('a route bucket override files the totals where it files the routing', () => {
+  const am = new AccountManager(accounts(['a']), 0.98, {
+    routes: [{ name: 'r', match: '*fable*', bucket: 'unified7d' }],
+  });
+  am.sessionTracker.touch(SID);
+  am.recordTokenUsage(0, SID, FABLE, startUsage());
+  assert.equal(am.accounts[0].usage.byBucket[FABLE_BUCKET], undefined,
+    'the override was ignored and the family default won');
+  assert.equal(am.accounts[0].usage.byBucket[OPUS_BUCKET].cacheReadTokens, 4000);
+  assert.equal(tokensFor(am.sessionTracker, SID, OPUS_BUCKET).cacheRead, 4000,
+    'the session totals and the account totals disagree about the bucket');
+});
+
+// ── what the fleet view reports ──────────────────────────────────────────────
+
+test('stats totals the known sessions and the live cached footprint', () => {
+  const t = new SessionTracker();
+  t.touch('a'); t.touch('b');
+  t.recordTokens('a', OPUS_BUCKET, startUsage());
+  t.recordTokens('b', OPUS_BUCKET, startUsage({ cache_read_input_tokens: 1000 }));
+  const s = t.stats();
+  assert.equal(s.tokens.cacheRead, 5000);
+  assert.equal(s.tokens.input, 24);
+  assert.equal(s.tokens.reports, 2);
+  assert.equal(s.tokens.activeContext, 4312 + 1312, 'the footprint sums the ACTIVE sessions');
+});
+
+test('an idle session keeps its totals but leaves the live footprint', () => {
+  let now = 1000;
+  const t = new SessionTracker({ activeTtlMs: 100, now: () => now });
+  t.touch('a');
+  t.recordTokens('a', OPUS_BUCKET, startUsage());
+  assert.equal(t.stats().tokens.activeContext, 4312);
+  now += 500;                                   // still known, no longer active
+  const s = t.stats();
+  assert.equal(s.active, 0);
+  assert.equal(s.tokens.cacheRead, 4000, 'a known session still counts toward the totals');
+  assert.equal(s.tokens.activeContext, 0, 'an idle session is not part of the live footprint');
+});
+
+test('stats reports each family and the total across them', () => {
+  const t = new SessionTracker();
+  t.touch('a');
+  t.recordTokens('a', OPUS_BUCKET, startUsage());
+  t.recordTokens('a', FABLE_BUCKET, startUsage({ cache_read_input_tokens: 90, input_tokens: 3 }));
+  const s = t.stats();
+  assert.equal(s.tokens.byBucket[OPUS_BUCKET].cacheRead, 4000);
+  assert.equal(s.tokens.byBucket[FABLE_BUCKET].cacheRead, 90);
+  assert.equal(s.tokens.cacheRead, 4090, 'the total across families is not reported');
+  assert.equal(s.tokens.byBucket[OPUS_BUCKET].activeContext, 4312);
+  assert.equal(s.tokens.byBucket[FABLE_BUCKET].activeContext, 393);
+  assert.equal(s.tokens.activeContext, 4705, 'the live footprint sums the families');
+});
+
+// ── the status payload ───────────────────────────────────────────────────────
+
+// `teamclaude status --json` is what an operator reads during an incident, and a
+// field that has stopped reading its source is worse than a missing one: it
+// answers confidently and wrongly. Zero is every one of these fields' default,
+// so a fixture that leaves any of them at zero would pass against a constant.
+// Every value below is therefore set away from its default AND made distinct
+// from every other, so a field wired to the wrong source reads as a different
+// number rather than as a coincidence.
+//
+// Two shapes the fixture needs on purpose, because freezing is not the only way
+// a field goes wrong:
+//
+//   - account 'a' spends TWO families, so its flat total (4200) differs from
+//     either of its per-bucket figures (4000, 200). With one family each, a
+//     per-bucket figure sourced from the flat total would read correct.
+//   - the two families report a DIFFERENT number of times (1 against 2), so a
+//     bucket swap that reached `reports` alone is visible. At one apiece the two
+//     are interchangeable.
+//
+// Account 'b' stays on one family, as the contrast.
+function payloadFixture() {
+  const am = new AccountManager(accounts(['a', 'b']), 0.98);
+  am.sessionTracker.touch('s1', 0);
+  am.sessionTracker.touch('s2', 1);
+  am.recordTokenUsage(0, 's1', OPUS, {
+    input_tokens: 11, cache_read_input_tokens: 4000,
+    cache_creation_input_tokens: 300, output_tokens: 7,
+  });
+  // A different family on purpose: the two must not be pooled on the way out.
+  am.recordTokenUsage(1, 's2', FABLE, {
+    input_tokens: 22, cache_read_input_tokens: 1000,
+    cache_creation_input_tokens: 50, output_tokens: 9,
+  });
+  // The same session and account as the first, in the other family.
+  am.recordTokenUsage(0, 's1', FABLE, {
+    input_tokens: 5, cache_read_input_tokens: 200,
+    cache_creation_input_tokens: 60, output_tokens: 14,
+  });
+  return am;
+}
+
+test('the status payload reports the fleet token totals and the live footprint', () => {
+  const s = payloadFixture().getStatus();
+  assert.equal(s.sessions.tokens.cacheRead, 5200, 'the cache-read total is not reported');
+  assert.equal(s.sessions.tokens.cacheCreation, 410, 'the cache-creation total is not reported');
+  assert.equal(s.sessions.tokens.input, 38, 'the per-session input total is not reported');
+  assert.equal(s.sessions.tokens.output, 30, 'the per-session output total is not reported');
+  assert.equal(s.sessions.tokens.reports, 3,
+    'the report count is not published, so no tokens and no observations read alike');
+  assert.equal(s.sessions.tokens.activeContext, 4311 + 265 + 1072,
+    'the live cached footprint is not reported');
+});
+
+test('the status payload splits the fleet totals by weekly family', () => {
+  const s = payloadFixture().getStatus();
+  const opus = s.sessions.tokens.byBucket[OPUS_BUCKET];
+  const fable = s.sessions.tokens.byBucket[FABLE_BUCKET];
+  assert.equal(opus.cacheRead, 4000, 'the Opus weekly bucket is not reported on its own');
+  assert.equal(fable.cacheRead, 1200,
+    'the Fable weekly bucket is not reported on its own, so the families are pooled');
+  assert.equal(opus.cacheCreation, 300);
+  assert.equal(fable.cacheCreation, 110);
+  assert.equal(opus.input, 11);
+  assert.equal(fable.input, 27);
+  assert.equal(opus.output, 7);
+  assert.equal(fable.output, 23);
+  assert.equal(opus.reports, 1);
+  assert.equal(fable.reports, 2, 'the two families report the same count, so a swap is invisible');
+  assert.equal(opus.activeContext, 4311);
+  assert.equal(fable.activeContext, 265 + 1072);
+});
+
+test('the status payload reports each account\'s cache totals and their split', () => {
+  const s = payloadFixture().getStatus();
+  assert.equal(s.accounts[0].usage.totalCacheReadTokens, 4200,
+    "the account's cache-read total is not reported");
+  assert.equal(s.accounts[0].usage.totalCacheCreationTokens, 360,
+    "the account's cache-creation total is not reported");
+  assert.equal(s.accounts[1].usage.totalCacheReadTokens, 1000,
+    'both accounts report the same cache total');
+  assert.equal(s.accounts[1].usage.totalCacheCreationTokens, 50);
+  // Each of these differs from the flat total above it, so a per-bucket figure
+  // sourced from that total is a different number rather than the same one.
+  assert.equal(s.accounts[0].usage.byBucket[OPUS_BUCKET].cacheReadTokens, 4000,
+    "the account's per-family split is not reported");
+  assert.equal(s.accounts[0].usage.byBucket[OPUS_BUCKET].cacheCreationTokens, 300);
+  assert.equal(s.accounts[0].usage.byBucket[FABLE_BUCKET].cacheReadTokens, 200,
+    "the account's second family is pooled into its first");
+  assert.equal(s.accounts[0].usage.byBucket[FABLE_BUCKET].cacheCreationTokens, 60);
+  assert.equal(s.accounts[1].usage.byBucket[FABLE_BUCKET].cacheReadTokens, 1000);
+  assert.equal(s.accounts[1].usage.byBucket[FABLE_BUCKET].cacheCreationTokens, 50);
+});
+
+// The payload is a snapshot. Every other counter under `usage` is a number and
+// is copied by the spread; `byBucket` is the one nested value, and left aliased
+// it would keep moving while the flat figures beside it on the same object
+// stayed frozen. Today's in-process readers serialise it immediately, so this
+// pins the property rather than repairing a live defect: an object named for
+// being a status snapshot should not be half snapshot and half window.
+test('the published per-family split is a snapshot, not a live reference', () => {
+  const am = payloadFixture();
+  const s = am.getStatus();
+  am.recordTokenUsage(0, 's1', OPUS, { cache_read_input_tokens: 777 });
+  assert.equal(s.accounts[0].usage.byBucket[OPUS_BUCKET].cacheReadTokens, 4000,
+    'the payload moved under its reader');
+  assert.equal(s.accounts[0].usage.totalCacheReadTokens, 4200,
+    'the flat total moved, so the fixture proves nothing about the nested one');
+});

--- a/test/streaming-usage-merge.test.js
+++ b/test/streaming-usage-merge.test.js
@@ -1,0 +1,223 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// A streaming turn reports its usage twice, and the second report is
+// CUMULATIVE for the whole message rather than an increment on the first. So
+// the two reports cannot both be added: `message_start` carries the input side
+// with a placeholder output figure, and `message_delta` supersedes every field
+// it carries.
+//
+// These drive the real proxy rather than the tracker, because the defect this
+// pins lives at the call site, not in the tracker: handing the whole object
+// over at both events double counts whatever appears in both, and no
+// tracker-level fixture can reach that. Each case asserts the record was
+// written at all before asserting its contents, so a stream that never reached
+// the accounting path fails loudly instead of reading as zero.
+
+const SID = 'sess-merge';
+const BUCKET = 'unified7d';
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+
+// The input side is settled at `message_start`; `output_tokens` there is a
+// placeholder (upstream's own examples show 1, 2 and 3), not a real count.
+const START = {
+  input_tokens: 12,
+  cache_read_input_tokens: 4000,
+  cache_creation_input_tokens: 300,
+  output_tokens: 2,
+};
+// Truth for one such turn, whatever shape the delta takes.
+const TRUTH = { cacheRead: 4000, cacheCreation: 300, input: 12, output: 500, context: 4312 };
+
+// Drives one streaming turn through the proxy and returns the session's
+// recorded totals. `events` chooses which reports the upstream sends.
+async function turn(events, { expectRecord = true } = {}) {
+  const upstream = http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    for (const e of events) {
+      res.write(`event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`);
+      await new Promise(r => setTimeout(r, 2));
+    }
+    res.end();
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k-a' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+
+  try {
+    await new Promise((resolve, reject) => {
+      const rq = http.request({
+        host: '127.0.0.1', port, path: '/v1/messages', method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-claude-code-session-id': SID },
+      }, (res) => { res.on('data', () => {}); res.on('end', resolve); });
+      rq.on('error', reject);
+      rq.end(JSON.stringify({ model: 'claude-opus-5', stream: true, messages: [] }));
+    });
+    // The record is written in streamResponse's finally, which can land a tick
+    // after the client's end event.
+    await new Promise(r => setTimeout(r, 60));
+    const got = am.sessionTracker.sessions.get(SID)?.tokens?.get(BUCKET);
+    if (expectRecord) {
+      assert.ok(got, 'nothing was recorded for the session, so this proves nothing');
+    }
+    return { tokens: got, usage: am.accounts[0].usage, tracker: am.sessionTracker };
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+const start = (usage = START) => ({ type: 'message_start', message: { usage } });
+const delta = (usage) => ({ type: 'message_delta', usage });
+const stop = { type: 'message_stop' };
+
+test('a delta carrying output alone does not add the message_start placeholder', async () => {
+  const { tokens } = await turn([start(), delta({ output_tokens: 500 }), stop]);
+  assert.equal(tokens.output, TRUTH.output,
+    "message_start's placeholder output was added to the delta's cumulative count");
+  assert.equal(tokens.input, TRUTH.input);
+  assert.equal(tokens.cacheRead, TRUTH.cacheRead);
+  assert.equal(tokens.reports, 1, 'a streaming turn is one message and must record once');
+});
+
+test('a delta repeating the input side does not double it', async () => {
+  const { tokens } = await turn([
+    start(),
+    delta({ ...START, output_tokens: 500 }),
+    stop,
+  ]);
+  assert.equal(tokens.cacheRead, TRUTH.cacheRead,
+    'the cache read was counted at both events');
+  assert.equal(tokens.cacheCreation, TRUTH.cacheCreation);
+  assert.equal(tokens.input, TRUTH.input);
+  assert.equal(tokens.output, TRUTH.output);
+  assert.equal(tokens.context, TRUTH.context);
+});
+
+// The delta's figures are cumulative for the message, so on a turn that ran
+// more than one inference (a server-tool turn) its input side EXCEEDS what
+// message_start reported. Superseding is right under both readings of
+// cumulative; adding is wrong under both, and taking message_start's figure
+// alone would silently understate exactly these turns.
+test('a cumulative delta supersedes rather than adds to message_start', async () => {
+  const { tokens } = await turn([
+    start(),
+    delta({ ...START, input_tokens: 10682, output_tokens: 500 }),
+    stop,
+  ]);
+  assert.equal(tokens.input, 10682,
+    'the cumulative input was added to message_start rather than superseding it');
+  assert.equal(tokens.cacheRead, TRUTH.cacheRead);
+  assert.equal(tokens.context, 10682 + 4000 + 300,
+    'context is a level and must reflect the settled figures, not an increment');
+  assert.equal(tokens.reports, 1);
+});
+
+// A stream can end after message_start without ever sending a delta. The prompt
+// was still processed and billed, so the input side it reported must survive;
+// there is simply no authoritative output figure to record.
+//
+// This is the CLEAN end of that shape: the upstream closes the stream properly.
+// The dirty end, where the read throws, is the next test, and the two are not
+// interchangeable: this one alone is satisfied by recording on the success path.
+test('a stream that ends after message_start still records the input it spent', async () => {
+  const { tokens } = await turn([start(), stop]);
+  assert.equal(tokens.input, TRUTH.input, 'the input side was dropped');
+  assert.equal(tokens.cacheRead, TRUTH.cacheRead);
+  assert.equal(tokens.cacheCreation, TRUTH.cacheCreation);
+  assert.equal(tokens.output, 2,
+    'with no delta the only output figure upstream gave is the placeholder');
+  assert.equal(tokens.reports, 1);
+});
+
+// THE REASON THE RECORD IS WRITTEN FROM `finally` AND NOT FROM THE SUCCESS PATH.
+//
+// Upstream writes message_start and then destroys the socket. The body reader
+// rejects, streamResponse rethrows to its caller's transient handler, and the
+// only code that still runs is the `finally`. Those tokens were spent upstream
+// whichever way the stream ended, so the input side has to survive the abort.
+//
+// Written because moving the record out of the `finally` onto the success path
+// passed the whole suite: every other streaming case here ends cleanly, so the
+// success path covers them all and nothing reached the throwing path. The
+// account assertion sits beside the session one because a single call writes
+// both scopes, so a record that never happens loses both.
+test('a stream aborted mid-flight still records the input it already spent', async () => {
+  const upstream = http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    res.write(`data: ${JSON.stringify({ type: 'message_start', message: { usage: START } })}\n\n`);
+    // Die mid-stream: no delta, no stop, no clean end.
+    setTimeout(() => { try { res.socket.destroy(); } catch { /* already gone */ } }, 25);
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k-a' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+
+  try {
+    // The client sees a broken response by design (a clean res.end() would look
+    // like a complete answer and suppress its retry), so every one of these
+    // settles the wait rather than only 'end'.
+    await new Promise((resolve) => {
+      const rq = http.request({
+        host: '127.0.0.1', port, path: '/v1/messages', method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-claude-code-session-id': SID },
+      }, (res) => { res.on('data', () => {}); res.on('end', resolve); res.on('error', resolve); });
+      rq.on('error', resolve);
+      rq.end(JSON.stringify({ model: 'claude-opus-5', stream: true, messages: [] }));
+    });
+    await new Promise(r => setTimeout(r, 150));
+
+    const t = am.sessionTracker.sessions.get(SID)?.tokens?.get(BUCKET);
+    assert.ok(t, 'a stream that died after message_start recorded nothing, so the input it spent was lost');
+    assert.equal(t.cacheRead, TRUTH.cacheRead);
+    assert.equal(t.input, TRUTH.input);
+    assert.equal(t.reports, 1, 'the abort was recorded as more than one observation');
+    assert.equal(am.accounts[0].usage.totalCacheReadTokens, TRUTH.cacheRead,
+      'the account was not charged for a context it really read');
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// Plenty of streams carry no usage at all: a ping, text deltas and nothing
+// else, or an upstream error after the headers. Writing the merge unguarded
+// would record an all-zero report for them, and the `reports` count on that
+// record would say one report arrived. That is precisely the distinction
+// `reports` exists to preserve, so an empty merge has to be written nowhere
+// rather than written as zeroes.
+//
+// The guard looks like defensive code and reads as deletable; this names what
+// it protects so that deleting it is a red test rather than a silent change of
+// meaning.
+test('a stream that reports no usage records nothing at all', async () => {
+  const { tokens, tracker } = await turn([
+    { type: 'ping' },
+    { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } },
+    stop,
+  ], { expectRecord: false });
+  assert.equal(tokens, undefined,
+    'a stream carrying no usage was recorded as a report of zero tokens');
+  assert.ok(tracker.sessions.get(SID),
+    'the session itself was never tracked, so this would pass for the wrong reason');
+});
+
+// The pre-existing account counter reads the same stream and is not part of
+// this change. It stays incremental and per-event, so a regression that
+// "fixed" it into the merged path would show up here.
+test('the account counters are unchanged by the merge', async () => {
+  const { usage } = await turn([
+    start(),
+    delta({ ...START, output_tokens: 500 }),
+    stop,
+  ]);
+  assert.equal(usage.totalInputTokens, 12, 'the legacy input counter moved');
+  assert.equal(usage.totalOutputTokens, 500, 'the legacy output counter moved');
+});

--- a/test/usage-attribution.test.js
+++ b/test/usage-attribution.test.js
@@ -1,0 +1,208 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// Who a usage report is charged to. The recording call takes the account that
+// served, the session that asked and the model that ran, and each of those can
+// be wrong independently: the right numbers on the wrong account, the wrong
+// family's weekly bucket, or a total attributed to nobody.
+//
+// The buffered path is covered here too. It reports once, so it cannot show
+// the double count the streaming merge exists to prevent, but it is the same
+// seam and nothing drove it end to end before.
+//
+// Magnitudes are of the order a real turn reports: it reads a large cached
+// prefix and sends almost no fresh input, which is why counting `input_tokens`
+// alone measured close to nothing. Over 873012 `usage` objects carrying an input
+// side in local Claude Code transcripts, the medians are `input_tokens` 2 and
+// `cache_read_input_tokens` 199824, and the two cache fields carry 99.95% of all
+// input-side tokens.
+//
+// The same corpus is the reason only the flat `cache_creation_input_tokens`
+// appears here: the wire also carries a nested `cache_creation` breaking the
+// same quantity down by cache TTL, and over 873391 objects carrying both, the
+// nested figures sum to the flat one on all but 51 (those being degenerate rows,
+// a flat 0 against a nested sum or the reverse). They are the same tokens
+// counted once, not two quantities to add.
+//
+// Both counts come from `~/.claude/projects` on one machine, so the magnitudes
+// are reproducible in shape and the absolute counts are not.
+const USAGE = {
+  input_tokens: 2,
+  cache_read_input_tokens: 377127,
+  cache_creation_input_tokens: 1092,
+  output_tokens: 714,
+};
+const CONTEXT = USAGE.cache_read_input_tokens + USAGE.cache_creation_input_tokens + USAGE.input_tokens;
+
+const OPUS = 'claude-opus-5';
+const FABLE = 'claude-fable-5';
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+const acct = (name) => ({ name, type: 'apikey', apiKey: `k-${name}` });
+
+// A buffered upstream: one JSON body carrying the whole usage object.
+function buffered() {
+  return http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'message', content: [], usage: USAGE }));
+  });
+}
+
+// A streaming upstream, split the way upstream's documented event sequence
+// splits it: the input side at `message_start` with a placeholder output, and
+// figures cumulative for the message at `message_delta`.
+function streaming() {
+  return http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    res.write(`data: ${JSON.stringify({ type: 'message_start', message: { usage: { ...USAGE, output_tokens: 1 } } })}\n\n`);
+    await new Promise(r => setTimeout(r, 3));
+    res.write(`data: ${JSON.stringify({ type: 'message_delta', usage: { output_tokens: USAGE.output_tokens } })}\n\n`);
+    res.end();
+  });
+}
+
+async function send(port, { sessionId, model, stream }) {
+  return new Promise((resolve, reject) => {
+    const rq = http.request({
+      host: '127.0.0.1', port, path: '/v1/messages', method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-claude-code-session-id': sessionId },
+    }, (res) => { res.on('data', () => {}); res.on('end', () => resolve(res.statusCode)); });
+    rq.on('error', reject);
+    rq.end(JSON.stringify({ model, stream: !!stream, messages: [] }));
+  });
+}
+
+async function withProxy(upstream, accounts, fn, amOpts = {}) {
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(accounts.map(acct), 0.98, amOpts);
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+  try {
+    return await fn(port, am);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+const tokensOf = (am, sid, bucket) => am.sessionTracker.sessions.get(sid)?.tokens?.get(bucket);
+
+for (const [label, make, stream] of [['buffered', buffered, false], ['streaming', streaming, true]]) {
+  test(`a ${label} response is attributed to the session that asked`, async () => {
+    await withProxy(make(), ['a'], async (port, am) => {
+      assert.equal(await send(port, { sessionId: 'sess-1', model: OPUS, stream }), 200);
+      await new Promise(r => setTimeout(r, 60));
+      const t = tokensOf(am, 'sess-1', 'unified7d');
+      assert.ok(t, 'nothing was recorded for the session, so this proves nothing');
+      assert.equal(t.cacheRead, USAGE.cache_read_input_tokens);
+      assert.equal(t.cacheCreation, USAGE.cache_creation_input_tokens);
+      assert.equal(t.input, USAGE.input_tokens);
+      assert.equal(t.output, USAGE.output_tokens);
+      assert.equal(t.context, CONTEXT);
+      assert.equal(t.reports, 1, 'one upstream message is one report on either path');
+    });
+  });
+
+  test(`a ${label} response lands in the weekly bucket of the model that ran`, async () => {
+    await withProxy(make(), ['a'], async (port, am) => {
+      assert.equal(await send(port, { sessionId: 'sess-f', model: FABLE, stream }), 200);
+      await new Promise(r => setTimeout(r, 60));
+      const fable = tokensOf(am, 'sess-f', 'unified7dFable');
+      assert.ok(fable, 'the Fable turn was not recorded against the Fable bucket');
+      assert.equal(fable.cacheRead, USAGE.cache_read_input_tokens);
+      assert.equal(tokensOf(am, 'sess-f', 'unified7d'), undefined,
+        "a Fable turn was charged to Opus's weekly bucket, which cannot be undone later");
+      assert.equal(am.accounts[0].usage.byBucket.unified7dFable.cacheReadTokens,
+        USAGE.cache_read_input_tokens, "the account's own split has the same family wrong");
+    });
+  });
+}
+
+// The account a report is charged to is the account that SERVED, which is only
+// distinguishable from "whichever account is current now" once the two differ.
+// A request is held open upstream; a second request meanwhile exhausts the
+// account they are both on and switches the fleet to another one. The held
+// request's usage still belongs to the account that did the work, which is no
+// longer the current account by the time it lands.
+//
+// `updateUsage` is the positive control: it takes the same account index and is
+// not part of this change, so its per-account output totals say which account
+// really served which request, independently of the field under test.
+//
+// Both paths are held, because they record at different moments: the buffered
+// one as soon as the body is parsed, the streaming one in the exit path after
+// the last event.
+for (const heldStreams of [false, true]) {
+  test(`a ${heldStreams ? 'streaming' : 'buffered'} report is charged to the account that served, not the current one`, async () => {
+    let release;
+    let rejections = 0;
+    const held = new Promise(r => { release = r; });
+    const upstream = http.createServer(async (req, res) => {
+      const sid = req.headers['x-claude-code-session-id'];
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      let body = {};
+      try { body = JSON.parse(Buffer.concat(chunks).toString() || '{}'); } catch { /* not JSON */ }
+      if (body.stream) {
+        res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+        res.write(`data: ${JSON.stringify({ type: 'message_start', message: { usage: { ...USAGE, output_tokens: 1 } } })}\n\n`);
+        if (sid === 'sess-held') await held;
+        res.write(`data: ${JSON.stringify({ type: 'message_delta', usage: { output_tokens: USAGE.output_tokens } })}\n\n`);
+        res.end();
+        return;
+      }
+      if (sid === 'sess-held') await held;
+      // Reject the second request once, on whichever account is current. That
+      // spends the account the held request is also on and moves the fleet off
+      // it, which is the only thing that makes the two indices disagree.
+      if (sid === 'sess-free' && rejections++ === 0) {
+        res.writeHead(429, {
+          'content-type': 'application/json',
+          'retry-after': '1',
+          'anthropic-ratelimit-unified-7d-status': 'rejected',
+        });
+        res.end('{}');
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'message', content: [], usage: USAGE }));
+    });
+
+    await withProxy(upstream, ['a', 'b'], async (port, am) => {
+      const first = send(port, { sessionId: 'sess-held', model: OPUS, stream: heldStreams });
+      // Let the held request take an account before the second one arrives.
+      await new Promise(r => setTimeout(r, 80));
+      const served = am.currentIndex;
+      assert.equal(await send(port, { sessionId: 'sess-free', model: OPUS, stream: false }), 200);
+      assert.notEqual(am.currentIndex, served,
+        'the fleet never switched accounts, so the two indices still agree and this proves nothing');
+      release();
+      assert.equal(await first, 200);
+      await new Promise(r => setTimeout(r, 60));
+
+      const out = am.accounts.map(a => a.usage.totalOutputTokens);
+      assert.deepEqual(out, [USAGE.output_tokens, USAGE.output_tokens],
+        `the two requests were not served by different accounts (${out}), so this proves nothing`);
+      const read = am.accounts.map(a => a.usage.totalCacheReadTokens);
+      assert.deepEqual(read, [USAGE.cache_read_input_tokens, USAGE.cache_read_input_tokens],
+        'a report was charged to the account that happened to be current when it landed');
+    });
+  });
+}
+
+// A usage report for a session the tracker does not have must not create one:
+// the id is a client-supplied header and records are capped.
+test('a response for an untracked session records nothing for it', async () => {
+  await withProxy(buffered(), ['a'], async (port, am) => {
+    assert.equal(await send(port, { sessionId: 'sess-real', model: OPUS, stream: false }), 200);
+    await new Promise(r => setTimeout(r, 60));
+    assert.ok(tokensOf(am, 'sess-real', 'unified7d'), 'the real session was not recorded');
+    assert.equal(am.sessionTracker.sessions.get('sess-never-seen'), undefined);
+    assert.equal(am.accounts[0].usage.totalCacheReadTokens, USAGE.cache_read_input_tokens,
+      "the account total is charged once regardless of the session's fate");
+  });
+});


### PR DESCRIPTION
Carries #192 by @ak2k rebased onto master (on top of #189, without #190): the `_live()` helper #192 took from #190 is added on its own, and the streaming usage path merges with #186's per-client `onUsage` callback (both run: the incremental per-client counter and the once-per-message `recordTokenUsage`).

What it records (nothing routes on it): per-account cache read/creation totals split by weekly bucket, and per-session token totals per bucket on the SessionTracker record (swept with the session; never resurrects a forgotten session), exposed in `getStatus().sessions.tokens`. SSE usage is merged last-wins across `message_start`/`message_delta` and recorded once in `finally`, so a stream that died after `message_start` still books the input it spent.

Supersedes #192; credit stays with its author in the commit history.