### PR TITLE
Bump to 1.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Ships everything merged since 1.1.13:

**Proxy and error handling**
  #182 (with #180, #181) every error path answers the socket, activity entries close exactly once, h2 client aborts stop the retry ladder and the stream
  #183 connect failures are logged with their per-address reasons
  #198 DNS/route failures are transient unless another host can serve (consolidates #184)
  #215 a Remote Control long-poll is torn down when the upstream leg dies mid-response
  #238 an upstream proxy that is this server is refused

**Accounts and auth**
  #185 macOS Keychain lookup scoped to the current user's item
  #187/#239 `teamclaude login --token`: copy/paste OAuth for headless machines
  #193 OAuth-entitlement-denied accounts are quarantined for five minutes
  #197 `teamclaude route` no longer crashes; reload applies `upstream`/`modelMap` edits
  #210 unidentified OAuth imports are refused instead of saved as placeholders
  #216 a rejected refresh token is not re-sent

**Quota and routing**
  #189 session pins are per weekly bucket; a session stays on its account for a new family
  #195 selection cursor tracked per route (no spurious ramp on interleaved routes)
  #211/#232 `distributeSessions` applies on reload; turning it off drains instead of cutting
  #226 a spent family bucket is revalidated instead of sealed in (fixes #167)
  #230 upstream `unified-status: rejected` is honoured while fresh; status names why an account is blocked (fixes #166)
  #231 model-scoped weekly buckets are learned from the usage payload
  #233 `switchThreshold` accepts a per-bucket table
  #240 the probe revalidates family buckets in full

**Observability**
  #186 per-client keys with per-client usage accounting
  #192/#241 per-session and per-family token accounting
  #225/#227 request log: level, body cap, retention, 0600 files, upstream body logged, malformed JSON no longer fails a request (closes #208, #217–#224)

**TUI**
  #178 burn-rate bar colouring, width-aware name column
  #179 display-width measurement for table columns
  #213 opt-in session titles in the activity log
  #214 fractional switch threshold
  #228 account row budgeted for every column it draws
  #227 eventLogging and blockedModels edits from the settings screen now persist