### PR TITLE
fix(log): keep control characters out of the terminal and activity log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ import { RemoteControl, createAttachSession } from './tui-remote.js';
 import { SxManager } from './sx.js';
 import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG_NAME } from './updater.js';
 import { renderStatus } from './status-renderer.js';
+import { sanitizeText } from './safe-text.js';
 import { ClientUsageTracker } from './client-usage.js';
 import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
@@ -400,8 +401,11 @@ async function serverCommand() {
     aStream.on('error', err => process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`));
     const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
     const writeActivity = msg => {
-      // Strip [TeamClaude] prefix to match TUI behaviour
-      aStream.write(`${ts()}  ${msg.replace(/^\[TeamClaude\]\s*/, '')}\n`);
+      // Strip [TeamClaude] prefix to match TUI behaviour. Sanitized because a
+      // log line is one line: a value carrying a newline would otherwise write
+      // a second entry that reads as genuine, and this file is what deployments
+      // join against to attribute traffic to a person.
+      aStream.write(`${ts()}  ${sanitizeText(msg.replace(/^\[TeamClaude\]\s*/, ''))}\n`);
     };
     // Capture request completions via the hook
     const inFlight = new Map();

--- a/src/safe-text.js
+++ b/src/safe-text.js
@@ -1,0 +1,36 @@
+// One decision about what may reach an operator's terminal or a log file.
+//
+// Not every value that ends up there is ours. A pin segment is percent-encoded
+// by the client and decoded here; an account name comes from an OAuth payload;
+// a session title is read out of a transcript on disk. A control character in
+// any of them is not cosmetic:
+//
+//   - an escape sequence repositions, colours, or clears the operator's
+//     terminal when the value is rendered or the log is `cat`ed;
+//   - a newline forges a whole log line. That is the one that matters, because
+//     the activity log is what a deployment joins against to attribute traffic
+//     to a person — a line an attacker can write is a line that can name
+//     somebody else.
+//
+// So it is stripped once at the boundary, rather than at each interpolation
+// where the next new field will forget to.
+
+// SGR is only one of the escape forms: `\x1b[2J` (erase) and `\x1b[1;1H`
+// (cursor home) are CSI sequences with a final byte outside `m`, so a
+// colour-only strip lets them through. `\p{C}` then covers the rest —
+// C0/C1 controls (including \n and \r), and format characters such as U+202E.
+const CONTROL = /\x1b\[[0-?]*[ -/]*[@-~]|\p{C}/gu;
+
+/**
+ * Strip escape sequences and control characters, collapsing the whitespace they
+ * leave behind so a stripped value cannot pad a column or split a line.
+ */
+export function sanitizeText(value) {
+  return String(value).replace(CONTROL, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/** sanitizeText, bounded — for a value rendered into a fixed-width column. */
+export function safeLine(value, max = 120) {
+  const cleaned = sanitizeText(value);
+  return cleaned.length > max ? cleaned.slice(0, max) : cleaned;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import { BodyWriter, truncationNote } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
+import { safeLine } from './safe-text.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -597,7 +598,9 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         try { token = decodeURIComponent(raw); } catch { token = null; }
         pinnedIndex = token == null ? null : resolveAccountPin(accountManager, token);
         if (pinnedIndex == null) {
-          const shown = token ?? raw;
+          // Client-supplied and already percent-decoded, so this is the one
+          // value on the path that can carry raw control bytes.
+          const shown = safeLine(token ?? raw);
           const reqId = ++counter;
           const sessionId = req.headers['x-claude-code-session-id'] || null;
           if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${shown}")`, status: 404, model: null, sessionId, pinned: false });
@@ -619,7 +622,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         if (pinnedIndex == null) {
           const reqId = ++counter;
           const sessionId = req.headers['x-claude-code-session-id'] || null;
-          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${forcedPin}")`, status: 404, model: null, sessionId, pinned: false });
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${safeLine(forcedPin)}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${forcedPin}" (from TC_ACCT)` } }));
           return;

--- a/src/session-titles.js
+++ b/src/session-titles.js
@@ -20,6 +20,7 @@ import { readdir, readFile, open } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { SESSION_KNOWN_TTL_MS } from './session-tracker.js';
+import { sanitizeText } from './safe-text.js';
 
 const DEFAULT_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
 
@@ -216,6 +217,6 @@ function isSessionId(value) {
  *  is an injection. Each becomes a space and runs of whitespace collapse. */
 function cleanTitle(value) {
   if (typeof value !== 'string') return null;
-  const cleaned = value.replace(/\p{Cc}/gu, ' ').replace(/\s+/g, ' ').trim();
+  const cleaned = sanitizeText(value);
   return cleaned || null;
 }

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -1,4 +1,5 @@
 import { findFamilyBlock, modelGlobOverlaps } from './model.js';
+import { safeLine } from './safe-text.js';
 
 const ESC = '\x1b[';
 const RESET = `${ESC}0m`;
@@ -307,10 +308,6 @@ function formatAccountProbe(accountName, probe, now, paint) {
   const duration = typeof row.durationMs === 'number' ? `, ${Math.round(row.durationMs)}ms` : '';
   const error = row.error ? `, ${safeLine(row.error)}` : '';
   return `${status}${when}${duration}${error}`;
-}
-
-function safeLine(value) {
-  return String(value).replace(/\x1b\[[0-?]*[ -/]*[@-~]|\p{C}/gu, ' ').replace(/\s+/g, ' ').trim().slice(0, 120);
 }
 
 function formatUsage(usage = {}, now) {

--- a/src/tui.js
+++ b/src/tui.js
@@ -8,6 +8,7 @@ import {
 } from './identity.js';
 import { formatPercent } from './status-renderer.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, describeSelfProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
+import { sanitizeText } from './safe-text.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -484,7 +485,9 @@ export class TUI {
     const t = timestamp();
     this.log.unshift({ t, msg });
     if (this.log.length > 200) this.log.length = 200;
-    if (this._activityStream) this._activityStream.write(`${t}  ${strip(msg)}\n`);
+    // sanitizeText, not `strip`: the latter removes SGR colour only, so an
+    // erase or cursor-move sequence reached the file, as did a newline.
+    if (this._activityStream) this._activityStream.write(`${t}  ${sanitizeText(msg)}\n`);
     if (this.running) this.render();
   }
 

--- a/test/safe-text.test.js
+++ b/test/safe-text.test.js
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+import { sanitizeText, safeLine } from '../src/safe-text.js';
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+test('sanitizeText removes every escape form, not just colour', () => {
+  // A colour-only strip (/\x1b\[[0-9;]*m/) lets these through: their final byte
+  // is not `m`, which is exactly what makes them able to move the cursor and
+  // erase what is already on screen.
+  assert.equal(sanitizeText('a\x1b[2Jb'), 'a b');
+  assert.equal(sanitizeText('a\x1b[1;1Hb'), 'a b');
+  assert.equal(sanitizeText('a\x1b[31mb'), 'a b');
+  // C1 CSI, the single-byte form of the same thing.
+  assert.equal(sanitizeText('a\x9bb'), 'a b');
+  // Newline and carriage return: the line-forging pair.
+  assert.equal(sanitizeText('a\nb\r\nc'), 'a b c');
+  // Bidi override, which reorders how the rest of the line reads.
+  assert.equal(sanitizeText('a‮b'), 'a b');
+  assert.equal(sanitizeText('  spaced   out  '), 'spaced out');
+  assert.equal(sanitizeText('\x00\x1b\x7f'), '');
+});
+
+test('safeLine bounds the result for a fixed-width column', () => {
+  assert.equal(safeLine('x'.repeat(300)).length, 120);
+  assert.equal(safeLine('x'.repeat(300), 10), 'x'.repeat(10));
+  assert.equal(safeLine('short'), 'short');
+});
+
+test('an unresolvable pin cannot forge a line in the activity log', async () => {
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'acct', type: 'api_key', apiKey: 'sk-a' }], 0.98);
+
+  // The activity log's own shape: one line per completed request. Mirrors the
+  // headless writer in index.js.
+  const lines = [];
+  const inFlight = new Map();
+  const hooks = {
+    onRequestStart: (id, info) => inFlight.set(id, info),
+    onRequestEnd: (id, info) => {
+      inFlight.delete(id);
+      lines.push(`${info.method} ${info.path} → ${info.account} (${info.status})`);
+    },
+  };
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` }, hooks);
+  const port = await listen(proxy);
+
+  try {
+    // The pin segment is percent-decoded by the proxy, so the client controls
+    // the bytes that reach the message — including ESC and newline.
+    const erase = '%1b%5b2J%1b%5b1;1H';
+    const forged = '%0a12:00:00  [someone-else] POST v1 messages';
+    for (const pin of [erase, forged]) {
+      const res = await fetch(`http://127.0.0.1:${port}/tc-acct/${pin}/v1/messages`, { method: 'POST', body: '{}' });
+      assert.equal(res.status, 404);
+      await res.text();
+    }
+
+    assert.equal(lines.length, 2);
+    for (const line of lines) {
+      assert.doesNotMatch(line, /\x1b/, 'no escape byte reaches the log');
+      assert.doesNotMatch(line, /[\r\n]/, 'a log line stays one line');
+    }
+    // The text survives, only its control bytes are gone — the operator can
+    // still see what was attempted.
+    assert.match(lines[1], /someone-else/);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});

--- a/test/session-titles.test.js
+++ b/test/session-titles.test.js
@@ -200,7 +200,9 @@ test('an upper-case UUID is still a session id', async () => {
 test('control characters in a title become spaces', async () => {
   const dir = await projects({ sidecar: JSON.stringify({ customTitle: 'adv\x1b[31m-review\r\nrewrite\x00\x7f\x9b!' }) });
   const titles = new SessionTitles({ enabled: true, projectsDir: dir });
-  assert.equal(await titles.resolve(SID), 'adv [31m-review rewrite !');
+  // The whole CSI sequence goes, not just its ESC byte: stripping the escape
+  // alone used to leave the literal '[31m' behind in the title.
+  assert.equal(await titles.resolve(SID), 'adv -review rewrite !');
 });
 
 test('a title made only of control characters is no title', async () => {


### PR DESCRIPTION
Found while security-reviewing the 1.1.13 → 1.1.14 delta before deploying it. Not a regression from that delta — it is reachable on 1.1.13 too — and independent of #188/#194, so this branches straight off master.

## The problem

The `/tc-acct/<pin>/` segment is percent-decoded before it is reported, so a client chooses the bytes that reach the unknown-pin message. That message is rendered in the TUI and appended to the activity log, and neither sink removed control characters:

- the TUI wrote the file through `strip`, which is SGR-only (`/\x1b\[[0-9;]*m/`), so `\x1b[2J` (erase) and `\x1b[1;1H` (cursor home) passed through — their final byte is not `m`, which is exactly what lets them move the cursor and erase what is on screen;
- the headless writer in `index.js` applied no filtering at all.

Reproduced against the real modules:

```
GET /tc-acct/%1b%5b2J%1b%5b1;1HPWNED/v1/messages
  → (unknown pin: "<real ESC>[2J<real ESC>[1;1HPWNED")
```

The screen-clearing is the less interesting half. A decoded `%0a` writes a **second line that reads exactly like a genuine entry**, attributed to whichever client the sender names:

```
POST /tc-acct/... → (unknown pin: "
12:00:00  [another-client] POST ") (404)
```

That matters because a deployment using `proxy.clientKeys` joins the activity log against nginx logs to attribute traffic to a person. A line an attacker can write is a line that can name somebody else — and the same request can erase the surrounding context when an operator views the file.

Preconditions are low: one HTTP request bearing any accepted proxy key, or loopback.

## The fix

One sanitizer decides what may reach a terminal or a log file, applied at the source (the decoded pin — both the URL and `TC_ACCT` forms) and again at each file sink, so the next field added to a log line does not have to remember.

- `status-renderer` keeps its existing behaviour; its local `safeLine` **was** this function, now shared rather than duplicated.
- `session-titles` moves onto it too, which widens `\p{Cc}` to `\p{C}` there and so also drops a bidi override read out of a transcript title.
- The TUI's own colouring is untouched — only the activity-file write is sanitized, not the in-memory pane.

## One existing expectation changes

`control characters in a title become spaces` asserted `adv [31m-review`: the ESC byte removed, the literal `[31m` left behind in the title. The whole sequence is now removed and it reads `adv -review`. Flagging it explicitly since a passing test was edited.

## Testing

`npm run lint` and `npm test` (861 tests). New `test/safe-text.test.js` covers each escape form, the C1 single-byte CSI, the bidi override, and drives both payloads end to end through a real proxy asserting no `\x1b` and no `[\r\n]` reaches a log line — while the text itself survives, so the operator can still see what was attempted.
