### PR TITLE
feat(usage): warn when an account bills real money, not just quota

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,4 +1,4 @@
-import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
+import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired, formatMoney } from './oauth.js';
 import { providerOf, DEFAULT_PROVIDER } from './provider.js';
 import { refreshCodexToken } from './codex-auth.js';
 import { parseCodexQuota, parseCodexPlanType } from './codex-quota.js';
@@ -73,6 +73,10 @@ function emptyQuota() {
     // Upstream owns this list and it changes, so it is learned rather than
     // declared — a family with no dedicated field above is still metered.
     scopedWeekly: {},
+    // Paid-overage state from the usage probe: null until a probe reports it.
+    // Not a quota — it says whether exceeding the quotas above costs money
+    // on this account rather than stopping it.
+    spend: null,
     resetsAt: null,
   };
 }
@@ -1798,6 +1802,21 @@ export class AccountManager {
     // applies, and keeping a remembered copy would gate on a limit that upstream
     // has stopped reporting.
     if (usage.scopedWeekly) q.scopedWeekly = { ...usage.scopedWeekly };
+
+    // Paid overage. Replaced wholesale like the buckets above, and announced
+    // once on the transition into billing: an account that starts drawing real
+    // money is the one usage change an operator cannot infer from the bars.
+    if (usage.spend) {
+      const was = q.spend;
+      q.spend = { ...usage.spend };
+      if (q.spend.enabled && !was?.enabled) {
+        console.log(`[TeamClaude] Account "${account.name}" can bill real money past its plan limits (extra usage is enabled upstream)`);
+      }
+      const spentNow = (q.spend.usedMinor || 0) > 0;
+      if (spentNow && !((was?.usedMinor || 0) > 0)) {
+        console.log(`[TeamClaude] Account "${account.name}" has started spending real money: ${formatMoney(q.spend)}`);
+      }
+    }
 
     // If we just learned this account's weekly window while probing, re-evaluate
     // selection (same path as learning it from a live response).

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -287,6 +287,85 @@ export function scopedWeeklyLimits(data) {
   return out;
 }
 
+/**
+ * Normalize the paid-overage ("extra usage") portion of a /api/oauth/usage
+ * payload into { enabled, usedMinor, limitMinor, currency, exponent,
+ * userDisabled, disabledReason }, or null when the payload said nothing about
+ * spend at all.
+ *
+ * This is the one part of the usage payload that is not about quota. Every
+ * other bucket answers "how much of the plan is left"; this answers "does
+ * running out of plan stop this account, or start charging for it". An account
+ * with `is_enabled` true does not refuse at its weekly limit — it keeps serving
+ * and bills, so the quota bars alone cannot tell an operator that rotation onto
+ * it costs money.
+ *
+ * `extra_usage.is_enabled` is the authority on whether billing can happen, not
+ * `spend.enabled` and not the profile endpoint's `has_extra_usage_enabled`:
+ * an org can have overage provisioned while the account itself cannot draw on
+ * it (out of credits, or switched off by the member), and only this field
+ * accounts for both. The amounts come from `spend`, which states its own
+ * currency and exponent rather than assuming cents or USD.
+ */
+export function normalizeSpend(data) {
+  const extra = data?.extra_usage;
+  const spend = data?.spend;
+  if ((!extra || typeof extra !== 'object') && (!spend || typeof spend !== 'object')) return null;
+
+  const money = (m) => {
+    if (!m || typeof m !== 'object') return null;
+    const minor = typeof m.amount_minor === 'number' ? m.amount_minor : parseFloat(m.amount_minor);
+    return Number.isFinite(minor) ? minor : null;
+  };
+
+  const usedMinor = money(spend?.used);
+  const limitMinor = money(spend?.limit);
+  // Prefer the currency/exponent the amounts were quoted in; fall back to the
+  // extra_usage block, which describes the same wallet in its own vocabulary.
+  const currency = spend?.used?.currency || spend?.limit?.currency || extra?.currency || null;
+  const rawExp = spend?.used?.exponent ?? spend?.limit?.exponent ?? extra?.decimal_places;
+  const exponent = Number.isFinite(rawExp) ? rawExp : 2;
+
+  return {
+    enabled: extra?.is_enabled === true,
+    usedMinor,
+    limitMinor,
+    currency,
+    exponent,
+    // Distinguishes "the member turned this off" from "upstream will not allow
+    // it" (no credits left, spend cap reached). Both read as not-enabled, but
+    // only the first is something the operator chose and can undo.
+    userDisabled: extra?.user_disabled === true,
+    disabledReason: typeof extra?.disabled_reason === 'string' ? extra.disabled_reason : null,
+  };
+}
+
+/**
+ * Render a normalized spend record's used (and, when known, capped) amount as
+ * text: "$12.34 of $10,000.00". Minor units and the exponent come from the
+ * payload, so a currency that is not two-decimal formats correctly rather than
+ * being silently divided by 100.
+ */
+export function formatMoney(spend) {
+  if (!spend) return 'unknown';
+  const sym = { USD: '$', EUR: '\u20ac', GBP: '\u00a3', JPY: '\u00a5' }[spend.currency] || '';
+  const unit = (minor) => {
+    if (minor == null) return null;
+    const v = minor / (10 ** (spend.exponent ?? 2));
+    const text = v.toLocaleString('en-US', {
+      minimumFractionDigits: spend.exponent ?? 2,
+      maximumFractionDigits: spend.exponent ?? 2,
+    });
+    // Suffix the code when there is no symbol for it, so an unfamiliar currency
+    // is still identifiable rather than rendering as a bare number.
+    return sym ? `${sym}${text}` : `${text}${spend.currency ? ' ' + spend.currency : ''}`;
+  };
+  const used = unit(spend.usedMinor);
+  const limit = unit(spend.limitMinor);
+  if (used == null) return limit == null ? 'unknown' : `cap ${limit}`;
+  return limit == null ? used : `${used} of ${limit}`;
+}
+
 // Normalize one usage bucket from the /api/oauth/usage payload into
 // { utilization: 0-1, resetAt: ms-epoch }. The endpoint reports utilization
 // as a percentage in the 0-100 range, so 1 means 1%, not 100%.
@@ -368,6 +447,10 @@ export function normalizeUsagePayload(data) {
     sevenDaySonnet: normalizeUsageBucket(data?.seven_day_sonnet) || scopedWeekly.sonnet || null,
     sevenDayFable: scopedWeekly.fable || null,
     scopedWeekly,
+    // Whether this account bills real money past its plan limits, and how
+    // much it already has. Carried beside the quota buckets because it comes
+    // from the same zero-spend probe response.
+    spend: normalizeSpend(data),
     // True when the payload carried that enumeration. It is what makes a
     // MISSING family meaningful: upstream listed this account's scoped weekly
     // caps and that family was not among them. Without the list, a missing

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -1,3 +1,4 @@
+import { formatMoney } from './oauth.js';
 import { findFamilyBlock, modelGlobOverlaps, gatingUtilization } from './model.js';
 import { safeLine } from './safe-text.js';
 
@@ -45,6 +46,8 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
     if (routing) lines.push(`  ${routing}`);
     const why = unavailableLine(account, paint);
     if (why) lines.push(`  ${why}`);
+    const spend = spendLine(account, paint);
+    if (spend) lines.push(`  ${spend}`);
     lines.push(`  ${paint.dim('Usage'.padEnd(8))} ${formatUsage(account.usage, now)}`);
     lines.push(`  ${paint.dim('Probe'.padEnd(8))} ${formatAccountProbe(account.name, probe, now, paint)}`);
     lines.push('');
@@ -83,6 +86,40 @@ const UNAVAILABLE_TEXT = {
   'advisor-quota': "advisor model's weekly bucket spent",
   'advisor-route': 'no route allows the advisor model',
 };
+
+/**
+ * The paid-overage warning line, or null when this account cannot bill and
+ * never has. Rendered separately from the quota bars on purpose: those all
+ * measure a plan allowance that simply runs out, while this one says that
+ * running out is billable here. An operator scanning the bars has no other way
+ * to see that rotation onto this account spends money rather than quota.
+ *
+ * Shown whenever billing is possible OR anything has already been billed — an
+ * account that spent this month and has since been switched off is still a
+ * fact about where the money went.
+ */
+export function spendLine(account, paint) {
+  const spend = account?.quota?.spend;
+  if (!spend) return null;
+  const spent = (spend.usedMinor || 0) > 0;
+  if (!spend.enabled && !spent) return null;
+
+  const amount = formatMoney(spend);
+  if (spend.enabled) {
+    // Already billing is the louder of the two: red, and named as money rather
+    // than as a percentage, so it cannot be mistaken for another quota bar.
+    const text = spent
+      ? `billing real money — ${amount} used this month`
+      : `can bill real money past its plan limits — ${amount} used`;
+    return `${paint.dim('Spend'.padEnd(8))} ${(spent ? paint.red : paint.yellow)(`\u26a0 ${text}`)}`;
+  }
+  // Not enabled, but money was spent this month. Say why it is off now, since
+  // "out_of_credits" and "the member turned it off" have different futures.
+  const why = spend.userDisabled ? 'now disabled by the account holder'
+    : spend.disabledReason ? `now off (${spend.disabledReason})`
+    : 'now off';
+  return `${paint.dim('Spend'.padEnd(8))} ${paint.yellow(`${amount} spent this month, ${why}`)}`;
+}
 
 export function unavailableLine(account, paint) {
   const reason = account?.unavailable;

--- a/src/tui.js
+++ b/src/tui.js
@@ -188,6 +188,22 @@ const NAME_MIN = 12;
 // column layout (which reserves the width that tag needs).
 // `threshold` is a number, or a per-bucket lookup (bucket → number) so a family
 // is judged against its OWN configured threshold rather than the global one.
+/**
+ * Short row tag for an account that bills real money past its plan limits:
+ * `$!` once something has actually been billed, `$` while it merely can be,
+ * '' when it cannot. ASCII on purpose — the row is width-budgeted to the cell,
+ * and a glyph whose width varies by terminal would push it past the edge.
+ *
+ * Deliberately not shown for an account that spent earlier and has since been
+ * switched off: the row reports what rotating onto this account costs now, and
+ * the status screen carries the fuller history.
+ */
+export function spendTag(quota) {
+  const spend = quota?.spend;
+  if (!spend?.enabled) return '';
+  return (spend.usedMinor || 0) > 0 ? '$!' : '$';
+}
+
 export function blockedFamilies(quota, threshold) {
   const at = typeof threshold === 'function' ? threshold : () => threshold;
   const out = [];
@@ -1311,7 +1327,14 @@ export class TUI {
         const names = blockedFamilies(a.quota, key => this.am.thresholdFor(key));
         return names.length ? Math.max(w, 4 + vw(names.join(' '))) : w;
       }, 0);
-      const fixed = 28 + NAME_MIN + (genRoutes.length ? genRoutes.length + 1 : 0) + tagW;
+      // Same rule for the `$`/`$!` money tag: a column the row can draw is a
+      // column the budget has to know about, or the row overflows exactly the
+      // way #228 fixed.
+      const spendW = this.am.accounts.reduce((w, a) => {
+        const tag = spendTag(a.quota);
+        return tag ? Math.max(w, 2 + vw(tag)) : w;
+      }, 0);
+      const fixed = 28 + NAME_MIN + (genRoutes.length ? genRoutes.length + 1 : 0) + tagW + spendW;
       const roomFor = n => fixed + 6 * (n - 1) + n * BAR_MIN <= W;
       // The family bars are the first thing to go: below the width where they
       // fit even at BAR_MIN they would push the row past the edge, and a row cut
@@ -1500,6 +1523,10 @@ export class TUI {
     // repeated here.
     const blocked = blockedFamilies(q, key => this.am.thresholdFor(key));
     if (blocked.length) line += `  ${red('⊘ ' + blocked.join(' '))}`;
+    // Money tag last, so it sits at the end of the row where the eye lands after
+    // the bars. Red once real money has moved, yellow while it only could.
+    const money = spendTag(q);
+    if (money) line += `  ${(money === '$!' ? red : yellow)(money)}`;
     return line;
   }
 

--- a/test/spend-warning.test.js
+++ b/test/spend-warning.test.js
@@ -1,0 +1,211 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeSpend, normalizeUsagePayload, formatMoney } from '../src/oauth.js';
+import { AccountManager } from '../src/account-manager.js';
+import { renderStatus, spendLine } from '../src/status-renderer.js';
+import { TUI, spendTag } from '../src/tui.js';
+
+// An account with paid overage enabled does not stop at its weekly limit — it
+// keeps serving and bills. The quota bars cannot express that, so rotation onto
+// such an account spends money with nothing on screen saying so. These tests pin
+// the whole path: parse it off the probe payload, carry it on the quota, and say
+// it in both dashboards.
+
+const strip = s => s.replace(/\x1b\[[0-9;]*m/g, '');
+const paint = new Proxy({}, { get: () => (v) => String(v) });
+
+// Payload shapes taken verbatim from /api/oauth/usage on live accounts.
+const BILLABLE = {
+  extra_usage: {
+    is_enabled: true, monthly_limit: 1000000, used_credits: 0, utilization: null,
+    currency: 'USD', decimal_places: 2, disabled_reason: null, user_disabled: false,
+    spend_limit_reached: false, credits_ever_enabled: true,
+  },
+  spend: {
+    used: { amount_minor: 0, currency: 'USD', exponent: 2 },
+    limit: { amount_minor: 1000000, currency: 'USD', exponent: 2 },
+    percent: 0, severity: 'normal', enabled: true,
+  },
+};
+const OUT_OF_CREDITS = {
+  extra_usage: {
+    is_enabled: false, monthly_limit: 2000, used_credits: 0, utilization: 0,
+    currency: 'EUR', decimal_places: 2, disabled_reason: 'out_of_credits',
+    user_disabled: false, spend_limit_reached: false, credits_ever_enabled: true,
+  },
+  spend: {
+    used: { amount_minor: 1500, currency: 'EUR', exponent: 2 },
+    limit: { amount_minor: 2000, currency: 'EUR', exponent: 2 },
+  },
+};
+const NEVER_ENABLED = {
+  extra_usage: {
+    is_enabled: false, monthly_limit: null, used_credits: null, currency: null,
+    decimal_places: null, disabled_reason: null, user_disabled: false,
+    credits_ever_enabled: false,
+  },
+  spend: { used: { amount_minor: 0, currency: 'USD', exponent: 2 }, enabled: false },
+};
+
+test('normalizeSpend reads whether the account can bill, not just whether an org provisioned it', () => {
+  assert.equal(normalizeSpend(BILLABLE).enabled, true);
+  // The decisive case: the org has overage, but this account cannot draw on it.
+  // Reading `spend.enabled` or the profile's has_extra_usage_enabled would call
+  // this billable and warn about money that cannot move.
+  assert.equal(normalizeSpend(OUT_OF_CREDITS).enabled, false);
+  assert.equal(normalizeSpend(OUT_OF_CREDITS).disabledReason, 'out_of_credits');
+  assert.equal(normalizeSpend(NEVER_ENABLED).enabled, false);
+  assert.equal(normalizeSpend({}), null);
+});
+
+test('normalizeSpend keeps the payload currency and exponent rather than assuming cents', () => {
+  const s = normalizeSpend(OUT_OF_CREDITS);
+  assert.equal(s.currency, 'EUR');
+  assert.equal(s.usedMinor, 1500);
+  assert.equal(s.limitMinor, 2000);
+  const jpy = normalizeSpend({
+    extra_usage: { is_enabled: true, currency: 'JPY', decimal_places: 0 },
+    spend: { used: { amount_minor: 500, currency: 'JPY', exponent: 0 } },
+  });
+  assert.equal(formatMoney(jpy), '¥500');
+});
+
+test('normalizeSpend separates a member switching it off from upstream refusing', () => {
+  const mine = normalizeSpend({ extra_usage: { is_enabled: false, user_disabled: true }, spend: {} });
+  assert.equal(mine.userDisabled, true);
+  assert.equal(normalizeSpend(OUT_OF_CREDITS).userDisabled, false);
+});
+
+test('formatMoney renders amount and cap, and stays readable for an unknown currency', () => {
+  assert.equal(formatMoney({ usedMinor: 0, limitMinor: 1000000, currency: 'USD', exponent: 2 }), '$0.00 of $10,000.00');
+  assert.equal(formatMoney({ usedMinor: 4237, limitMinor: null, currency: 'USD', exponent: 2 }), '$42.37');
+  assert.equal(formatMoney({ usedMinor: 42, limitMinor: 100, currency: 'XYZ', exponent: 2 }), '0.42 XYZ of 1.00 XYZ');
+  assert.equal(formatMoney(null), 'unknown');
+});
+
+test('the probe carries spend onto the quota and announces the transition once', () => {
+  const am = new AccountManager([{ name: 'work', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }], 0.98);
+  const said = [];
+  const realLog = console.log;
+  console.log = (m) => said.push(String(m));
+  try {
+    am.applyUsageData(0, normalizeUsagePayload({ ...NEVER_ENABLED, limits: [] }));
+    assert.equal(am.accounts[0].quota.spend.enabled, false);
+    assert.equal(said.filter(l => /bill real money/.test(l)).length, 0);
+
+    am.applyUsageData(0, normalizeUsagePayload({ ...BILLABLE, limits: [] }));
+    assert.equal(am.accounts[0].quota.spend.enabled, true);
+    assert.equal(said.filter(l => /can bill real money/.test(l)).length, 1);
+
+    // Still enabled on the next probe — the operator is told once, not every 5m.
+    am.applyUsageData(0, normalizeUsagePayload({ ...BILLABLE, limits: [] }));
+    assert.equal(said.filter(l => /can bill real money/.test(l)).length, 1);
+
+    // Money actually moves: that is its own event, and it is worth saying.
+    const spent = { ...BILLABLE, spend: { ...BILLABLE.spend, used: { amount_minor: 4237, currency: 'USD', exponent: 2 } } };
+    am.applyUsageData(0, normalizeUsagePayload({ ...spent, limits: [] }));
+    const started = said.filter(l => /started spending real money/.test(l));
+    assert.equal(started.length, 1);
+    assert.match(started[0], /\$42\.37 of \$10,000\.00/);
+  } finally {
+    console.log = realLog;
+  }
+});
+
+test('the status screen warns while it can bill, and louder once it has', () => {
+  const acct = (spend) => ({ quota: { spend } });
+  assert.equal(spendLine(acct(null), paint), null);
+  assert.equal(spendLine(acct(normalizeSpend(NEVER_ENABLED)), paint), null);
+
+  const canBill = spendLine(acct(normalizeSpend(BILLABLE)), paint);
+  assert.match(canBill, /can bill real money/);
+  assert.match(canBill, /\$0\.00 of \$10,000\.00/);
+
+  const billing = spendLine(acct(normalizeSpend({
+    ...BILLABLE, spend: { ...BILLABLE.spend, used: { amount_minor: 4237, currency: 'USD', exponent: 2 } },
+  })), paint);
+  assert.match(billing, /billing real money/);
+
+  // Spent this month but switched off since: still reported, with the reason.
+  const past = spendLine(acct(normalizeSpend(OUT_OF_CREDITS)), paint);
+  assert.match(past, /€15\.00 of €20\.00 spent this month/);
+  assert.match(past, /out_of_credits/);
+});
+
+test('the status screen stays silent for accounts that cannot bill', () => {
+  const mk = (name, spend) => ({ name, type: 'oauth', status: 'active', quota: { unified5h: 0.2, unified7d: 0.3, spend }, usage: {}, sessions: 0 });
+  const out = renderStatus({
+    currentAccount: 'a', switchThreshold: 0.98, routes: [], sessions: {},
+    accounts: [mk('plain', normalizeSpend(NEVER_ENABLED)), mk('noprobe', null)],
+  }, { color: false });
+  assert.equal(/Spend/.test(out), false);
+});
+
+test('spendTag marks only what billing costs now', () => {
+  assert.equal(spendTag({ spend: normalizeSpend(BILLABLE) }), '$');
+  assert.equal(spendTag({ spend: normalizeSpend({
+    ...BILLABLE, spend: { ...BILLABLE.spend, used: { amount_minor: 1, currency: 'USD', exponent: 2 } },
+  }) }), '$!');
+  // Spent-then-disabled is history, not a cost of routing here now.
+  assert.equal(spendTag({ spend: normalizeSpend(OUT_OF_CREDITS) }), '');
+  assert.equal(spendTag({ spend: null }), '');
+  assert.equal(spendTag({}), '');
+});
+
+// The row is budgeted to the terminal cell. #228 fixed an overflow caused by a
+// column the budget did not know about; the money tag is another such column,
+// so it gets the same treatment and the same guard.
+function renderRows(width, spends) {
+  const am = new AccountManager(spends.map((_, i) => ({
+    name: `acct${i}@example.com`, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000,
+  })), 0.98);
+  const h = 3600_000;
+  am.accounts.forEach((a, i) => {
+    a.quota.unified5h = 0.4; a.quota.unified5hReset = Date.now() + 4 * h;
+    a.quota.unified7d = 0.3; a.quota.unified7dReset = Date.now() + (i + 1) * 24 * h;
+    a.quota.unified7dFable = 0.2; a.quota.unified7dFableReset = Date.now() + (i + 1) * 24 * h;
+    a.quota.spend = spends[i];
+  });
+  const tui = new TUI({
+    accountManager: am, config: { proxy: { port: 1 }, accounts: [], routes: [] }, sx: null,
+    saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {}, probeQuota: () => {},
+  });
+  const cols = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+  const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+  Object.defineProperty(process.stdout, 'columns', { value: width, configurable: true });
+  Object.defineProperty(process.stdout, 'rows', { value: 40, configurable: true });
+  const drawn = [];
+  try {
+    const real = tui._renderAcct.bind(tui);
+    tui._renderAcct = (...args) => { const out = real(...args); drawn.push(strip(out)); return out; };
+    tui._paint = () => {};
+    tui.running = true;
+    tui.render(true);
+  } finally {
+    if (cols) Object.defineProperty(process.stdout, 'columns', cols);
+    if (rows) Object.defineProperty(process.stdout, 'rows', rows);
+  }
+  return drawn;
+}
+
+test('the money tag never pushes an account row past the terminal edge', () => {
+  const billing = normalizeSpend({ ...BILLABLE, spend: { ...BILLABLE.spend, used: { amount_minor: 4237, currency: 'USD', exponent: 2 } } });
+  const spends = [null, normalizeSpend(BILLABLE), billing, normalizeSpend(NEVER_ENABLED), null, billing];
+  for (const w of [60, 70, 76, 80, 86, 100, 120, 160]) {
+    const rows = renderRows(w, spends);
+    const widest = Math.max(...rows.map(r => r.length));
+    assert.ok(widest <= w, `W=${w}: widest row is ${widest} columns`);
+    assert.ok(rows.some(r => /\$/.test(r)), `W=${w}: the tag was budgeted but never drawn`);
+  }
+});
+
+test('a fleet with nothing billable spends no columns reserving for the tag', () => {
+  // The reserve is conditional: with nothing to mark, those columns go to the
+  // bars instead of sitting empty at the end of every row (the mistake #228 was
+  // about, in the opposite direction).
+  const none = [null, null, null, null, null, null];
+  for (const w of [80, 100, 120]) {
+    const widest = Math.max(...renderRows(w, none).map(r => r.length));
+    assert.ok(w - widest <= 3, `W=${w}: ${w - widest} columns left unused with no tag to draw`);
+  }
+});


### PR DESCRIPTION
## The gap

Every bar on both dashboards measures a plan allowance that runs out and stops. Paid overage does not: an account with extra usage enabled keeps serving past its weekly limit and **charges for it**. Nothing on screen said so — so rotating onto such an account spends money silently, and rotation is what this proxy does.

Concretely, on a six-account fleet: one account sits at 100% of its 5-hour window with overage enabled and a $10,000/month cap. The bars for it look like any other spent account.

## The data was already arriving

The quota probe reads `/api/oauth/usage`, whose payload carries `extra_usage` and `spend`. `normalizeUsagePayload` dropped both. This parses them and carries the result on the quota beside the buckets it came in with.

## Which field decides

Keyed on `extra_usage.is_enabled` — deliberately **not** `spend.enabled`, and not the profile endpoint's `has_extra_usage_enabled`.

An org can have overage provisioned while the account itself cannot draw on it (out of credits, or switched off by the member). Only `is_enabled` accounts for both. On a live fleet the two weaker signals each flagged an account whose payload reads `"disabled_reason": "out_of_credits"` and which cannot bill a cent. Warning about money that cannot move is how a warning gets ignored.

## What it shows

- **status** — a `Spend` line: yellow while it *can* bill, red once it *has*.
  ```
  thomas@example.com (oauth, prio 0) active
  Session  [██████████████████] 100% reset 13m
  Weekly   [█████░░░░░░░░░░░░░]  26% reset 1d16h
  Spend    ⚠ can bill real money past its plan limits — $0.00 of $10,000.00 used
  ```
- **TUI** — a `$` / `$!` row tag. ASCII on purpose: the row is budgeted to the cell, and a glyph whose width varies by terminal would push it past the edge. The width budget learns about the tag, or the row overflows exactly the way #228 fixed. Reserved only when some account is billable, so a fleet with none spends the columns on bars.
- **log** — once on gaining the ability to bill, once on the first actual spend. Not every probe.

Amounts use the payload's own currency and exponent rather than assuming USD cents, so a EUR wallet or a zero-decimal currency renders correctly.

## Passive

Per the policy in #229: this reads a response the probe already fetched and originates nothing on its own schedule. It follows that the warning is only as live as the probe — with the probe off there is no reading. That is the same tradeoff every model-scoped bucket already makes, and it is stated rather than worked around.

It also reports an account that spent this month and has since been switched off, with the reason — still a fact about where money went, and `out_of_credits` and "the member turned it off" have different futures.

## Scope

This says an account *can* bill. It does not stop it — that stays the operator's call via `teamclaude disable`, and a policy that refuses billable accounts would be a separate change.

## Tests

`test/spend-warning.test.js`, 10 cases: the field-choice above pinned against all three live payload shapes, currency/exponent handling, the log firing once per transition, both dashboards' output, and the row-width guard at eight terminal widths (plus the inverse — that an absent tag reserves nothing).

Full suite: **868 passing**, eslint clean. Verified end-to-end against six live accounts: exactly one warns, and it is the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FgVD2djKUuKWr4maN34H9
