### PR TITLE
feat(quota): per-account usage caps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
+| `accounts[].maxUsage` | Hard per-account usage cap: a number, or a per-bucket table like `{ "unified7d": 0.6, "unified7dFable": 0.8 }` (same keys as `switchThreshold`; `default` covers unlisted buckets, anything else is uncapped). At the cap the account receives **no** requests — rotation skips it, the all-exhausted revalidation probe skips it, and a pin gets the exhausted answer. Model-scoped like the thresholds, applied live on reload. See [Per-account usage caps](quota.md#per-account-usage-caps) |
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
 | `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only — see [third-party backends](accounts.md#third-party-backend-accounts) |
 | `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |

--- a/docs/quota.md
+++ b/docs/quota.md
@@ -98,6 +98,18 @@ At the cap, that account receives **nothing**:
 
 Caps are model-scoped exactly like thresholds. `unified5h` and `unified7d` stop every model; `unified7dFable` stops only Fable, so the example above keeps serving Opus and Sonnet from the same account after Fable is done. The cap binds at the level you set (`>=`), and a window that has reset is never capped on the old reading.
 
+A cap shows on the status screen before it binds — marked on the bar it applies to, named in percent beside it, and reflected in the `Models` row:
+
+```
+  Session  [██░░░░░░░░░┃░░░░░░] 10% cap 60%
+  Weekly   [███████████┃░░░░░░] 62% cap 60%
+  Fable    [██░░░░░░░░░░░░┃░░░] 10% cap 80%
+  Models   Opus ✗   Fable ✗
+  Blocked  account usage cap reached (maxUsage)
+```
+
+The mark stays inside the bar rather than widening it, so capped and uncapped rows still line up. In the TUI the bar reddens at the cap instead of at the switch threshold.
+
 Edits apply live on config reload — no restart.
 
 ## Hold on exhaustion

--- a/docs/quota.md
+++ b/docs/quota.md
@@ -75,6 +75,31 @@ teamclaude threshold unified7d=default  # drop it again
 
 A running server picks the change up on the reload the command sends it. This is the only way to edit a per-bucket table in place: the TUI shows it read-only, and the single-number form there would flatten it.
 
+## Per-account usage caps
+
+`switchThreshold` is fleet-wide, and it is a *preference*: at that level rotation prefers another account, but when every account is over it the proxy still sends one revalidating request, because a threshold decision can rest on a stale reading and refusing forever is worse. That makes it the wrong tool for "this account may spend only part of its quota".
+
+`accounts[].maxUsage` is that tool. Same shapes, per account:
+
+```json
+{
+  "name": "spare@example.com",
+  "maxUsage": { "unified5h": 0.6, "unified7d": 0.6, "unified7dFable": 0.8 }
+}
+```
+
+A bare number caps every bucket. Keys are the same quota field names as `switchThreshold`, and `default` covers the ones a table does not list — but a bucket that is neither listed nor covered by `default` is **uncapped**, so a cap is only ever what you asked for.
+
+At the cap, that account receives **nothing**:
+
+- rotation skips it, reporting `capped` (or `advisor-capped`) in `teamclaude status`;
+- the all-exhausted revalidation probe skips it, unlike a `switchThreshold` decision;
+- a pinned request (`TC_ACCT`, `/tc-acct/<name>`) gets the exhausted answer rather than spending past the cap. A pin still never leaks to another account.
+
+Caps are model-scoped exactly like thresholds. `unified5h` and `unified7d` stop every model; `unified7dFable` stops only Fable, so the example above keeps serving Opus and Sonnet from the same account after Fable is done. The cap binds at the level you set (`>=`), and a window that has reset is never capped on the old reading.
+
+Edits apply live on config reload — no restart.
+
 ## Hold on exhaustion
 
 By default, when all accounts are exhausted TeamClaude returns a `429` immediately, which causes Claude Code to abort the current task. With `holdSeconds` set, the proxy **holds the HTTP connection open** instead and polls silently every ~60 seconds; the instant any account's quota resets, the request is forwarded and Claude Code resumes — the interruption never happens.

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -3,7 +3,7 @@ import { providerOf, DEFAULT_PROVIDER } from './provider.js';
 import { refreshCodexToken } from './codex-auth.js';
 import { parseCodexQuota, parseCodexPlanType } from './codex-quota.js';
 import { sameIdentity } from './identity.js';
-import { weeklyBucketForModel, modelGlobMatches, modelFamily, gatingUtilization } from './model.js';
+import { weeklyBucketForModel, modelGlobMatches, modelFamily, gatingUtilization, resolveMaxUsage } from './model.js';
 import { SessionTracker } from './session-tracker.js';
 
 // Re-exported for callers that import these model helpers from here.
@@ -318,13 +318,7 @@ export class AccountManager {
    * uncapped, so a cap is only ever what was asked for.
    */
   capFor(bucket, account) {
-    const m = account?.maxUsage;
-    if (typeof m === 'number' && Number.isFinite(m)) return m;
-    if (m && typeof m === 'object') {
-      const v = m[bucket] ?? m.default;
-      if (typeof v === 'number' && Number.isFinite(v)) return v;
-    }
-    return null;
+    return resolveMaxUsage(account?.maxUsage, bucket);
   }
 
   /**

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -114,6 +114,7 @@ function makeAccount(acct, index) {
     orgName: acct.orgName || null,
     priority: acct.priority || 0,
     disabled: acct.disabled || false,
+    maxUsage: acct.maxUsage ?? null,
     upstream: acct.upstream || null,
     modelMap: acct.modelMap || null,
     // Fields to drop from request bodies for this account (third-party upstreams
@@ -293,6 +294,95 @@ export class AccountManager {
    * places that show one (status header, TUI settings row). */
   get effectiveThreshold() {
     return this.thresholdFor('default');
+  }
+
+  /**
+   * A per-account usage cap, or null when that bucket is uncapped.
+   *
+   * `switchThreshold` is a rotation preference: at that level the fleet PREFERS
+   * another account, but the all-exhausted probe path deliberately overrides it,
+   * because a threshold decision can rest on a stale reading and refusing
+   * forever is worse than one revalidating request. A budget is not that. An
+   * operator who says "this account stops at 60% of its weekly" wants zero
+   * requests past 60%, so `accounts[].maxUsage` is a separate, harder setting —
+   * see capExceeded.
+   *
+   * Same shapes as switchThreshold, per account:
+   *
+   *   "maxUsage": 0.6
+   *   "maxUsage": { "unified5h": 0.6, "unified7d": 0.6, "unified7dFable": 0.8 }
+   *
+   * Bucket keys are the quota field names (unified5h, unified7d, unified7dFable,
+   * unified7dSonnet, tokens, requests). A bare number caps every bucket; in the
+   * map form, a bucket that is neither listed nor covered by `default` is
+   * uncapped, so a cap is only ever what was asked for.
+   */
+  capFor(bucket, account) {
+    const m = account?.maxUsage;
+    if (typeof m === 'number' && Number.isFinite(m)) return m;
+    if (m && typeof m === 'object') {
+      const v = m[bucket] ?? m.default;
+      if (typeof v === 'number' && Number.isFinite(v)) return v;
+    }
+    return null;
+  }
+
+  /**
+   * The bucket that has reached this account's cap for `model`, or null.
+   *
+   * The shared buckets (unified5h, unified7d) cap every request; a family bucket
+   * caps only the family it meters, so a Fable cap stops Fable and leaves Opus
+   * alone. Both apply: a Fable request is capped by whichever binds first.
+   */
+  capExceeded(account, model = null) {
+    if (!account?.maxUsage) return null;
+    const q = account.quota;
+    // Same reason _isNearQuota does this first: a window that has already reset
+    // must not read as capped on a value that no longer applies.
+    this._clearExpiredQuotas(account);
+
+    const cap5h = this.capFor('unified5h', account);
+    if (cap5h != null && q.unified5h != null && q.unified5h >= cap5h) return 'unified5h';
+
+    // The shared weekly bucket caps every request, family requests included:
+    // family spend meters into BOTH its own bucket and the shared one (#175), so
+    // a budget written against the shared weekly is one that Fable can overrun
+    // if only the governing bucket is checked. This is not _isNearQuota's rule —
+    // a threshold gates on the governing bucket alone — but a threshold is a
+    // preference and a cap is a total.
+    const capWeekly = this.capFor('unified7d', account);
+    if (capWeekly != null && q.unified7d != null && q.unified7d >= capWeekly) return 'unified7d';
+
+    // …and on top of it, the family bucket that meters THIS model, when the
+    // family has one. A Fable cap stops Fable and leaves Opus alone.
+    const familyKey = this._weeklyBucketFor(model);
+    if (familyKey !== 'unified7d') {
+      const familyCap = this.capFor(familyKey, account);
+      const familyVal = q[familyKey];
+      if (familyCap != null && familyVal != null && familyVal >= familyCap) return familyKey;
+    }
+
+    const tokensCap = this.capFor('tokens', account);
+    if (tokensCap != null && q.tokensLimit != null && q.tokensRemaining != null
+      && 1 - q.tokensRemaining / q.tokensLimit >= tokensCap) return 'tokens';
+
+    const requestsCap = this.capFor('requests', account);
+    if (requestsCap != null && q.requestsLimit != null && q.requestsRemaining != null
+      && 1 - q.requestsRemaining / q.requestsLimit >= requestsCap) return 'requests';
+
+    return null;
+  }
+
+  /** The family weekly bucket that has reached its cap for `model`, or null.
+   * The advisor check needs this narrower form: the shared buckets were already
+   * decided for the executor model, and only the advisor's own family is new. */
+  _familyCapExceeded(account, model) {
+    if (!account?.maxUsage) return null;
+    const key = this._weeklyBucketFor(model);
+    if (key === 'unified7d') return null;
+    const cap = this.capFor(key, account);
+    const val = account.quota[key];
+    return cap != null && val != null && val >= cap ? key : null;
   }
 
   /** Start (or restart) the ramp window for an account that just became current,
@@ -795,6 +885,10 @@ export class AccountManager {
       // would just 429 again — so skip it (Fable/Sonnet) and let the caller emit
       // the synthetic 429 when no other account is available.
       if (model && this._modelWeeklyExhausted(account, model)) continue;
+      // A cap is the operator's own decision, not a reading that a live request
+      // might refresh, so the exhausted-fleet probe does not get to override it.
+      // Checked here rather than in _isProbeable because a cap is model-scoped.
+      if (this.capExceeded(account, model)) continue;
       // Same for routing/ownership: a probe for a routed or owned model must not
       // land on an ineligible account (it would just reject the unknown model id).
       if (model && !this._routeAllows(account, model)) continue;
@@ -840,6 +934,12 @@ export class AccountManager {
     // Manually disabled accounts are skipped entirely until re-enabled.
     if (account.disabled) return 'disabled';
 
+    // An operator budget cap. Checked here, above every transient state, because
+    // it is a decision rather than an estimate — and unlike the switch threshold
+    // nothing overrides it: _selectProbe skips a capped account too, so an
+    // account at its cap receives no requests at all.
+    if (this.capExceeded(account, model)) return 'capped';
+
     // A structured organization-policy 403 means this account cannot serve OAuth
     // requests right now. Skip it across requests until the short cooldown ends.
     if (this._entitlementDenied(account)) return false;
@@ -879,6 +979,7 @@ export class AccountManager {
     // already checked above for the executor) and any route/ownership rule for
     // it must allow this account.
     if (advisorModel) {
+      if (this._familyCapExceeded(account, advisorModel)) return 'advisor-capped';
       if (this._modelWeeklyExhausted(account, advisorModel)) return 'advisor-quota';
       if (!this._routeAllows(account, advisorModel)) return 'advisor-route';
     }
@@ -2065,6 +2166,7 @@ export class AccountManager {
         orgName: a.orgName || null,
         priority: a.priority || 0,
         disabled: a.disabled || false,
+        maxUsage: a.maxUsage ?? null,
         status: a.status,
         // Why the account is out of rotation right now (null = it can serve).
         // Distinguishes a local threshold decision from an upstream rejection —

--- a/src/model.js
+++ b/src/model.js
@@ -31,6 +31,20 @@ const FAMILY_WEEKLY_BUCKET = {
   sonnet: 'unified7dSonnet',
 };
 
+// A per-account usage cap (accounts[].maxUsage) for one quota bucket, or null
+// when that bucket is uncapped. Shapes mirror switchThreshold: a bare number
+// caps every bucket, a table caps the buckets it lists, and `default` covers the
+// rest. Lives here, beside the bucket keys, so the status renderer can draw a
+// cap without importing the account manager (it renders remote JSON too).
+export function resolveMaxUsage(maxUsage, bucket) {
+  if (typeof maxUsage === 'number' && Number.isFinite(maxUsage)) return maxUsage;
+  if (maxUsage && typeof maxUsage === 'object') {
+    const v = maxUsage[bucket] ?? maxUsage.default;
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
 // The weekly quota bucket key that governs a model, e.g. a Fable request is
 // gated by 'unified7dFable' rather than the shared 'unified7d'. Used by account
 // selection so a spent family bucket only bars that family's requests.

--- a/src/server.js
+++ b/src/server.js
@@ -1321,8 +1321,15 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // A pinned request (via /tc-acct/<name>) forces one exact account and never
   // rotates or fails over: once that account has been tried, `account` is null
   // and the caller gets the exhausted response rather than leaking to another.
+  // A cap outranks the pin. Rotation checks it through unavailableReason, but a
+  // pinned request never reaches that walk, and a budget a pin can spend past is
+  // not a budget. The request gets the exhausted response, exactly as it would
+  // for an already-tried pin — it still never leaks to another account.
+  const pinned = ctx.pinnedIndex != null && !ctx.tried.has(ctx.pinnedIndex)
+    ? accountManager.accounts[ctx.pinnedIndex]
+    : null;
   const account = ctx.pinnedIndex != null
-    ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
+    ? (pinned && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
     : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider);
   if (!account) {
     // Every candidate was refused by upstream (403). Waiting will not help — the

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -82,6 +82,8 @@ export const UNAVAILABLE_TEXT = {
   error: 'account error (see logs)',
   'upstream-rejected': 'upstream reports quota rejected',
   quota: 'local switch threshold reached',
+  capped: 'account usage cap reached (maxUsage)',
+  'advisor-capped': "advisor model's usage cap reached (maxUsage)",
   route: 'no route allows this account',
   'advisor-quota': "advisor model's weekly bucket spent",
   'advisor-route': 'no route allows the advisor model',

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -1,5 +1,5 @@
 import { formatMoney } from './oauth.js';
-import { findFamilyBlock, modelGlobOverlaps, gatingUtilization } from './model.js';
+import { findFamilyBlock, modelGlobOverlaps, gatingUtilization, resolveMaxUsage } from './model.js';
 import { safeLine } from './safe-text.js';
 
 const ESC = '\x1b[';
@@ -249,7 +249,19 @@ function modelRoutingLine(account, threshold, blocked, now, paint) {
   const q = account.quota || {};
   if (q.unified7dSonnet == null && q.unified7dFable == null) return null;
   const t = Number(threshold);
-  const fiveOver = q.unified5h != null && !Number.isNaN(t) && q.unified5h >= t;
+  const overThreshold = v => v != null && !Number.isNaN(t) && v >= t;
+  // A per-account cap is the other ceiling a family can be over. Without it a
+  // capped family reads ✓ on the very line that exists to say where a model can
+  // still run, right beside the Blocked line saying it cannot.
+  const overCap = (v, bucket) => {
+    const cap = resolveMaxUsage(account.maxUsage, bucket);
+    return cap != null && v != null && v >= cap;
+  };
+  // Blocks every family: the shared 5-hour bucket, and the shared weekly at its
+  // CAP — family spend meters into the shared bucket, so a cap written against
+  // it stops the families too (see AccountManager.capExceeded).
+  const sharedOver = overThreshold(q.unified5h) || overCap(q.unified5h, 'unified5h')
+    || overCap(q.unified7d, 'unified7d');
 
   const cell = (label, bucketKey, reset) => {
     // The blocklist outranks quota: a blocked family cannot be served however
@@ -258,9 +270,19 @@ function modelRoutingLine(account, threshold, blocked, now, paint) {
     if (findFamilyBlock(blocked, label)) {
       return `${label} ${paint.red('⊘')}${paint.dim(' blocked')}`;
     }
+    // Two different ceilings, deliberately read from two different values —
+    // this row mirrors routing, and routing does not treat them alike:
+    //   - the THRESHOLD gates on the governing value, the max of this family's
+    //     bucket and the shared weekly (#175), which is what _governingWeekly
+    //     hands the selector;
+    //   - the CAP is compared against the family's OWN spend, because that is
+    //     what AccountManager.capExceeded does. The shared weekly's own cap is
+    //     folded into `sharedOver` instead, so a family still inherits it.
+    // Using the governing value for the cap would redden Fable because Opus
+    // spent the shared weekly, which is not a decision the router made.
     const gating = gatingUtilization(q, bucketKey);
-    const weeklyOver = gating != null && !Number.isNaN(t) && gating >= t;
-    const mark = fiveOver || weeklyOver ? paint.red('✗') : paint.green('✓');
+    const weeklyOver = overThreshold(gating) || overCap(q[bucketKey] ?? null, bucketKey);
+    const mark = sharedOver || weeklyOver ? paint.red('✗') : paint.green('✓');
     // The recovery time is the LATEST reset among the two WEEKLY buckets
     // currently over the threshold, not this bucket's. The weekly half of the
     // mark comes from a maximum, so it only clears once BOTH weekly blockers
@@ -302,46 +324,64 @@ function quotaLines(account, now, paint) {
   const quota = account.quota || {};
   const lines = [];
 
+  // A configured cap (accounts[].maxUsage) is drawn on the bucket it caps, so the
+  // budget is visible before it binds rather than only as a Blocked line after.
+  const cap = bucket => resolveMaxUsage(account.maxUsage, bucket);
+
   if (quota.unified5h != null || quota.unified7d != null || quota.unified7dSonnet != null || quota.unified7dFable != null) {
-    lines.push(formatQuotaLine('Session', quota.unified5h, quota.unified5hReset, now, paint));
-    lines.push(formatQuotaLine('Weekly', quota.unified7d, quota.unified7dReset, now, paint));
+    lines.push(formatQuotaLine('Session', quota.unified5h, quota.unified5hReset, now, paint, cap('unified5h')));
+    lines.push(formatQuotaLine('Weekly', quota.unified7d, quota.unified7dReset, now, paint, cap('unified7d')));
     if (quota.unified7dSonnet != null) {
-      lines.push(formatQuotaLine('Sonnet', quota.unified7dSonnet, quota.unified7dSonnetReset, now, paint));
+      lines.push(formatQuotaLine('Sonnet', quota.unified7dSonnet, quota.unified7dSonnetReset, now, paint, cap('unified7dSonnet')));
     }
     if (quota.unified7dFable != null) {
-      lines.push(formatQuotaLine('Fable', quota.unified7dFable, quota.unified7dFableReset, now, paint));
+      lines.push(formatQuotaLine('Fable', quota.unified7dFable, quota.unified7dFableReset, now, paint, cap('unified7dFable')));
     }
     return lines;
   }
 
   if (quota.tokensLimit != null && quota.tokensRemaining != null) {
     const ratio = 1 - quota.tokensRemaining / quota.tokensLimit;
-    lines.push(formatQuotaLine('Tokens', ratio, quota.resetsAt, now, paint));
+    lines.push(formatQuotaLine('Tokens', ratio, quota.resetsAt, now, paint, cap('tokens')));
   }
   if (quota.requestsLimit != null && quota.requestsRemaining != null) {
     const ratio = 1 - quota.requestsRemaining / quota.requestsLimit;
-    lines.push(formatQuotaLine('Requests', ratio, quota.resetsAt, now, paint));
+    lines.push(formatQuotaLine('Requests', ratio, quota.resetsAt, now, paint, cap('requests')));
   }
   if (lines.length === 0) lines.push(`${paint.dim('Quota'.padEnd(8))} ${paint.gray('unknown')}`);
   return lines;
 }
 
-function formatQuotaLine(label, ratio, resetAt, now, paint) {
+function formatQuotaLine(label, ratio, resetAt, now, paint, cap = null) {
   const resetTs = parseTs(resetAt);
   const reset = resetTs && resetTs > now ? ` reset ${formatDuration(resetTs - now)}` : '';
-  return `${paint.dim(label.padEnd(8))} ${usageBar(ratio, paint)} ${formatPercent(ratio)}${reset}`;
+  // Name the cap in words as well as marking it on the bar: one bar cell is ~6%,
+  // so the mark alone cannot say 60% rather than 61%.
+  const reached = cap != null && ratio != null && Number(ratio) >= cap;
+  const capText = cap == null ? ''
+    : ` ${(reached ? paint.red : paint.yellow)(`cap ${formatPercent(cap)}`)}`;
+  return `${paint.dim(label.padEnd(8))} ${usageBar(ratio, paint, cap)} ${formatPercent(ratio)}${capText}${reset}`;
 }
 
-function usageBar(ratio, paint) {
+const BAR_WIDTH = 18;
+
+function usageBar(ratio, paint, cap = null) {
   if (ratio == null || Number.isNaN(Number(ratio))) return `[${paint.gray('??????????????????')}]`;
-  const width = 18;
+  const width = BAR_WIDTH;
   const safeRatio = Math.max(0, Math.min(1, Number(ratio)));
   const full = Math.round(safeRatio * width);
-  const fill = Array.from({ length: full }, (_, i) => {
+  const cells = Array.from({ length: width }, (_, i) => {
+    if (i >= full) return paint.gray('░');
     const [r, g, b] = gradientColor(i, width);
     return paint.rgb(r, g, b, '█');
-  }).join('');
-  return `[${fill}${paint.gray('░'.repeat(width - full))}]`;
+  });
+  // The cap sits where the bar may not pass. Drawn INSIDE the bar rather than
+  // inserted, so a capped row still lines up with an uncapped one.
+  if (cap != null && cap > 0 && cap < 1) {
+    const at = Math.min(width - 1, Math.round(cap * width));
+    cells[at] = (safeRatio >= cap ? paint.red : paint.yellow)('┃');
+  }
+  return `[${cells.join('')}]`;
 }
 
 function gradientColor(index, width) {

--- a/src/sync-accounts.js
+++ b/src/sync-accounts.js
@@ -67,6 +67,10 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     if (diskAcct.orgName && !mgr.orgName) mgr.orgName = diskAcct.orgName;
     if (diskAcct.name && mgr.name !== diskAcct.name) mgr.name = diskAcct.name;
     if (diskAcct.priority != null && mgr.priority !== diskAcct.priority) mgr.priority = diskAcct.priority;
+    // A cap edit applies live for the same reason priority does: it is an
+    // operator decision about a running fleet, and waiting for a restart to
+    // honour a budget defeats the budget.
+    mgr.maxUsage = diskAcct.maxUsage ?? null;
     // Third-party-backend bindings are read per request off this object
     // (`account.upstream || upstream`, `account.modelMap` in server.js), so a
     // disk edit must land here to take effect on reload. `|| null` mirrors the
@@ -84,6 +88,7 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     if (cfgAcct) {
       if (diskAcct.upstream) cfgAcct.upstream = diskAcct.upstream; else delete cfgAcct.upstream;
       if (diskAcct.modelMap) cfgAcct.modelMap = diskAcct.modelMap; else delete cfgAcct.modelMap;
+      if (diskAcct.maxUsage != null) cfgAcct.maxUsage = diskAcct.maxUsage; else delete cfgAcct.maxUsage;
     }
     // Pick up enable/disable toggles; re-enabling clears a stuck error state.
     const wantDisabled = !!diskAcct.disabled;

--- a/src/tui.js
+++ b/src/tui.js
@@ -11,6 +11,7 @@ import {
 import { configIndexFor, managerAccountFor } from './account-pairing.js';
 import { mintAccountId } from './account-id.js';
 import { formatPercent } from './status-renderer.js';
+import { resolveMaxUsage } from './model.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, describeSelfProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
 import { sanitizeText } from './safe-text.js';
 
@@ -1501,8 +1502,18 @@ export class TUI {
     // the weekly one lower than the 5-hour one); the attach-mode manager
     // mirrors thresholdFor, so both dashboards agree with the gate.
     const thFor = (k) => (typeof this.am.thresholdFor === 'function' ? this.am.thresholdFor(k) : this.am.switchThreshold);
-    const th1 = thFor(r1 === q.unified5h ? 'unified5h' : 'tokens');
-    const th2 = thFor(r2 === q.unified7d ? 'unified7d' : 'requests');
+    // A per-account cap (accounts[].maxUsage) is the lower ceiling when it is
+    // set, and it is the harder one — past it the account is sent nothing at
+    // all. Reddening at the cap keeps the bar honest about where this account
+    // actually stops. Read straight off the account so the attached dashboard,
+    // which has the payload but no AccountManager, agrees with the server.
+    const limFor = (k) => {
+      const cap = resolveMaxUsage(a.maxUsage, k);
+      const th = thFor(k);
+      return cap == null ? th : (typeof th === 'number' ? Math.min(th, cap) : cap);
+    };
+    const th1 = limFor(r1 === q.unified5h ? 'unified5h' : 'tokens');
+    const th2 = limFor(r2 === q.unified7d ? 'unified7d' : 'requests');
 
     let line = ` ${sel}${cur} ${startSlot}${name} ${type} ${status} ${l1} ${bar(r1, bw, t1, w1, th1)}`;
     if (showBoth) {
@@ -1510,18 +1521,22 @@ export class TUI {
       // Sonnet weekly bar — only shown when the usage probe has populated it. A
       // leading ► (in place of a padding space) marks a Sonnet route on this account.
       if (showFamily && q.unified7dSonnet != null) {
-        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, thFor('unified7dSonnet'))}`;
+        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, limFor('unified7dSonnet'))}`;
       }
       // Fable weekly bar — only shown when the usage probe has populated it.
       if (showFamily && q.unified7dFable != null) {
-        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, thFor('unified7dFable'))}`;
+        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, limFor('unified7dFable'))}`;
       }
     }
     // Explicit "disabled for these models" tag (issue #85): a family the account
     // can't serve even while it is otherwise active. A spent shared 5h blocks
     // everything and is already conveyed by the Ses bar + status, so it's not
     // repeated here.
-    const blocked = blockedFamilies(q, key => this.am.thresholdFor(key));
+    //
+    // limFor, not thresholdFor: it is min(per-bucket threshold, per-account cap),
+    // so the tag covers both ceilings and still judges each family against its
+    // OWN configured threshold.
+    const blocked = blockedFamilies(q, limFor);
     if (blocked.length) line += `  ${red('⊘ ' + blocked.join(' '))}`;
     // Money tag last, so it sits at the end of the row where the eye lands after
     // the bars. Red once real money has moved, yellow while it only could.

--- a/test/account-max-usage.test.js
+++ b/test/account-max-usage.test.js
@@ -1,0 +1,224 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+const OPUS = 'claude-opus-5';
+const FABLE = 'claude-fable-5-1';
+
+// The case the feature exists for: one account in a fleet is allowed to spend
+// only part of its quota, and must receive nothing past that point.
+function fleet(maxUsage) {
+  const am = new AccountManager([oauth('a'), oauth('capped', { maxUsage })], 0.98);
+  return am;
+}
+
+function setQuota(account, q) {
+  Object.assign(account.quota, q);
+}
+
+// ── capFor ───────────────────────────────────────────────────
+
+test('a bare number caps every bucket, a map caps the listed ones', () => {
+  const am = fleet(0.6);
+  const capped = am.accounts[1];
+  for (const b of ['unified5h', 'unified7d', 'unified7dFable', 'tokens']) {
+    assert.equal(am.capFor(b, capped), 0.6, b);
+  }
+
+  const am2 = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const c2 = am2.accounts[1];
+  assert.equal(am2.capFor('unified7d', c2), 0.6);
+  assert.equal(am2.capFor('unified7dFable', c2), 0.8);
+  // Not listed and no `default`: uncapped. A cap is only ever what was asked for.
+  assert.equal(am2.capFor('unified5h', c2), null);
+  // An account with no maxUsage at all is uncapped everywhere.
+  assert.equal(am2.capFor('unified7d', am2.accounts[0]), null);
+});
+
+test('`default` covers the buckets a map does not list', () => {
+  const am = fleet({ default: 0.5, unified7dFable: 0.8 });
+  const c = am.accounts[1];
+  assert.equal(am.capFor('unified5h', c), 0.5);
+  assert.equal(am.capFor('unified7dFable', c), 0.8);
+});
+
+// ── capExceeded: model scoping ───────────────────────────────
+
+test('a family cap stops that family and leaves the others alone', () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified5h: 0.1, unified7d: 0.2, unified7dFable: 0.8 });
+
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7dFable');
+  assert.equal(am.capExceeded(capped, OPUS), null);      // Opus is metered elsewhere
+  assert.equal(am.capExceeded(capped, null), null);
+});
+
+test('the session and weekly caps stop every model', () => {
+  const am = fleet({ unified5h: 0.6, unified7d: 0.6 });
+  const capped = am.accounts[1];
+
+  setQuota(capped, { unified5h: 0.6, unified7d: 0.1 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified5h');
+  assert.equal(am.capExceeded(capped, FABLE), 'unified5h');
+
+  setQuota(capped, { unified5h: 0.1, unified7d: 0.61 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+  // Family spend meters into the shared weekly too (#175), so a shared cap that
+  // Fable could walk past would not be a cap. This is where a cap parts company
+  // with switchThreshold, which gates on the governing bucket alone.
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+});
+
+test('the shared and family caps both apply to a family request', () => {
+  const am = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+
+  // Under both: serving.
+  setQuota(capped, { unified7d: 0.5, unified7dFable: 0.7 });
+  assert.equal(am.capExceeded(capped, FABLE), null);
+
+  // Family bucket alone is over: Fable stops, Opus keeps going.
+  setQuota(capped, { unified7d: 0.5, unified7dFable: 0.8 });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7dFable');
+  assert.equal(am.capExceeded(capped, OPUS), null);
+
+  // Shared bucket alone is over: everything stops, Fable included.
+  setQuota(capped, { unified7d: 0.6, unified7dFable: 0.1 });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+});
+
+// An unreported family bucket used to fall back to the shared VALUE while being
+// compared against the FAMILY cap — 60% of the shared weekly read as under an
+// 80% Fable cap, and the request went through.
+test('an unreported family bucket does not escape the shared cap', () => {
+  const am = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.6, unified7dFable: null });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+});
+
+// The cap is a ceiling, not a target: at exactly the configured level the
+// account is done, matching how switchThreshold reads (>=).
+test('the cap binds at the configured level, not past it', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.59 });
+  assert.equal(am.capExceeded(capped, OPUS), null);
+  setQuota(capped, { unified7d: 0.6 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+});
+
+test('a window that has already reset is not capped on a stale reading', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.9, unified7dReset: Date.now() - 1000 });
+  assert.equal(am.capExceeded(capped, OPUS), null);
+  assert.equal(capped.quota.unified7d, null);
+});
+
+// ── selection: zero requests past the cap ────────────────────
+
+test('a capped account is not selected and says why', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.7 });
+  am.currentIndex = 1;
+
+  assert.equal(am.unavailableReason(capped, OPUS), 'capped');
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'a');
+});
+
+// The whole point of the setting. switchThreshold is a preference the
+// exhausted-fleet probe deliberately overrides; a budget is not.
+test('the exhausted-fleet probe does not override a cap', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const [normal, capped] = am.accounts;
+  setQuota(normal, { unified7d: 0.99 });      // over the switch threshold
+  setQuota(capped, { unified7d: 0.7 });       // over its own cap
+
+  // Every account is out: the normal one may still be probed, the capped one
+  // must not be. With the normal account excluded, nothing is left at all.
+  assert.equal(am.getActiveAccount(new Set([normal.index]), OPUS), null);
+});
+
+test('a capped account still serves the models its cap does not meter', () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7dFable: 0.9 });
+  am.currentIndex = 1;
+
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'a');
+  // Selection stays on whichever account it just moved to, so put it back
+  // before asking the other question (as the Fable-exhaustion test does).
+  am.currentIndex = 1;
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'capped');
+});
+
+test("an advisor model's cap is checked too", () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7dFable: 0.85 });
+  // Executing Opus while advising with Fable still touches the capped bucket.
+  assert.equal(am.unavailableReason(capped, OPUS, FABLE), 'advisor-capped');
+});
+
+test('an uncapped fleet behaves exactly as before', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  setQuota(am.accounts[0], { unified7d: 0.7, unified7dFable: 0.9 });
+  assert.equal(am.capExceeded(am.accounts[0], FABLE), null);
+  assert.equal(am.unavailableReason(am.accounts[0], FABLE), null);
+});
+
+test('the cap is visible in status output', () => {
+  const am = fleet({ unified7d: 0.6 });
+  setQuota(am.accounts[1], { unified7d: 0.7 });
+  const status = am.getStatus();
+  assert.deepEqual(status.accounts[1].maxUsage, { unified7d: 0.6 });
+  assert.equal(status.accounts[1].unavailable, 'capped');
+  assert.equal(status.accounts[0].maxUsage, null);
+});
+
+// ── the pinned path ──────────────────────────────────────────
+
+// A pinned request never enters the selection walk, so the cap has to be
+// enforced where the pin is resolved. Without this, `TC_ACCT` (or a
+// /tc-acct/<name> URL) would spend straight past a budget.
+test('a pinned request to a capped account reaches no upstream at all', async () => {
+  const http = await import('node:http');
+  const { createProxyServer } = await import('../src/server.js');
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise(r => upstream.listen(0, '127.0.0.1', r));
+
+  const am = new AccountManager([oauth('alpha'), oauth('beta', { maxUsage: { unified7d: 0.6 } })], 0.98);
+  setQuota(am.accounts[1], { unified7d: 0.7 });
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstream.address().port}`,
+  });
+  await new Promise(r => proxy.listen(0, '127.0.0.1', r));
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxy.address().port}/tc-acct/beta/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 429);      // the exhausted answer, as for a spent pin
+    assert.deepEqual(seen, []);         // and nothing was sent, to beta or anyone else
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -221,3 +221,61 @@ test('renderStatus still lists accounts for a route the blocklist does not cover
   const output = renderStatus(status, { color: false, now });
   assert.match(output, /\*sonnet\*\s+→ a \(auto\)/);
 });
+
+// ── per-account usage caps (accounts[].maxUsage) ──────────────
+
+function cappedStatus(quota, maxUsage) {
+  return {
+    currentAccount: 'a',
+    switchThreshold: 0.98,
+    accounts: [{
+      name: 'a', type: 'oauth', priority: 0, status: 'active',
+      quota, maxUsage, usage: {},
+    }],
+  };
+}
+
+test('renderStatus marks the cap on the bar and names it', () => {
+  const out = renderStatus(cappedStatus({ unified5h: 0.1, unified7d: 0.1 },
+    { unified5h: 0.6, unified7d: 0.6 }), { color: false, now });
+  // The mark sits where the bar may not pass, and the number says which percent
+  // it is — one cell is ~6%, so the mark alone cannot tell 60% from 61%.
+  assert.match(out, /Session\s+\[██░░░░░░░░░┃░░░░░░\] 10% cap 60%/);
+});
+
+test('a capped bar is the same width as an uncapped one', () => {
+  const capped = renderStatus(cappedStatus({ unified7d: 0.1 }, { unified7d: 0.6 }), { color: false, now });
+  const plain = renderStatus(cappedStatus({ unified7d: 0.1 }, null), { color: false, now });
+  const width = out => out.match(/Weekly\s+\[([^\]]*)\]/)[1].length;
+  assert.equal(width(capped), width(plain));   // rows still line up
+  assert.doesNotMatch(plain, /cap /);          // and nothing is drawn without a cap
+});
+
+test('an uncapped bucket on a capped account is left alone', () => {
+  const out = renderStatus(cappedStatus({ unified5h: 0.1, unified7d: 0.1 },
+    { unified7d: 0.6 }), { color: false, now });
+  assert.match(out, /Session\s+\[██░░░░░░░░░░░░░░░░\] 10%$/m);
+  assert.match(out, /Weekly\s+.*cap 60%/);
+});
+
+test('a family over its cap reads ✗ while the others keep serving', () => {
+  const out = renderStatus(cappedStatus(
+    { unified5h: 0.1, unified7d: 0.1, unified7dFable: 0.85 },
+    { unified7d: 0.6, unified7dFable: 0.8 }), { color: false, now });
+  assert.match(out, /Models\s+Opus ✓\s+Fable ✗/);
+});
+
+// The shared weekly bucket meters family spend too, so a cap on it stops every
+// family — the Models line must not advertise one as available.
+test('a shared weekly cap marks every family unavailable', () => {
+  const out = renderStatus(cappedStatus(
+    { unified5h: 0.1, unified7d: 0.62, unified7dFable: 0.1 },
+    { unified7d: 0.6, unified7dFable: 0.8 }), { color: false, now });
+  assert.match(out, /Models\s+Opus ✗\s+Fable ✗/);
+});
+
+test('the blocked line names the cap as the reason', () => {
+  const status = cappedStatus({ unified7d: 0.7 }, { unified7d: 0.6 });
+  status.accounts[0].unavailable = 'capped';
+  assert.match(renderStatus(status, { color: false, now }), /Blocked\s+account usage cap reached \(maxUsage\)/);
+});


### PR DESCRIPTION
`switchThreshold` answers "when should the fleet prefer another account". It cannot answer "this account may spend only 60% of its weekly", for two reasons: it is fleet-wide, and it is a preference rather than a limit — when every account is over it, `_selectProbe` sends one request anyway, on purpose, because a threshold decision can rest on a stale reading and refusing forever is worse than revalidating.

That is right for a rotation threshold and wrong for a budget. A cap the probe path can step over is not a cap.

<img width="479" height="124" alt="image" src="https://github.com/user-attachments/assets/b13656dc-71ae-4dba-941e-13bc59212358" />

## The setting

```json
{
  "name": "spare@example.com",
  "maxUsage": { "unified5h": 0.6, "unified7d": 0.6, "unified7dFable": 0.8 }
}
```

Same two shapes as `switchThreshold`. A bare number caps every bucket. In a table, `default` covers the buckets that are not listed, and a bucket covered by neither is **uncapped** — a cap is only ever what was asked for, so adding one bucket never quietly constrains the rest.

Keys are the quota field names, which makes a cap model-scoped exactly like a threshold: `unified5h` and `unified7d` stop every model, `unified7dFable` stops Fable alone. The example keeps serving Opus and Sonnet from that account after its Fable budget is gone.

## What "capped" means

At the cap the account receives nothing:

- `unavailableReason` returns `capped`, or `advisor-capped` when it is the advisor model's family that is over. It is checked above every transient state, because a cap is a decision, not an estimate — and status names it, as #166 asked of every other local refusal.
- `_selectProbe` skips it. This is the point of the feature.
- a pinned request (`TC_ACCT`, `/tc-acct/<name>`) is answered with the exhausted response rather than spending past the cap. A pinned request never enters the selection walk, so a budget that only rotation enforced would be one `TC_ACCT` away from being ignored. The pin still never leaks to another account, and nothing changes for an uncapped one.

## Why a new key rather than a per-account `switchThreshold`

Both would compare a bucket to a number, but they mean opposite things about the probe path, and one key that hardens depending on where it is written is worse than two keys that each say what they do. `switchThreshold` keeps its current meaning everywhere.

## Details

- `capExceeded` clears expired windows first, so an account whose window has already reset is never capped on the reading that reset invalidated.
- An account with no `maxUsage` takes an early return; the uncapped path is unchanged, which the "behaves exactly as before" test pins.
- Edits apply live on reload, mirrored onto the memConfig entry like `upstream`/`modelMap` so a later TUI save cannot revert a hand edit.
- `getStatus` reports `maxUsage` per account.

13 tests in `test/account-max-usage.test.js`: resolution (number, table, `default`, unlisted), model scoping, the `>=` boundary, the reset-window case, rotation skipping, the probe path not overriding, an advisor model's family, an uncapped fleet, status output, and an end-to-end pinned request proving no upstream call is made.

`npm test` 871 pass, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
