### PR TITLE
feat: stripRequestFields — drop request fields third-party upstreams reject

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
 | `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only — see [third-party backends](accounts.md#third-party-backend-accounts) |
 | `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |
+| `accounts[].stripRequestFields` | Array of **top-level** request-body fields to drop before forwarding to this account. For third-party upstreams that implement the Anthropic message API but reject fields Claude Code sends (e.g. `["context_management"]`, which some return a `400 Extra inputs are not permitted` for — breaking every request once that account is selected). Applies to this account only; Anthropic accounts are untouched |
 | `accounts[].models` | **Deprecated** — use a [`routes`](routing.md#model-routes) entry with `match` and `accounts` instead. Array of model names this account exclusively handles; kept for backward compatibility with pre-routes configs |
 
 ## Environment variables

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -98,6 +98,9 @@ function makeAccount(acct, index) {
     disabled: acct.disabled || false,
     upstream: acct.upstream || null,
     modelMap: acct.modelMap || null,
+    // Fields to drop from request bodies for this account (third-party upstreams
+    // that reject e.g. `context_management`). See server.js stripBodyFields.
+    stripRequestFields: acct.stripRequestFields || null,
     models: acct.models || null,
     credential: acct.accessToken || acct.apiKey,
     refreshToken: acct.refreshToken || null,

--- a/src/server.js
+++ b/src/server.js
@@ -1961,10 +1961,6 @@ function extractUsageFromBody(buffer, accountIndex, accountManager, onUsage = nu
   }
 }
 
-// Rewrite the `model` field in a JSON request body using a per-account map.
-// Returns the original buffer unchanged if the model isn't in the map or the
-// body isn't valid JSON, so non-messages endpoints pass through safely.
-// Exported for tests.
 // Remove top-level fields from a JSON request body (see stripRequestFields).
 // Returns the original buffer when nothing changed or the body isn't JSON, so
 // non-messages endpoints pass through untouched. Exported for tests.
@@ -1980,6 +1976,10 @@ export function stripBodyFields(body, fields) {
   return body;
 }
 
+// Rewrite the `model` field in a JSON request body using a per-account map.
+// Returns the original buffer unchanged if the model isn't in the map or the
+// body isn't valid JSON, so non-messages endpoints pass through safely.
+// Exported for tests.
 export function rewriteModel(body, modelMap) {
   try {
     const obj = JSON.parse(body.toString('utf8'));

--- a/src/server.js
+++ b/src/server.js
@@ -1446,8 +1446,18 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // Rewrite the model name for accounts that target a different upstream (e.g.
   // GLM), which uses different model identifiers than Anthropic.
   if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);
-  // If the body changed length (sanitize or model rewrite), update Content-Length
-  // so the upstream doesn't receive a mismatched framing and truncate or stall.
+  // Third-party upstreams (e.g. OpenCode Zen, GLM) implement the Anthropic
+  // message API but reject fields Claude Code legitimately sends — observed:
+  // `context_management` -> 400 "Extra inputs are not permitted", which breaks
+  // EVERY request once such an account is selected. Drop the configured fields
+  // for those accounts only; Anthropic accounts are untouched. Content-Length is
+  // refreshed below because the body shrinks.
+  if (Array.isArray(account.stripRequestFields) && account.stripRequestFields.length) {
+    sendBody = stripBodyFields(sendBody, account.stripRequestFields);
+  }
+  // If the body changed length (sanitize, model rewrite, or field strip), update
+  // Content-Length so the upstream doesn't receive a mismatched framing and
+  // truncate or stall.
   if (sendBody !== body) headers['content-length'] = String(sendBody.length);
 
   // Streaming request log, opened lazily on the first terminal outcome (a
@@ -1955,6 +1965,21 @@ function extractUsageFromBody(buffer, accountIndex, accountManager, onUsage = nu
 // Returns the original buffer unchanged if the model isn't in the map or the
 // body isn't valid JSON, so non-messages endpoints pass through safely.
 // Exported for tests.
+// Remove top-level fields from a JSON request body (see stripRequestFields).
+// Returns the original buffer when nothing changed or the body isn't JSON, so
+// non-messages endpoints pass through untouched. Exported for tests.
+export function stripBodyFields(body, fields) {
+  try {
+    const obj = JSON.parse(body.toString('utf8'));
+    let changed = false;
+    for (const f of fields) {
+      if (Object.prototype.hasOwnProperty.call(obj, f)) { delete obj[f]; changed = true; }
+    }
+    if (changed) return Buffer.from(JSON.stringify(obj), 'utf8');
+  } catch { /* not JSON — pass through unchanged */ }
+  return body;
+}
+
 export function rewriteModel(body, modelMap) {
   try {
     const obj = JSON.parse(body.toString('utf8'));

--- a/test/strip-request-fields.test.js
+++ b/test/strip-request-fields.test.js
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripBodyFields } from '../src/server.js';
+import { AccountManager } from '../src/account-manager.js';
+
+// Third-party upstreams implement the Anthropic message API but reject fields
+// Claude Code legitimately sends — observed: `context_management` drawing a 400
+// "Extra inputs are not permitted", which breaks EVERY request once such an
+// account is selected. stripRequestFields drops them for those accounts only.
+
+const buf = (obj) => Buffer.from(JSON.stringify(obj), 'utf8');
+const parse = (b) => JSON.parse(b.toString('utf8'));
+
+test('a configured field is dropped and the rest of the body survives', () => {
+  const body = buf({ model: 'claude-x', context_management: { enabled: true }, messages: [{ role: 'user' }] });
+  const out = stripBodyFields(body, ['context_management']);
+  const obj = parse(out);
+  assert.equal('context_management' in obj, false);
+  assert.equal(obj.model, 'claude-x');
+  assert.deepEqual(obj.messages, [{ role: 'user' }]);
+});
+
+test('several fields can be dropped at once', () => {
+  const out = stripBodyFields(buf({ a: 1, b: 2, c: 3 }), ['a', 'c']);
+  assert.deepEqual(parse(out), { b: 2 });
+});
+
+// The caller refreshes Content-Length only when the buffer actually changes, so
+// "nothing matched" has to return the very same buffer, not an equal one.
+test('a body with none of the fields is returned untouched', () => {
+  const body = buf({ model: 'claude-x' });
+  assert.equal(stripBodyFields(body, ['context_management']), body);
+});
+
+test('only top-level fields are removed', () => {
+  const out = stripBodyFields(buf({ tools: [{ context_management: 1 }] }), ['context_management']);
+  assert.deepEqual(parse(out), { tools: [{ context_management: 1 }] });
+});
+
+// Non-JSON bodies reach this path too (any non-messages endpoint), and must not
+// be corrupted or throw.
+test('a non-JSON body passes through unchanged', () => {
+  const body = Buffer.from('not json at all', 'utf8');
+  assert.equal(stripBodyFields(body, ['x']), body);
+});
+
+test('a field explicitly set to null still counts as present', () => {
+  const out = stripBodyFields(buf({ context_management: null, model: 'm' }), ['context_management']);
+  assert.deepEqual(parse(out), { model: 'm' });
+});
+
+test('the account carries stripRequestFields through from config', () => {
+  const am = new AccountManager([
+    { name: 'zen', type: 'apikey', apiKey: 'k', upstream: 'https://zen.example', stripRequestFields: ['context_management'] },
+    { name: 'anthropic', type: 'apikey', apiKey: 'k2' },
+  ], 0.98);
+  assert.deepEqual(am.accounts[0].stripRequestFields, ['context_management']);
+  // Anthropic accounts must stay untouched — the strip is opt-in per account.
+  assert.equal(am.accounts[1].stripRequestFields, null);
+});


### PR DESCRIPTION
Third-party upstreams that implement the Anthropic Messages API (OpenCode Zen, GLM, vLLM, …) reject fields Claude Code legitimately sends. Observed: `context_management` → `400 "Extra inputs are not permitted"`, which breaks **every** request once such an account is selected — the account looks healthy in status but cannot serve anything.

This adds a per-account `stripRequestFields` list:

```json
{ "name": "zen", "upstream": "https://opencode.ai/zen", "stripRequestFields": ["context_management"] }
```

- applied only to accounts that declare it; Anthropic accounts are untouched
- runs after `modelMap` rewriting, so both compose
- Content-Length is refreshed because the body shrinks (a stale length makes the upstream truncate or stall)

Tests included. Full suite green on this branch against current master (858/858).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
