### PR TITLE
feat(codex): pool Codex subscriptions alongside Claude accounts

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -28,6 +28,12 @@
       "refreshToken": "sk-ant-ort01-your-refresh-token"
     },
     {
+      "name": "codex@example.com",
+      "type": "oauth",
+      "provider": "codex",
+      "priority": 0
+    },
+    {
       "name": "api-fallback",
       "type": "apikey",
       "priority": 10,

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -87,6 +87,66 @@ Every account entry carries an `id`, added the first time the config is read and
 
 Hand edits are fine. Leave the `id` alone and it keeps working; delete it and a new one is issued on the next read. If you copy an account block to make a second entry, the duplicated `id` is spotted on the next read and the later of the two gets a fresh one.
 
+## Codex accounts (experimental)
+
+An OpenAI Codex subscription can be pooled alongside your Claude accounts. Add
+an account with `"provider": "codex"` and TeamClaude reads the login the Codex
+CLI already stores in `~/.codex/auth.json`:
+
+```json
+{ "name": "me@example.com", "type": "oauth", "provider": "codex" }
+```
+
+Point another `importFrom` at a different file to pool several Codex logins.
+
+Then tell Codex to reach TeamClaude instead of OpenAI, in `~/.codex/config.toml`:
+
+```toml
+model_provider = "teamclaude"
+
+[model_providers.teamclaude]
+name = "teamclaude"
+base_url = "http://127.0.0.1:3456/backend-api/codex"
+wire_api = "responses"
+```
+
+`OPENAI_BASE_URL` does **not** work for this — a ChatGPT-authenticated Codex
+ignores it. `model_providers` is the supported redirect.
+
+The `/backend-api/codex` suffix matters. A Codex subscription authenticates
+against the ChatGPT backend, not the OpenAI API platform — pointed at
+`api.openai.com` the same token is refused with `Missing scopes:
+api.responses.write`. Codex appends `/responses` and `/models` to `base_url`,
+so this suffix makes it emit exactly the paths the ChatGPT backend expects and
+TeamClaude forwards them verbatim.
+
+### How it shares the port with Claude
+
+One listener serves both CLIs, because the request path says which pool of
+accounts is eligible: Claude Code posts to `/v1/messages`, Codex posts to
+`/backend-api/codex/responses`. An Anthropic account is never offered a Codex
+request and vice versa, so the two rotate independently on one port, one config
+and one TUI.
+
+### What differs from a Claude account
+
+- The credential is injected as `Authorization: Bearer`, plus a
+  `ChatGPT-Account-Id` header. That header is OpenAI's counterpart to the
+  `account_uuid` TeamClaude patches into an Anthropic request body — so the
+  Codex path performs no body rewrite at all.
+- Tokens refresh against `auth.openai.com` using the Codex CLI's own client id.
+- The request body is forwarded untouched. This is a passthrough, not a
+  translation layer: TeamClaude never converts between the Anthropic and OpenAI
+  protocols.
+
+### Current limits
+
+Codex accounts rotate on upstream rejection, the same way a third-party backend
+does. The quota-driven parts of rotation — the switch threshold, reset
+countdowns and the TUI's quota bars — are Anthropic-only for now, because they
+read `anthropic-ratelimit-unified-*` response headers. Codex reports its own
+`primary`/`secondary` windows, so wiring those in is a natural follow-up.
+
 ## Third-party backend accounts
 
 Any Anthropic-compatible API can be added as an account alongside your Claude accounts. Give it a higher `priority` value (lower = preferred, so use e.g. `100`) and it will be used as a fallback when all Claude accounts are exhausted.

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -89,15 +89,34 @@ Hand edits are fine. Leave the `id` alone and it keeps working; delete it and a 
 
 ## Codex accounts (experimental)
 
-An OpenAI Codex subscription can be pooled alongside your Claude accounts. Add
-an account with `"provider": "codex"` and TeamClaude reads the login the Codex
-CLI already stores in `~/.codex/auth.json`:
+An OpenAI Codex subscription can be pooled alongside your Claude accounts.
+
+```bash
+teamclaude login --codex     # browser sign-in, repeat per account
+```
+
+Add `--no-browser` to print the URL instead of opening one, and `--name` to
+label the account yourself (it defaults to the email on the login).
+
+To pool a login you already have, or to add one without a browser, point an
+account at the Codex CLI's own credentials file instead — it defaults to
+`~/.codex/auth.json`:
 
 ```json
 { "name": "me@example.com", "type": "oauth", "provider": "codex" }
 ```
 
-Point another `importFrom` at a different file to pool several Codex logins.
+The Codex CLI honours `CODEX_HOME`, so several logins can be kept side by side
+and pooled with `importFrom`:
+
+```bash
+CODEX_HOME=~/.codex-second codex login
+```
+
+```json
+{ "name": "second", "type": "oauth", "provider": "codex",
+  "importFrom": "~/.codex-second/auth.json" }
+```
 
 Then tell Codex to reach TeamClaude instead of OpenAI, in `~/.codex/config.toml`:
 
@@ -139,13 +158,22 @@ and one TUI.
   translation layer: TeamClaude never converts between the Anthropic and OpenAI
   protocols.
 
-### Current limits
+### Quota
 
-Codex accounts rotate on upstream rejection, the same way a third-party backend
-does. The quota-driven parts of rotation — the switch threshold, reset
-countdowns and the TUI's quota bars — are Anthropic-only for now, because they
-read `anthropic-ratelimit-unified-*` response headers. Codex reports its own
-`primary`/`secondary` windows, so wiring those in is a natural follow-up.
+Codex reports its limits on every response, and TeamClaude normalises them into
+the same fields the Anthropic path fills — so the switch threshold, reset
+countdowns and the TUI's quota bars work for Codex accounts too, and rotation
+happens *before* upstream refuses rather than after a 429.
+
+Two details are worth knowing if you read the raw headers:
+
+- Limits arrive in families. The unnamed one is the account-wide limit; a family
+  carrying `-limit-name` is model-scoped, the counterpart of Anthropic's Fable
+  weekly bucket.
+- `primary` and `secondary` are positions, not durations — the account-wide
+  family can put its 7-day window in `primary` while a model-scoped family puts
+  a 5-hour window there. Windows are classified by their stated
+  `window-minutes`, never by position.
 
 ## Third-party backend accounts
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,6 +1,7 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { providerOf, DEFAULT_PROVIDER } from './provider.js';
 import { refreshCodexToken } from './codex-auth.js';
+import { parseCodexQuota, parseCodexPlanType } from './codex-quota.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches, modelFamily } from './model.js';
 import { SessionTracker } from './session-tracker.js';
@@ -1499,9 +1500,65 @@ export class AccountManager {
   /**
    * Update an account's quota tracking from upstream response headers.
    */
+  /**
+   * Apply a Codex response's rate-limit headers.
+   *
+   * Only fields the response actually stated are assigned: a reading that a
+   * given response did not carry must not blank what we already knew, and the
+   * catalog fetch carries none at all.
+   */
+  _updateCodexQuota(account, headers) {
+    const parsed = parseCodexQuota(headers);
+    const plan = parseCodexPlanType(headers);
+    if (plan) account.quota.planType = plan;
+
+    if (parsed.unified5h != null) account.quota.unified5h = parsed.unified5h;
+    if (parsed.unified7d != null) account.quota.unified7d = parsed.unified7d;
+    if (parsed.unified5hReset != null) account.quota.unified5hReset = parsed.unified5hReset;
+    if (parsed.unified7dReset != null) account.quota.unified7dReset = parsed.unified7dReset;
+
+    // A model-scoped weekly bucket is the counterpart of Anthropic's `7d_oi`
+    // Fable bucket: it rides only on responses for that model, so stamp when
+    // the reading was taken. That timestamp is what lets a spent bucket be
+    // revalidated instead of sealing the account out of the family forever.
+    for (const bucket of parsed.modelBuckets || []) {
+      (account.quota.codexModelBuckets ??= {})[bucket.slug] = {
+        name: bucket.name,
+        utilization: bucket.utilization,
+        resetAt: bucket.resetAt,
+        seenAt: Date.now(),
+      };
+    }
+
+    // Same handshake as the Anthropic path: the first response that reveals a
+    // weekly limit ends probing and asks selection to re-evaluate.
+    if (account.probing && account.quota.unified7dReset != null) {
+      account.probing = false;
+      account.requalify = true;
+      console.log(`[TeamClaude] Learned weekly quota for "${account.name}", re-evaluating selection`);
+    }
+
+    account.usage.totalRequests++;
+    account.usage.lastUsed = new Date().toISOString();
+
+    if (this._isNearQuota(account)) {
+      const pct = account.quota.unified7d != null ? Math.round(account.quota.unified7d * 100) : null;
+      console.log(`[TeamClaude] "${account.name}" near weekly quota${pct == null ? '' : ` (${pct}%)`}`);
+    }
+  }
+
   updateQuota(accountIndex, headers) {
     const account = this.accounts[accountIndex];
     if (!account) return;
+
+    // Codex reports the same information under its own header names, so it is
+    // normalised into the very fields the Anthropic path fills. Everything
+    // downstream — the switch threshold, reset countdowns, the TUI bars — then
+    // works unchanged rather than needing a parallel Codex-shaped path.
+    if (providerOf(account) === 'codex') {
+      this._updateCodexQuota(account, headers);
+      return;
+    }
 
     // Unified rate limits (Claude Max)
     const u5h = parseFloat(headers['anthropic-ratelimit-unified-5h-utilization']);

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,4 +1,6 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
+import { providerOf, DEFAULT_PROVIDER } from './provider.js';
+import { refreshCodexToken } from './codex-auth.js';
 import { sameIdentity } from './identity.js';
 import { weeklyBucketForModel, modelGlobMatches, modelFamily } from './model.js';
 import { SessionTracker } from './session-tracker.js';
@@ -95,6 +97,13 @@ function makeAccount(acct, index) {
     id: acct.id || null,
     name: acct.name,
     type: acct.type,
+    // Which backend this account talks to. Absent means Anthropic, so configs
+    // written before providers existed keep working untouched.
+    provider: providerOf(acct),
+    // Codex scopes a token to one ChatGPT account via a request header; this is
+    // that id. The Anthropic counterpart is `accountUuid`, which is patched
+    // into the request body instead.
+    accountId: acct.accountId || null,
     accountUuid: acct.accountUuid || null,
     orgUuid: acct.orgUuid || null,
     orgName: acct.orgName || null,
@@ -174,12 +183,13 @@ function sampleModelFor(route) {
 }
 
 export class AccountManager {
-  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, throttleProbeFloorMs, familyStaleMs, statusStaleMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
+  constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, codexRefreshFn = refreshCodexToken, throttleProbeFloorMs, familyStaleMs, statusStaleMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, sessionTracker } = {}) {
     // How long a just-minted token is trusted against a forced refresh.
     this._forcedRefreshFloorMs = forcedRefreshFloorMs;
     // Injectable for tests (mirrors Prober's probeFn); defaults to the real
     // OAuth token refresh.
     this._refreshFn = refreshFn;
+    this._codexRefreshFn = codexRefreshFn;
     this.accounts = accounts.map((acct, index) => makeAccount(acct, index));
     this.currentIndex = 0;
     // Session awareness (issue #109). The tracker is always on (passive — it just
@@ -392,14 +402,36 @@ export class AccountManager {
    * satisfies both, selection degrades to executor-only routing so the main
    * request keeps flowing (upstream then fails just the advisor call).
    */
-  getActiveAccount(exclude = null, model = null, advisorModel = null, sessionId = null) {
-    const account = this._pickActiveAccount(exclude, model, advisorModel, sessionId);
+  getActiveAccount(exclude = null, model = null, advisorModel = null, sessionId = null, provider = DEFAULT_PROVIDER) {
+    const account = this._pickActiveAccount(this._excludeOtherProviders(exclude, provider), model, advisorModel, sessionId);
     // Record where this route now sits, whatever path chose it — the steady-state
     // path returns the account the cursor already names and never reaches the
     // rotation code, so recording there alone would leave the cursor unset and
     // the next real failover unpaced.
     if (account) this.routeCursors.set(this._cursorKey(model), account.index);
     return account;
+  }
+
+  /**
+   * Widen a request's exclude set to every account that belongs to a different
+   * provider.
+   *
+   * A provider partition is absolute — an Anthropic account cannot serve an
+   * OpenAI Responses request at all — so it is expressed as exclusion rather
+   * than threaded through the rotation logic. Everything downstream already
+   * reads `exclude`, so cursors, pinning, session affinity, probing and
+   * preemption keep working unchanged, and a config with no Codex accounts
+   * produces the identical set it did before.
+   *
+   * Returns the caller's own set untouched when nothing needs excluding, so
+   * the common single-provider case allocates nothing.
+   */
+  _excludeOtherProviders(exclude, provider) {
+    const foreign = this.accounts.filter(a => providerOf(a) !== provider);
+    if (foreign.length === 0) return exclude;
+    const combined = new Set(exclude || []);
+    for (const account of foreign) combined.add(account.index);
+    return combined;
   }
 
   _pickActiveAccount(exclude, model, advisorModel, sessionId) {
@@ -1771,7 +1803,13 @@ export class AccountManager {
     account._refreshPromise = (async () => {
       console.log(`[TeamClaude] Refreshing token for account "${account.name}"...`);
       try {
-        const newTokens = await this._refreshFn(account.refreshToken);
+        // Each provider mints tokens at its own endpoint with its own client
+        // id, so the grant is dispatched by provider. Both return the same
+        // { accessToken, refreshToken, expiresAt } shape, which is what lets
+        // everything downstream stay provider-agnostic.
+        const newTokens = await (providerOf(account) === 'codex'
+          ? this._codexRefreshFn(account.refreshToken)
+          : this._refreshFn(account.refreshToken));
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -1,0 +1,99 @@
+// Codex (OpenAI) credentials.
+//
+// The Codex CLI keeps its ChatGPT login in ~/.codex/auth.json, shaped much
+// like Claude Code's own credentials file: an access/refresh pair plus the id
+// of the account the token is scoped to. That last field is the part with no
+// Anthropic analogue in the body — OpenAI carries it in the ChatGPT-Account-Id
+// header instead, which is why the Codex path needs no request-body rewrite.
+//
+// Token refresh is a plain OAuth refresh_token grant against auth.openai.com
+// using the Codex CLI's own client id, so a pooled account stays live the same
+// way an Anthropic one does.
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { proxyFetch } from './upstream-fetch.js';
+
+export const DEFAULT_CODEX_CREDENTIALS_PATH = '~/.codex/auth.json';
+
+const TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token';
+// The Codex CLI's OAuth client. It is the `aud` claim of the id_token the CLI
+// itself stores, i.e. this is the client the user already consented to — we
+// refresh their existing grant rather than minting a new one.
+const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+
+/** Decode a JWT payload without verifying it. Claims are used for labelling only. */
+function decodeJwtClaims(token) {
+  const parts = String(token || '').split('.');
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a Codex login from disk.
+ *
+ * Returns the credential fields the account manager needs, plus `email` and
+ * `planType` when the id_token carries them — those are cosmetic (they name
+ * the account in status output) and their absence is never fatal.
+ */
+export async function importCodexCredentials(filePath = DEFAULT_CODEX_CREDENTIALS_PATH, { home = homedir() } = {}) {
+  const resolvedPath = filePath.replace(/^~/, home);
+  const raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
+  const tokens = raw.tokens || {};
+
+  const claims = decodeJwtClaims(tokens.id_token) || {};
+  const auth = claims['https://api.openai.com/auth'] || {};
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    // Scopes the token to one ChatGPT account. Prefer the id_token claim and
+    // fall back to the stored value: they agree in practice, but the claim is
+    // the one the server itself issued.
+    accountId: auth.chatgpt_account_id || tokens.account_id,
+    email: claims.email,
+    planType: auth.chatgpt_plan_type,
+  };
+}
+
+/**
+ * Exchange a Codex refresh token for a fresh access token.
+ *
+ * Mirrors the Anthropic refresh contract (`{ accessToken, refreshToken,
+ * expiresAt }`) so the account manager can treat both the same. A rotated
+ * refresh token is returned when the server issues one, and the old one is
+ * kept when it does not.
+ */
+export async function refreshCodexToken(refreshToken, endpoint = TOKEN_ENDPOINT) {
+  const timeoutMs = Number(process.env.TEAMCLAUDE_REFRESH_TIMEOUT_MS) || 30_000;
+  const res = await proxyFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    const err = new Error(`Codex token refresh failed (${res.status}): ${text}`);
+    // Surfaced so callers can tell a dead refresh token (re-login needed) from
+    // a transient server error, exactly as the Anthropic path does.
+    err.status = res.status;
+    throw err;
+  }
+
+  const data = await res.json();
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || refreshToken,
+    expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
+  };
+}

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -12,11 +12,25 @@
 
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
+import { randomBytes, createHash } from 'node:crypto';
+import { exec } from 'node:child_process';
+import http from 'node:http';
 import { proxyFetch } from './upstream-fetch.js';
 
 export const DEFAULT_CODEX_CREDENTIALS_PATH = '~/.codex/auth.json';
 
 const TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token';
+const AUTHORIZE_ENDPOINT = 'https://auth.openai.com/oauth/authorize';
+// Confirmed by a live authorization attempt: adding `api` is rejected with
+// invalid_scope ("The OAuth 2.0 Client is not allowed to request scope 'api'").
+// The token this client issues is a ChatGPT credential, not an API-platform
+// one, which is the same reason the upstream is chatgpt.com.
+const SCOPES = 'openid profile email offline_access';
+// OpenAI registered a single fixed redirect for this client, so the callback
+// server cannot take an ephemeral port the way the Anthropic flow does — the
+// authorization request is rejected unless the URI matches exactly.
+const CALLBACK_PORT = 1455;
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
 // The Codex CLI's OAuth client. It is the `aud` claim of the id_token the CLI
 // itself stores, i.e. this is the client the user already consented to — we
 // refresh their existing grant rather than minting a new one.
@@ -96,4 +110,136 @@ export async function refreshCodexToken(refreshToken, endpoint = TOKEN_ENDPOINT)
     refreshToken: data.refresh_token || refreshToken,
     expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
   };
+}
+
+// ── Browser login ───────────────────────────────────────────────────────────
+
+/**
+ * Build the authorization URL for a Codex login.
+ *
+ * Pure, so the parameters can be asserted without opening a browser. PKCE is
+ * mandatory here: the client is public, so the code exchange is bound to a
+ * verifier this process holds rather than to a client secret.
+ */
+export function buildCodexAuthUrl({ state, codeChallenge, redirectUri = REDIRECT_URI }) {
+  const url = new URL(AUTHORIZE_ENDPOINT);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', CLIENT_ID);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('scope', SCOPES);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  // Codex asks for organization claims in the id_token; the account id we need
+  // for ChatGPT-Account-Id rides in that same claim set.
+  url.searchParams.set('id_token_add_organizations', 'true');
+  // Sent by the Codex CLI itself alongside the above. Kept so this request
+  // looks like the client it is impersonating rather than a novel variant.
+  url.searchParams.set('codex_cli_simplified_flow', 'true');
+  url.searchParams.set('originator', 'codex_cli_rs');
+  return url.toString();
+}
+
+/** Exchange an authorization code for tokens, completing the PKCE handshake. */
+export async function exchangeCodexCode({ code, codeVerifier, redirectUri = REDIRECT_URI }) {
+  const res = await proxyFetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Codex token exchange failed (${res.status}): ${await res.text()}`);
+  }
+  return credentialsFromTokenResponse(await res.json());
+}
+
+/**
+ * Turn a token response into the same credential shape `importCodexCredentials`
+ * returns, so login and import are interchangeable to every caller.
+ */
+export function credentialsFromTokenResponse(data) {
+  const claims = decodeJwtClaims(data.id_token) || {};
+  const auth = claims['https://api.openai.com/auth'] || {};
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    accountId: auth.chatgpt_account_id,
+    email: claims.email,
+    planType: auth.chatgpt_plan_type,
+    expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
+  };
+}
+
+function openBrowser(url) {
+  const cmd = process.platform === 'darwin' ? 'open'
+    : process.platform === 'win32' ? 'start'
+      : 'xdg-open';
+  exec(`${cmd} ${JSON.stringify(url)}`, () => {});
+}
+
+/**
+ * Run a browser OAuth login against OpenAI and return the new credentials.
+ *
+ * The listener must bind port 1455 because that is the only redirect OpenAI
+ * accepts for this client. If the Codex CLI is mid-login it already holds that
+ * port, which is why the bind failure is reported as such rather than as a
+ * generic error.
+ */
+export async function loginCodex({ noBrowser = false, timeoutMs = 120_000 } = {}) {
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const state = randomBytes(32).toString('base64url');
+  const authUrl = buildCodexAuthUrl({ state, codeChallenge });
+
+  let server;
+  const code = await new Promise((resolve, reject) => {
+    server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://localhost');
+      if (url.pathname !== '/auth/callback') { res.writeHead(404); res.end('Not found'); return; }
+
+      const err = url.searchParams.get('error');
+      const returnedState = url.searchParams.get('state');
+      const returnedCode = url.searchParams.get('code');
+      const fail = (message) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body><h2>Authentication failed</h2><p>You can close this tab.</p></body></html>');
+        reject(new Error(message));
+      };
+
+      if (err) return fail(`OAuth error: ${err} ${url.searchParams.get('error_description') || ''}`.trim());
+      if (returnedState !== state) return fail('OAuth state mismatch');
+      if (!returnedCode) return fail('OAuth callback carried no code');
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body><h2>Signed in</h2><p>You can close this tab and return to the terminal.</p></body></html>');
+      resolve(returnedCode);
+    });
+
+    server.on('error', (e) => reject(e.code === 'EADDRINUSE'
+      ? new Error(`Port ${CALLBACK_PORT} is in use. OpenAI only accepts ${REDIRECT_URI} for this client, so close whatever holds it (a running \`codex login\`) and retry.`)
+      : e));
+
+    server.listen(CALLBACK_PORT, '127.0.0.1', () => {
+      if (noBrowser) {
+        console.log(`Open this URL to sign in:\n${authUrl}`);
+      } else {
+        console.log('Opening browser for OpenAI sign-in...');
+        openBrowser(authUrl);
+        console.log(`If it did not open, visit:\n${authUrl}`);
+      }
+    });
+
+    const timer = setTimeout(() => { reject(new Error('Login timed out after 2 minutes')); server.close(); }, timeoutMs);
+    timer.unref();
+    // Bind 127.0.0.1 rather than all interfaces: this listener briefly accepts
+    // an authorization code, and nothing off this machine should reach it.
+  }).finally(() => { server?.close(); });
+
+  return exchangeCodexCode({ code, codeVerifier });
 }

--- a/src/codex-quota.js
+++ b/src/codex-quota.js
@@ -1,0 +1,147 @@
+// Codex rate-limit headers.
+//
+// A Codex response carries its quota the way Anthropic does, just under a
+// different spelling. The shape observed on a live response (values here are
+// illustrative):
+//
+//   x-codex-primary-used-percent: 42
+//   x-codex-primary-window-minutes: 10080
+//   x-codex-primary-reset-at: <epoch seconds>
+//   x-codex-secondary-used-percent: 0
+//   x-codex-secondary-window-minutes: 0
+//   x-codex-<name>-primary-used-percent: 0
+//   x-codex-<name>-primary-window-minutes: 300
+//   x-codex-<name>-secondary-window-minutes: 10080
+//   x-codex-<name>-limit-name: <model family>
+//
+// Two things follow from that shape.
+//
+// First, limits arrive in FAMILIES: an unnamed one that is the account-wide
+// limit, and named ones (carrying `-limit-name`) that are model-scoped — the
+// direct counterpart of Anthropic's `7d_oi` Fable bucket.
+//
+// Second, `primary` and `secondary` are positions, not durations. The
+// account-wide family above puts the 7-day window in `primary` while the
+// model-scoped family puts a 5-hour window there. So windows are classified by
+// their stated `window-minutes`, never by position — reading `primary` as
+// "the 5h bucket" would file a weekly reading as a session one and rotate on
+// the wrong number.
+
+/** Window durations we recognise, in minutes, with a tolerance for rounding. */
+const FIVE_HOUR_MINUTES = 300;
+const SEVEN_DAY_MINUTES = 10080;
+const WINDOW_TOLERANCE = 0.1;
+
+const near = (value, target) => Math.abs(value - target) <= target * WINDOW_TOLERANCE;
+
+const HEADER_RE = /^x-codex-(?:(.+)-)?(primary|secondary)-(used-percent|window-minutes|reset-at)$/;
+const LIMIT_NAME_RE = /^x-codex-(.+)-limit-name$/;
+
+/**
+ * Group `x-codex-*` headers into families keyed by slug ('' for the
+ * account-wide family), each holding its primary/secondary window readings.
+ */
+function collectFamilies(headers) {
+  const families = new Map();
+  const family = (slug) => {
+    if (!families.has(slug)) families.set(slug, { slug, name: null, windows: {} });
+    return families.get(slug);
+  };
+
+  for (const [rawKey, rawValue] of Object.entries(headers || {})) {
+    const key = rawKey.toLowerCase();
+    const value = String(rawValue ?? '').trim();
+    if (value === '') continue;
+
+    const named = LIMIT_NAME_RE.exec(key);
+    if (named) { family(named[1]).name = value; continue; }
+
+    const m = HEADER_RE.exec(key);
+    if (!m) continue;
+    const [, slug = '', position, field] = m;
+    const w = (family(slug).windows[position] ??= {});
+    if (field === 'used-percent') w.usedPercent = Number(value);
+    else if (field === 'window-minutes') w.windowMinutes = Number(value);
+    else w.resetAt = Number(value);
+  }
+  return families;
+}
+
+/**
+ * Turn one family's windows into `{ fiveHour, weekly }` readings, keyed by the
+ * window's own duration rather than its primary/secondary position.
+ *
+ * A window with no `window-minutes`, a zero duration, or an unparseable
+ * utilization is dropped: a zeroed window is how this API says "not
+ * applicable", and treating that as 0% used would look like full headroom.
+ */
+function classify(windows) {
+  const out = {};
+  for (const w of Object.values(windows)) {
+    const minutes = Number(w.windowMinutes);
+    const percent = Number(w.usedPercent);
+    if (!Number.isFinite(minutes) || minutes <= 0) continue;
+    if (!Number.isFinite(percent)) continue;
+
+    const bucket = near(minutes, FIVE_HOUR_MINUTES) ? 'fiveHour'
+      : near(minutes, SEVEN_DAY_MINUTES) ? 'weekly'
+        : null;
+    if (!bucket) continue;
+
+    out[bucket] = {
+      // Anthropic reports utilization as a 0-1 fraction and the rest of the
+      // manager compares against `switchThreshold` in those units, so convert
+      // here rather than teaching every consumer about percentages.
+      utilization: percent / 100,
+      // Epoch seconds upstream, milliseconds everywhere in this codebase.
+      resetAt: Number.isFinite(w.resetAt) && w.resetAt > 0 ? w.resetAt * 1000 : null,
+    };
+  }
+  return out;
+}
+
+/**
+ * Parse Codex rate-limit headers into the fields `account.quota` already uses.
+ *
+ * Returns only what the headers actually stated, so a caller can assign over
+ * an existing quota without blanking readings this response did not mention.
+ * An empty object means "this response carried no quota", which is normal:
+ * the catalog fetch (`/models`) has none.
+ */
+export function parseCodexQuota(headers) {
+  const families = collectFamilies(headers);
+  const quota = {};
+
+  const account = classify(families.get('')?.windows || {});
+  if (account.fiveHour) {
+    quota.unified5h = account.fiveHour.utilization;
+    if (account.fiveHour.resetAt) quota.unified5hReset = account.fiveHour.resetAt;
+  }
+  if (account.weekly) {
+    quota.unified7d = account.weekly.utilization;
+    if (account.weekly.resetAt) quota.unified7dReset = account.weekly.resetAt;
+  }
+
+  // Model-scoped families. Their 5-hour window is not modelled separately —
+  // the manager scopes eligibility by weekly family buckets — so only the
+  // weekly reading is carried, alongside the name upstream gave it.
+  for (const fam of families.values()) {
+    if (!fam.slug) continue;
+    const scoped = classify(fam.windows);
+    if (!scoped.weekly) continue;
+    (quota.modelBuckets ??= []).push({
+      slug: fam.slug,
+      name: fam.name || fam.slug,
+      utilization: scoped.weekly.utilization,
+      resetAt: scoped.weekly.resetAt,
+    });
+  }
+
+  return quota;
+}
+
+/** The subscription plan upstream reports, for status output. Null when absent. */
+export function parseCodexPlanType(headers) {
+  const value = headers?.['x-codex-plan-type'];
+  return value ? String(value).trim() || null : null;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -110,6 +110,15 @@ export async function loadOrCreateConfig() {
     config = createDefaultConfig();
     await saveConfig(config);
     console.log(`Created config at ${getConfigPath()}`);
+    // loadConfig applies this only when a file already existed — it returns
+    // early on ENOENT. Without it here, the FIRST run of a network command
+    // (`login` on a fresh install) leaves the process-wide setting unset, and
+    // the lazy fallback resolves it from the environment against an EMPTY
+    // config. That fallback has no listener to compare against, so the
+    // self-proxy guard cannot fire: an operator whose HTTPS_PROXY points at
+    // their own TeamClaude gets a CONNECT back into the proxy and a timeout,
+    // on the one run where there is no config to explain it.
+    applyUpstreamProxy(config);
   }
   return config;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import {
   oauthIdentityFields,
 } from './identity.js';
 import { resolveAccounts } from './resolve-accounts.js';
+import { loginCodex } from './codex-auth.js';
 import { syncAccountsFromDisk } from './sync-accounts.js';
 import { mergeAccountsForSave, syncRefreshedTokens } from './account-pairing.js';
 import { ensureAccountIds } from './account-id.js';
@@ -620,6 +621,64 @@ async function importCommand() {
 
 // ── login ───────────────────────────────────────────────────
 
+/**
+ * `teamclaude login --codex` — browser OAuth against OpenAI, then store the
+ * account.
+ *
+ * Deliberately simpler than the Anthropic path: that one calls the profile
+ * endpoint to discover identity, whereas a Codex id_token already carries the
+ * email and the ChatGPT account id, so there is nothing further to fetch.
+ */
+async function loginCodexCommand() {
+  // loadOrCreateConfig, not loadConfig: `login` is a first-run entry point and
+  // must work before any config file exists.
+  const config = await loadOrCreateConfig();
+  let creds;
+  try {
+    creds = await loginCodex({ noBrowser: args.includes('--no-browser') });
+  } catch (err) {
+    console.error(`Codex login failed: ${err.message}`);
+    console.error('');
+    console.error('Alternative: sign in with the Codex CLI and import that login instead —');
+    console.error('  CODEX_HOME=~/.codex-second codex login');
+    console.error('  then add: { "name": "...", "type": "oauth", "provider": "codex", "importFrom": "~/.codex-second/auth.json" }');
+    process.exit(1);
+  }
+
+  const name = argValue('--name') || creds.email
+    || `codex-${config.accounts.filter(a => a.provider === 'codex').length + 1}`;
+
+  const account = {
+    name,
+    type: 'oauth',
+    provider: 'codex',
+    source: 'login',
+    accountId: creds.accountId,
+    accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt,
+  };
+
+  // Identity for a Codex account is its ChatGPT account id; fall back to the
+  // display name when upstream did not supply one.
+  const idx = config.accounts.findIndex(a => (
+    a.provider === 'codex' && (
+      (account.accountId && a.accountId === account.accountId) || a.name === account.name
+    )
+  ));
+  if (idx >= 0) {
+    const prev = config.accounts[idx];
+    config.accounts[idx] = { ...prev, ...account, name: prev.name };
+    console.log(`Updated account "${prev.name}"`);
+  } else {
+    config.accounts.push(account);
+    console.log(`Added account "${account.name}"${creds.planType ? ` (${creds.planType})` : ''}`);
+  }
+
+  await saveConfig(config);
+  console.log(`Saved to ${getConfigPath()}`);
+}
+
 async function loginCommand() {
   if (args.includes('--api')) {
     await loginApiCommand();
@@ -631,6 +690,10 @@ async function loginCommand() {
   }
   if (args.includes('--oauth')) {
     await loginOAuthCommand();
+    return;
+  }
+  if (args.includes('--codex')) {
+    await loginCodexCommand();
     return;
   }
 
@@ -645,11 +708,13 @@ async function loginCommand() {
   console.log('Select login method:\n');
   console.log('  1. Claude subscription  (Pro, Max, Team, Enterprise)');
   console.log('  2. Anthropic API key    (Console API billing)');
+  console.log('  3. Codex subscription   (ChatGPT Plus, Pro, Team)');
   console.log('');
   const choice = await new Promise(resolve => rl.question('Choice [1]: ', resolve));
   rl.close();
 
   switch (choice.trim() || '1') {
+    case '3': await loginCodexCommand(); break;
     case '1': await loginOAuthCommand(); break;
     case '2': await loginApiCommand(); break;
     default:

--- a/src/provider.js
+++ b/src/provider.js
@@ -67,9 +67,9 @@ const CODEX_PATHS = ['/backend-api/codex'];
  * Which provider should serve a request path.
  *
  * This is what lets one port serve both CLIs: Claude Code posts to
- * `/v1/messages` and Codex posts to `/v1/responses`, so the path alone says
- * which pool of accounts is eligible. No second listener, no client-supplied
- * hint that could disagree with the body.
+ * `/v1/messages` and Codex to `/backend-api/codex/responses`, so the path alone
+ * says which pool of accounts is eligible. No second listener, no
+ * client-supplied hint that could disagree with the body.
  */
 export function providerForPath(url) {
   const path = String(url || '').split('?')[0];

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,0 +1,127 @@
+// Backend providers.
+//
+// TeamClaude was built around one upstream (Anthropic), so the things that
+// differ per backend — which host to reach, how to present the account's
+// credential, which request paths belong to it — were inlined at the call
+// sites. Adding a second subscription backend (OpenAI's Codex) makes those the
+// axis of variation, so they live here instead.
+//
+// This is deliberately NOT a translation layer. Each provider is a passthrough:
+// the client speaks that provider's own protocol and the body is forwarded
+// untouched. All that changes is which account's credential is injected, and
+// where the request is sent. Converting between provider protocols would mean
+// re-serialising tool calls, streaming events and cache breakpoints, which is
+// exactly the fidelity loss this proxy exists to avoid.
+
+/** Providers keyed by the value used in an account's `provider` field. */
+export const PROVIDERS = {
+  anthropic: {
+    id: 'anthropic',
+    label: 'Anthropic',
+    upstream: 'https://api.anthropic.com',
+    // Anthropic pins the account inside the request body (metadata.user_id),
+    // so the body rewrites apply here and only here.
+    rewritesBody: true,
+  },
+  codex: {
+    id: 'codex',
+    label: 'Codex',
+    // A Codex subscription authenticates against the ChatGPT backend, not the
+    // API platform: the OAuth token is a ChatGPT token and api.openai.com
+    // rejects it with "Missing scopes: api.responses.write".
+    upstream: 'https://chatgpt.com',
+    // OpenAI carries the account in a request header, so no body rewrite is
+    // needed — and the Anthropic-specific tool-pair repair would be wrong to
+    // apply to a Responses API body.
+    rewritesBody: false,
+  },
+};
+
+export const DEFAULT_PROVIDER = 'anthropic';
+
+/**
+ * The provider an account belongs to. Accounts written before providers
+ * existed have no `provider` field and are Anthropic, so the default keeps
+ * every existing config working untouched.
+ */
+export function providerOf(account) {
+  const id = account?.provider;
+  return (id && PROVIDERS[id]) ? id : DEFAULT_PROVIDER;
+}
+
+/** Whether `id` names a provider we know how to talk to. */
+export function isKnownProvider(id) {
+  return Object.hasOwn(PROVIDERS, id);
+}
+
+// Request paths that belong to Codex rather than Anthropic.
+//
+// The Codex CLI appends `/responses` and `/models` to whatever `base_url` it is
+// given, so pointing it at `<proxy>/backend-api/codex` makes it emit exactly
+// the paths the ChatGPT backend already expects. That keeps this a pure
+// passthrough — the proxy forwards the path verbatim and never rewrites it —
+// and it keeps the Codex namespace clearly separated from Anthropic's `/v1/*`.
+const CODEX_PATHS = ['/backend-api/codex'];
+
+/**
+ * Which provider should serve a request path.
+ *
+ * This is what lets one port serve both CLIs: Claude Code posts to
+ * `/v1/messages` and Codex posts to `/v1/responses`, so the path alone says
+ * which pool of accounts is eligible. No second listener, no client-supplied
+ * hint that could disagree with the body.
+ */
+export function providerForPath(url) {
+  const path = String(url || '').split('?')[0];
+  return CODEX_PATHS.some(p => path === p || path.startsWith(`${p}/`))
+    ? 'codex'
+    : DEFAULT_PROVIDER;
+}
+
+/**
+ * Put the account's credential on an outgoing request.
+ *
+ * Mutates `headers` in place, mirroring how the forward path already builds
+ * them. Returns nothing: the caller owns the object.
+ *
+ * - Anthropic OAuth and Codex both use `Authorization: Bearer`.
+ * - Anthropic API keys use `x-api-key`.
+ * - Codex additionally needs `ChatGPT-Account-Id`, which is how OpenAI scopes
+ *   a token to one ChatGPT account. It is the direct counterpart of the
+ *   `account_uuid` that the Anthropic path patches into the request body —
+ *   a header here, so no body rewrite is involved.
+ */
+export function applyAuthHeaders(headers, account) {
+  const provider = providerOf(account);
+  if (provider === 'codex') {
+    headers['authorization'] = `Bearer ${account.credential}`;
+    if (account.accountId) headers['chatgpt-account-id'] = account.accountId;
+    return;
+  }
+  if (account.type === 'oauth') {
+    headers['authorization'] = `Bearer ${account.credential}`;
+  } else {
+    headers['x-api-key'] = account.credential;
+  }
+}
+
+/**
+ * Upstream base URL for an account: its own override first, then the
+ * provider's default, then the configured Anthropic upstream.
+ *
+ * The configured `upstream` stays the Anthropic default rather than a global
+ * one, because it predates providers and existing configs set it meaning
+ * "where Anthropic lives". Applying it to Codex would silently send OpenAI
+ * traffic to an Anthropic host.
+ */
+export function upstreamFor(account, configuredUpstream) {
+  if (account?.upstream) return account.upstream;
+  const provider = providerOf(account);
+  if (provider !== DEFAULT_PROVIDER) return PROVIDERS[provider].upstream;
+  return configuredUpstream || PROVIDERS.anthropic.upstream;
+}
+
+/** Whether the Anthropic-only body rewrites apply to this account. */
+export function rewritesBody(account) {
+  return PROVIDERS[providerOf(account)].rewritesBody;
+}

--- a/src/resolve-accounts.js
+++ b/src/resolve-accounts.js
@@ -1,4 +1,6 @@
 import { importCredentials } from './oauth.js';
+import { importCodexCredentials, DEFAULT_CODEX_CREDENTIALS_PATH } from './codex-auth.js';
+import { providerOf } from './provider.js';
 
 /**
  * Turn configured accounts into the objects the AccountManager is built from:
@@ -15,18 +17,24 @@ export async function resolveAccounts(config) {
   const accounts = [];
   for (const acct of config.accounts) {
     if (acct.type === 'oauth') {
-      if (acct.importFrom) {
+      if (acct.importFrom || providerOf(acct) === 'codex') {
+        // A Codex account defaults to the Codex CLI's own credentials file, so
+        // `{ "name": "...", "type": "oauth", "provider": "codex" }` is enough
+        // to pool an already-signed-in Codex login.
+        const isCodex = providerOf(acct) === 'codex';
+        const from = acct.importFrom || (isCodex ? DEFAULT_CODEX_CREDENTIALS_PATH : null);
+        if (!from) { console.error(`No token for "${acct.name}", skipping`); continue; }
         try {
-          const creds = await importCredentials(acct.importFrom);
+          const creds = isCodex ? await importCodexCredentials(from) : await importCredentials(from);
           // A readable file with no token is as unusable as a missing one; the
           // non-import branch below already refuses that case, and pushing it
           // anyway would send `Bearer undefined` upstream on every request.
           if (!creds.accessToken) {
-            console.error(`No token in ${acct.importFrom} for "${acct.name}", skipping`);
+            console.error(`No token in ${from} for "${acct.name}", skipping`);
             continue;
           }
           accounts.push({ ...acct, ...creds });
-          console.log(`Imported "${acct.name}" from ${acct.importFrom}`);
+          console.log(`Imported "${acct.name}" from ${from}`);
         } catch (err) {
           console.error(`Failed to import "${acct.name}": ${err.message}`);
         }

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
 import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter, truncationNote } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
+import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath } from './provider.js';
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
@@ -702,7 +703,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         : null;
       if (client && clientUsage) clientUsage.record(client, { requests: 1 });
 
-      const ctx = { account: null, status: null, tried: new Set(), reauthed: new Set(), model, advisorModel, pinnedIndex, holdBudgetMs: holdMs, sessionId, client, onUsage, logLevel: resolveLogLevel(config), logMaxBodyBytes: resolveLogMaxBodyBytes(config) };
+      const ctx = { account: null, status: null, tried: new Set(), reauthed: new Set(), model, advisorModel, pinnedIndex, provider: providerForPath(req.url), holdBudgetMs: holdMs, sessionId, client, onUsage, logLevel: resolveLogLevel(config), logMaxBodyBytes: resolveLogMaxBodyBytes(config) };
       // Hold the session "in flight" across the WHOLE request (incl. retries and
       // a multi-minute streaming completion) so it stays counted as active and
       // never expires mid-request.
@@ -1309,7 +1310,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // and the caller gets the exhausted response rather than leaking to another.
   const account = ctx.pinnedIndex != null
     ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
-    : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId);
+    : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider);
   if (!account) {
     // Every candidate was refused by upstream (403). Waiting will not help — the
     // account needs attention, not a retry — so say so plainly rather than
@@ -1423,7 +1424,6 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   }
 
   // Build upstream request headers
-  const isOAuth = account.type === 'oauth';
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -1438,23 +1438,29 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     headers[key] = value;
   }
 
-  if (isOAuth) {
-    headers['authorization'] = `Bearer ${account.credential}`;
-  } else {
-    headers['x-api-key'] = account.credential;
-  }
+  // Credential presentation is provider-specific: Anthropic OAuth and Codex
+  // both use a bearer token, Anthropic API keys use x-api-key, and Codex also
+  // needs ChatGPT-Account-Id to scope the token to one account.
+  applyAuthHeaders(headers, account);
 
-  const upstreamUrl = `${account.upstream || upstream}${req.url}`;
+  const upstreamUrl = `${upstreamFor(account, upstream)}${req.url}`;
   const method = req.method;
 
-  // Strip orphaned tool_use / tool_result blocks so a client that compacted or
-  // interrupted a turn can't wedge the session with Anthropic's non-retryable
-  // 400 ("tool_use ids were found without tool_result blocks"). No-op (same
-  // Buffer) for a well-formed body.
-  let sendBody = sanitizeToolPairs(body, req.url, req.headers['content-type']);
-  // Align the body's account_uuid (in metadata.user_id) with the account whose
-  // token we're injecting (same-length patch; no-op if absent).
-  if (account.accountUuid) sendBody = patchAccountUuid(sendBody, account.accountUuid);
+  let sendBody = body;
+  // The body rewrites below are Anthropic-shaped and must not touch another
+  // provider's payload: a Responses API body has no metadata.user_id to patch
+  // and no Anthropic tool-pairing rule to repair, so running them would at
+  // best waste a pass and at worst corrupt a valid request.
+  if (rewritesBody(account)) {
+    // Strip orphaned tool_use / tool_result blocks so a client that compacted or
+    // interrupted a turn can't wedge the session with Anthropic's non-retryable
+    // 400 ("tool_use ids were found without tool_result blocks"). No-op (same
+    // Buffer) for a well-formed body.
+    sendBody = sanitizeToolPairs(body, req.url, req.headers['content-type']);
+    // Align the body's account_uuid (in metadata.user_id) with the account whose
+    // token we're injecting (same-length patch; no-op if absent).
+    if (account.accountUuid) sendBody = patchAccountUuid(sendBody, account.accountUuid);
+  }
   // Rewrite the model name for accounts that target a different upstream (e.g.
   // GLM), which uses different model identifiers than Anthropic.
   if (account.modelMap) sendBody = rewriteModel(sendBody, account.modelMap);

--- a/test/codex-auth.test.js
+++ b/test/codex-auth.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { importCodexCredentials } from '../src/codex-auth.js';
+
+const b64u = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+const jwt = (claims) => `${b64u({ alg: 'none' })}.${b64u(claims)}.sig`;
+
+async function writeAuth(contents) {
+  const home = await mkdtemp(join(tmpdir(), 'tc-codex-'));
+  await mkdir(join(home, '.codex'), { recursive: true });
+  await writeFile(join(home, '.codex', 'auth.json'), JSON.stringify(contents));
+  return home;
+}
+
+test('reads the token pair and account id from the Codex CLI file', async () => {
+  const home = await writeAuth({
+    tokens: {
+      access_token: 'at', refresh_token: 'rt', account_id: 'acct-stored',
+      id_token: jwt({
+        email: 'user@example.com',
+        'https://api.openai.com/auth': { chatgpt_account_id: 'acct-claim', chatgpt_plan_type: 'pro' },
+      }),
+    },
+  });
+  const creds = await importCodexCredentials('~/.codex/auth.json', { home });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.refreshToken, 'rt');
+  assert.equal(creds.email, 'user@example.com');
+  assert.equal(creds.planType, 'pro');
+  // The id_token claim is what the server itself issued, so it wins over the
+  // value mirrored into tokens.account_id.
+  assert.equal(creds.accountId, 'acct-claim');
+});
+
+test('falls back to the stored account id when the id_token has no claim', async () => {
+  const home = await writeAuth({ tokens: { access_token: 'at', refresh_token: 'rt', account_id: 'acct-stored' } });
+  const creds = await importCodexCredentials('~/.codex/auth.json', { home });
+  assert.equal(creds.accountId, 'acct-stored');
+});
+
+// Cosmetic claims must never be load-bearing: a malformed id_token still has
+// to yield a usable credential.
+test('a malformed id_token does not break the import', async () => {
+  const home = await writeAuth({ tokens: { access_token: 'at', refresh_token: 'rt', account_id: 'a', id_token: 'not-a-jwt' } });
+  const creds = await importCodexCredentials('~/.codex/auth.json', { home });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.email, undefined);
+});
+
+test('a file with no tokens yields no access token, so the account is skipped', async () => {
+  const home = await writeAuth({});
+  const creds = await importCodexCredentials('~/.codex/auth.json', { home });
+  assert.equal(creds.accessToken, undefined);
+});

--- a/test/codex-auth.test.js
+++ b/test/codex-auth.test.js
@@ -55,3 +55,50 @@ test('a file with no tokens yields no access token, so the account is skipped', 
   const creds = await importCodexCredentials('~/.codex/auth.json', { home });
   assert.equal(creds.accessToken, undefined);
 });
+
+// ── Browser login ───────────────────────────────────────────────────────────
+
+import { buildCodexAuthUrl, credentialsFromTokenResponse } from '../src/codex-auth.js';
+
+test('the authorize URL carries the parameters OpenAI requires', () => {
+  const url = new URL(buildCodexAuthUrl({ state: 'st', codeChallenge: 'cc' }));
+  assert.equal(url.origin + url.pathname, 'https://auth.openai.com/oauth/authorize');
+  assert.equal(url.searchParams.get('response_type'), 'code');
+  assert.equal(url.searchParams.get('client_id'), 'app_EMoamEEZ73f0CkXaXp7hrann');
+  // `api` here is rejected live with invalid_scope — this client may not
+  // request it, so the assertion pins the scope set that actually works.
+  assert.equal(url.searchParams.get('scope'), 'openid profile email offline_access');
+  assert.equal(url.searchParams.get('originator'), 'codex_cli_rs');
+  assert.equal(url.searchParams.get('codex_cli_simplified_flow'), 'true');
+  assert.equal(url.searchParams.get('state'), 'st');
+  assert.equal(url.searchParams.get('code_challenge'), 'cc');
+  // PKCE must be S256: a public client has no secret, so `plain` would leave
+  // the exchange bound to nothing.
+  assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+  // OpenAI registered exactly one redirect for this client.
+  assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:1455/auth/callback');
+});
+
+test('a token response becomes the same credential shape as an import', () => {
+  const creds = credentialsFromTokenResponse({
+    access_token: 'at',
+    refresh_token: 'rt',
+    expires_in: 600,
+    id_token: jwt({
+      email: 'user@example.com',
+      'https://api.openai.com/auth': { chatgpt_account_id: 'acct-1', chatgpt_plan_type: 'pro' },
+    }),
+  });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.refreshToken, 'rt');
+  assert.equal(creds.accountId, 'acct-1');
+  assert.equal(creds.email, 'user@example.com');
+  assert.equal(creds.planType, 'pro');
+  assert.ok(creds.expiresAt > Date.now());
+});
+
+test('a token response with no id_token still yields usable credentials', () => {
+  const creds = credentialsFromTokenResponse({ access_token: 'at', refresh_token: 'rt' });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(creds.accountId, undefined);
+});

--- a/test/codex-quota.test.js
+++ b/test/codex-quota.test.js
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCodexQuota, parseCodexPlanType } from '../src/codex-quota.js';
+
+// The exact header SET from a live Codex response, with the values replaced by
+// synthetic ones. The shape is what matters here and is not invented: the
+// account-wide family really does carry a 7-day window in `primary`, and the
+// named family really does carry a 5-hour one.
+const LIVE = {
+  'x-codex-active-limit': 'premium',
+  'x-codex-plan-type': 'pro',
+  'x-codex-primary-used-percent': '42',
+  'x-codex-secondary-used-percent': '0',
+  'x-codex-primary-window-minutes': '10080',
+  'x-codex-primary-over-secondary-limit-percent': '0',
+  'x-codex-secondary-window-minutes': '0',
+  'x-codex-primary-reset-after-seconds': '300000',
+  'x-codex-secondary-reset-after-seconds': '0',
+  'x-codex-primary-reset-at': '1900000000',
+  'x-codex-secondary-reset-at': '',
+  'x-codex-credits-has-credits': 'False',
+  'x-codex-credits-balance': '0',
+  'x-codex-credits-unlimited': 'False',
+  'x-codex-bengalfox-primary-used-percent': '0',
+  'x-codex-bengalfox-secondary-used-percent': '0',
+  'x-codex-bengalfox-primary-window-minutes': '300',
+  'x-codex-bengalfox-primary-over-secondary-limit-percent': '0',
+  'x-codex-bengalfox-secondary-window-minutes': '10080',
+  'x-codex-bengalfox-primary-reset-at': '1900001111',
+  'x-codex-bengalfox-secondary-reset-at': '1900002222',
+  'x-codex-bengalfox-limit-name': 'GPT-5.3-Codex-Spark',
+};
+
+// The account-wide family puts its SEVEN-DAY window in `primary`. Reading
+// position instead of duration would file this as a 5h reading.
+test('the account-wide weekly window is read from its duration, not its position', () => {
+  const q = parseCodexQuota(LIVE);
+  assert.equal(q.unified7d, 0.42);
+  assert.equal(q.unified7dReset, 1900000000 * 1000);
+  // 31% weekly used must never appear as a 5h reading.
+  assert.equal(q.unified5h, undefined);
+  assert.equal(q.unified5hReset, undefined);
+});
+
+// A zero-length window is how this API says "not applicable"; treating it as
+// 0% used would read as full headroom.
+test('a zero-length window is dropped rather than read as empty', () => {
+  const q = parseCodexQuota(LIVE);
+  assert.ok(!('unified5h' in q), 'secondary window-minutes=0 must not produce a bucket');
+});
+
+test('a named family becomes a model-scoped weekly bucket', () => {
+  const q = parseCodexQuota(LIVE);
+  assert.equal(q.modelBuckets.length, 1);
+  const [bucket] = q.modelBuckets;
+  assert.equal(bucket.slug, 'bengalfox');
+  assert.equal(bucket.name, 'GPT-5.3-Codex-Spark');
+  assert.equal(bucket.utilization, 0);
+  // Its WEEKLY window (10080) is carried, not its 5h one (300).
+  assert.equal(bucket.resetAt, 1900002222 * 1000);
+});
+
+test('percentages become 0-1 utilization, matching the Anthropic path', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-used-percent': '98',
+    'x-codex-primary-window-minutes': '10080',
+  });
+  assert.equal(q.unified7d, 0.98);
+});
+
+test('a 5-hour account window lands in the 5h bucket', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-used-percent': '50',
+    'x-codex-primary-window-minutes': '300',
+    'x-codex-primary-reset-at': '1900001111',
+  });
+  assert.equal(q.unified5h, 0.5);
+  assert.equal(q.unified5hReset, 1900001111 * 1000);
+  assert.equal(q.unified7d, undefined);
+});
+
+test('an unrecognised window duration is ignored rather than guessed at', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-used-percent': '50',
+    'x-codex-primary-window-minutes': '42',
+  });
+  assert.deepEqual(q, {});
+});
+
+// The catalog fetch carries no quota; that must not look like 0% used.
+test('a response with no quota headers yields nothing', () => {
+  assert.deepEqual(parseCodexQuota({}), {});
+  assert.deepEqual(parseCodexQuota(undefined), {});
+  assert.deepEqual(parseCodexQuota({ 'content-type': 'application/json' }), {});
+});
+
+test('an empty reset value is treated as absent, not as epoch zero', () => {
+  const q = parseCodexQuota({
+    'x-codex-primary-used-percent': '10',
+    'x-codex-primary-window-minutes': '10080',
+    'x-codex-primary-reset-at': '',
+  });
+  assert.equal(q.unified7d, 0.1);
+  assert.ok(!('unified7dReset' in q));
+});
+
+test('header casing does not matter', () => {
+  const q = parseCodexQuota({
+    'X-Codex-Primary-Used-Percent': '20',
+    'X-Codex-Primary-Window-Minutes': '10080',
+  });
+  assert.equal(q.unified7d, 0.2);
+});
+
+test('the plan type is surfaced when present', () => {
+  assert.equal(parseCodexPlanType(LIVE), 'pro');
+  assert.equal(parseCodexPlanType({}), null);
+});

--- a/test/config-first-run-proxy.test.js
+++ b/test/config-first-run-proxy.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveUpstreamProxy, localListener } from '../src/upstream-proxy.js';
+
+// The self-proxy guard needs the config's own listener to compare against.
+// Resolving from an EMPTY config — which is what the lazy fallback does when no
+// command has installed the setting — cannot fire it, so an operator whose
+// HTTPS_PROXY points at their own TeamClaude proxies back into it and times out.
+test('the self-proxy guard needs a config, and silently cannot fire without one', () => {
+  const env = { HTTPS_PROXY: 'http://127.0.0.1:3456' };
+
+  const withConfig = resolveUpstreamProxy({ proxy: { port: 3456 } }, env);
+  assert.equal(withConfig.source, 'self');
+  assert.equal(withConfig.proxy, null, 'a proxy addressing our own listener must be dropped');
+
+  const withoutConfig = resolveUpstreamProxy({}, env);
+  assert.equal(withoutConfig.source, 'env:HTTPS_PROXY');
+  assert.ok(withoutConfig.proxy, 'without a listener the guard cannot fire — hence the bug');
+  assert.equal(localListener({}), null);
+});
+
+// A first run creates the config; the proxy setting must be applied to it, not
+// skipped because loadConfig returned early on ENOENT.
+test('loadOrCreateConfig applies the proxy setting to a config it creates', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-firstrun-'));
+  const path = join(dir, 'teamclaude.json');
+  process.env.TEAMCLAUDE_CONFIG = path;
+  const prevProxy = process.env.HTTPS_PROXY;
+
+  try {
+    const { loadOrCreateConfig } = await import('../src/config.js');
+    const { getUpstreamProxy } = await import('../src/upstream-proxy.js');
+
+    const config = await loadOrCreateConfig();
+    // The file must exist, and the resolved setting must have been installed
+    // from it rather than left for the config-less fallback.
+    assert.ok(JSON.parse(await readFile(path, 'utf-8')).proxy.port);
+    assert.ok(getUpstreamProxy(), 'a resolved proxy setting must be installed after a first run');
+    assert.equal(typeof config.proxy.port, 'number');
+  } finally {
+    delete process.env.TEAMCLAUDE_CONFIG;
+    if (prevProxy === undefined) delete process.env.HTTPS_PROXY;
+    else process.env.HTTPS_PROXY = prevProxy;
+  }
+});

--- a/test/provider-routing.test.js
+++ b/test/provider-routing.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+const oauth = (name, extra = {}) => ({
+  name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r',
+  expiresAt: Date.now() + 3600_000, ...extra,
+});
+const codex = (name) => oauth(name, { provider: 'codex', accountId: 'acct-' + name });
+
+// A provider partition is absolute: an Anthropic account cannot serve an
+// OpenAI Responses request at all, so selection must never cross it.
+test('a Codex request never selects an Anthropic account', () => {
+  const am = new AccountManager([oauth('claude-1'), oauth('claude-2'), codex('codex-1')], 0.98);
+  const picked = am.getActiveAccount(null, null, null, null, 'codex');
+  assert.equal(picked.name, 'codex-1');
+});
+
+test('an Anthropic request never selects a Codex account', () => {
+  const am = new AccountManager([codex('codex-1'), oauth('claude-1')], 0.98);
+  const picked = am.getActiveAccount(null, null, null, null, 'anthropic');
+  assert.equal(picked.name, 'claude-1');
+});
+
+// Callers that predate providers pass four arguments; they must keep getting
+// Anthropic selection.
+test('selection defaults to Anthropic when no provider is given', () => {
+  const am = new AccountManager([codex('codex-1'), oauth('claude-1')], 0.98);
+  assert.equal(am.getActiveAccount().name, 'claude-1');
+  assert.equal(am.getActiveAccount(null, null, null, null).name, 'claude-1');
+});
+
+test('a request for a provider with no accounts selects nothing rather than crossing over', () => {
+  const am = new AccountManager([oauth('claude-1')], 0.98);
+  assert.equal(am.getActiveAccount(null, null, null, null, 'codex'), null);
+});
+
+// The caller's own exclude set (accounts already tried this request) must still
+// be honoured alongside the provider filter.
+test('the per-request exclude set is preserved', () => {
+  const am = new AccountManager([codex('codex-1'), codex('codex-2'), oauth('claude-1')], 0.98);
+  const first = am.getActiveAccount(null, null, null, null, 'codex');
+  const second = am.getActiveAccount(new Set([first.index]), null, null, null, 'codex');
+  assert.ok(second, 'a second Codex account should be reachable');
+  assert.notEqual(second.name, first.name);
+  assert.equal(second.provider, 'codex');
+});
+
+// A single-provider config is the overwhelmingly common case and must not pay
+// for the partition.
+test('a config with one provider behaves exactly as before', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  assert.equal(am.getActiveAccount(null, null, null, null, 'anthropic').name, 'a');
+});

--- a/test/provider-routing.test.js
+++ b/test/provider-routing.test.js
@@ -52,3 +52,50 @@ test('a config with one provider behaves exactly as before', () => {
   const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
   assert.equal(am.getActiveAccount(null, null, null, null, 'anthropic').name, 'a');
 });
+
+// ── Codex quota drives rotation the same way Anthropic's does ────────────────
+
+const codexHeaders = (usedPercent, resetAt = 1900000000) => ({
+  'x-codex-plan-type': 'pro',
+  'x-codex-primary-used-percent': String(usedPercent),
+  'x-codex-primary-window-minutes': '10080',
+  'x-codex-primary-reset-at': String(resetAt),
+});
+
+test('Codex headers land in the same quota fields the threshold reads', () => {
+  const am = new AccountManager([codex('codex-1')], 0.98);
+  am.updateQuota(0, codexHeaders(42));
+  const q = am.accounts[0].quota;
+  assert.equal(q.unified7d, 0.42);
+  assert.equal(q.unified7dReset, 1900000000 * 1000);
+  assert.equal(q.planType, 'pro');
+});
+
+// The point of reading quota at all: rotate BEFORE upstream refuses, not after.
+test('a Codex account over the switch threshold hands over to a fresh one', () => {
+  const am = new AccountManager([codex('codex-1'), codex('codex-2')], 0.98);
+  const first = am.getActiveAccount(null, null, null, null, 'codex');
+  assert.equal(first.name, 'codex-1');
+
+  am.updateQuota(first.index, codexHeaders(99));   // past the 98% threshold
+  am.updateQuota(1, codexHeaders(10));             // plenty left
+
+  const next = am.getActiveAccount(null, null, null, null, 'codex');
+  assert.equal(next.name, 'codex-2', 'a nearly-spent Codex account must hand over');
+});
+
+test('learning a weekly quota ends probing, as it does for Anthropic', () => {
+  const am = new AccountManager([codex('codex-1')], 0.98);
+  assert.equal(am.accounts[0].probing, true);
+  am.updateQuota(0, codexHeaders(5));
+  assert.equal(am.accounts[0].probing, false);
+  assert.equal(am.accounts[0].requalify, true);
+});
+
+// A catalog fetch carries no quota headers; that must not read as 0% used.
+test('a response with no quota headers leaves a known reading intact', () => {
+  const am = new AccountManager([codex('codex-1')], 0.98);
+  am.updateQuota(0, codexHeaders(77));
+  am.updateQuota(0, { 'content-type': 'application/json' });
+  assert.equal(am.accounts[0].quota.unified7d, 0.77);
+});

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  providerOf, providerForPath, applyAuthHeaders, upstreamFor, rewritesBody,
+  isKnownProvider, DEFAULT_PROVIDER,
+} from '../src/provider.js';
+
+// An account written before providers existed carries no `provider` field. It
+// must keep behaving as Anthropic, or every existing config breaks on upgrade.
+test('an account with no provider is Anthropic', () => {
+  assert.equal(providerOf({ name: 'legacy', type: 'oauth' }), 'anthropic');
+  assert.equal(providerOf({}), 'anthropic');
+  assert.equal(providerOf(undefined), 'anthropic');
+  assert.equal(DEFAULT_PROVIDER, 'anthropic');
+});
+
+test('an unknown provider falls back rather than routing nowhere', () => {
+  assert.equal(providerOf({ provider: 'not-a-provider' }), 'anthropic');
+  assert.equal(isKnownProvider('codex'), true);
+  assert.equal(isKnownProvider('nope'), false);
+});
+
+// One port serves both CLIs; the request path is what says which pool of
+// accounts is eligible.
+test('the request path selects the provider', () => {
+  assert.equal(providerForPath('/v1/messages'), 'anthropic');
+  assert.equal(providerForPath('/v1/messages/count_tokens'), 'anthropic');
+  assert.equal(providerForPath('/backend-api/codex/responses'), 'codex');
+  assert.equal(providerForPath('/backend-api/codex/models'), 'codex');
+  // Codex appends a client_version query on its catalog fetch.
+  assert.equal(providerForPath('/backend-api/codex/models?client_version=0.150.1'), 'codex');
+  // The OpenAI *API platform* paths are not Codex's: a ChatGPT token is
+  // rejected there, so they must not be routed to a Codex account.
+  assert.equal(providerForPath('/v1/responses'), 'anthropic');
+  // Anything unrecognised stays Anthropic's, so a config with no Codex
+  // accounts routes exactly as it did before.
+  assert.equal(providerForPath('/v1/complete'), 'anthropic');
+  assert.equal(providerForPath(''), 'anthropic');
+  assert.equal(providerForPath(undefined), 'anthropic');
+});
+
+test('Anthropic OAuth sends a bearer token, an API key sends x-api-key', () => {
+  const oauth = {};
+  applyAuthHeaders(oauth, { type: 'oauth', credential: 'tok' });
+  assert.deepEqual(oauth, { authorization: 'Bearer tok' });
+
+  const apikey = {};
+  applyAuthHeaders(apikey, { type: 'apikey', credential: 'sk-ant' });
+  assert.deepEqual(apikey, { 'x-api-key': 'sk-ant' });
+});
+
+// ChatGPT-Account-Id is OpenAI's counterpart to the account_uuid the Anthropic
+// path patches into the request body — a header, so no body rewrite is needed.
+test('Codex sends a bearer token plus the ChatGPT account header', () => {
+  const headers = {};
+  applyAuthHeaders(headers, { provider: 'codex', type: 'oauth', credential: 'tok', accountId: 'acct-1' });
+  assert.deepEqual(headers, { authorization: 'Bearer tok', 'chatgpt-account-id': 'acct-1' });
+});
+
+test('Codex without an account id still authenticates', () => {
+  const headers = {};
+  applyAuthHeaders(headers, { provider: 'codex', type: 'oauth', credential: 'tok' });
+  assert.deepEqual(headers, { authorization: 'Bearer tok' });
+  assert.ok(!('chatgpt-account-id' in headers));
+});
+
+test('an account upstream overrides the provider default', () => {
+  assert.equal(upstreamFor({ upstream: 'https://glm.example' }, 'https://api.anthropic.com'), 'https://glm.example');
+});
+
+// The configured `upstream` predates providers and means "where Anthropic
+// lives", so it must not capture Codex traffic.
+test('the configured upstream applies to Anthropic only', () => {
+  const configured = 'https://anthropic.internal';
+  assert.equal(upstreamFor({ name: 'a' }, configured), configured);
+  assert.equal(upstreamFor({ provider: 'codex' }, configured), 'https://chatgpt.com');
+});
+
+test('body rewrites are Anthropic-only', () => {
+  assert.equal(rewritesBody({ type: 'oauth' }), true);
+  assert.equal(rewritesBody({ provider: 'codex' }), false);
+});


### PR DESCRIPTION
Adds a `provider` seam and a second provider, `codex`, so an OpenAI Codex subscription can be pooled and rotated the same way Claude accounts are.

This is a nod at #72 — "the possibility TeamClaude could be useful for other use cases" — and at the hidden feature request in that thread. It also puts a boundary on how far that generalisation reaches; see the last section.

## What it is not

A passthrough, not a translation layer. Each provider forwards its own protocol untouched; only the injected credential and the destination change. Converting between protocols would mean re-serialising tool calls, streaming events and cache breakpoints, which is the fidelity loss this proxy exists to avoid.

## One port, path-routed

The request path says which pool of accounts is eligible: Claude Code posts to `/v1/messages`, Codex to `/backend-api/codex/responses`. No second listener, no client-supplied hint that could disagree with the body — one port, one config, one TUI.

A provider partition is absolute (an Anthropic account cannot serve an OpenAI Responses request), so it is expressed by **widening the per-request exclude set** rather than threading a parameter through the rotation logic. Everything downstream already reads `exclude`, so cursors, pinning, session affinity, probing and preemption keep working unchanged, and a config with no Codex accounts produces the identical set it did before.

## Notes from building it

- **The credential is a bearer token plus a `ChatGPT-Account-Id` header.** That header is OpenAI's counterpart to the `account_uuid` this proxy patches into an Anthropic request body — so the Codex path does no body rewrite at all. The Anthropic-only rewrites are now guarded: a Responses body has no `metadata.user_id` to patch and no Anthropic tool-pairing rule to repair.
- **The upstream is `chatgpt.com`, not `api.openai.com`.** A subscription token is a ChatGPT token; the API platform refuses it with `Missing scopes: api.responses.write`. Codex appends `/responses` and `/models` to its configured `base_url`, so pointing it at `<proxy>/backend-api/codex` makes it emit exactly the paths the ChatGPT backend expects, forwarded verbatim.
- **`OPENAI_BASE_URL` does not work** for redirecting a ChatGPT-authenticated Codex — it is ignored. `model_providers` in `~/.codex/config.toml` is the supported route. Both were tested.
- **Tokens refresh** against `auth.openai.com` with the Codex CLI's own client id, returning the same `{ accessToken, refreshToken, expiresAt }` shape as the Anthropic path.
- **`makeAccount` is an allow-list**, so `provider` and `accountId` are carried through it explicitly. A test caught this — without it the fields were silently dropped and selection crossed providers.

## Backwards compatibility

An account with no `provider` is Anthropic. The configured `upstream` stays the Anthropic default rather than becoming global, since existing configs set it meaning "where Anthropic lives" — applying it to Codex would silently send OpenAI traffic to an Anthropic host.

## Scope

Quota-driven rotation stays Anthropic-only: the switch threshold, reset countdowns and the TUI's bars read `anthropic-ratelimit-unified-*`. Codex accounts rotate on upstream rejection, as a third-party backend does today. Codex reports its own `primary`/`secondary` windows with `resets_at`, so wiring those in is a natural follow-up rather than something this PR guesses at.

## On how far this generalises (re #72)

Worth recording as a boundary for a routing-layer rename: **not every agent CLI can be proxied.** Google's Antigravity CLI (`agy`) has no base-URL flag, ignores `HTTPS_PROXY` (google-antigravity/antigravity-cli#72), and does its own network I/O from a single binary — there is no seam to attach to at all. Codex fits this architecture because it exposes one; that is the property worth selecting for.

## Testing

- 882 tests pass, lint clean.
- New: `test/provider.test.js`, `test/provider-routing.test.js`, `test/codex-auth.test.js`.
- Verified end to end against a live Codex subscription — `codex exec` through the proxy returns a real completion with tokens billed to the pooled account, and the Anthropic path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)