### PR TITLE
Add integrated Git deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 config.json
 *.log
 package-lock.json
+.env.local
+.planning/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Step-by-step lifecycle: [docs/routing.md](docs/routing.md#request-lifecycle).
 | [Routing](docs/routing.md) | Rotation, the two kinds of 429, storm control, model routes, session spreading, pinning, prompt cache |
 | [Quota](docs/quota.md) | Quota probe, keep-warm, holding on exhaustion |
 | [Configuration](docs/configuration.md) | Config format, every field, environment variables, network tuning |
+| [Git deployment](docs/deployment.md) | Release worktrees, branch switching, systemd, rollback, and operations |
 | [Proxy modes](docs/proxy-modes.md) | MITM forward proxy, sx.org residential egress |
 | [Compliance](docs/compliance.md) | Terms of service notes |
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Step-by-step lifecycle: [docs/routing.md](docs/routing.md#request-lifecycle).
 | [Routing](docs/routing.md) | Rotation, the two kinds of 429, storm control, model routes, session spreading, pinning, prompt cache |
 | [Quota](docs/quota.md) | Quota probe, keep-warm, holding on exhaustion |
 | [Configuration](docs/configuration.md) | Config format, every field, environment variables, network tuning |
-| [Git deployment](docs/deployment.md) | Release worktrees, branch switching, systemd, rollback, and operations |
+| [Git deployment](docs/deployment.md) | Integrated Linux/macOS install, ref switching, rollback, logs, and safe uninstall |
 | [Proxy modes](docs/proxy-modes.md) | MITM forward proxy, sx.org residential egress |
 | [Compliance](docs/compliance.md) | Terms of service notes |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,291 @@
+# Git deployment
+
+This page describes the release-based Linux deployment used for running a
+TeamClaude Git fork behind systemd. It supports switching between remote
+branches, tags, and commits while keeping the last healthy release available
+for rollback.
+
+This is different from the global npm installation described in the quick
+start. The deployment helper is currently installed by the server operator; it
+is **not** included in the `@karpeleslab/teamclaude` npm package.
+
+## What is installed
+
+The deployment uses these paths:
+
+```text
+/opt/teamclaude/
+├── repo/                    # persistent clone of the Git fork
+├── releases/                # detached worktrees, one per deployment
+├── current -> releases/...  # active, last successfully deployed release
+└── previous -> releases/... # release that was active before current
+
+/etc/systemd/system/teamclaude.service
+/usr/local/bin/teamclaude
+/usr/local/sbin/teamclaude-deploy
+/usr/local/libexec/teamclaude-node
+```
+
+The `teamclaude` command is a small wrapper around the active
+`current/src/index.js`. The service and terminal command therefore use the same
+code. `teamclaude-node` points at the absolute Node.js executable selected when
+the deployment was installed.
+
+The account configuration and runtime quota state stay outside Git:
+
+```text
+/root/.config/teamclaude.json
+/root/.config/teamclaude.state.json
+```
+
+Deploying another ref does not replace either file.
+
+## Requirements
+
+- Linux with systemd
+- Git
+- Node.js 20 or newer
+- A remote Git repository reachable by the VPS
+- A valid TeamClaude config containing at least one account
+- Root access for updating the system service
+
+The reference deployment uses an NVM Node installation. The systemd unit keeps
+the matching NVM directory on `PATH`, so TeamClaude can also find programs such
+as `claude` when it launches them.
+
+## Everyday commands
+
+Show the active proxy status:
+
+```bash
+teamclaude status
+```
+
+Follow service logs:
+
+```bash
+journalctl -u teamclaude.service -f
+```
+
+Restart the active release without changing it:
+
+```bash
+systemctl restart teamclaude.service
+```
+
+Check service startup configuration:
+
+```bash
+systemctl is-enabled teamclaude.service
+systemctl is-active teamclaude.service
+systemctl show teamclaude.service -p ExecStart -p WorkingDirectory
+```
+
+An enabled system-level unit under `multi-user.target` starts the selected
+`current` release after a VPS reboot.
+
+## Deploy a branch, tag, or commit
+
+Deploy the default branch:
+
+```bash
+teamclaude-deploy master
+```
+
+Deploy another remote branch:
+
+```bash
+teamclaude-deploy my-feature
+```
+
+Deploy a tag or commit:
+
+```bash
+teamclaude-deploy v1.2.0
+teamclaude-deploy 0123456789abcdef
+```
+
+A local development branch must be pushed to the configured `origin` before
+the VPS can deploy it:
+
+```bash
+git push -u origin my-feature
+ssh root@your-vps teamclaude-deploy my-feature
+```
+
+The helper performs the following sequence:
+
+1. Fetches branches and tags from `origin`.
+2. Resolves the requested ref to an immutable commit.
+3. Creates a detached worktree below `/opt/teamclaude/releases`.
+4. Runs the complete Node test suite.
+5. Records the old `current` release as `previous`.
+6. Atomically switches `current` to the candidate.
+7. Restarts `teamclaude.service`.
+8. Checks both systemd state and `teamclaude status`.
+
+Fetch, ref-resolution, worktree, or test failures leave the running release
+untouched. A failed service health check switches `current` back to the former
+release and restarts it automatically. The command exits non-zero whenever the
+candidate was not activated.
+
+The restart creates a short interruption, normally a few seconds. A reverse
+proxy may remain online during that interval, but requests reaching TeamClaude
+can fail until the health check passes.
+
+## Inspect the active and previous releases
+
+```bash
+readlink -f /opt/teamclaude/current
+git -C /opt/teamclaude/current rev-parse HEAD
+
+readlink -f /opt/teamclaude/previous
+git -C /opt/teamclaude/previous rev-parse HEAD
+```
+
+Confirm Git provenance:
+
+```bash
+git -C /opt/teamclaude/current remote get-url origin
+git -C /opt/teamclaude/current log -1 --oneline
+```
+
+## Roll back
+
+The normal rollback is another tested deployment of a known-good ref:
+
+```bash
+teamclaude-deploy <known-good-branch-tag-or-commit>
+```
+
+If the Git remote is unavailable and an emergency rollback is required, point
+`current` at the already-tested `previous` worktree and restart the service:
+
+```bash
+previous="$(readlink -f /opt/teamclaude/previous)"
+test -n "$previous"
+test -f "$previous/src/index.js"
+ln -s "$previous" "/opt/teamclaude/current.next.$$"
+mv -Tf "/opt/teamclaude/current.next.$$" /opt/teamclaude/current
+systemctl restart teamclaude.service
+teamclaude status
+```
+
+Always verify status after a manual rollback. The deployment helper is preferred
+because it also runs tests, records the release transition, and performs health
+verification.
+
+## Reverse proxy
+
+TeamClaude listens on the loopback address by default. A typical nginx upstream
+is:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:3456;
+}
+```
+
+Keep the TeamClaude listener on loopback when nginx is the only public entry
+point. If TeamClaude is bound to a non-loopback interface instead, configure
+`proxy.apiKey`; remote clients must not have unauthenticated access to a proxy
+that injects account credentials.
+
+An HTTP `401 Unauthorized` from the public nginx endpoint can be the expected
+result when nginx authentication is enabled. Check the local TeamClaude status
+separately to distinguish proxy authentication from an unhealthy application:
+
+```bash
+teamclaude status
+curl -fsS http://127.0.0.1:3456/teamclaude/status
+```
+
+## Logs and troubleshooting
+
+Show recent service failures:
+
+```bash
+systemctl status teamclaude.service --no-pager
+journalctl -u teamclaude.service -n 100 --no-pager
+```
+
+Validate the installed unit and deployment script:
+
+```bash
+systemd-analyze verify /etc/systemd/system/teamclaude.service
+bash -n /usr/local/sbin/teamclaude-deploy
+```
+
+If a ref cannot be resolved:
+
+```bash
+git -C /opt/teamclaude/repo fetch --prune --tags origin
+git -C /opt/teamclaude/repo branch -r
+git -C /opt/teamclaude/repo tag --list
+```
+
+If a deployment stops at the test step, run the same suite in the candidate
+release shown in its output:
+
+```bash
+cd /opt/teamclaude/releases/<candidate-release>
+/usr/local/libexec/teamclaude-node --test --test-timeout=120000
+```
+
+If the terminal cannot find `teamclaude-deploy`, verify whether
+`/usr/local/sbin` is on `PATH`:
+
+```bash
+command -v teamclaude-deploy
+print -r -- $path  # zsh
+```
+
+For zsh, add it when necessary:
+
+```zsh
+path=(/usr/local/sbin $path)
+export PATH
+```
+
+The reference VPS uses Bash as root's login shell. Zsh must be installed and
+configured separately if it is preferred.
+
+## Backups and old releases
+
+The initial migration stores the former systemd and nginx files below:
+
+```text
+/root/teamclaude-migration-backup/<UTC timestamp>/
+```
+
+Do not delete `current` or `previous`. Older detached worktrees can be listed
+and removed explicitly:
+
+```bash
+git -C /opt/teamclaude/repo worktree list
+git -C /opt/teamclaude/repo worktree remove /opt/teamclaude/releases/<old-release>
+git -C /opt/teamclaude/repo worktree prune
+```
+
+Check both symlink targets before removing an old release.
+
+## npm packaging status
+
+The current npm package contains `src/` and exposes one binary:
+
+```json
+{
+  "bin": {
+    "teamclaude": "src/index.js"
+  }
+}
+```
+
+Consequently, `npm install -g @karpeleslab/teamclaude` does not install
+`teamclaude-deploy`, the Git release layout, or the systemd unit. Adding that
+behavior upstream requires a separately designed cross-platform installer or
+additional npm binary. Until such a feature is released, treat
+`teamclaude-deploy` as operator-managed VPS tooling.
+
+Installing the global npm package is unnecessary for this layout. The service
+and `teamclaude` wrapper both run the source selected by `current`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,184 +1,242 @@
 # Git deployment
 
-This page describes the release-based Linux deployment used for running a
-TeamClaude Git fork behind systemd. It supports switching between remote
-branches, tags, and commits while keeping the last healthy release available
-for rollback.
+TeamClaude can replace a regular global npm installation with a persistent Git
+deployment. Each deployed branch, tag, or commit becomes an immutable release;
+the service and the `teamclaude` terminal command both run the selected release.
 
-This is different from the global npm installation described in the quick
-start. The deployment helper is currently installed by the server operator; it
-is **not** included in the `@karpeleslab/teamclaude` npm package.
+The deployment command is part of the normal TeamClaude binary. There is no
+separate `teamclaude-deploy` package or second npm executable.
 
-## What is installed
+## Quick start
 
-The deployment uses these paths:
+Install TeamClaude and create a usable account configuration first:
+
+```bash
+npm install -g @karpeleslab/teamclaude
+teamclaude login                 # or: teamclaude import
+teamclaude deploy install https://github.com/OWNER/teamclaude.git --ref master
+```
+
+`deploy install` checks the existing config, Git, Node.js, the remote URL, and
+the requested ref before writing the deployment. It then clones or adopts the
+repository, creates a detached candidate release, runs the complete test suite,
+installs a boot-persistent service, checks service and application health, and
+finally hands the `teamclaude` command to the Git deployment.
+
+The global npm package is removed only after the Git launcher passes a smoke
+test. TeamClaude records the exact npm version and executable so uninstall can
+restore them later. If npm cleanup fails, the healthy Git deployment remains
+active and the command reports this recovery step:
+
+```bash
+npm uninstall -g @karpeleslab/teamclaude
+```
+
+## Daily operations
+
+```bash
+teamclaude deploy status
+teamclaude deploy ref feature/name
+teamclaude deploy restart
+teamclaude deploy logs
+teamclaude deploy logs --lines 250 --no-follow
+teamclaude deploy rollback
+teamclaude deploy uninstall
+```
+
+`teamclaude deploy status --json` emits only JSON and is suitable for scripts.
+`teamclaude status` is a different command: it queries the running proxy and its
+accounts, while `teamclaude deploy status` describes Git releases, the service,
+launcher, Node executable, and deployment metadata.
+
+`deploy logs` follows logs by default. Use `--no-follow` for finite output.
+`deploy rollback` swaps `current` and `previous`, so running it twice toggles
+back to the original release.
+
+## Selecting a ref
+
+Deploy a remote branch, tag, or commit:
+
+```bash
+teamclaude deploy ref master
+teamclaude deploy ref v1.2.0
+teamclaude deploy ref 0123456789abcdef
+```
+
+The resolver checks a remote branch first, then a tag, then an explicit commit.
+A local development branch must be pushed to the deployment repository before
+the server can resolve it.
+
+Every candidate is fetched into the persistent repository and checked out as a
+detached worktree. TeamClaude runs its full Node test suite before changing
+`current`. After the atomic switch it restarts the service and verifies both the
+service manager and `current/src/index.js status`. A failed test never activates
+the candidate. A failed restart or health check restores the exact previous
+`current`/`previous` pair, restarts it, and verifies the restored application.
+
+The candidate worktree is retained when deployment fails, making it available
+for diagnosis.
+
+## Linux layout and startup
+
+Linux deployment is system-wide and must be installed or mutated as root. It
+uses:
 
 ```text
 /opt/teamclaude/
-├── repo/                    # persistent clone of the Git fork
-├── releases/                # detached worktrees, one per deployment
-├── current -> releases/...  # active, last successfully deployed release
-└── previous -> releases/... # release that was active before current
+├── repo/                    # persistent Git repository
+├── releases/                # detached immutable worktrees
+├── current -> releases/...  # active release
+├── previous -> releases/... # prior release
+├── backups/                 # validated displaced service definition
+└── deployment.json          # private deployment metadata
 
 /etc/systemd/system/teamclaude.service
 /usr/local/bin/teamclaude
-/usr/local/sbin/teamclaude-deploy
-/usr/local/libexec/teamclaude-node
 ```
 
-The `teamclaude` command is a small wrapper around the active
-`current/src/index.js`. The service and terminal command therefore use the same
-code. `teamclaude-node` points at the absolute Node.js executable selected when
-the deployment was installed.
+The systemd unit is enabled under `multi-user.target`, uses `Restart=always`,
+and starts the last selected `current` release after a reboot. It records an
+absolute Node executable rather than depending on systemd's minimal PATH, so an
+NVM installation is supported.
 
-The account configuration and runtime quota state stay outside Git:
-
-```text
-/root/.config/teamclaude.json
-/root/.config/teamclaude.state.json
-```
-
-Deploying another ref does not replace either file.
-
-## Requirements
-
-- Linux with systemd
-- Git
-- Node.js 20 or newer
-- A remote Git repository reachable by the VPS
-- A valid TeamClaude config containing at least one account
-- Root access for updating the system service
-
-The reference deployment uses an NVM Node installation. The systemd unit keeps
-the matching NVM directory on `PATH`, so TeamClaude can also find programs such
-as `claude` when it launches them.
-
-## Everyday commands
-
-Show the active proxy status:
-
-```bash
-teamclaude status
-```
-
-Follow service logs:
-
-```bash
-journalctl -u teamclaude.service -f
-```
-
-Restart the active release without changing it:
-
-```bash
-systemctl restart teamclaude.service
-```
-
-Check service startup configuration:
+Useful checks are:
 
 ```bash
 systemctl is-enabled teamclaude.service
 systemctl is-active teamclaude.service
 systemctl show teamclaude.service -p ExecStart -p WorkingDirectory
+teamclaude deploy status
 ```
 
-An enabled system-level unit under `multi-user.target` starts the selected
-`current` release after a VPS reboot.
+## macOS layout and startup
 
-## Deploy a branch, tag, or commit
+macOS deployment is per-user and does not require root. It uses:
 
-Deploy the default branch:
+```text
+$HOME/Library/Application Support/TeamClaude/deploy/
+├── repo/
+├── releases/
+├── current -> releases/...
+├── previous -> releases/...
+├── backups/
+└── deployment.json
+
+$HOME/Library/LaunchAgents/com.karpeleslab.teamclaude.plist
+$HOME/Library/Logs/teamclaude.log
+```
+
+The LaunchAgent has `RunAtLoad` and `KeepAlive`, so the last selected release
+starts at login and restarts after an unexpected exit.
+
+The installer places the stable launcher in the first writable stable PATH
+directory among `/usr/local/bin`, `/opt/homebrew/bin`, and `$HOME/.local/bin`.
+It deliberately avoids version-specific NVM, asdf, Volta, and Homebrew Cellar
+directories. If none is available, the launcher is stored in the deployment's
+`bin` directory and the installer prints this exact zsh setup:
+
+```zsh
+path=("$HOME/Library/Application Support/TeamClaude/deploy/bin" $path)
+export PATH
+```
+
+## Configuration and data preservation
+
+The account config and runtime state remain outside the removable deployment
+root. The normal defaults are:
+
+```text
+Linux: $HOME/.config/teamclaude.json
+       $HOME/.config/teamclaude.state.json
+
+macOS: $HOME/.config/teamclaude.json
+       $HOME/.config/teamclaude.state.json
+```
+
+`TEAMCLAUDE_CONFIG` and `XDG_CONFIG_HOME` continue to select custom locations.
+Installation is refused if the config is inside the deployment root, because
+that root can be removed by uninstall.
+
+Deploy, rollback, and uninstall never purge the TeamClaude config or state.
+They also do not create, edit, reload, or remove nginx configuration. Retained
+service logs outside the deployment root are preserved. Version 1 intentionally
+has no config-purge option.
+
+## Uninstall
+
+Interactive and scripted forms are:
 
 ```bash
-teamclaude-deploy master
+teamclaude deploy uninstall
+teamclaude deploy uninstall --yes
+teamclaude deploy uninstall --yes --restore-npm
+teamclaude deploy uninstall --yes --no-restore-npm
 ```
 
-Deploy another remote branch:
+Without flags, TeamClaude asks:
+
+```text
+Remove the Git deployment, service, releases, and launcher? [y/N]
+Restore @karpeleslab/teamclaude as a global npm package? [Y/n]
+```
+
+`--yes` answers only the first question. `--restore-npm` and
+`--no-restore-npm` answer only the second. A non-interactive invocation must
+provide `--yes` and exactly one npm choice.
+
+When npm restoration is selected, TeamClaude resolves the predicted global
+command path, installs and verifies npm before stopping the healthy Git
+service, and only then removes deployment-owned resources. A deployment that
+started from a global npm package restores its exact recorded version. An
+adopted or source-based deployment, which has no trustworthy former version,
+restores `@karpeleslab/teamclaude@latest`; it never silently substitutes latest
+for a recorded exact version.
+
+The displaced service is restored only when its validated backup is npm-backed
+and outside the Git deployment root. A legacy service that refers to
+`/opt/teamclaude` is not restored because removing that root would make it
+invalid.
+
+Every destructive step checks owner markers, regular-file identity, safe
+release links, backup hashes, and the exact platform root. An unmarked operator
+launcher or service is preserved or causes a preflight refusal. If teardown
+fails before its commit boundary, TeamClaude restores the Git service and
+launcher, restarts the unchanged release, and checks its health. If root removal
+fails after npm and the prior service have been restored, uninstall reports
+partial success and lists the remaining path instead of undoing the healthy
+replacement.
+
+With `--no-restore-npm`, the global package and prior service are not restored.
+The `teamclaude` command is intentionally removed together with the Git
+deployment. Config, state, nginx, and retained logs are still preserved.
+
+## Migrating an existing VPS release layout
+
+An existing `/opt/teamclaude` repository, `releases`, `current`, `previous`, and
+system service can be adopted in place. First use the legacy operator helper to
+deploy a ref that already contains the integrated `teamclaude deploy` command.
+Then run from that active release:
 
 ```bash
-teamclaude-deploy my-feature
+teamclaude deploy install https://github.com/OWNER/teamclaude.git --ref <same-ref>
 ```
 
-Deploy a tag or commit:
+The installer verifies that the existing repository has the same origin and
+that every selection link resolves to a direct child of `releases`. It reruns
+the candidate tests, replaces the service and launcher with owner-marked
+definitions, and writes deployment metadata. It does not reclone the repository
+or remove a release. Config, nginx, `current`, `previous`, and releases are not
+migrated or rewritten merely to adopt the layout.
 
-```bash
-teamclaude-deploy v1.2.0
-teamclaude-deploy 0123456789abcdef
-```
-
-A local development branch must be pushed to the configured `origin` before
-the VPS can deploy it:
-
-```bash
-git push -u origin my-feature
-ssh root@your-vps teamclaude-deploy my-feature
-```
-
-The helper performs the following sequence:
-
-1. Fetches branches and tags from `origin`.
-2. Resolves the requested ref to an immutable commit.
-3. Creates a detached worktree below `/opt/teamclaude/releases`.
-4. Runs the complete Node test suite.
-5. Records the old `current` release as `previous`.
-6. Atomically switches `current` to the candidate.
-7. Restarts `teamclaude.service`.
-8. Checks both systemd state and `teamclaude status`.
-
-Fetch, ref-resolution, worktree, or test failures leave the running release
-untouched. A failed service health check switches `current` back to the former
-release and restarts it automatically. The command exits non-zero whenever the
-candidate was not activated.
-
-The restart creates a short interruption, normally a few seconds. A reverse
-proxy may remain online during that interval, but requests reaching TeamClaude
-can fail until the health check passes.
-
-## Inspect the active and previous releases
-
-```bash
-readlink -f /opt/teamclaude/current
-git -C /opt/teamclaude/current rev-parse HEAD
-
-readlink -f /opt/teamclaude/previous
-git -C /opt/teamclaude/previous rev-parse HEAD
-```
-
-Confirm Git provenance:
-
-```bash
-git -C /opt/teamclaude/current remote get-url origin
-git -C /opt/teamclaude/current log -1 --oneline
-```
-
-## Roll back
-
-The normal rollback is another tested deployment of a known-good ref:
-
-```bash
-teamclaude-deploy <known-good-branch-tag-or-commit>
-```
-
-If the Git remote is unavailable and an emergency rollback is required, point
-`current` at the already-tested `previous` worktree and restart the service:
-
-```bash
-previous="$(readlink -f /opt/teamclaude/previous)"
-test -n "$previous"
-test -f "$previous/src/index.js"
-ln -s "$previous" "/opt/teamclaude/current.next.$$"
-mv -Tf "/opt/teamclaude/current.next.$$" /opt/teamclaude/current
-systemctl restart teamclaude.service
-teamclaude status
-```
-
-Always verify status after a manual rollback. The deployment helper is preferred
-because it also runs tests, records the release transition, and performs health
-verification.
+Exercise `teamclaude deploy ref`, verify application health, and reboot the VPS
+before retiring the legacy helper. Back up `/usr/local/sbin/teamclaude-deploy`
+first; remove it only after the integrated commands and reboot startup have both
+been verified.
 
 ## Reverse proxy
 
-TeamClaude listens on the loopback address by default. A typical nginx upstream
-is:
+Reverse-proxy management is intentionally outside the deploy command. A typical
+nginx upstream remains:
 
 ```nginx
 location / {
@@ -186,37 +244,20 @@ location / {
 }
 ```
 
-Keep the TeamClaude listener on loopback when nginx is the only public entry
-point. If TeamClaude is bound to a non-loopback interface instead, configure
-`proxy.apiKey`; remote clients must not have unauthenticated access to a proxy
-that injects account credentials.
+Keep TeamClaude on loopback when nginx is the only public entry point. An HTTP
+`401 Unauthorized` from the public endpoint can be the expected nginx-auth
+response; use `teamclaude deploy status` and `teamclaude status` locally to
+distinguish proxy authentication from application health.
 
-An HTTP `401 Unauthorized` from the public nginx endpoint can be the expected
-result when nginx authentication is enabled. Check the local TeamClaude status
-separately to distinguish proxy authentication from an unhealthy application:
+## Troubleshooting
 
-```bash
-teamclaude status
-curl -fsS http://127.0.0.1:3456/teamclaude/status
-```
-
-## Logs and troubleshooting
-
-Show recent service failures:
+Inspect recent logs without following:
 
 ```bash
-systemctl status teamclaude.service --no-pager
-journalctl -u teamclaude.service -n 100 --no-pager
+teamclaude deploy logs --lines 100 --no-follow
 ```
 
-Validate the installed unit and deployment script:
-
-```bash
-systemd-analyze verify /etc/systemd/system/teamclaude.service
-bash -n /usr/local/sbin/teamclaude-deploy
-```
-
-If a ref cannot be resolved:
+Inspect available refs directly when resolution fails:
 
 ```bash
 git -C /opt/teamclaude/repo fetch --prune --tags origin
@@ -224,54 +265,17 @@ git -C /opt/teamclaude/repo branch -r
 git -C /opt/teamclaude/repo tag --list
 ```
 
-If a deployment stops at the test step, run the same suite in the candidate
-release shown in its output:
+If candidate tests fail, the error names the retained release directory. Run
+the same command there with the Node path reported by deploy status:
 
 ```bash
 cd /opt/teamclaude/releases/<candidate-release>
-/usr/local/libexec/teamclaude-node --test --test-timeout=120000
+<absolute-node> --test --test-timeout=120000
 ```
 
-If the terminal cannot find `teamclaude-deploy`, verify whether
-`/usr/local/sbin` is on `PATH`:
+## npm packaging
 
-```bash
-command -v teamclaude-deploy
-print -r -- $path  # zsh
-```
-
-For zsh, add it when necessary:
-
-```zsh
-path=(/usr/local/sbin $path)
-export PATH
-```
-
-The reference VPS uses Bash as root's login shell. Zsh must be installed and
-configured separately if it is preferred.
-
-## Backups and old releases
-
-The initial migration stores the former systemd and nginx files below:
-
-```text
-/root/teamclaude-migration-backup/<UTC timestamp>/
-```
-
-Do not delete `current` or `previous`. Older detached worktrees can be listed
-and removed explicitly:
-
-```bash
-git -C /opt/teamclaude/repo worktree list
-git -C /opt/teamclaude/repo worktree remove /opt/teamclaude/releases/<old-release>
-git -C /opt/teamclaude/repo worktree prune
-```
-
-Check both symlink targets before removing an old release.
-
-## npm packaging status
-
-The current npm package contains `src/` and exposes one binary:
+The npm package still exposes one binary:
 
 ```json
 {
@@ -281,11 +285,6 @@ The current npm package contains `src/` and exposes one binary:
 }
 ```
 
-Consequently, `npm install -g @karpeleslab/teamclaude` does not install
-`teamclaude-deploy`, the Git release layout, or the systemd unit. Adding that
-behavior upstream requires a separately designed cross-platform installer or
-additional npm binary. Until such a feature is released, treat
-`teamclaude-deploy` as operator-managed VPS tooling.
-
-Installing the global npm package is unnecessary for this layout. The service
-and `teamclaude` wrapper both run the source selected by `current`.
+All deployment modules ship below `src/deploy/`. There is no postinstall hook:
+installing the npm package alone does not create a service or mutate deployment
+state. The explicit `teamclaude deploy install` command performs the handoff.

--- a/src/deploy/cli.js
+++ b/src/deploy/cli.js
@@ -1,0 +1,257 @@
+import { createInterface } from 'node:readline';
+import { resolveDeployLayout } from './layout.js';
+import { createDeployManager } from './manager.js';
+
+const HELP = `teamclaude deploy install <git-url> [--ref master]
+teamclaude deploy ref <branch|tag|commit>
+teamclaude deploy rollback
+teamclaude deploy restart
+teamclaude deploy logs [--lines 100] [--no-follow]
+teamclaude deploy status [--json]
+teamclaude deploy uninstall [--yes] [--restore-npm|--no-restore-npm]
+teamclaude deploy help
+`;
+
+function usageError(message) {
+  const error = new Error(message);
+  error.exitCode = 64;
+  return error;
+}
+
+function rejectExtra(command, argv) {
+  if (argv.length) throw usageError(`Unexpected arguments for deploy ${command}: ${argv.join(' ')}`);
+  return { command };
+}
+
+function takeUniqueFlag(argv, flag, { value = false } = {}) {
+  const indices = argv.flatMap((item, index) => item === flag ? [index] : []);
+  if (indices.length > 1) throw usageError(`Duplicate option: ${flag}`);
+  if (indices.length === 0) return { found: false, argv };
+  const index = indices[0];
+  if (!value) return { found: true, argv: argv.toSpliced(index, 1) };
+  const selected = argv[index + 1];
+  if (!selected || selected.startsWith('--')) throw usageError(`${flag} requires a value`);
+  return { found: true, selected, argv: argv.toSpliced(index, 2) };
+}
+
+export function parseDeployArgs(argv) {
+  const [command = 'help', ...rest] = argv;
+  if (command === 'help') return rejectExtra('help', rest);
+  if (command === 'install') {
+    const refFlag = takeUniqueFlag(rest, '--ref', { value: true });
+    if (refFlag.argv.length !== 1 || refFlag.argv[0].startsWith('--')) {
+      throw usageError('deploy install requires exactly one <git-url>');
+    }
+    return { command, remoteUrl: refFlag.argv[0], ref: refFlag.found ? refFlag.selected : 'master' };
+  }
+  if (command === 'ref') {
+    if (rest.length !== 1 || rest[0].startsWith('--')) throw usageError('deploy ref requires one branch, tag, or commit');
+    return { command, ref: rest[0] };
+  }
+  if (command === 'rollback' || command === 'restart') return rejectExtra(command, rest);
+  if (command === 'logs') {
+    const noFollow = takeUniqueFlag(rest, '--no-follow');
+    const linesFlag = takeUniqueFlag(noFollow.argv, '--lines', { value: true });
+    if (linesFlag.argv.length) throw usageError(`Unknown deploy logs option: ${linesFlag.argv[0]}`);
+    const lines = linesFlag.found ? Number(linesFlag.selected) : 100;
+    if (!Number.isInteger(lines) || lines < 1 || lines > 100_000) {
+      throw usageError('--lines must be an integer from 1 to 100000');
+    }
+    return { command, lines, follow: !noFollow.found };
+  }
+  if (command === 'status') {
+    const json = takeUniqueFlag(rest, '--json');
+    if (json.argv.length) throw usageError(`Unknown deploy status option: ${json.argv[0]}`);
+    return { command, json: json.found };
+  }
+  if (command === 'uninstall') {
+    const yes = takeUniqueFlag(rest, '--yes');
+    const restore = takeUniqueFlag(yes.argv, '--restore-npm');
+    const noRestore = takeUniqueFlag(restore.argv, '--no-restore-npm');
+    if (restore.found && noRestore.found) {
+      throw usageError('--restore-npm and --no-restore-npm cannot be used together');
+    }
+    if (noRestore.argv.length) throw usageError(`Unknown deploy uninstall option: ${noRestore.argv[0]}`);
+    return {
+      command,
+      yes: yes.found,
+      restoreNpm: restore.found ? true : noRestore.found ? false : null,
+    };
+  }
+  throw usageError(`Unknown deploy command: ${command}`);
+}
+
+export function showDeployHelp(out = process.stdout) {
+  out.write(HELP);
+}
+
+const promptReaders = new WeakMap();
+
+function promptReader(input) {
+  let state = promptReaders.get(input);
+  if (!state) {
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    state = { lines, iterator: lines[Symbol.asyncIterator]() };
+    promptReaders.set(input, state);
+  }
+  return state;
+}
+
+function closePromptReader(input) {
+  const state = promptReaders.get(input);
+  if (state) state.lines.close();
+  promptReaders.delete(input);
+}
+
+export async function promptYesNo({ input, output, question, defaultValue }) {
+  const { iterator } = promptReader(input);
+  while (true) {
+    output.write(`${question} `);
+    const next = await iterator.next();
+    if (next.done) return null;
+    const answer = next.value.trim().toLowerCase();
+    if (!answer) return defaultValue;
+    if (answer === 'y' || answer === 'yes') return true;
+    if (answer === 'n' || answer === 'no') return false;
+    output.write('Please answer yes or no.\n');
+  }
+}
+
+function defaultManager() {
+  return createDeployManager({ layout: resolveDeployLayout() });
+}
+
+function printHumanStatus(status, stdout) {
+  if (status.installed === false) {
+    stdout.write(`Status:       not installed\nPlatform:     ${status.platform}\nRoot:         ${status.root}\n`);
+    return;
+  }
+  const service = status.service || {};
+  const serviceText = service.running ? (service.detail || 'running') : (service.detail || 'stopped');
+  stdout.write([
+    `Platform:     ${status.platform}`,
+    `Root:         ${status.root}`,
+    `Remote:       ${status.remoteUrl}`,
+    `Requested:    ${status.requestedRef}`,
+    `Current:      ${status.current ? `${status.current.commit}  ${status.current.path}` : '-'}`,
+    `Previous:     ${status.previous ? `${status.previous.commit}  ${status.previous.path}` : '-'}`,
+    `Service:      ${serviceText}`,
+    `Node:         ${status.nodePath}`,
+    `Launcher:     ${status.launcherPath}`,
+    `Config:       ${status.configPath}`,
+    `npm cleanup:  ${status.npmCleanupPending ? 'pending' : 'complete'}`,
+    '',
+  ].join('\n'));
+}
+
+function printDeploymentResult(result, output) {
+  if (result.commit) output.write(`Commit: ${result.commit}\n`);
+  if (result.releasePath) output.write(`Release: ${result.releasePath}\n`);
+  if (result.warning) output.write(`${result.warning}\n`);
+}
+
+async function resolveUninstall(parsed, { input, output }) {
+  const interactive = input.isTTY === true;
+  if (!interactive && (!parsed.yes || parsed.restoreNpm === null)) {
+    output.write('Non-interactive uninstall requires one of:\n');
+    output.write('  teamclaude deploy uninstall --yes --restore-npm\n');
+    output.write('  teamclaude deploy uninstall --yes --no-restore-npm\n');
+    return { code: 64 };
+  }
+  try {
+    if (!parsed.yes) {
+      const remove = await promptYesNo({
+        input, output,
+        question: 'Remove the Git deployment, service, releases, and launcher? [y/N]',
+        defaultValue: false,
+      });
+      if (remove !== true) return { code: 0 };
+    }
+    let restoreNpm = parsed.restoreNpm;
+    if (restoreNpm === null) {
+      restoreNpm = await promptYesNo({
+        input, output,
+        question: 'Restore @karpeleslab/teamclaude as a global npm package? [Y/n]',
+        defaultValue: true,
+      });
+      if (restoreNpm === null) return { code: 0 };
+    }
+    if (!restoreNpm) output.write('The teamclaude command will be removed with the Git deployment.\n');
+    return { restoreNpm };
+  } finally {
+    closePromptReader(input);
+  }
+}
+
+export async function runDeployCli(argv, {
+  input = process.stdin,
+  output = process.stderr,
+  stdout = process.stdout,
+  createManager = defaultManager,
+} = {}) {
+  let parsed;
+  try {
+    parsed = parseDeployArgs(argv);
+  } catch (error) {
+    output.write(`${error.message}\n`);
+    return error.exitCode || 64;
+  }
+  if (parsed.command === 'help') {
+    showDeployHelp(stdout);
+    return 0;
+  }
+
+  let uninstallDecision = null;
+  if (parsed.command === 'uninstall') {
+    uninstallDecision = await resolveUninstall(parsed, { input, output });
+    if (Object.hasOwn(uninstallDecision, 'code')) return uninstallDecision.code;
+  }
+
+  let manager;
+  try {
+    manager = createManager();
+    if (parsed.command === 'install') {
+      const result = await manager.install({ remoteUrl: parsed.remoteUrl, ref: parsed.ref });
+      printDeploymentResult(result, result.partial ? output : stdout);
+      return result.ok ? 0 : 1;
+    }
+    if (parsed.command === 'ref') {
+      const result = await manager.deployRef({ ref: parsed.ref });
+      printDeploymentResult(result, stdout);
+      return result.ok ? 0 : 1;
+    }
+    if (parsed.command === 'rollback') {
+      const result = await manager.rollback();
+      stdout.write(`Current: ${result.current}\nPrevious: ${result.previous}\n`);
+      return result.ok ? 0 : 1;
+    }
+    if (parsed.command === 'restart') {
+      const result = await manager.restart();
+      if (result.ok) stdout.write('TeamClaude restarted and is healthy.\n');
+      return result.ok ? 0 : 1;
+    }
+    if (parsed.command === 'logs') {
+      const result = await manager.logs({ lines: parsed.lines, follow: parsed.follow });
+      return result.code;
+    }
+    if (parsed.command === 'status') {
+      const status = await manager.status();
+      if (parsed.json) stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+      else printHumanStatus(status, stdout);
+      return 0;
+    }
+    const result = await manager.uninstall({ restoreNpm: uninstallDecision.restoreNpm });
+    if (result.restoredNpm) {
+      stdout.write(`Restored: ${result.packageSpec}\nCommand: ${result.commandPath}\n`);
+    }
+    if (result.restoredService) stdout.write('The prior TeamClaude service was restored.\n');
+    if (result.warning) (result.partial ? output : stdout).write(`${result.warning}\n`);
+    if (result.partial) {
+      for (const path of result.remainingPaths) output.write(`Remaining: ${path}\n`);
+    }
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    output.write(`teamclaude deploy ${parsed.command} failed: ${error.message}\n`);
+    return 1;
+  }
+}

--- a/src/deploy/git-releases.js
+++ b/src/deploy/git-releases.js
@@ -1,0 +1,269 @@
+import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import * as fsPromises from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
+const COMMAND_TIMEOUT_MS = 120_000;
+
+function defaultRun(command, argv, { cwd, timeoutMs = COMMAND_TIMEOUT_MS, stdio = 'pipe' } = {}) {
+  const result = spawnSync(command, argv, {
+    cwd,
+    encoding: 'utf8',
+    stdio,
+    timeout: timeoutMs,
+  });
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || result.error?.message || '',
+  };
+}
+
+function commandError(command, argv, result) {
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+  return new Error(`${command} ${argv.join(' ')} failed (${result.code}): ${detail}`);
+}
+
+export function validateRemoteUrl(remoteUrl) {
+  if (typeof remoteUrl !== 'string' || !remoteUrl || /[\0\r\n]/.test(remoteUrl)) {
+    throw new Error('Invalid Git remote URL');
+  }
+  if (/^[^/@\s]+@[^:\s]+:.+/.test(remoteUrl)) return remoteUrl;
+  let parsed;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    throw new Error(`Invalid Git remote URL: ${remoteUrl}`);
+  }
+  if (!['https:', 'ssh:', 'git:', 'file:'].includes(parsed.protocol)) {
+    throw new Error(`Unsupported Git remote URL protocol: ${parsed.protocol}`);
+  }
+  if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') && (parsed.username || parsed.password)) {
+    throw new Error('Git remote URL must not contain credentials');
+  }
+  return remoteUrl;
+}
+
+export function validateRequestedRef(ref) {
+  if (typeof ref !== 'string' || !ref) throw new Error('A Git ref is required');
+  if (ref.startsWith('-')) throw new Error('Git refs must not start with -');
+  if (/[\0\r\n\\]/.test(ref) || ref.includes('..') || ref.includes('@{')) {
+    throw new Error(`Invalid ref: ${ref}`);
+  }
+  if (/^[a-f0-9]{7,40}$/i.test(ref)) return ref;
+  const checked = spawnSync('git', ['check-ref-format', `refs/teamclaude/${ref}`], {
+    encoding: 'utf8', timeout: 5000,
+  });
+  if (checked.status !== 0) throw new Error(`Invalid ref: ${ref}`);
+  return ref;
+}
+
+function timestamp(date) {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function isBelow(parent, child) {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel !== '' && rel !== '..' && !rel.startsWith('../') && !isAbsolute(rel);
+}
+
+export function createGitReleaseStore({
+  layout,
+  run = defaultRun,
+  fs = fsPromises,
+  now = () => new Date(),
+} = {}) {
+  if (!layout) throw new Error('A deployment layout is required');
+
+  const runGit = (argv, options = {}) => {
+    const result = run('git', argv, options);
+    if (result.code !== 0) throw commandError('git', argv, result);
+    return result.stdout.trim();
+  };
+
+  const tryGit = (argv, options = {}) => {
+    const result = run('git', argv, options);
+    return result.code === 0 ? result.stdout.trim() : null;
+  };
+
+  async function exists(path) {
+    try {
+      await fs.lstat(path);
+      return true;
+    } catch (error) {
+      if (error.code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  async function ensureRepository(remoteUrl) {
+    const validated = validateRemoteUrl(remoteUrl);
+    if (!await exists(layout.repo)) {
+      await fs.mkdir(dirname(layout.repo), { recursive: true, mode: 0o755 });
+      runGit(['clone', '--origin', 'origin', '--', validated, layout.repo]);
+      return { cloned: true, remoteUrl: validated };
+    }
+    const inside = tryGit(['-C', layout.repo, 'rev-parse', '--is-inside-work-tree']);
+    if (inside !== 'true') throw new Error(`${layout.repo} is not a Git working tree`);
+    const configured = runGit(['-C', layout.repo, 'remote', 'get-url', 'origin']);
+    if (configured !== validated) {
+      throw new Error(`Deployment repository uses a different remote: ${configured}`);
+    }
+    return { cloned: false, remoteUrl: configured };
+  }
+
+  function fetch() {
+    runGit(['-C', layout.repo, 'fetch', '--prune', '--tags', 'origin']);
+  }
+
+  function resolveRef(ref) {
+    const validated = validateRequestedRef(ref);
+    const candidates = [
+      `refs/remotes/origin/${validated}`,
+      `refs/tags/${validated}`,
+    ];
+    if (/^[a-f0-9]{7,40}$/i.test(validated)) candidates.push(validated);
+    for (const candidate of candidates) {
+      const commit = tryGit(['-C', layout.repo, 'rev-parse', '--verify', '--quiet', `${candidate}^{commit}`]);
+      if (commit && /^[a-f0-9]{40}$/i.test(commit)) return commit;
+    }
+    throw new Error(`Cannot resolve Git ref to a commit: ${validated}`);
+  }
+
+  async function createCandidate(commit) {
+    if (!/^[a-f0-9]{40}$/i.test(commit)) throw new Error(`Invalid commit: ${commit}`);
+    const verified = tryGit(['-C', layout.repo, 'rev-parse', '--verify', '--quiet', `${commit}^{commit}`]);
+    if (!verified) throw new Error(`Commit is not available in the deployment repository: ${commit}`);
+    await fs.mkdir(layout.releases, { recursive: true, mode: 0o755 });
+    const base = `${timestamp(now())}-${verified.slice(0, 12)}`;
+    let path = join(layout.releases, base);
+    let suffix = 1;
+    while (await exists(path)) path = join(layout.releases, `${base}-${suffix++}`);
+    runGit(['-C', layout.repo, 'worktree', 'add', '--detach', path, verified]);
+    return { path, commit: verified };
+  }
+
+  async function safeRelease(path, label = 'release') {
+    let target;
+    try {
+      target = await fs.realpath(path);
+    } catch (error) {
+      throw new Error(`${label} is dangling or cannot resolve: ${path}`, { cause: error });
+    }
+    let releases;
+    try {
+      releases = await fs.realpath(layout.releases);
+    } catch (error) {
+      throw new Error(`Releases directory cannot resolve: ${layout.releases}`, { cause: error });
+    }
+    if (!isBelow(releases, target) || dirname(target) !== releases) {
+      throw new Error(`${label} resolves outside the releases directory: ${target}`);
+    }
+    const stat = await fs.lstat(target);
+    if (!stat.isDirectory()) throw new Error(`${label} is not a release directory: ${target}`);
+    return target;
+  }
+
+  async function readLink(link, label) {
+    let stat;
+    try {
+      stat = await fs.lstat(link);
+    } catch (error) {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (!stat.isSymbolicLink()) throw new Error(`${label} must be a symbolic link`);
+    return safeRelease(link, label);
+  }
+
+  async function readSelection() {
+    return {
+      current: await readLink(layout.current, 'current'),
+      previous: await readLink(layout.previous, 'previous'),
+    };
+  }
+
+  async function atomicLink(link, target) {
+    const safeTarget = await safeRelease(target, basename(link));
+    const temporary = `${link}.next-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.symlink(safeTarget, temporary);
+      await fs.rename(temporary, link);
+    } catch (error) {
+      await fs.rm(temporary, { force: true }).catch(() => {});
+      throw error;
+    }
+  }
+
+  async function restoreLink(link, target) {
+    if (target === null) {
+      await fs.rm(link, { force: true });
+    } else {
+      await atomicLink(link, target);
+    }
+  }
+
+  async function activate(candidatePath) {
+    const candidate = await safeRelease(candidatePath, 'candidate');
+    const original = await readSelection();
+    try {
+      if (original.current) await atomicLink(layout.previous, original.current);
+      await atomicLink(layout.current, candidate);
+    } catch (error) {
+      await restoreLink(layout.previous, original.previous).catch(() => {});
+      await restoreLink(layout.current, original.current).catch(() => {});
+      throw error;
+    }
+    return { current: candidate, previous: original.current };
+  }
+
+  async function swapForRollback() {
+    const original = await readSelection();
+    if (!original.current || !original.previous) throw new Error('Both current and previous releases are required for rollback');
+    try {
+      await atomicLink(layout.current, original.previous);
+      await atomicLink(layout.previous, original.current);
+    } catch (error) {
+      await restoreLink(layout.current, original.current).catch(() => {});
+      await restoreLink(layout.previous, original.previous).catch(() => {});
+      throw error;
+    }
+    return { current: original.previous, previous: original.current };
+  }
+
+  async function restoreSelection(selection) {
+    if (!selection || !Object.hasOwn(selection, 'current') || !Object.hasOwn(selection, 'previous')) {
+      throw new Error('A complete release selection is required');
+    }
+    if (selection.current) await safeRelease(selection.current, 'current restore target');
+    if (selection.previous) await safeRelease(selection.previous, 'previous restore target');
+    const original = await readSelection();
+    try {
+      await restoreLink(layout.current, selection.current);
+      await restoreLink(layout.previous, selection.previous);
+    } catch (error) {
+      await restoreLink(layout.current, original.current).catch(() => {});
+      await restoreLink(layout.previous, original.previous).catch(() => {});
+      throw error;
+    }
+  }
+
+  async function describeRelease(path) {
+    if (!path) return null;
+    const safePath = await safeRelease(path);
+    const commit = runGit(['-C', safePath, 'rev-parse', '--verify', 'HEAD^{commit}']);
+    return { path: safePath, commit };
+  }
+
+  return {
+    ensureRepository,
+    fetch,
+    resolveRef,
+    createCandidate,
+    readSelection,
+    activate,
+    swapForRollback,
+    restoreSelection,
+    describeRelease,
+  };
+}

--- a/src/deploy/launcher.js
+++ b/src/deploy/launcher.js
@@ -62,7 +62,9 @@ export function discoverBootstrap({
   findExecutable = defaultFindExecutable,
   realpath = realpathSync,
   isExecutable = defaultIsExecutable,
-  installKind = detectInstallKind(),
+  installKind,
+  classifyInstall = detectInstallKind,
+  run = defaultRun,
   packageVersion = currentVersion(),
   invokedCommandPath = process.argv[1] ? resolve(process.argv[1]) : null,
 } = {}) {
@@ -80,11 +82,18 @@ export function discoverBootstrap({
     throw new Error(`The running Node executable is not accessible: ${nodePath}`);
   }
 
-  const npmPath = findExecutable('npm', pathEnv);
+  const adjacentNpm = join(dirname(nodePath), 'npm');
+  const npmPath = isExecutable(adjacentNpm) ? adjacentNpm : findExecutable('npm', pathEnv);
   if (!npmPath || !isAbsolute(npmPath) || !isExecutable(npmPath)) {
     throw new Error('Could not find an executable npm on PATH');
   }
-  return { nodePath, npmPath, invokedCommandPath, installKind, packageVersion };
+  let resolvedInstallKind = installKind;
+  if (resolvedInstallKind === undefined) {
+    const rootResult = run(nodePath, [npmPath, 'root', '--global']);
+    const root = commandSucceeded(rootResult) ? String(rootResult.stdout || '').trim() : '';
+    resolvedInstallKind = classifyInstall({ globalRoot: isAbsolute(root) ? root : null });
+  }
+  return { nodePath, npmPath, invokedCommandPath, installKind: resolvedInstallKind, packageVersion };
 }
 
 function isVersionOwnedDirectory(directory) {
@@ -178,7 +187,7 @@ export async function handoffLauncher({
   let warning;
   if (bootstrap.installKind === 'global') {
     const uninstallArgs = ['uninstall', '-g', PKG_NAME];
-    const uninstall = run(bootstrap.npmPath, uninstallArgs);
+    const uninstall = run(bootstrap.nodePath, [bootstrap.npmPath, ...uninstallArgs]);
     if (!commandSucceeded(uninstall)) {
       npmCleanupPending = true;
       warning = `Global npm cleanup is still pending. Run: npm uninstall -g ${PKG_NAME}`;
@@ -230,18 +239,18 @@ export async function resolveNpmRestore({
     }
   }
   const packageSpec = `${PKG_NAME}@${npmRestore.version ?? 'latest'}`;
-  const prefixResult = run(npmPath, ['prefix', '--global']);
+  const prefixResult = run(nodePath, [npmPath, 'prefix', '--global']);
   if (!commandSucceeded(prefixResult)) throw commandError(npmPath, ['prefix', '--global'], prefixResult);
   const prefix = String(prefixResult.stdout || '').trim();
   if (!isAbsolute(prefix)) throw new Error(`npm returned an invalid global prefix: ${prefix || '(empty)'}`);
-  return { packageSpec, npmPath, commandPath: join(prefix, 'bin', 'teamclaude') };
+  return { packageSpec, nodePath, npmPath, commandPath: join(prefix, 'bin', 'teamclaude') };
 }
 
 export async function restoreGlobalNpm(resolved, { run = defaultRun } = {}) {
   const installArgs = ['install', '--global', resolved.packageSpec];
-  const installed = run(resolved.npmPath, installArgs, { stdio: 'inherit' });
+  const installed = run(resolved.nodePath, [resolved.npmPath, ...installArgs], { stdio: 'inherit' });
   if (!commandSucceeded(installed)) throw commandError(resolved.npmPath, installArgs, installed);
-  const verified = run(resolved.commandPath, ['version']);
+  const verified = run(resolved.nodePath, [resolved.commandPath, 'version']);
   if (!commandSucceeded(verified)) throw commandError(resolved.commandPath, ['version'], verified);
   return { ...resolved };
 }

--- a/src/deploy/launcher.js
+++ b/src/deploy/launcher.js
@@ -1,0 +1,278 @@
+import { spawnSync } from 'node:child_process';
+import {
+  accessSync,
+  constants,
+  existsSync,
+  realpathSync,
+} from 'node:fs';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile as fsReadFile,
+  rename as fsRename,
+  rm as fsRm,
+  writeFile as fsWriteFile,
+} from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { currentVersion, installKind as detectInstallKind, PKG_NAME } from '../updater.js';
+
+export const LAUNCHER_OWNER = 'teamclaude-git-deploy-v1';
+
+function defaultFindExecutable(command, pathEnv = process.env.PATH || '') {
+  for (const directory of pathEnv.split(':').filter(Boolean)) {
+    const candidate = resolve(directory, command);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch { /* keep searching */ }
+  }
+  return null;
+}
+
+function defaultIsExecutable(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandSucceeded(value) {
+  return value && !value.error && (value.code ?? value.status) === 0;
+}
+
+function commandError(command, argv, value) {
+  const detail = String(value?.stderr || value?.error?.message || '').trim();
+  const code = value?.code ?? value?.status ?? 'unknown';
+  return new Error(`${command} ${argv.join(' ')} failed with exit code ${code}${detail ? `: ${detail}` : ''}`);
+}
+
+function defaultRun(command, argv, options = {}) {
+  const value = spawnSync(command, argv, { encoding: 'utf8', ...options });
+  return { ...value, code: value.status };
+}
+
+export function discoverBootstrap({
+  execPath = process.execPath,
+  nodeVersion = process.versions.node,
+  pathEnv = process.env.PATH || '',
+  findExecutable = defaultFindExecutable,
+  realpath = realpathSync,
+  isExecutable = defaultIsExecutable,
+  installKind = detectInstallKind(),
+  packageVersion = currentVersion(),
+  invokedCommandPath = process.argv[1] ? resolve(process.argv[1]) : null,
+} = {}) {
+  const major = Number.parseInt(String(nodeVersion).split('.')[0], 10);
+  if (!Number.isInteger(major) || major < 20) {
+    throw new Error(`teamclaude deploy requires Node.js 20 or newer; found ${nodeVersion}`);
+  }
+
+  let nodePath = execPath;
+  const pathNode = findExecutable('node', pathEnv);
+  try {
+    if (pathNode && realpath(pathNode) === realpath(execPath)) nodePath = pathNode;
+  } catch { /* process.execPath remains authoritative */ }
+  if (!isAbsolute(nodePath) || !isExecutable(nodePath)) {
+    throw new Error(`The running Node executable is not accessible: ${nodePath}`);
+  }
+
+  const npmPath = findExecutable('npm', pathEnv);
+  if (!npmPath || !isAbsolute(npmPath) || !isExecutable(npmPath)) {
+    throw new Error('Could not find an executable npm on PATH');
+  }
+  return { nodePath, npmPath, invokedCommandPath, installKind, packageVersion };
+}
+
+function isVersionOwnedDirectory(directory) {
+  const normalized = directory.replaceAll('\\', '/');
+  return [
+    '/.nvm/versions/node/',
+    '/.asdf/installs/nodejs/',
+    '/.volta/tools/image/node/',
+    '/Cellar/node/',
+  ].some(fragment => normalized.includes(fragment));
+}
+
+export function chooseLauncherPath({
+  layout,
+  pathEnv = process.env.PATH || '',
+  access = directory => {
+    try {
+      accessSync(directory, constants.W_OK | constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+}) {
+  if (layout.platform === 'linux') {
+    return { path: layout.defaultLauncher || '/usr/local/bin/teamclaude', pathInstruction: null };
+  }
+
+  const stable = new Set(['/usr/local/bin', '/opt/homebrew/bin', join(layout.home, '.local', 'bin')]);
+  for (const directory of pathEnv.split(':').filter(Boolean)) {
+    if (stable.has(directory) && !isVersionOwnedDirectory(directory) && access(directory)) {
+      return { path: join(directory, 'teamclaude'), pathInstruction: null };
+    }
+  }
+  const binDir = layout.binDir || join(layout.root, 'bin');
+  const homeRelative = binDir.startsWith(`${layout.home}/`) ? `$HOME/${binDir.slice(layout.home.length + 1)}` : binDir;
+  return {
+    path: join(binDir, 'teamclaude'),
+    pathInstruction: `path=("${homeRelative}" $path)\nexport PATH`,
+  };
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`;
+}
+
+export function renderLauncher({ nodePath, entryPath }) {
+  return [
+    '#!/bin/sh',
+    `# TeamClaude-Owner: ${LAUNCHER_OWNER}`,
+    `exec ${shellQuote(nodePath)} ${shellQuote(entryPath)} "$@"`,
+    '',
+  ].join('\n');
+}
+
+export async function handoffLauncher({
+  bootstrap,
+  launcherPath,
+  entryPath,
+  run = defaultRun,
+  writeFile = fsWriteFile,
+  chmodFile = chmod,
+  rename = fsRename,
+  nonce = randomUUID(),
+  pid = process.pid,
+  onEvent = () => {},
+}) {
+  if (bootstrap.installKind === 'global' && !bootstrap.packageVersion) {
+    throw new Error('Cannot hand off a global npm installation without its exact npm package version');
+  }
+  const stagedPath = `${launcherPath}.next-${pid}-${nonce}`;
+  await mkdir(dirname(launcherPath), { recursive: true, mode: 0o755 });
+  const script = renderLauncher({ nodePath: bootstrap.nodePath, entryPath });
+  await writeFile(stagedPath, script, { flag: 'wx', mode: 0o755 });
+  onEvent('write', stagedPath);
+  await chmodFile(stagedPath, 0o755);
+  onEvent('chmod', stagedPath, 0o755);
+
+  const smoke = run(stagedPath, ['version']);
+  if (!commandSucceeded(smoke)) {
+    await fsRm(stagedPath, { force: true }).catch(() => {});
+    throw commandError(stagedPath, ['version'], smoke);
+  }
+
+  const npmRestore = {
+    packageName: PKG_NAME,
+    version: bootstrap.installKind === 'global' ? bootstrap.packageVersion : null,
+    npmPath: bootstrap.npmPath,
+  };
+  let npmCleanupPending = false;
+  let warning;
+  if (bootstrap.installKind === 'global') {
+    const uninstallArgs = ['uninstall', '-g', PKG_NAME];
+    const uninstall = run(bootstrap.npmPath, uninstallArgs);
+    if (!commandSucceeded(uninstall)) {
+      npmCleanupPending = true;
+      warning = `Global npm cleanup is still pending. Run: npm uninstall -g ${PKG_NAME}`;
+    }
+  }
+
+  try {
+    await rename(stagedPath, launcherPath);
+    onEvent('rename', stagedPath, launcherPath);
+  } catch (error) {
+    throw new Error(`Could not publish launcher; staged launcher remains available at ${stagedPath}: ${error.message}`, { cause: error });
+  }
+  const verification = run(launcherPath, ['version']);
+  if (!commandSucceeded(verification)) throw commandError(launcherPath, ['version'], verification);
+
+  return {
+    launcherPath,
+    npmCleanupPending,
+    npmRestore,
+    ...(warning ? { warning } : {}),
+  };
+}
+
+async function pathExists(path, exists) {
+  return Boolean(await exists(path));
+}
+
+export async function resolveNpmRestore({
+  npmRestore,
+  nodePath,
+  run = defaultRun,
+  exists = async path => existsSync(path),
+  pathEnv = process.env.PATH || '',
+  findExecutable = defaultFindExecutable,
+}) {
+  if (!npmRestore || npmRestore.packageName !== PKG_NAME) {
+    throw new Error('Invalid npm restoration metadata');
+  }
+  let npmPath = npmRestore.npmPath;
+  if (!await pathExists(npmPath, exists)) {
+    const adjacent = join(dirname(nodePath), 'npm');
+    if (await pathExists(adjacent, exists)) npmPath = adjacent;
+    else {
+      const pathNpm = findExecutable('npm', pathEnv);
+      if (!pathNpm || !await pathExists(pathNpm, exists)) {
+        throw new Error('Could not find npm to restore the global TeamClaude package');
+      }
+      npmPath = pathNpm;
+    }
+  }
+  const packageSpec = `${PKG_NAME}@${npmRestore.version ?? 'latest'}`;
+  const prefixResult = run(npmPath, ['prefix', '--global']);
+  if (!commandSucceeded(prefixResult)) throw commandError(npmPath, ['prefix', '--global'], prefixResult);
+  const prefix = String(prefixResult.stdout || '').trim();
+  if (!isAbsolute(prefix)) throw new Error(`npm returned an invalid global prefix: ${prefix || '(empty)'}`);
+  return { packageSpec, npmPath, commandPath: join(prefix, 'bin', 'teamclaude') };
+}
+
+export async function restoreGlobalNpm(resolved, { run = defaultRun } = {}) {
+  const installArgs = ['install', '--global', resolved.packageSpec];
+  const installed = run(resolved.npmPath, installArgs, { stdio: 'inherit' });
+  if (!commandSucceeded(installed)) throw commandError(resolved.npmPath, installArgs, installed);
+  const verified = run(resolved.commandPath, ['version']);
+  if (!commandSucceeded(verified)) throw commandError(resolved.commandPath, ['version'], verified);
+  return { ...resolved };
+}
+
+function sameFile(left, right) {
+  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode;
+}
+
+export async function removeOwnedLauncher({
+  launcherPath,
+  readFile = fsReadFile,
+  rm = fsRm,
+  stat = lstat,
+}) {
+  let before;
+  try {
+    before = await stat(launcherPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') return { removed: false, preserved: false };
+    throw error;
+  }
+  if (!before.isFile() || before.isSymbolicLink()) return { removed: false, preserved: true };
+  const firstContents = await readFile(launcherPath, 'utf8');
+  if (!firstContents.includes(`TeamClaude-Owner: ${LAUNCHER_OWNER}`)) {
+    return { removed: false, preserved: true };
+  }
+  const secondContents = await readFile(launcherPath, 'utf8');
+  const after = await stat(launcherPath);
+  if (!sameFile(before, after) || secondContents !== firstContents || !secondContents.includes(`TeamClaude-Owner: ${LAUNCHER_OWNER}`)) {
+    return { removed: false, preserved: true };
+  }
+  await rm(launcherPath);
+  return { removed: true, preserved: false };
+}

--- a/src/deploy/layout.js
+++ b/src/deploy/layout.js
@@ -1,0 +1,190 @@
+import { randomUUID } from 'node:crypto';
+import { lstat, mkdir, readFile, realpath, rename, rm, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { getConfigPath } from '../config.js';
+
+export const DEPLOYMENT_SCHEMA_VERSION = 1;
+const PACKAGE_NAME = '@karpeleslab/teamclaude';
+
+function isAtOrBelow(parent, candidate) {
+  const rel = relative(resolve(parent), resolve(candidate));
+  return rel === '' || (!rel.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) && rel !== '..' && !isAbsolute(rel));
+}
+
+function platformRoot(platform, home) {
+  return platform === 'linux'
+    ? '/opt/teamclaude'
+    : join(home, 'Library', 'Application Support', 'TeamClaude', 'deploy');
+}
+
+export function resolveDeployLayout({
+  platform = process.platform,
+  home = homedir(),
+  configPath = getConfigPath(),
+} = {}) {
+  if (platform !== 'linux' && platform !== 'darwin') {
+    throw new Error(`teamclaude deploy supports Linux and macOS, not ${platform}`);
+  }
+  const root = platformRoot(platform, home);
+  if (isAtOrBelow(root, configPath)) {
+    throw new Error(`TeamClaude config cannot be stored inside the deployment root: ${configPath}`);
+  }
+  const kind = platform === 'linux' ? 'systemd' : 'launchd';
+  return Object.freeze({
+    platform,
+    home,
+    kind,
+    root,
+    repo: join(root, 'repo'),
+    releases: join(root, 'releases'),
+    current: join(root, 'current'),
+    previous: join(root, 'previous'),
+    binDir: join(root, 'bin'),
+    backups: join(root, 'backups'),
+    metadataFile: join(root, 'deployment.json'),
+    serviceFile: platform === 'linux'
+      ? '/etc/systemd/system/teamclaude.service'
+      : join(home, 'Library', 'LaunchAgents', 'com.karpeleslab.teamclaude.plist'),
+    logFile: platform === 'darwin' ? join(home, 'Library', 'Logs', 'teamclaude.log') : null,
+    defaultLauncher: platform === 'linux' ? '/usr/local/bin/teamclaude' : null,
+    configPath,
+  });
+}
+
+export function assertMutationAllowed(layout, { uid = process.getuid?.() } = {}) {
+  if (layout.platform === 'linux' && uid !== 0) {
+    throw new Error('teamclaude deploy mutations require root on Linux');
+  }
+}
+
+export function validateInstallConfig(config) {
+  if (!config) return { ok: false, reason: 'config not found' };
+  if (!Array.isArray(config.accounts) || config.accounts.length === 0) {
+    return { ok: false, reason: 'no accounts configured' };
+  }
+  const usable = config.accounts.some(account => {
+    if (!account || account.disabled) return false;
+    if (account.type === 'apikey') return !!account.apiKey;
+    if (account.type === 'oauth') {
+      return !!(account.accessToken || account.refreshToken || account.importFrom);
+    }
+    return false;
+  });
+  return usable
+    ? { ok: true }
+    : { ok: false, reason: 'no enabled account has usable credentials' };
+}
+
+function requireString(value, field) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid deployment metadata field: ${field}`);
+  }
+}
+
+function validateRemoteWithoutCredentials(remoteUrl) {
+  requireString(remoteUrl, 'remoteUrl');
+  try {
+    const parsed = new URL(remoteUrl);
+    if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') && (parsed.username || parsed.password)) {
+      throw new Error('Deployment remote URL must not contain credentials');
+    }
+  } catch (error) {
+    if (error.message.includes('credentials')) throw error;
+    // SCP-style Git remotes are intentionally not URL-parsed here.
+  }
+}
+
+function validateMetadata(layout, value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid deployment metadata object');
+  }
+  if (value.schemaVersion !== DEPLOYMENT_SCHEMA_VERSION) {
+    throw new Error(`Unsupported deployment metadata schema version: ${value.schemaVersion}`);
+  }
+  validateRemoteWithoutCredentials(value.remoteUrl);
+  if (value.serviceKind !== layout.kind) {
+    throw new Error(`Deployment service kind ${value.serviceKind} does not match ${layout.kind}`);
+  }
+  for (const field of ['nodePath', 'launcherPath', 'configPath', 'installedAt', 'requestedRef']) {
+    requireString(value[field], field);
+  }
+  if (resolve(value.configPath) !== resolve(layout.configPath)) {
+    throw new Error('Deployment metadata configPath does not match this layout');
+  }
+  if (isAtOrBelow(layout.root, value.configPath)) {
+    throw new Error('Deployment config cannot be inside the deployment root');
+  }
+  if (typeof value.npmCleanupPending !== 'boolean') {
+    throw new Error('Invalid deployment metadata field: npmCleanupPending');
+  }
+  const npm = value.npmRestore;
+  if (!npm || npm.packageName !== PACKAGE_NAME || (npm.version !== null && (typeof npm.version !== 'string' || !npm.version))) {
+    throw new Error('Invalid deployment metadata field: npmRestore');
+  }
+  requireString(npm.npmPath, 'npmRestore.npmPath');
+  if (!isAbsolute(npm.npmPath)) throw new Error('npmRestore.npmPath must be absolute');
+
+  const backup = value.serviceBackup;
+  if (backup !== null) {
+    if (!backup || typeof backup !== 'object') throw new Error('Invalid service backup metadata');
+    requireString(backup.source, 'serviceBackup.source');
+    requireString(backup.backupPath, 'serviceBackup.backupPath');
+    if (!isAtOrBelow(layout.backups, backup.backupPath)) {
+      throw new Error('Service backup path must be below the deployment backups directory');
+    }
+    if (!/^[a-f0-9]{64}$/i.test(backup.sha256 || '')) {
+      throw new Error('Invalid service backup SHA-256');
+    }
+    if (typeof backup.wasRunning !== 'boolean' || typeof backup.restoreOnUninstall !== 'boolean') {
+      throw new Error('Invalid service backup state');
+    }
+  }
+  return value;
+}
+
+export async function readDeployment(layout) {
+  let text;
+  try {
+    text = await readFile(layout.metadataFile, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Cannot parse deployment metadata ${layout.metadataFile}: ${error.message}`, { cause: error });
+  }
+  return validateMetadata(layout, value);
+}
+
+export async function writeDeployment(layout, value) {
+  validateMetadata(layout, value);
+  await mkdir(layout.root, { recursive: true, mode: 0o755 });
+  const temporary = join(dirname(layout.metadataFile), `.deployment.json.next-${process.pid}-${randomUUID()}`);
+  try {
+    await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600, flag: 'wx' });
+    await rename(temporary, layout.metadataFile);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export async function assertSafeRootRemoval(layout, metadata) {
+  const expectedRoot = platformRoot(layout.platform, layout.home);
+  if (resolve(layout.root) !== resolve(expectedRoot)) {
+    throw new Error(`Refusing to remove unexpected deployment root: ${layout.root}`);
+  }
+  validateMetadata(layout, metadata);
+  const stat = await lstat(layout.root);
+  if (stat.isSymbolicLink()) throw new Error('Refusing to remove a symlink deployment root');
+  if (!stat.isDirectory()) throw new Error('Deployment root is not a directory');
+  const actual = await realpath(layout.root);
+  const expectedActual = await realpath(expectedRoot);
+  if (resolve(actual) !== resolve(expectedActual)) {
+    throw new Error(`Deployment root resolves elsewhere: ${actual}`);
+  }
+}

--- a/src/deploy/manager.js
+++ b/src/deploy/manager.js
@@ -95,7 +95,7 @@ export function createDeployManager(dependencies = {}) {
   const removeDeploymentRoot = dependencies.removeDeploymentRoot
     || (() => fs.rm(layout.root, { recursive: true, force: false }));
   const verifyRestoredCommand = dependencies.verifyRestoredCommand || (async resolved => {
-    const result = run(resolved.commandPath, ['version']);
+    const result = run(resolved.nodePath, [resolved.commandPath, 'version']);
     if (commandFailed(result)) throw new Error(`Restored command failed verification: ${resolved.commandPath} version`);
   });
   const validateLauncher = dependencies.validateLauncher || (async path => {

--- a/src/deploy/manager.js
+++ b/src/deploy/manager.js
@@ -1,0 +1,563 @@
+import { spawnSync } from 'node:child_process';
+import * as fsPromises from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { loadConfig as defaultLoadConfig } from '../config.js';
+import {
+  DEPLOYMENT_SCHEMA_VERSION,
+  assertSafeRootRemoval as defaultAssertSafeRootRemoval,
+  assertMutationAllowed,
+  readDeployment as defaultReadDeployment,
+  validateInstallConfig,
+  writeDeployment as defaultWriteDeployment,
+} from './layout.js';
+import { createGitReleaseStore, validateRemoteUrl, validateRequestedRef } from './git-releases.js';
+import {
+  createDeployServiceAdapter,
+  isDeploymentOwnedDefinition,
+  renderLaunchAgent,
+  renderSystemdService,
+} from './service.js';
+import {
+  chooseLauncherPath as defaultChooseLauncherPath,
+  discoverBootstrap as defaultDiscoverBootstrap,
+  handoffLauncher as defaultHandoffLauncher,
+  LAUNCHER_OWNER,
+  removeOwnedLauncher as defaultRemoveOwnedLauncher,
+  resolveNpmRestore as defaultResolveNpmRestore,
+  restoreGlobalNpm as defaultRestoreGlobalNpm,
+} from './launcher.js';
+
+export const TEST_TIMEOUT_MS = 120_000;
+export const HEALTH_ATTEMPTS = 20;
+export const HEALTH_INTERVAL_MS = 1_000;
+
+function defaultRun(command, argv, { cwd, timeoutMs = 30_000, stdio = 'pipe', env } = {}) {
+  const result = spawnSync(command, argv, { cwd, encoding: 'utf8', timeout: timeoutMs, stdio, env });
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || result.error?.message || '',
+  };
+}
+
+function commandFailed(result) {
+  return !result || (result.code ?? result.status) !== 0;
+}
+
+function below(parent, child) {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel === '' || (rel !== '..' && !rel.startsWith('../') && !isAbsolute(rel));
+}
+
+function publicBackup(backup) {
+  if (!backup) return null;
+  const { source, backupPath, sha256, wasRunning, restoreOnUninstall } = backup;
+  return { source, backupPath, sha256, wasRunning, restoreOnUninstall };
+}
+
+function defaultRenderService({ layout, nodePath }) {
+  return layout.kind === 'systemd'
+    ? renderSystemdService({ layout, nodePath })
+    : renderLaunchAgent({ layout, nodePath });
+}
+
+export function createDeployManager(dependencies = {}) {
+  const layout = dependencies.layout;
+  if (!layout) throw new Error('A deployment layout is required');
+  const run = dependencies.run || defaultRun;
+  const store = dependencies.store || createGitReleaseStore({ layout, run });
+  const service = dependencies.service || createDeployServiceAdapter({ layout, run });
+  const loadConfig = dependencies.loadConfig || defaultLoadConfig;
+  const readDeployment = dependencies.readDeployment || defaultReadDeployment;
+  const writeDeployment = dependencies.writeDeployment || defaultWriteDeployment;
+  const discoverBootstrap = dependencies.discoverBootstrap || defaultDiscoverBootstrap;
+  const chooseLauncherPath = dependencies.chooseLauncherPath || defaultChooseLauncherPath;
+  const handoffLauncher = dependencies.handoffLauncher || defaultHandoffLauncher;
+  const fs = dependencies.fs || fsPromises;
+  const validateUninstallLayout = dependencies.validateUninstallLayout || defaultAssertSafeRootRemoval;
+  const assertSafeRootRemoval = dependencies.assertSafeRootRemoval || defaultAssertSafeRootRemoval;
+  const readServiceDefinition = dependencies.readServiceDefinition || (async () => {
+    const before = await fs.lstat(layout.serviceFile);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      throw new Error(`Service definition must be a regular file: ${layout.serviceFile}`);
+    }
+    const contents = await fs.readFile(layout.serviceFile, 'utf8');
+    const after = await fs.lstat(layout.serviceFile);
+    if (!after.isFile() || after.isSymbolicLink() || before.dev !== after.dev || before.ino !== after.ino) {
+      throw new Error(`Service definition changed during inspection: ${layout.serviceFile}`);
+    }
+    return contents;
+  });
+  const resolveNpmRestore = dependencies.resolveNpmRestore || defaultResolveNpmRestore;
+  const restoreGlobalNpm = dependencies.restoreGlobalNpm || defaultRestoreGlobalNpm;
+  const removeOwnedLauncher = dependencies.removeOwnedLauncher || defaultRemoveOwnedLauncher;
+  const removeDeploymentRoot = dependencies.removeDeploymentRoot
+    || (() => fs.rm(layout.root, { recursive: true, force: false }));
+  const verifyRestoredCommand = dependencies.verifyRestoredCommand || (async resolved => {
+    const result = run(resolved.commandPath, ['version']);
+    if (commandFailed(result)) throw new Error(`Restored command failed verification: ${resolved.commandPath} version`);
+  });
+  const validateLauncher = dependencies.validateLauncher || (async path => {
+    try {
+      const stat = await fs.lstat(path);
+      if (stat.isSymbolicLink()) return { exists: true, owned: false, symlink: true };
+      if (!stat.isFile()) return { exists: true, owned: false, symlink: false };
+      const contents = await fs.readFile(path, 'utf8');
+      return { exists: true, owned: contents.includes(`TeamClaude-Owner: ${LAUNCHER_OWNER}`), symlink: false };
+    } catch (error) {
+      if (error.code === 'ENOENT') return { exists: false, owned: false, symlink: false };
+      throw error;
+    }
+  });
+  const stageLauncher = dependencies.stageLauncher || (async launcherPath => {
+    const directory = await fs.mkdtemp(join(tmpdir(), 'teamclaude-uninstall-'));
+    const path = join(directory, 'teamclaude');
+    await fs.copyFile(launcherPath, path);
+    await fs.chmod(path, 0o700);
+    return { path };
+  });
+  const restoreStagedLauncher = dependencies.restoreStagedLauncher || (async (staged, launcherPath) => {
+    await fs.mkdir(dirname(launcherPath), { recursive: true, mode: 0o755 });
+    await fs.copyFile(staged.path, launcherPath);
+    await fs.chmod(launcherPath, 0o755);
+  });
+  const cleanupStagedLauncher = dependencies.cleanupStagedLauncher || (async staged => {
+    if (staged?.path) await fs.rm(dirname(staged.path), { recursive: true, force: true });
+  });
+  const renderService = dependencies.renderService || defaultRenderService;
+  const sleep = dependencies.sleep || (milliseconds => new Promise(resolvePromise => setTimeout(resolvePromise, milliseconds)));
+  const now = dependencies.now || (() => new Date());
+  const onStage = dependencies.onStage || (() => {});
+  const uid = dependencies.uid ?? process.getuid?.();
+
+  const runCandidateTests = dependencies.runCandidateTests || (async (candidate, nodePath) => {
+    const result = run(nodePath, ['--test', `--test-timeout=${TEST_TIMEOUT_MS}`], {
+      cwd: candidate.path,
+      timeoutMs: TEST_TIMEOUT_MS + 30_000,
+      stdio: 'inherit',
+    });
+    if (commandFailed(result)) throw new Error(`candidate tests exited ${result?.code ?? result?.status ?? 'unknown'}`);
+  });
+
+  const checkHealth = dependencies.checkHealth || (async metadata => {
+    const entry = join(layout.current, 'src', 'index.js');
+    const result = run(metadata.nodePath, [entry, 'status'], {
+      timeoutMs: 10_000,
+      env: { ...process.env, TEAMCLAUDE_CONFIG: metadata.configPath },
+    });
+    return !commandFailed(result);
+  });
+
+  async function preflight({ remoteUrl, ref }) {
+    onStage('preflight');
+    if (layout.platform !== 'linux' && layout.platform !== 'darwin') {
+      throw new Error(`teamclaude deploy supports Linux and macOS, not ${layout.platform}`);
+    }
+    assertMutationAllowed(layout, { uid });
+    if (below(layout.root, layout.configPath)) {
+      throw new Error(`TeamClaude config cannot be stored inside the deployment root: ${layout.configPath}`);
+    }
+    validateRemoteUrl(remoteUrl);
+    validateRequestedRef(ref);
+    const config = await loadConfig();
+    const eligible = validateInstallConfig(config);
+    if (!eligible.ok) throw new Error(`TeamClaude config is not deployable: ${eligible.reason}`);
+    const bootstrap = discoverBootstrap();
+    const git = run('git', ['--version'], { timeoutMs: 5_000 });
+    if (commandFailed(git)) throw new Error('Git is required for teamclaude deploy install');
+    return { config, bootstrap };
+  }
+
+  async function waitForHealth(metadata) {
+    for (let attempt = 1; attempt <= HEALTH_ATTEMPTS; attempt += 1) {
+      const serviceState = await service.status();
+      if (serviceState.running && await checkHealth(metadata)) return serviceState;
+      if (attempt < HEALTH_ATTEMPTS) await sleep(HEALTH_INTERVAL_MS);
+    }
+    throw new Error(`deployment did not become healthy after ${HEALTH_ATTEMPTS} attempts`);
+  }
+
+  async function requireMetadata({ mutation = true } = {}) {
+    const metadata = await readDeployment(layout);
+    if (!metadata) {
+      throw new Error('Git deployment is not installed. Run: teamclaude deploy install <git-url>');
+    }
+    if (mutation) assertMutationAllowed(layout, { uid });
+    return metadata;
+  }
+
+  function rollbackAggregate(candidateError, rollbackError) {
+    const logCommand = layout.kind === 'systemd'
+      ? 'teamclaude deploy logs --no-follow'
+      : `tail -n 100 ${layout.logFile}`;
+    return new AggregateError(
+      [candidateError, rollbackError],
+      `Candidate deployment failed: ${candidateError.message}. Rollback also failed: ${rollbackError.message}. Inspect logs with: ${logCommand}`,
+    );
+  }
+
+  async function restoreRuntime(selection, metadata, candidateError) {
+    try {
+      await store.restoreSelection(selection);
+      await service.restart();
+      await waitForHealth(metadata);
+    } catch (rollbackError) {
+      throw rollbackAggregate(candidateError, rollbackError);
+    }
+    throw candidateError;
+  }
+
+  async function install({ remoteUrl, ref = 'master' }) {
+    const { bootstrap } = await preflight({ remoteUrl, ref });
+    const existingMetadata = await readDeployment(layout);
+    if (existingMetadata && existingMetadata.remoteUrl !== remoteUrl) {
+      throw new Error(`Deployment already uses a different remote: ${existingMetadata.remoteUrl}`);
+    }
+    const repository = await store.ensureRepository(remoteUrl);
+    await store.fetch();
+    const commit = await store.resolveRef(ref);
+    const originalSelection = await store.readSelection();
+    const currentRelease = originalSelection.current
+      ? await store.describeRelease(originalSelection.current)
+      : null;
+    const candidate = currentRelease?.commit === commit
+      ? currentRelease
+      : await store.createCandidate(commit);
+    await runCandidateTests(candidate, bootstrap.nodePath);
+
+    const definition = renderService({ layout, nodePath: bootstrap.nodePath });
+    await service.validateDefinition(definition);
+    const serviceBackup = await service.backupExisting();
+    const adopted = !existingMetadata && !repository.cloned && Boolean(originalSelection.current);
+    const launcherSelection = existingMetadata
+      ? { path: existingMetadata.launcherPath, pathInstruction: null }
+      : chooseLauncherPath({ layout });
+    const provisionalMetadata = {
+      schemaVersion: DEPLOYMENT_SCHEMA_VERSION,
+      remoteUrl,
+      requestedRef: ref,
+      nodePath: bootstrap.nodePath,
+      launcherPath: launcherSelection.path,
+      configPath: layout.configPath,
+      serviceKind: layout.kind,
+      installedAt: existingMetadata?.installedAt || now().toISOString(),
+      npmCleanupPending: false,
+      npmRestore: existingMetadata?.npmRestore || {
+        packageName: '@karpeleslab/teamclaude', version: null, npmPath: bootstrap.npmPath,
+      },
+      serviceBackup: existingMetadata?.serviceBackup ?? publicBackup(serviceBackup),
+    };
+    let serviceTakeoverAttempted = false;
+    let candidateActivated = false;
+    let handoff;
+    try {
+      if (serviceBackup) {
+        serviceTakeoverAttempted = true;
+        await service.stop();
+      }
+      if (candidate.path !== originalSelection.current) {
+        await store.activate(candidate.path);
+        candidateActivated = true;
+      }
+      serviceTakeoverAttempted = true;
+      await service.install(definition);
+      await service.start();
+      await waitForHealth(provisionalMetadata);
+      handoff = await handoffLauncher({
+        bootstrap: adopted ? { ...bootstrap, installKind: 'git', packageVersion: null } : bootstrap,
+        launcherPath: launcherSelection.path,
+        entryPath: join(layout.current, 'src', 'index.js'),
+      });
+    } catch (candidateError) {
+      if (!serviceTakeoverAttempted && !candidateActivated) throw candidateError;
+      const rollbackErrors = [];
+      if (serviceTakeoverAttempted) {
+        try {
+          await service.restore(serviceBackup);
+        } catch (error) {
+          rollbackErrors.push(error);
+        }
+      }
+      if (candidateActivated) {
+        try {
+          await store.restoreSelection(originalSelection);
+        } catch (error) {
+          rollbackErrors.push(error);
+        }
+      }
+      if (rollbackErrors.length === 0) {
+        try {
+          await waitForHealth(provisionalMetadata);
+        } catch (error) {
+          rollbackErrors.push(error);
+        }
+      }
+      if (rollbackErrors.length > 0) {
+        const logCommand = layout.kind === 'systemd'
+          ? 'teamclaude deploy logs --no-follow'
+          : `tail -n 100 ${layout.logFile}`;
+        const detail = rollbackErrors.map(error => error.message).join('; ');
+        throw new AggregateError(
+          [candidateError, ...rollbackErrors],
+          `Candidate deployment failed: ${candidateError.message}. Rollback also failed: ${detail}. Inspect logs with: ${logCommand}`,
+        );
+      }
+      throw candidateError;
+    }
+    const metadata = {
+      ...provisionalMetadata,
+      launcherPath: handoff.launcherPath,
+      npmCleanupPending: handoff.npmCleanupPending,
+      npmRestore: existingMetadata?.npmRestore || handoff.npmRestore,
+    };
+    await writeDeployment(layout, metadata);
+    const partial = Boolean(handoff.npmCleanupPending);
+    return {
+      ok: !partial,
+      partial,
+      requestedRef: ref,
+      commit,
+      releasePath: candidate.path,
+      launcherPath: handoff.launcherPath,
+      npmCleanupPending: handoff.npmCleanupPending,
+      npmRestore: metadata.npmRestore,
+      serviceBackup: metadata.serviceBackup,
+      ...(handoff.warning ? { warning: handoff.warning } : {}),
+    };
+  }
+
+  async function deployRef({ ref }) {
+    const metadata = await requireMetadata();
+    validateRequestedRef(ref);
+    await store.ensureRepository(metadata.remoteUrl);
+    await store.fetch();
+    const commit = await store.resolveRef(ref);
+    const candidate = await store.createCandidate(commit);
+    await runCandidateTests(candidate, metadata.nodePath);
+    const originalSelection = await store.readSelection();
+    await store.activate(candidate.path);
+    try {
+      await service.restart();
+      await waitForHealth(metadata);
+    } catch (candidateError) {
+      return restoreRuntime(originalSelection, metadata, candidateError);
+    }
+    await writeDeployment(layout, { ...metadata, requestedRef: ref });
+    return {
+      ok: true,
+      requestedRef: ref,
+      commit,
+      releasePath: candidate.path,
+      previous: originalSelection.current,
+    };
+  }
+
+  async function rollback() {
+    const metadata = await requireMetadata();
+    const originalSelection = await store.readSelection();
+    const selection = await store.swapForRollback();
+    try {
+      await service.restart();
+      await waitForHealth(metadata);
+    } catch (candidateError) {
+      return restoreRuntime(originalSelection, metadata, candidateError);
+    }
+    return { ok: true, current: selection.current, previous: selection.previous };
+  }
+
+  async function restart() {
+    const metadata = await requireMetadata();
+    await service.restart();
+    await waitForHealth(metadata);
+    return { ok: true };
+  }
+
+  async function logs({ lines = 100, follow = true } = {}) {
+    if (!Number.isInteger(lines) || lines < 1 || lines > 100_000) {
+      throw new Error('logs lines must be an integer from 1 to 100000');
+    }
+    await requireMetadata({ mutation: false });
+    const result = await service.logs({ lines, follow });
+    return { ok: result.code === 0, code: result.code };
+  }
+
+  async function status() {
+    const metadata = await readDeployment(layout);
+    if (!metadata) {
+      return { installed: false, platform: layout.platform, root: layout.root, detail: 'not installed' };
+    }
+    const selection = await store.readSelection();
+    const [current, previous, serviceState] = await Promise.all([
+      selection.current ? store.describeRelease(selection.current) : null,
+      selection.previous ? store.describeRelease(selection.previous) : null,
+      service.status(),
+    ]);
+    return {
+      schemaVersion: metadata.schemaVersion,
+      platform: layout.platform,
+      root: layout.root,
+      remoteUrl: metadata.remoteUrl,
+      requestedRef: metadata.requestedRef,
+      current,
+      previous,
+      service: serviceState,
+      nodePath: metadata.nodePath,
+      launcherPath: metadata.launcherPath,
+      configPath: metadata.configPath,
+      npmCleanupPending: metadata.npmCleanupPending,
+      npmRestore: metadata.npmRestore,
+      serviceBackup: metadata.serviceBackup,
+    };
+  }
+
+  async function uninstall({ restoreNpm } = {}) {
+    if (typeof restoreNpm !== 'boolean') {
+      throw new Error('uninstall restoreNpm must be an explicit boolean');
+    }
+    const metadata = await requireMetadata();
+    await validateUninstallLayout(layout, metadata);
+    await store.readSelection();
+    const deploymentDefinition = await readServiceDefinition();
+    if (!isDeploymentOwnedDefinition(deploymentDefinition)) {
+      throw new Error(`Service definition is not deployment-owned: ${layout.serviceFile}`);
+    }
+    const validBackup = metadata.serviceBackup
+      ? await service.validateBackup(metadata.serviceBackup)
+      : null;
+    const launcherState = await validateLauncher(metadata.launcherPath);
+    if (launcherState.exists && !launcherState.owned && restoreNpm) {
+      throw new Error(`Refusing to overwrite a launcher that is not deployment-owned: ${metadata.launcherPath}`);
+    }
+
+    let resolvedNpm = null;
+    if (restoreNpm) {
+      resolvedNpm = await resolveNpmRestore({
+        npmRestore: metadata.npmRestore,
+        nodePath: metadata.nodePath,
+        run,
+      });
+      const commandState = resolvedNpm.commandPath === metadata.launcherPath
+        ? launcherState
+        : await validateLauncher(resolvedNpm.commandPath);
+      if (commandState.exists && !commandState.owned) {
+        throw new Error(`Refusing to overwrite a non-deployment command: ${resolvedNpm.commandPath}`);
+      }
+      if (!launcherState.exists || !launcherState.owned || launcherState.symlink) {
+        throw new Error(`A regular deployment-owned launcher is required for safe npm restoration: ${metadata.launcherPath}`);
+      }
+    }
+
+    const stagedLauncher = launcherState.exists && launcherState.owned
+      ? await stageLauncher(metadata.launcherPath)
+      : null;
+    let npmRestored = false;
+    if (restoreNpm) {
+      try {
+        await restoreGlobalNpm(resolvedNpm, { run });
+        npmRestored = true;
+      } catch (error) {
+        if (stagedLauncher) await restoreStagedLauncher(stagedLauncher, metadata.launcherPath).catch(() => {});
+        await cleanupStagedLauncher(stagedLauncher).catch(() => {});
+        throw new Error(
+          `npm restoration failed: ${error.message}. Retry manually: npm install --global ${resolvedNpm.packageSpec}`,
+          { cause: error },
+        );
+      }
+    }
+
+    const shouldRestorePriorService = Boolean(
+      restoreNpm && validBackup?.restoreOnUninstall,
+    );
+    let restoredService = false;
+    let launcherRemoved = false;
+    let commitBoundary = false;
+    try {
+      await service.stop();
+      await service.removeOwnedDefinition();
+      if (shouldRestorePriorService) {
+        await service.restore(validBackup);
+        const priorState = await service.status();
+        if (!priorState.installed || (validBackup.wasRunning && !priorState.running)) {
+          throw new Error('The prior TeamClaude service did not restore to its recorded state');
+        }
+        restoredService = true;
+      }
+      const launcherResult = await removeOwnedLauncher({ launcherPath: metadata.launcherPath });
+      launcherRemoved = launcherResult.removed;
+      await assertSafeRootRemoval(layout, metadata);
+      commitBoundary = true;
+      await removeDeploymentRoot(layout.root);
+    } catch (primaryError) {
+      if (commitBoundary) {
+        if (restoreNpm) await verifyRestoredCommand(resolvedNpm).catch(() => {});
+        await cleanupStagedLauncher(stagedLauncher).catch(() => {});
+        return {
+          ok: false,
+          partial: true,
+          restoredNpm: npmRestored,
+          packageSpec: resolvedNpm?.packageSpec || null,
+          commandPath: resolvedNpm?.commandPath || null,
+          restoredService,
+          launcherRemoved,
+          removedRoot: false,
+          remainingPaths: [layout.root],
+          warning: `Deployment teardown committed, but the deployment root remains: ${primaryError.message}`,
+        };
+      }
+
+      const compensationErrors = [];
+      try {
+        await service.stop().catch(() => {});
+        await service.install(deploymentDefinition);
+        if (stagedLauncher) await restoreStagedLauncher(stagedLauncher, metadata.launcherPath);
+        await service.start();
+        await waitForHealth(metadata);
+      } catch (error) {
+        compensationErrors.push(error);
+      }
+      await cleanupStagedLauncher(stagedLauncher).catch(() => {});
+      if (compensationErrors.length > 0) {
+        throw rollbackAggregate(primaryError, compensationErrors[0]);
+      }
+      throw primaryError;
+    }
+
+    if (restoreNpm) {
+      try {
+        await verifyRestoredCommand(resolvedNpm);
+      } catch (error) {
+        await cleanupStagedLauncher(stagedLauncher).catch(() => {});
+        return {
+          ok: false,
+          partial: true,
+          restoredNpm: npmRestored,
+          packageSpec: resolvedNpm.packageSpec,
+          commandPath: resolvedNpm.commandPath,
+          restoredService,
+          launcherRemoved,
+          removedRoot: true,
+          remainingPaths: [resolvedNpm.commandPath],
+          warning: `Deployment was removed, but the restored npm command failed verification: ${error.message}`,
+        };
+      }
+    }
+    await cleanupStagedLauncher(stagedLauncher);
+    return {
+      ok: true,
+      partial: false,
+      restoredNpm: npmRestored,
+      packageSpec: resolvedNpm?.packageSpec || null,
+      commandPath: resolvedNpm?.commandPath || null,
+      restoredService,
+      launcherRemoved,
+      removedRoot: true,
+      remainingPaths: [],
+      ...(!restoreNpm ? {
+        warning: 'TeamClaude was intentionally left uninstalled; the config, state, nginx, and retained logs were preserved.',
+      } : {}),
+    };
+  }
+
+  return { install, deployRef, rollback, restart, logs, status, uninstall };
+}

--- a/src/deploy/service.js
+++ b/src/deploy/service.js
@@ -1,0 +1,327 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import * as fsPromises from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
+export const DEPLOYMENT_OWNER = 'teamclaude-git-deploy-v1';
+export const SERVICE_LABEL = 'com.karpeleslab.teamclaude';
+export const UNIT_NAME = 'teamclaude.service';
+
+function defaultRun(command, argv, { stdio = 'pipe', timeoutMs = 30_000 } = {}) {
+  const result = spawnSync(command, argv, { encoding: 'utf8', stdio, timeout: timeoutMs });
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || result.error?.message || '',
+  };
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function servicePath(nodePath) {
+  return [...new Set([
+    dirname(nodePath), '/usr/local/bin', '/opt/homebrew/bin',
+    '/usr/bin', '/bin', '/usr/sbin', '/sbin',
+  ])].join(':');
+}
+
+export function isDeploymentOwnedDefinition(text = '') {
+  return text.includes(`TeamClaude-Owner: ${DEPLOYMENT_OWNER}`)
+    || new RegExp(`<key>TeamClaudeOwner</key>\\s*<string>${DEPLOYMENT_OWNER}</string>`).test(text);
+}
+
+export function renderSystemdService({ layout, nodePath }) {
+  return `# TeamClaude-Owner: ${DEPLOYMENT_OWNER}
+[Unit]
+Description=TeamClaude multi-account Claude proxy from Git
+Documentation=https://github.com/KarpelesLab/teamclaude
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=${layout.current}
+ExecStart=${nodePath} ${join(layout.current, 'src', 'index.js')} server --headless
+Restart=always
+RestartSec=5
+Environment=PATH=${servicePath(nodePath)}
+Environment=TEAMCLAUDE_CONFIG=${layout.configPath}
+Environment=TEAMCLAUDE_DISABLE_AUTOUPDATE=1
+
+[Install]
+WantedBy=multi-user.target
+`;
+}
+
+export function renderLaunchAgent({ layout, nodePath }) {
+  const args = [nodePath, join(layout.current, 'src', 'index.js'), 'server', '--headless'];
+  const env = {
+    PATH: servicePath(nodePath),
+    TEAMCLAUDE_CONFIG: layout.configPath,
+    TEAMCLAUDE_DISABLE_AUTOUPDATE: '1',
+  };
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>TeamClaudeOwner</key>
+  <string>${DEPLOYMENT_OWNER}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.map(arg => `    <string>${xmlEscape(arg)}</string>`).join('\n')}
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(layout.current)}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(layout.logFile)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(layout.logFile)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+${Object.entries(env).map(([key, value]) => `    <key>${key}</key>\n    <string>${xmlEscape(value)}</string>`).join('\n')}
+  </dict>
+</dict>
+</plist>
+`;
+}
+
+function timestamp(date) {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function sha256(contents) {
+  return createHash('sha256').update(contents).digest('hex');
+}
+
+function below(parent, child) {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel !== '' && rel !== '..' && !rel.startsWith('../') && !isAbsolute(rel);
+}
+
+export function createDeployServiceAdapter({
+  layout,
+  run = defaultRun,
+  fs = fsPromises,
+  uid = process.getuid?.() ?? 0,
+  now = () => new Date(),
+} = {}) {
+  if (!layout) throw new Error('A deployment layout is required');
+  const domain = `gui/${uid}`;
+  const serviceTarget = `${domain}/${SERVICE_LABEL}`;
+
+  const checked = (command, argv, options = {}) => {
+    const result = run(command, argv, options);
+    if (result.code !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+      throw new Error(`${command} ${argv.join(' ')} failed (${result.code}): ${detail}`);
+    }
+    return result;
+  };
+
+  async function exists(path) {
+    try {
+      await fs.lstat(path);
+      return true;
+    } catch (error) {
+      if (error.code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  async function readRegularDefinition() {
+    const before = await fs.lstat(layout.serviceFile);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      throw new Error(`Service definition must be a regular file, not a symbolic link: ${layout.serviceFile}`);
+    }
+    const contents = await fs.readFile(layout.serviceFile, 'utf8');
+    const after = await fs.lstat(layout.serviceFile);
+    if (!after.isFile() || after.isSymbolicLink() || before.dev !== after.dev || before.ino !== after.ino) {
+      throw new Error(`Service definition changed during inspection: ${layout.serviceFile}`);
+    }
+    return contents;
+  }
+
+  async function atomicWrite(path, contents, mode = 0o644) {
+    await fs.mkdir(dirname(path), { recursive: true });
+    const temporary = `${path}.next-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.writeFile(temporary, contents, { mode, flag: 'wx' });
+      await fs.rename(temporary, path);
+    } catch (error) {
+      await fs.rm(temporary, { force: true }).catch(() => {});
+      throw error;
+    }
+  }
+
+  async function validateDefinition(contents) {
+    const directory = await fs.mkdtemp(join(tmpdir(), 'teamclaude-service-'));
+    const file = join(directory, layout.kind === 'systemd' ? UNIT_NAME : `${SERVICE_LABEL}.plist`);
+    try {
+      await fs.writeFile(file, contents, { mode: 0o600 });
+      if (layout.kind === 'systemd') checked('systemd-analyze', ['verify', file]);
+      else checked('plutil', ['-lint', file]);
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  }
+
+  async function status() {
+    const installed = await exists(layout.serviceFile);
+    if (layout.kind === 'systemd') {
+      const enabledResult = run('systemctl', ['is-enabled', UNIT_NAME]);
+      const activeResult = run('systemctl', ['is-active', UNIT_NAME]);
+      const detail = activeResult.stdout.trim() || activeResult.stderr.trim() || 'inactive';
+      return {
+        kind: 'systemd',
+        installed,
+        enabled: enabledResult.code === 0 && enabledResult.stdout.trim() === 'enabled',
+        running: activeResult.code === 0 && activeResult.stdout.trim() === 'active',
+        detail,
+      };
+    }
+    const result = run('launchctl', ['print', serviceTarget]);
+    const pid = /\bpid = (\d+)/.exec(result.stdout)?.[1] || null;
+    return {
+      kind: 'launchd',
+      installed,
+      enabled: installed,
+      running: result.code === 0 && !!pid,
+      ...(pid ? { pid } : {}),
+      detail: result.code === 0 ? 'loaded' : 'not loaded',
+    };
+  }
+
+  async function backupExisting() {
+    if (!await exists(layout.serviceFile)) return null;
+    const contents = await readRegularDefinition();
+    const state = await status();
+    const base = join(layout.backups, timestamp(now()));
+    let directory = base;
+    let suffix = 1;
+    while (await exists(directory)) directory = `${base}-${suffix++}`;
+    const backupPath = join(directory, layout.kind === 'systemd' ? UNIT_NAME : `${SERVICE_LABEL}.plist`);
+    await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+    await fs.writeFile(backupPath, contents, { mode: 0o600, flag: 'wx' });
+    const mentionsDeployRoot = [layout.root, layout.repo, layout.current, layout.releases]
+      .filter(Boolean).some(path => contents.includes(path));
+    const looksNpmBacked = /(?:node_modules\/@karpeleslab\/teamclaude|\/bin\/teamclaude)\b/.test(contents);
+    return {
+      source: layout.serviceFile,
+      backupPath,
+      contents,
+      sha256: sha256(contents),
+      wasRunning: state.running,
+      restoreOnUninstall: looksNpmBacked && !mentionsDeployRoot,
+    };
+  }
+
+  async function validateBackup(backup) {
+    if (!backup) return null;
+    if (backup.source !== layout.serviceFile || !below(layout.backups, backup.backupPath)) {
+      throw new Error('Service backup path or source is outside the deployment layout');
+    }
+    const stat = await fs.lstat(backup.backupPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('Service backup must be a regular file');
+    const contents = await fs.readFile(backup.backupPath, 'utf8');
+    if (sha256(contents) !== backup.sha256) throw new Error('Service backup SHA-256 does not match metadata');
+    return { ...backup, contents };
+  }
+
+  async function stop() {
+    if (layout.kind === 'systemd') {
+      checked('systemctl', ['stop', UNIT_NAME]);
+      return;
+    }
+    const result = run('launchctl', ['bootout', serviceTarget]);
+    if (result.code !== 0 && !/could not find|no such process|not loaded/i.test(result.stderr)) {
+      const detail = result.stderr.trim() || `exit ${result.code}`;
+      throw new Error(`launchctl bootout failed (${result.code}): ${detail}`);
+    }
+  }
+
+  async function install(contents) {
+    if (!isDeploymentOwnedDefinition(contents)) throw new Error('Refusing to install an unowned deployment service definition');
+    await atomicWrite(layout.serviceFile, contents, 0o644);
+    if (layout.kind === 'systemd') {
+      checked('systemctl', ['daemon-reload']);
+      checked('systemctl', ['enable', UNIT_NAME]);
+    }
+  }
+
+  async function start() {
+    if (layout.kind === 'systemd') checked('systemctl', ['start', UNIT_NAME]);
+    else checked('launchctl', ['bootstrap', domain, layout.serviceFile]);
+  }
+
+  async function restart() {
+    if (layout.kind === 'systemd') checked('systemctl', ['restart', UNIT_NAME]);
+    else checked('launchctl', ['kickstart', '-k', serviceTarget]);
+  }
+
+  async function removeOwnedDefinition() {
+    if (!await exists(layout.serviceFile)) return { removed: false };
+    const contents = await readRegularDefinition();
+    if (!isDeploymentOwnedDefinition(contents)) {
+      throw new Error(`Service definition is not deployment-owned: ${layout.serviceFile}`);
+    }
+    if (layout.kind === 'systemd') checked('systemctl', ['disable', UNIT_NAME]);
+    await fs.rm(layout.serviceFile);
+    if (layout.kind === 'systemd') checked('systemctl', ['daemon-reload']);
+    return { removed: true };
+  }
+
+  async function restore(backup) {
+    if (!backup) {
+      if (await exists(layout.serviceFile)) await fs.rm(layout.serviceFile);
+      if (layout.kind === 'systemd') checked('systemctl', ['daemon-reload']);
+      return { restored: false };
+    }
+    const valid = backup.contents && sha256(backup.contents) === backup.sha256
+      ? backup
+      : await validateBackup(backup);
+    await atomicWrite(valid.source, valid.contents, 0o644);
+    if (layout.kind === 'systemd') checked('systemctl', ['daemon-reload']);
+    if (valid.wasRunning) {
+      if (layout.kind === 'systemd') checked('systemctl', ['start', UNIT_NAME]);
+      else checked('launchctl', ['bootstrap', domain, valid.source]);
+    }
+    return { restored: true, running: valid.wasRunning };
+  }
+
+  function logs({ lines = 100, follow = true } = {}) {
+    const args = layout.kind === 'systemd'
+      ? ['--unit', UNIT_NAME, '--lines', String(lines), follow ? '--follow' : '--no-pager']
+      : ['-n', String(lines), ...(follow ? ['-f'] : []), layout.logFile];
+    const command = layout.kind === 'systemd' ? 'journalctl' : 'tail';
+    const result = run(command, args, { stdio: 'inherit' });
+    return { code: result.code };
+  }
+
+  return {
+    validateDefinition,
+    backupExisting,
+    validateBackup,
+    stop,
+    install,
+    removeOwnedDefinition,
+    restore,
+    start,
+    restart,
+    status,
+    logs,
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
+import { runDeployCli } from './deploy/cli.js';
 
 // These constants are referenced by routeCommand, which the dispatch below
 // reaches through a top-level `await`. The await suspends module evaluation at
@@ -117,6 +118,9 @@ switch (command) {
   case 'service':
     await serviceCommand();
     process.exit(0);
+    break;
+  case 'deploy':
+    process.exit(await runDeployCli(args.slice(1)));
     break;
   case 'probe':
     await probeCommand();
@@ -1562,6 +1566,8 @@ Commands:
                       restarts on its own: install | uninstall | status | print
                       (LaunchAgent on macOS, systemd --user unit on Linux;
                       'print' writes the unit to stdout without touching anything)
+  deploy <sub>        Install and operate a boot-persistent Git deployment;
+                      run 'teamclaude deploy help' for subcommands
   status [--json]     Show rich proxy/account/probe status (live)
                       Use --color=always|never to control ANSI colors
   attach              Open the live dashboard against a running server; s

--- a/src/service.js
+++ b/src/service.js
@@ -14,6 +14,7 @@ import { existsSync, realpathSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { isDeploymentOwnedDefinition } from './deploy/service.js';
 
 export const LABEL = 'com.karpeleslab.teamclaude';
 export const UNIT_NAME = 'teamclaude.service';
@@ -146,6 +147,23 @@ function runCommand(cmd, args) {
 /** `gui/<uid>` — the launchd domain a per-user agent lives in. */
 const guiDomain = (uid = process.getuid?.() ?? 0) => `gui/${uid}`;
 
+const DEPLOYMENT_OWNED_REFUSAL = Object.freeze({
+  ok: false,
+  error: 'This service is managed by teamclaude deploy. Use: teamclaude deploy status',
+  deploymentOwned: true,
+});
+
+async function refuseDeploymentOwned(file) {
+  try {
+    return isDeploymentOwnedDefinition(await readFile(file, 'utf8'))
+      ? { ...DEPLOYMENT_OWNED_REFUSAL }
+      : null;
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
 export async function installService({
   kind = serviceKind(), home = homedir(), platform = process.platform,
   exec = resolveExec(), run = runCommand, configPath = null, log = console.log,
@@ -157,6 +175,8 @@ export async function installService({
 
   if (kind === 'launchd') {
     const plist = launchAgentPath(home);
+    const refusal = await refuseDeploymentOwned(plist);
+    if (refusal) return refusal;
     await mkdir(dirname(plist), { recursive: true });
     await mkdir(dirname(logFile), { recursive: true });
     await writeFile(plist, renderLaunchAgent({ ...exec, log: logFile, path, configPath }), { mode: 0o644 });
@@ -172,6 +192,8 @@ export async function installService({
   }
 
   const unit = systemdUnitPath(home, xdgConfig);
+  const refusal = await refuseDeploymentOwned(unit);
+  if (refusal) return refusal;
   await mkdir(dirname(unit), { recursive: true });
   await writeFile(unit, renderSystemdUnit({ ...exec, path, configPath }), { mode: 0o644 });
   run('systemctl', ['--user', 'daemon-reload']);
@@ -192,12 +214,16 @@ export async function uninstallService({
   if (!kind) return { ok: false, error: 'No service integration for this platform' };
   if (kind === 'launchd') {
     const plist = launchAgentPath(home);
+    const refusal = await refuseDeploymentOwned(plist);
+    if (refusal) return refusal;
     run('launchctl', ['bootout', `${guiDomain()}/${LABEL}`]);
     await rm(plist, { force: true });
     log(`[TeamClaude] Service removed: ${plist}`);
     return { ok: true, file: plist };
   }
   const unit = systemdUnitPath(home, xdgConfig);
+  const refusal = await refuseDeploymentOwned(unit);
+  if (refusal) return refusal;
   run('systemctl', ['--user', 'disable', '--now', UNIT_NAME]);
   await rm(unit, { force: true });
   run('systemctl', ['--user', 'daemon-reload']);

--- a/test/deploy-cli.test.js
+++ b/test/deploy-cli.test.js
@@ -1,0 +1,230 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  parseDeployArgs,
+  promptYesNo,
+  runDeployCli,
+  showDeployHelp,
+} from '../src/deploy/cli.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const entry = join(here, '..', 'src', 'index.js');
+
+function streamPair(inputText = '', isTTY = true) {
+  const input = new PassThrough();
+  input.isTTY = isTTY;
+  input.end(inputText);
+  const output = new PassThrough();
+  const stdout = new PassThrough();
+  return {
+    input, output, stdout,
+    errorText: () => output.read()?.toString() || '',
+    stdoutText: () => stdout.read()?.toString() || '',
+  };
+}
+
+function fakeManager(overrides = {}) {
+  const calls = [];
+  const manager = {
+    install: async options => { calls.push(['install', options]); return { ok: true, partial: false, commit: 'a'.repeat(40), releasePath: '/release' }; },
+    deployRef: async options => { calls.push(['deployRef', options]); return { ok: true, commit: 'b'.repeat(40), releasePath: '/release' }; },
+    rollback: async () => { calls.push(['rollback']); return { ok: true, current: '/current', previous: '/previous' }; },
+    restart: async () => { calls.push(['restart']); return { ok: true }; },
+    logs: async options => { calls.push(['logs', options]); return { ok: true, code: 0 }; },
+    status: async () => { calls.push(['status']); return { installed: false, platform: 'linux', root: '/opt/teamclaude', detail: 'not installed' }; },
+    uninstall: async options => { calls.push(['uninstall', options]); return {
+      ok: true, partial: false, restoredNpm: options.restoreNpm,
+      packageSpec: options.restoreNpm ? '@karpeleslab/teamclaude@1.1.13' : null,
+      commandPath: options.restoreNpm ? '/prefix/bin/teamclaude' : null,
+      restoredService: options.restoreNpm, launcherRemoved: !options.restoreNpm,
+      removedRoot: true, remainingPaths: [],
+    }; },
+    ...overrides,
+  };
+  return { manager, calls };
+}
+
+test('deploy parser accepts every public command form', () => {
+  assert.deepEqual(parseDeployArgs(['install', 'https://example/repo.git']),
+    { command: 'install', remoteUrl: 'https://example/repo.git', ref: 'master' });
+  assert.deepEqual(parseDeployArgs(['install', 'https://example/repo.git', '--ref', 'feature']),
+    { command: 'install', remoteUrl: 'https://example/repo.git', ref: 'feature' });
+  assert.deepEqual(parseDeployArgs(['ref', 'v1.2.0']), { command: 'ref', ref: 'v1.2.0' });
+  assert.deepEqual(parseDeployArgs(['rollback']), { command: 'rollback' });
+  assert.deepEqual(parseDeployArgs(['restart']), { command: 'restart' });
+  assert.deepEqual(parseDeployArgs(['logs']), { command: 'logs', lines: 100, follow: true });
+  assert.deepEqual(parseDeployArgs(['logs', '--lines', '250', '--no-follow']),
+    { command: 'logs', lines: 250, follow: false });
+  assert.deepEqual(parseDeployArgs(['status', '--json']), { command: 'status', json: true });
+  assert.deepEqual(parseDeployArgs(['uninstall']), { command: 'uninstall', yes: false, restoreNpm: null });
+  assert.deepEqual(parseDeployArgs(['uninstall', '--yes', '--restore-npm']),
+    { command: 'uninstall', yes: true, restoreNpm: true });
+  assert.deepEqual(parseDeployArgs(['uninstall', '--yes', '--no-restore-npm']),
+    { command: 'uninstall', yes: true, restoreNpm: false });
+  assert.deepEqual(parseDeployArgs([]), { command: 'help' });
+  assert.deepEqual(parseDeployArgs(['help']), { command: 'help' });
+});
+
+test('deploy parser rejects ambiguous or malformed arguments with usage status', () => {
+  for (const argv of [
+    ['install'], ['install', 'url', '--ref'], ['install', 'url', '--json'],
+    ['ref'], ['ref', 'a', 'b'], ['rollback', 'extra'], ['logs', '--lines', '0'],
+    ['logs', '--lines', '1.5'], ['logs', '--lines', '100001'], ['logs', '--wat'],
+    ['status', '--json', '--json'], ['uninstall', '--yes', '--yes'],
+    ['uninstall', '--restore-npm', '--no-restore-npm'], ['unknown'],
+  ]) {
+    assert.throws(() => parseDeployArgs(argv), error => error.exitCode === 64, argv.join(' '));
+  }
+});
+
+test('deploy help is the exact public command surface', () => {
+  const output = new PassThrough();
+  showDeployHelp(output);
+  assert.equal(output.read().toString(), `teamclaude deploy install <git-url> [--ref master]
+teamclaude deploy ref <branch|tag|commit>
+teamclaude deploy rollback
+teamclaude deploy restart
+teamclaude deploy logs [--lines 100] [--no-follow]
+teamclaude deploy status [--json]
+teamclaude deploy uninstall [--yes] [--restore-npm|--no-restore-npm]
+teamclaude deploy help
+`);
+});
+
+test('yes/no prompt handles defaults, case, retries, and EOF', async () => {
+  for (const [inputText, defaultValue, expected] of [
+    ['y\n', false, true], ['YES\n', false, true], ['n\n', true, false], ['No\n', true, false],
+    ['\n', false, false], ['\n', true, true], ['maybe\nyes\n', false, true], ['', false, null],
+  ]) {
+    const io = streamPair(inputText);
+    assert.equal(await promptYesNo({ input: io.input, output: io.output, question: 'Continue?', defaultValue }), expected);
+  }
+});
+
+test('interactive uninstall resolves both decisions before calling manager', async () => {
+  for (const [argv, answers, expectedRestore, firstPrompt, secondPrompt] of [
+    [['uninstall'], 'yes\nno\n', false, true, true],
+    [['uninstall', '--yes'], 'yes\n', true, false, true],
+    [['uninstall', '--restore-npm'], 'yes\n', true, true, false],
+    [['uninstall', '--no-restore-npm'], 'yes\n', false, true, false],
+  ]) {
+    const io = streamPair(answers, true);
+    const fake = fakeManager();
+    let factoryCalls = 0;
+    const code = await runDeployCli(argv, {
+      ...io,
+      createManager: () => { factoryCalls += 1; return fake.manager; },
+    });
+    assert.equal(code, 0);
+    assert.equal(factoryCalls, 1);
+    assert.deepEqual(fake.calls, [['uninstall', { restoreNpm: expectedRestore }]]);
+    const text = io.errorText();
+    assert.equal(text.includes('Remove the Git deployment, service, releases, and launcher? [y/N]'), firstPrompt);
+    assert.equal(text.includes('Restore @karpeleslab/teamclaude as a global npm package? [Y/n]'), secondPrompt);
+    assert.equal(text.includes('The teamclaude command will be removed with the Git deployment.'), !expectedRestore);
+  }
+});
+
+test('interactive uninstall cancellation is a successful no-op', async () => {
+  for (const answer of ['no\n', '\n', '']) {
+    const io = streamPair(answer, true);
+    let factoryCalls = 0;
+    const code = await runDeployCli(['uninstall'], {
+      ...io, createManager: () => { factoryCalls += 1; return fakeManager().manager; },
+    });
+    assert.equal(code, 0);
+    assert.equal(factoryCalls, 0);
+  }
+});
+
+test('non-interactive uninstall requires confirmation and an explicit npm decision', async () => {
+  for (const argv of [
+    ['uninstall'], ['uninstall', '--yes'], ['uninstall', '--restore-npm'],
+  ]) {
+    const io = streamPair('', false);
+    let factoryCalls = 0;
+    assert.equal(await runDeployCli(argv, {
+      ...io, createManager: () => { factoryCalls += 1; return fakeManager().manager; },
+    }), 64);
+    assert.equal(factoryCalls, 0);
+    const text = io.errorText();
+    assert.match(text, /uninstall --yes --restore-npm/);
+    assert.match(text, /uninstall --yes --no-restore-npm/);
+  }
+
+  for (const [flag, expected] of [['--restore-npm', true], ['--no-restore-npm', false]]) {
+    const io = streamPair('', false);
+    const fake = fakeManager();
+    assert.equal(await runDeployCli(['uninstall', '--yes', flag], { ...io, createManager: () => fake.manager }), 0);
+    assert.deepEqual(fake.calls, [['uninstall', { restoreNpm: expected }]]);
+  }
+});
+
+test('each deploy command dispatches once with parsed options', async () => {
+  const cases = [
+    [['install', 'https://example/repo.git', '--ref', 'dev'], ['install', { remoteUrl: 'https://example/repo.git', ref: 'dev' }]],
+    [['ref', 'v1.2.0'], ['deployRef', { ref: 'v1.2.0' }]],
+    [['rollback'], ['rollback']],
+    [['restart'], ['restart']],
+    [['logs', '--lines', '25', '--no-follow'], ['logs', { lines: 25, follow: false }]],
+  ];
+  for (const [argv, expected] of cases) {
+    const io = streamPair('', true);
+    const fake = fakeManager();
+    assert.equal(await runDeployCli(argv, { ...io, createManager: () => fake.manager }), 0);
+    assert.deepEqual(fake.calls, [expected]);
+  }
+});
+
+test('status supports clean JSON and readable human output', async () => {
+  const status = {
+    schemaVersion: 1, platform: 'linux', root: '/opt/teamclaude', remoteUrl: 'https://example/repo.git',
+    requestedRef: 'master', current: { commit: 'a'.repeat(40), path: '/release/a' },
+    previous: { commit: 'b'.repeat(40), path: '/release/b' },
+    service: { running: true, detail: 'active' }, nodePath: '/node', launcherPath: '/usr/local/bin/teamclaude',
+    configPath: '/root/.config/teamclaude.json', npmCleanupPending: false, npmRestore: {}, serviceBackup: null,
+  };
+  for (const json of [true, false]) {
+    const io = streamPair('', true);
+    const fake = fakeManager({ status: async () => { fake.calls.push(['status']); return status; } });
+    assert.equal(await runDeployCli(['status', ...(json ? ['--json'] : [])], { ...io, createManager: () => fake.manager }), 0);
+    const text = io.stdoutText();
+    if (json) assert.equal(text, `${JSON.stringify(status, null, 2)}\n`);
+    else {
+      for (const value of ['linux', '/opt/teamclaude', 'https://example/repo.git', 'master', 'a'.repeat(40),
+        '/release/a', 'b'.repeat(40), '/release/b', 'active', '/node', '/usr/local/bin/teamclaude',
+        '/root/.config/teamclaude.json']) assert.match(text, new RegExp(value.replaceAll('/', '\\/')));
+    }
+    assert.equal(io.errorText(), '');
+  }
+});
+
+test('operational and partial failures return one without exiting the process', async () => {
+  const thrown = streamPair('', true);
+  assert.equal(await runDeployCli(['restart'], {
+    ...thrown, createManager: () => fakeManager({ restart: async () => { throw new Error('restart failed'); } }).manager,
+  }), 1);
+  assert.match(thrown.errorText(), /restart failed/);
+
+  const partial = streamPair('', true);
+  assert.equal(await runDeployCli(['install', 'https://example/repo.git'], {
+    ...partial,
+    createManager: () => fakeManager({ install: async () => ({
+      ok: false, partial: true, commit: 'a'.repeat(40), releasePath: '/release', warning: 'npm cleanup pending',
+    }) }).manager,
+  }), 1);
+  assert.match(partial.errorText(), /npm cleanup pending/);
+});
+
+test('top-level deploy dispatch exposes help and usage failures', () => {
+  const help = spawnSync(process.execPath, [entry, 'deploy', 'help'], { encoding: 'utf8', timeout: 10_000 });
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /teamclaude deploy install/);
+  const unknown = spawnSync(process.execPath, [entry, 'deploy', 'wat'], { encoding: 'utf8', timeout: 10_000 });
+  assert.equal(unknown.status, 64);
+  assert.match(unknown.stderr, /Unknown deploy command/);
+});

--- a/test/deploy-git-releases.test.js
+++ b/test/deploy-git-releases.test.js
@@ -1,0 +1,170 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readlink, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resolveDeployLayout } from '../src/deploy/layout.js';
+import {
+  createGitReleaseStore,
+  validateRemoteUrl,
+  validateRequestedRef,
+} from '../src/deploy/git-releases.js';
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+async function fixture(t) {
+  const home = await mkdtemp(join(tmpdir(), 'tc-git-store-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const source = join(home, 'source');
+  const remote = join(home, 'remote.git');
+  await mkdir(source);
+  git(source, 'init', '-b', 'master');
+  git(source, 'config', 'user.email', 'test@example.com');
+  git(source, 'config', 'user.name', 'TeamClaude Test');
+  await writeFile(join(source, 'value.txt'), 'one\n');
+  git(source, 'add', 'value.txt');
+  git(source, 'commit', '-m', 'first');
+  const first = git(source, 'rev-parse', 'HEAD');
+  git(source, 'tag', 'v1.0.0');
+  git(source, 'switch', '-c', 'feature');
+  await writeFile(join(source, 'value.txt'), 'two\n');
+  git(source, 'commit', '-am', 'feature');
+  const feature = git(source, 'rev-parse', 'HEAD');
+  git(source, 'switch', 'master');
+  git(home, 'clone', '--bare', source, remote);
+  const remoteUrl = pathToFileURL(remote).href;
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home: join(home, 'deploy-home'),
+    configPath: join(home, 'config', 'teamclaude.json'),
+  });
+  return { home, source, remote, remoteUrl, layout, first, feature };
+}
+
+test('remote and ref validation rejects injection-shaped inputs', () => {
+  assert.equal(validateRemoteUrl('https://github.com/dzamataev/teamclaude.git'), 'https://github.com/dzamataev/teamclaude.git');
+  assert.equal(validateRemoteUrl('git@github.com:dzamataev/teamclaude.git'), 'git@github.com:dzamataev/teamclaude.git');
+  assert.equal(validateRemoteUrl('file:///tmp/teamclaude.git'), 'file:///tmp/teamclaude.git');
+  assert.throws(() => validateRemoteUrl('https://token@github.com/org/repo.git'), /credentials/);
+  assert.throws(() => validateRemoteUrl('/tmp/local-path'), /remote URL/);
+  assert.throws(() => validateRequestedRef('-c core.sshCommand=evil'), /start with/);
+  assert.throws(() => validateRequestedRef('master~1'), /invalid ref/i);
+  assert.throws(() => validateRequestedRef('master..other'), /invalid ref/i);
+  assert.equal(validateRequestedRef('feature/deploy-cli'), 'feature/deploy-cli');
+  assert.equal(validateRequestedRef('1342e92b7207'), '1342e92b7207');
+});
+
+test('repository setup is idempotent and refuses a different origin', async (t) => {
+  const f = await fixture(t);
+  const store = createGitReleaseStore({ layout: f.layout });
+  await store.ensureRepository(f.remoteUrl);
+  assert.equal(git(f.layout.repo, 'remote', 'get-url', 'origin'), f.remoteUrl);
+  await store.ensureRepository(f.remoteUrl);
+  await assert.rejects(store.ensureRepository('file:///tmp/other.git'), /different remote/i);
+  assert.equal(git(f.layout.repo, 'remote', 'get-url', 'origin'), f.remoteUrl);
+});
+
+test('branches, tags, and commits resolve to immutable commits', async (t) => {
+  const f = await fixture(t);
+  const store = createGitReleaseStore({ layout: f.layout });
+  await store.ensureRepository(f.remoteUrl);
+  await store.fetch();
+  assert.equal(await store.resolveRef('feature'), f.feature);
+  assert.equal(await store.resolveRef('v1.0.0'), f.first);
+  assert.equal(await store.resolveRef(f.first.slice(0, 12)), f.first);
+  assert.throws(() => store.resolveRef('does-not-exist'), /cannot resolve/i);
+
+  const blob = git(f.layout.repo, 'hash-object', '-w', join(f.source, 'value.txt'));
+  assert.throws(() => store.resolveRef(blob), /cannot resolve|commit/i);
+});
+
+test('candidate releases are detached worktrees below releases', async (t) => {
+  const f = await fixture(t);
+  const store = createGitReleaseStore({
+    layout: f.layout,
+    now: () => new Date('2026-08-27T10:30:03.000Z'),
+  });
+  await store.ensureRepository(f.remoteUrl);
+  await store.fetch();
+  const candidate = await store.createCandidate(f.feature);
+  assert.equal(dirname(candidate.path), f.layout.releases);
+  assert.match(candidate.path, /20260827T103003Z-[a-f0-9]{12}$/);
+  assert.equal(candidate.commit, f.feature);
+  assert.equal(git(candidate.path, 'rev-parse', 'HEAD'), f.feature);
+  assert.equal(spawnSync('git', ['symbolic-ref', '-q', 'HEAD'], { cwd: candidate.path }).status, 1);
+});
+
+test('activation and rollback toggle only safe release links', async (t) => {
+  const f = await fixture(t);
+  const store = createGitReleaseStore({ layout: f.layout });
+  const releaseA = join(f.layout.releases, 'release-a');
+  const releaseB = join(f.layout.releases, 'release-b');
+  await mkdir(releaseA, { recursive: true });
+  await mkdir(releaseB);
+  await symlink(releaseA, f.layout.current);
+
+  await store.activate(releaseB);
+  assert.equal(await realpath(f.layout.current), await realpath(releaseB));
+  assert.equal(await realpath(f.layout.previous), await realpath(releaseA));
+
+  await store.swapForRollback();
+  assert.equal(await realpath(f.layout.current), await realpath(releaseA));
+  assert.equal(await realpath(f.layout.previous), await realpath(releaseB));
+
+  await store.swapForRollback();
+  assert.equal(await realpath(f.layout.current), await realpath(releaseB));
+  assert.equal(await realpath(f.layout.previous), await realpath(releaseA));
+  assert.ok((await readlink(f.layout.current)).includes('release-b'));
+});
+
+test('selection rejects regular files, dangling links, and outside targets', async (t) => {
+  const f = await fixture(t);
+  const store = createGitReleaseStore({ layout: f.layout });
+  await mkdir(f.layout.releases, { recursive: true });
+
+  await writeFile(f.layout.current, 'not a link');
+  await assert.rejects(store.readSelection(), /symbolic link/i);
+  await rm(f.layout.current);
+
+  await symlink(join(f.layout.releases, 'missing'), f.layout.current);
+  await assert.rejects(store.readSelection(), /dangling|resolve/i);
+  await rm(f.layout.current);
+
+  const outside = join(f.home, 'outside');
+  await mkdir(outside);
+  await symlink(outside, f.layout.current);
+  await assert.rejects(store.readSelection(), /outside|releases/i);
+});
+
+test('a failed second rename restores the original selection', async (t) => {
+  const f = await fixture(t);
+  const releaseA = join(f.layout.releases, 'release-a');
+  const releaseB = join(f.layout.releases, 'release-b');
+  const releaseC = join(f.layout.releases, 'release-c');
+  await mkdir(releaseA, { recursive: true });
+  await mkdir(releaseB);
+  await mkdir(releaseC);
+  await symlink(releaseA, f.layout.current);
+  await symlink(releaseB, f.layout.previous);
+
+  const fs = await import('node:fs/promises');
+  let renames = 0;
+  const store = createGitReleaseStore({
+    layout: f.layout,
+    fs: {
+      ...fs,
+      rename: async (...args) => {
+        renames++;
+        if (renames === 2) throw new Error('injected rename failure');
+        return fs.rename(...args);
+      },
+    },
+  });
+
+  await assert.rejects(store.activate(releaseC), /injected rename failure/);
+  assert.equal(await realpath(f.layout.current), await realpath(releaseA));
+  assert.equal(await realpath(f.layout.previous), await realpath(releaseB));
+});

--- a/test/deploy-launcher.test.js
+++ b/test/deploy-launcher.test.js
@@ -55,6 +55,49 @@ test('bootstrap discovery rejects old Node and ignores a PATH node from another 
   assert.equal(bootstrap.npmPath, '/opt/homebrew/bin/npm');
 });
 
+test('bootstrap discovery finds npm beside NVM Node when non-interactive PATH omits NVM', () => {
+  const nodePath = '/root/.nvm/versions/node/v24.19.0/bin/node';
+  const npmPath = '/root/.nvm/versions/node/v24.19.0/bin/npm';
+  const bootstrap = discoverBootstrap({
+    execPath: nodePath,
+    nodeVersion: '24.19.0',
+    pathEnv: '/usr/local/bin:/usr/bin:/bin',
+    findExecutable: command => command === 'node' ? '/usr/bin/node' : null,
+    realpath: value => value === '/usr/bin/node' ? '/usr/bin/node-v18' : value,
+    isExecutable: value => value === nodePath || value === npmPath,
+    installKind: 'git',
+    packageVersion: '1.1.13',
+    invokedCommandPath: '/usr/local/bin/teamclaude',
+  });
+  assert.equal(bootstrap.nodePath, nodePath);
+  assert.equal(bootstrap.npmPath, npmPath);
+});
+
+test('bootstrap discovery classifies global npm with the selected Node when PATH omits NVM', () => {
+  const nodePath = '/root/.nvm/versions/node/v24.19.0/bin/node';
+  const npmPath = '/root/.nvm/versions/node/v24.19.0/bin/npm';
+  const bootstrap = discoverBootstrap({
+    execPath: nodePath,
+    nodeVersion: '24.19.0',
+    pathEnv: '/usr/local/bin:/usr/bin:/bin',
+    findExecutable: () => null,
+    realpath: value => value,
+    isExecutable: value => value === nodePath || value === npmPath,
+    classifyInstall: ({ globalRoot }) => globalRoot === '/root/.nvm/versions/node/v24.19.0/lib/node_modules'
+      ? 'global'
+      : 'local',
+    run: (command, argv) => command === nodePath
+      && argv.join(' ') === `${npmPath} root --global`
+      ? result(0, '/root/.nvm/versions/node/v24.19.0/lib/node_modules\n')
+      : result(127, '', 'not found'),
+    packageVersion: '1.1.13',
+    invokedCommandPath: npmPath,
+  });
+
+  assert.equal(bootstrap.installKind, 'global');
+  assert.equal(bootstrap.packageVersion, '1.1.13');
+});
+
 test('launcher selection is fixed on Linux and stable on macOS', () => {
   const linux = { platform: 'linux', defaultLauncher: '/usr/local/bin/teamclaude' };
   assert.deepEqual(chooseLauncherPath({ layout: linux }), {
@@ -121,7 +164,7 @@ test('global npm handoff smoke-tests, uninstalls, publishes atomically, and veri
     ['write', `${launcherPath}.next-42-fixed`],
     ['chmod', `${launcherPath}.next-42-fixed`, 0o755],
     ['run', `${launcherPath}.next-42-fixed`, 'version'],
-    ['run', '/absolute/npm', 'uninstall', '-g', packageName],
+    ['run', '/absolute/node', '/absolute/npm', 'uninstall', '-g', packageName],
     ['rename', `${launcherPath}.next-42-fixed`, launcherPath],
     ['run', launcherPath, 'version'],
   ]);
@@ -163,7 +206,7 @@ test('npm cleanup failure still publishes the launcher with actionable partial s
   const outcome = await handoffLauncher({
     bootstrap: { nodePath: '/node', npmPath: '/npm', installKind: 'global', packageVersion: '1.1.13' },
     launcherPath, entryPath: '/deploy/current/src/index.js',
-    run: (command, argv) => argv[0] === 'uninstall' ? result(1, '', 'permission denied') : result(),
+    run: (command, argv) => argv[1] === 'uninstall' ? result(1, '', 'permission denied') : result(),
   });
   assert.equal(outcome.npmCleanupPending, true);
   assert.match(outcome.warning, /npm uninstall -g @karpeleslab\/teamclaude/);
@@ -191,7 +234,7 @@ test('npm restoration resolves exact command path, installs requested version, a
   const calls = [];
   const run = (command, argv, options = {}) => {
     calls.push({ command, argv, options });
-    if (argv[0] === 'prefix') return result(0, '/opt/npm-global\n');
+    if (argv[1] === 'prefix') return result(0, '/opt/npm-global\n');
     return result();
   };
   const resolved = await resolveNpmRestore({
@@ -199,13 +242,26 @@ test('npm restoration resolves exact command path, installs requested version, a
     nodePath: '/absolute/node', run, exists: async path => path === '/absolute/npm',
   });
   assert.deepEqual(resolved, {
-    packageSpec: '@karpeleslab/teamclaude@1.1.13', npmPath: '/absolute/npm',
+    packageSpec: '@karpeleslab/teamclaude@1.1.13', nodePath: '/absolute/node', npmPath: '/absolute/npm',
     commandPath: '/opt/npm-global/bin/teamclaude',
   });
   await restoreGlobalNpm(resolved, { run });
-  assert.deepEqual(calls.slice(1), [
-    { command: '/absolute/npm', argv: ['install', '--global', '@karpeleslab/teamclaude@1.1.13'], options: { stdio: 'inherit' } },
-    { command: '/opt/npm-global/bin/teamclaude', argv: ['version'], options: {} },
+  assert.deepEqual(calls, [
+    {
+      command: '/absolute/node',
+      argv: ['/absolute/npm', 'prefix', '--global'],
+      options: {},
+    },
+    {
+      command: '/absolute/node',
+      argv: ['/absolute/npm', 'install', '--global', '@karpeleslab/teamclaude@1.1.13'],
+      options: { stdio: 'inherit' },
+    },
+    {
+      command: '/absolute/node',
+      argv: ['/opt/npm-global/bin/teamclaude', 'version'],
+      options: {},
+    },
   ]);
 });
 
@@ -214,9 +270,10 @@ test('npm restoration uses latest only for a null recorded version and falls bac
     npmRestore: { packageName, version: null, npmPath: '/missing/npm' },
     nodePath: '/opt/homebrew/bin/node',
     exists: async path => path === '/opt/homebrew/bin/npm',
-    run: (command, argv) => argv[0] === 'prefix' ? result(0, '/prefix') : result(),
+    run: (command, argv) => argv[1] === 'prefix' ? result(0, '/prefix') : result(),
   });
   assert.equal(resolved.packageSpec, '@karpeleslab/teamclaude@latest');
+  assert.equal(resolved.nodePath, '/opt/homebrew/bin/node');
   assert.equal(resolved.npmPath, '/opt/homebrew/bin/npm');
   assert.equal(resolved.commandPath, '/prefix/bin/teamclaude');
 });
@@ -227,7 +284,8 @@ test('failed npm restore does not touch the active Git launcher', async (t) => {
   const launcher = join(root, 'teamclaude');
   await writeFile(launcher, '# TeamClaude-Owner: teamclaude-git-deploy-v1\n');
   await assert.rejects(restoreGlobalNpm({
-    packageSpec: '@karpeleslab/teamclaude@1.1.13', npmPath: '/npm', commandPath: '/prefix/bin/teamclaude',
+    packageSpec: '@karpeleslab/teamclaude@1.1.13', nodePath: '/node', npmPath: '/npm',
+    commandPath: '/prefix/bin/teamclaude',
   }, { run: () => result(1, '', 'registry unavailable') }), /registry unavailable/);
   assert.match(await readFile(launcher, 'utf8'), /TeamClaude-Owner/);
 });

--- a/test/deploy-launcher.test.js
+++ b/test/deploy-launcher.test.js
@@ -1,0 +1,262 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  chooseLauncherPath,
+  discoverBootstrap,
+  handoffLauncher,
+  removeOwnedLauncher,
+  renderLauncher,
+  resolveNpmRestore,
+  restoreGlobalNpm,
+} from '../src/deploy/launcher.js';
+
+const packageName = '@karpeleslab/teamclaude';
+
+function result(code = 0, stdout = '', stderr = '') {
+  return { code, stdout, stderr };
+}
+
+test('bootstrap discovery keeps the executable matching the running Node across Homebrew and NVM', () => {
+  const fixture = nodePath => ({
+    execPath: nodePath,
+    nodeVersion: '24.19.0',
+    pathEnv: `${nodePath.slice(0, nodePath.lastIndexOf('/'))}:/usr/bin`,
+    findExecutable: command => command === 'node' ? nodePath : `${nodePath.slice(0, nodePath.lastIndexOf('/'))}/npm`,
+    realpath: value => value,
+    isExecutable: () => true,
+    installKind: 'global',
+    packageVersion: '1.1.13',
+    invokedCommandPath: '/usr/local/bin/teamclaude',
+  });
+
+  assert.equal(discoverBootstrap(fixture('/opt/homebrew/bin/node')).nodePath, '/opt/homebrew/bin/node');
+  assert.equal(
+    discoverBootstrap(fixture('/Users/a/.nvm/versions/node/v24.19.0/bin/node')).nodePath,
+    '/Users/a/.nvm/versions/node/v24.19.0/bin/node',
+  );
+});
+
+test('bootstrap discovery rejects old Node and ignores a PATH node from another installation', () => {
+  assert.throws(() => discoverBootstrap({ execPath: '/node', nodeVersion: '18.20.0' }), /Node.js 20/);
+  const bootstrap = discoverBootstrap({
+    execPath: '/opt/homebrew/bin/node',
+    nodeVersion: '24.19.0',
+    findExecutable: command => command === 'node' ? '/usr/local/bin/node' : '/opt/homebrew/bin/npm',
+    realpath: value => value,
+    isExecutable: value => value !== '/usr/local/bin/node',
+    installKind: 'git',
+    packageVersion: '1.1.13',
+    invokedCommandPath: '/checkout/src/index.js',
+  });
+  assert.equal(bootstrap.nodePath, '/opt/homebrew/bin/node');
+  assert.equal(bootstrap.npmPath, '/opt/homebrew/bin/npm');
+});
+
+test('launcher selection is fixed on Linux and stable on macOS', () => {
+  const linux = { platform: 'linux', defaultLauncher: '/usr/local/bin/teamclaude' };
+  assert.deepEqual(chooseLauncherPath({ layout: linux }), {
+    path: '/usr/local/bin/teamclaude', pathInstruction: null,
+  });
+
+  const mac = {
+    platform: 'darwin', home: '/Users/a', root: '/Users/a/Library/Application Support/TeamClaude/deploy',
+    binDir: '/Users/a/Library/Application Support/TeamClaude/deploy/bin',
+  };
+  const selected = chooseLauncherPath({
+    layout: mac,
+    pathEnv: '/Users/a/.nvm/versions/node/v24/bin:/opt/homebrew/bin:/usr/bin',
+    access: path => path === '/opt/homebrew/bin',
+  });
+  assert.deepEqual(selected, { path: '/opt/homebrew/bin/teamclaude', pathInstruction: null });
+
+  const fallback = chooseLauncherPath({ layout: mac, pathEnv: '/usr/bin', access: () => false });
+  assert.deepEqual(fallback, {
+    path: '/Users/a/Library/Application Support/TeamClaude/deploy/bin/teamclaude',
+    pathInstruction: 'path=("$HOME/Library/Application Support/TeamClaude/deploy/bin" $path)\nexport PATH',
+  });
+});
+
+test('macOS launcher selection excludes version-owned runtime directories', () => {
+  const layout = { platform: 'darwin', home: '/Users/a', binDir: '/deploy/bin' };
+  for (const directory of [
+    '/Users/a/.nvm/versions/node/v24/bin',
+    '/Users/a/.asdf/installs/nodejs/24/bin',
+    '/Users/a/.volta/tools/image/node/24/bin',
+    '/opt/homebrew/Cellar/node/24/bin',
+  ]) {
+    assert.equal(chooseLauncherPath({ layout, pathEnv: directory, access: () => true }).path, '/deploy/bin/teamclaude');
+  }
+});
+
+test('rendered launcher safely quotes paths and forwards all arguments', () => {
+  assert.equal(renderLauncher({ nodePath: "/opt/O'Brien/node", entryPath: "/deploy/current/src/index.js" }),
+    "#!/bin/sh\n# TeamClaude-Owner: teamclaude-git-deploy-v1\nexec '/opt/O'\"'\"'Brien/node' '/deploy/current/src/index.js' \"$@\"\n");
+});
+
+test('global npm handoff smoke-tests, uninstalls, publishes atomically, and verifies', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const launcherPath = join(root, 'bin', 'teamclaude');
+  const events = [];
+  const run = (command, argv) => {
+    events.push(['run', command, ...argv]);
+    return result();
+  };
+  const outcome = await handoffLauncher({
+    bootstrap: {
+      nodePath: '/absolute/node', npmPath: '/absolute/npm', installKind: 'global', packageVersion: '1.1.13',
+    },
+    launcherPath,
+    entryPath: '/deploy/current/src/index.js',
+    nonce: 'fixed',
+    pid: 42,
+    run,
+    onEvent: (...event) => events.push(event),
+  });
+
+  assert.deepEqual(events, [
+    ['write', `${launcherPath}.next-42-fixed`],
+    ['chmod', `${launcherPath}.next-42-fixed`, 0o755],
+    ['run', `${launcherPath}.next-42-fixed`, 'version'],
+    ['run', '/absolute/npm', 'uninstall', '-g', packageName],
+    ['rename', `${launcherPath}.next-42-fixed`, launcherPath],
+    ['run', launcherPath, 'version'],
+  ]);
+  assert.deepEqual(outcome, {
+    launcherPath,
+    npmCleanupPending: false,
+    npmRestore: { packageName, version: '1.1.13', npmPath: '/absolute/npm' },
+  });
+  assert.match(await readFile(launcherPath, 'utf8'), /TeamClaude-Owner: teamclaude-git-deploy-v1/);
+});
+
+test('source handoff keeps npm installed and records latest as the future restore target', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const calls = [];
+  const outcome = await handoffLauncher({
+    bootstrap: { nodePath: '/node', npmPath: '/npm', installKind: 'git', packageVersion: '1.1.13' },
+    launcherPath: join(root, 'teamclaude'), entryPath: '/deploy/current/src/index.js',
+    run: (command, argv) => { calls.push([command, ...argv]); return result(); },
+  });
+  assert.equal(calls.some(call => call.includes('uninstall')), false);
+  assert.deepEqual(outcome.npmRestore, { packageName, version: null, npmPath: '/npm' });
+});
+
+test('global npm handoff refuses to invent a restore version', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await assert.rejects(handoffLauncher({
+    bootstrap: { nodePath: '/node', npmPath: '/npm', installKind: 'global', packageVersion: null },
+    launcherPath: join(root, 'teamclaude'), entryPath: '/deploy/current/src/index.js',
+    run: () => result(),
+  }), /exact npm package version/i);
+});
+
+test('npm cleanup failure still publishes the launcher with actionable partial state', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const launcherPath = join(root, 'teamclaude');
+  const outcome = await handoffLauncher({
+    bootstrap: { nodePath: '/node', npmPath: '/npm', installKind: 'global', packageVersion: '1.1.13' },
+    launcherPath, entryPath: '/deploy/current/src/index.js',
+    run: (command, argv) => argv[0] === 'uninstall' ? result(1, '', 'permission denied') : result(),
+  });
+  assert.equal(outcome.npmCleanupPending, true);
+  assert.match(outcome.warning, /npm uninstall -g @karpeleslab\/teamclaude/);
+  assert.match(await readFile(launcherPath, 'utf8'), /TeamClaude-Owner/);
+});
+
+test('failed publication reports the preserved staged launcher without leaking config', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const launcherPath = join(root, 'teamclaude');
+  await assert.rejects(handoffLauncher({
+    bootstrap: { nodePath: '/node', npmPath: '/npm', installKind: 'git', packageVersion: null },
+    launcherPath, entryPath: '/deploy/current/src/index.js', nonce: 'kept', pid: 7,
+    run: () => result(),
+    rename: async () => { throw new Error('read-only filesystem'); },
+    config: { apiKey: 'super-secret-value' },
+  }), error => {
+    assert.match(error.message, new RegExp(`${launcherPath}\\.next-7-kept`));
+    assert.doesNotMatch(error.message, /super-secret-value/);
+    return true;
+  });
+});
+
+test('npm restoration resolves exact command path, installs requested version, and verifies it', async () => {
+  const calls = [];
+  const run = (command, argv, options = {}) => {
+    calls.push({ command, argv, options });
+    if (argv[0] === 'prefix') return result(0, '/opt/npm-global\n');
+    return result();
+  };
+  const resolved = await resolveNpmRestore({
+    npmRestore: { packageName, version: '1.1.13', npmPath: '/absolute/npm' },
+    nodePath: '/absolute/node', run, exists: async path => path === '/absolute/npm',
+  });
+  assert.deepEqual(resolved, {
+    packageSpec: '@karpeleslab/teamclaude@1.1.13', npmPath: '/absolute/npm',
+    commandPath: '/opt/npm-global/bin/teamclaude',
+  });
+  await restoreGlobalNpm(resolved, { run });
+  assert.deepEqual(calls.slice(1), [
+    { command: '/absolute/npm', argv: ['install', '--global', '@karpeleslab/teamclaude@1.1.13'], options: { stdio: 'inherit' } },
+    { command: '/opt/npm-global/bin/teamclaude', argv: ['version'], options: {} },
+  ]);
+});
+
+test('npm restoration uses latest only for a null recorded version and falls back beside Node', async () => {
+  const resolved = await resolveNpmRestore({
+    npmRestore: { packageName, version: null, npmPath: '/missing/npm' },
+    nodePath: '/opt/homebrew/bin/node',
+    exists: async path => path === '/opt/homebrew/bin/npm',
+    run: (command, argv) => argv[0] === 'prefix' ? result(0, '/prefix') : result(),
+  });
+  assert.equal(resolved.packageSpec, '@karpeleslab/teamclaude@latest');
+  assert.equal(resolved.npmPath, '/opt/homebrew/bin/npm');
+  assert.equal(resolved.commandPath, '/prefix/bin/teamclaude');
+});
+
+test('failed npm restore does not touch the active Git launcher', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const launcher = join(root, 'teamclaude');
+  await writeFile(launcher, '# TeamClaude-Owner: teamclaude-git-deploy-v1\n');
+  await assert.rejects(restoreGlobalNpm({
+    packageSpec: '@karpeleslab/teamclaude@1.1.13', npmPath: '/npm', commandPath: '/prefix/bin/teamclaude',
+  }, { run: () => result(1, '', 'registry unavailable') }), /registry unavailable/);
+  assert.match(await readFile(launcher, 'utf8'), /TeamClaude-Owner/);
+});
+
+test('owned launcher removal preserves symlinks and unmarked or replaced files', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tc-launcher-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const owned = join(root, 'owned');
+  const operator = join(root, 'operator');
+  const link = join(root, 'link');
+  await writeFile(owned, '#!/bin/sh\n# TeamClaude-Owner: teamclaude-git-deploy-v1\n');
+  await writeFile(operator, '#!/bin/sh\n# operator file\n');
+  await symlink(operator, link);
+
+  assert.deepEqual(await removeOwnedLauncher({ launcherPath: owned }), { removed: true, preserved: false });
+  assert.deepEqual(await removeOwnedLauncher({ launcherPath: operator }), { removed: false, preserved: true });
+  assert.deepEqual(await removeOwnedLauncher({ launcherPath: link }), { removed: false, preserved: true });
+
+  const changing = join(root, 'changing');
+  await writeFile(changing, '# TeamClaude-Owner: teamclaude-git-deploy-v1\n');
+  let reads = 0;
+  const outcome = await removeOwnedLauncher({
+    launcherPath: changing,
+    readFile: async (...args) => {
+      reads += 1;
+      if (reads === 2) await writeFile(changing, '# operator replacement\n');
+      return readFile(...args);
+    },
+  });
+  assert.deepEqual(outcome, { removed: false, preserved: true });
+  assert.equal(await readFile(changing, 'utf8'), '# operator replacement\n');
+});

--- a/test/deploy-layout.test.js
+++ b/test/deploy-layout.test.js
@@ -1,0 +1,163 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, lstat, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEPLOYMENT_SCHEMA_VERSION,
+  assertMutationAllowed,
+  assertSafeRootRemoval,
+  readDeployment,
+  resolveDeployLayout,
+  validateInstallConfig,
+  writeDeployment,
+} from '../src/deploy/layout.js';
+
+function metadata(layout, overrides = {}) {
+  return {
+    schemaVersion: DEPLOYMENT_SCHEMA_VERSION,
+    remoteUrl: 'https://github.com/dzamataev/teamclaude.git',
+    serviceKind: layout.kind,
+    nodePath: '/absolute/node',
+    launcherPath: join(layout.binDir, 'teamclaude'),
+    configPath: layout.configPath,
+    installedAt: '2026-08-27T10:30:03.000Z',
+    requestedRef: 'master',
+    npmCleanupPending: false,
+    npmRestore: {
+      packageName: '@karpeleslab/teamclaude',
+      version: null,
+      npmPath: '/absolute/npm',
+    },
+    serviceBackup: null,
+    ...overrides,
+  };
+}
+
+test('Linux deployment is system-wide and root-only', () => {
+  const layout = resolveDeployLayout({
+    platform: 'linux', home: '/root', configPath: '/root/.config/teamclaude.json',
+  });
+  assert.equal(layout.root, '/opt/teamclaude');
+  assert.equal(layout.serviceFile, '/etc/systemd/system/teamclaude.service');
+  assert.equal(layout.defaultLauncher, '/usr/local/bin/teamclaude');
+  assert.throws(() => assertMutationAllowed(layout, { uid: 1000 }), /root/);
+  assert.doesNotThrow(() => assertMutationAllowed(layout, { uid: 0 }));
+});
+
+test('macOS deployment is per-user and does not require root', () => {
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home: '/Users/a', configPath: '/Users/a/.config/teamclaude.json',
+  });
+  assert.equal(layout.root, '/Users/a/Library/Application Support/TeamClaude/deploy');
+  assert.equal(layout.serviceFile, '/Users/a/Library/LaunchAgents/com.karpeleslab.teamclaude.plist');
+  assert.equal(layout.logFile, '/Users/a/Library/Logs/teamclaude.log');
+  assert.doesNotThrow(() => assertMutationAllowed(layout, { uid: 501 }));
+});
+
+test('unsupported platforms fail before a layout can be created', () => {
+  assert.throws(
+    () => resolveDeployLayout({ platform: 'win32', home: 'C:\\Users\\a' }),
+    /Linux and macOS/,
+  );
+});
+
+test('config cannot live inside the removable deployment root', () => {
+  assert.throws(() => resolveDeployLayout({
+    platform: 'darwin',
+    home: '/Users/a',
+    configPath: '/Users/a/Library/Application Support/TeamClaude/deploy/config.json',
+  }), /config.*deployment root/i);
+});
+
+test('install config requires at least one enabled usable account', () => {
+  assert.deepEqual(validateInstallConfig(null), { ok: false, reason: 'config not found' });
+  assert.equal(validateInstallConfig({ accounts: [] }).ok, false);
+  assert.equal(validateInstallConfig({ accounts: [{ type: 'apikey', apiKey: 'k' }] }).ok, true);
+  assert.equal(validateInstallConfig({ accounts: [{ type: 'oauth', refreshToken: 'r' }] }).ok, true);
+  assert.equal(validateInstallConfig({ accounts: [{ type: 'oauth', importFrom: '/credentials' }] }).ok, true);
+  assert.equal(validateInstallConfig({ accounts: [{ type: 'apikey', apiKey: 'k', disabled: true }] }).ok, false);
+});
+
+test('deployment metadata round-trips atomically with private mode', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-layout-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home, configPath: join(home, '.config', 'teamclaude.json'),
+  });
+  const value = metadata(layout, {
+    serviceBackup: {
+      source: layout.serviceFile,
+      backupPath: join(layout.backups, 'stamp', 'service.plist'),
+      sha256: 'a'.repeat(64),
+      wasRunning: true,
+      restoreOnUninstall: false,
+    },
+  });
+  await writeDeployment(layout, value);
+  assert.deepEqual(await readDeployment(layout), value);
+  assert.equal((await lstat(layout.metadataFile)).mode & 0o777, 0o600);
+  assert.deepEqual((await readFile(layout.root, { encoding: 'utf8' }).catch(() => null)), null);
+  const names = await import('node:fs/promises').then(fs => fs.readdir(layout.root));
+  assert.equal(names.some(name => name.includes('.next-')), false);
+});
+
+test('metadata rejects unsafe or credential-bearing values', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-layout-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home, configPath: join(home, '.config', 'teamclaude.json'),
+  });
+  await assert.rejects(
+    writeDeployment(layout, metadata(layout, { remoteUrl: 'https://token@github.com/o/r.git' })),
+    /credentials/,
+  );
+  await assert.rejects(
+    writeDeployment(layout, metadata(layout, {
+      serviceBackup: {
+        source: layout.serviceFile,
+        backupPath: join(home, 'outside.service'),
+        sha256: 'b'.repeat(64),
+        wasRunning: false,
+        restoreOnUninstall: true,
+      },
+    })),
+    /backup/i,
+  );
+  await assert.rejects(
+    writeDeployment(layout, metadata(layout, { schemaVersion: 99 })),
+    /schema version/i,
+  );
+});
+
+test('malformed metadata names its file', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-layout-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home, configPath: join(home, '.config', 'teamclaude.json'),
+  });
+  await mkdir(layout.root, { recursive: true });
+  await writeFile(layout.metadataFile, '{broken');
+  await assert.rejects(readDeployment(layout), new RegExp(layout.metadataFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('safe root removal rejects symlink roots and mismatched metadata', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-layout-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const layout = resolveDeployLayout({
+    platform: 'darwin', home, configPath: join(home, '.config', 'teamclaude.json'),
+  });
+  await mkdir(layout.root, { recursive: true });
+  await assertSafeRootRemoval(layout, metadata(layout));
+  await assert.rejects(
+    assertSafeRootRemoval(layout, metadata(layout, { serviceKind: 'systemd' })),
+    /service kind/i,
+  );
+
+  await rm(layout.root, { recursive: true, force: true });
+  const target = join(home, 'not-the-deploy-root');
+  await mkdir(target);
+  await mkdir(join(home, 'Library', 'Application Support', 'TeamClaude'), { recursive: true });
+  await symlink(target, layout.root);
+  await assert.rejects(assertSafeRootRemoval(layout, metadata(layout)), /symlink/i);
+});

--- a/test/deploy-manager.test.js
+++ b/test/deploy-manager.test.js
@@ -1,0 +1,453 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDeployManager } from '../src/deploy/manager.js';
+
+const remoteUrl = 'https://github.com/dzamataev/teamclaude.git';
+const oldRelease = '/opt/teamclaude/releases/old';
+const candidate = {
+  path: '/opt/teamclaude/releases/20260827T103003Z-1342e92b7207',
+  commit: '1342e92b7207d5e3bb5af08402909810d7378019',
+};
+
+function validConfig() {
+  return { accounts: [{ type: 'apikey', apiKey: 'secret' }] };
+}
+
+function deploymentMetadata(layout, overrides = {}) {
+  return {
+    schemaVersion: 1,
+    remoteUrl,
+    requestedRef: 'master',
+    nodePath: '/absolute/node',
+    launcherPath: '/usr/local/bin/teamclaude',
+    configPath: layout.configPath,
+    serviceKind: 'systemd',
+    installedAt: '2026-08-27T10:30:03.000Z',
+    npmCleanupPending: false,
+    npmRestore: { packageName: '@karpeleslab/teamclaude', version: null, npmPath: '/absolute/npm' },
+    serviceBackup: null,
+    ...overrides,
+  };
+}
+
+function fixture(overrides = {}) {
+  const calls = [];
+  const metadataWrites = [];
+  const layout = {
+    platform: 'linux', kind: 'systemd', root: '/opt/teamclaude', repo: '/opt/teamclaude/repo',
+    releases: '/opt/teamclaude/releases', current: '/opt/teamclaude/current',
+    previous: '/opt/teamclaude/previous', binDir: '/opt/teamclaude/bin', backups: '/opt/teamclaude/backups',
+    metadataFile: '/opt/teamclaude/deployment.json', serviceFile: '/etc/systemd/system/teamclaude.service',
+    defaultLauncher: '/usr/local/bin/teamclaude', configPath: '/root/.config/teamclaude.json',
+  };
+  const backup = {
+    source: layout.serviceFile,
+    backupPath: '/opt/teamclaude/backups/20260827T103003Z/teamclaude.service',
+    contents: '[Service]\nExecStart=/npm/teamclaude\n',
+    sha256: 'a'.repeat(64),
+    wasRunning: true,
+    restoreOnUninstall: true,
+  };
+  const dependencies = {
+    layout,
+    uid: 0,
+    loadConfig: async () => validConfig(),
+    readDeployment: async () => null,
+    writeDeployment: async (_layout, value) => { calls.push('writeMetadataWithRestoreState'); metadataWrites.push(value); },
+    run: (command, argv) => command === 'git' && argv[0] === '--version'
+      ? { code: 0, stdout: 'git version 2.51.0\n', stderr: '' }
+      : { code: 0, stdout: '', stderr: '' },
+    discoverBootstrap: () => ({
+      nodePath: '/absolute/node', npmPath: '/absolute/npm', invokedCommandPath: '/usr/local/bin/teamclaude',
+      installKind: 'global', packageVersion: '1.1.13',
+    }),
+    chooseLauncherPath: () => ({ path: '/usr/local/bin/teamclaude', pathInstruction: null }),
+    handoffLauncher: async () => {
+      calls.push('handoffLauncher');
+      return {
+        launcherPath: '/usr/local/bin/teamclaude', npmCleanupPending: false,
+        npmRestore: { packageName: '@karpeleslab/teamclaude', version: '1.1.13', npmPath: '/absolute/npm' },
+      };
+    },
+    renderService: () => { calls.push('renderService'); return '# owned service'; },
+    store: {
+      ensureRepository: async () => { calls.push('ensureRepository'); return { cloned: true, remoteUrl }; },
+      fetch: () => calls.push('fetch'),
+      resolveRef: () => { calls.push('resolveRef'); return candidate.commit; },
+      createCandidate: async () => { calls.push('createCandidate'); return candidate; },
+      readSelection: async () => ({ current: oldRelease, previous: null }),
+      activate: async () => { calls.push('activateCandidate'); return { current: candidate.path, previous: oldRelease }; },
+      swapForRollback: async () => { calls.push('swapForRollback'); return { current: oldRelease, previous: candidate.path }; },
+      restoreSelection: async () => calls.push('restoreSelection'),
+      describeRelease: async path => ({ path, commit: path === candidate.path ? candidate.commit : 'b'.repeat(40) }),
+    },
+    service: {
+      validateDefinition: async () => calls.push('validateService'),
+      backupExisting: async () => { calls.push('backupService'); return backup; },
+      stop: async () => calls.push('stopOldService'),
+      install: async () => calls.push('installService'),
+      start: async () => calls.push('startService'),
+      restart: async () => calls.push('restartService'),
+      restore: async () => calls.push('restoreService'),
+      status: async () => { calls.push('serviceHealth'); return { kind: 'systemd', running: true }; },
+    },
+    runCandidateTests: async () => calls.push('testCandidate'),
+    checkHealth: async () => { calls.push('applicationHealth'); return true; },
+    sleep: async () => {},
+    now: () => new Date('2026-08-27T10:30:03.000Z'),
+    onStage: stage => { if (stage === 'preflight') calls.push(stage); },
+    ...overrides,
+  };
+  return { calls, metadataWrites, dependencies, layout, backup };
+}
+
+test('preflight failures never begin repository, service, or launcher mutation', async () => {
+  const cases = [
+    ['unsupported platform', { layout: { ...fixture().layout, platform: 'win32' } }, /supports Linux and macOS/i],
+    ['non-root Linux', { uid: 501 }, /require root/i],
+    ['old Node', { discoverBootstrap: () => { throw new Error('Node.js 20 or newer is required'); } }, /Node\.js 20/],
+    ['missing Git', { run: () => ({ code: 127, stdout: '', stderr: 'not found' }) }, /Git is required/i],
+    ['missing config', { loadConfig: async () => null }, /config/i],
+    ['empty config', { loadConfig: async () => ({ accounts: [] }) }, /accounts|configured/i],
+  ];
+  for (const [name, override, pattern] of cases) {
+    const { calls, dependencies } = fixture(override);
+    const manager = createDeployManager(dependencies);
+    await assert.rejects(manager.install({ remoteUrl, ref: 'master' }), pattern, name);
+    assert.deepEqual(calls.filter(call => call !== 'preflight'), [], name);
+  }
+
+  for (const [name, input] of [
+    ['bad URL', { remoteUrl: 'https://user:secret@example.test/repo.git', ref: 'master' }],
+    ['bad ref', { remoteUrl, ref: '--upload-pack=evil' }],
+  ]) {
+    const { calls, dependencies } = fixture();
+    await assert.rejects(createDeployManager(dependencies).install(input), /credential|ref/i, name);
+    assert.deepEqual(calls.filter(call => call !== 'preflight'), [], name);
+  }
+});
+
+test('clean install takes over only after candidate and service validation', async () => {
+  const { calls, dependencies, metadataWrites, backup } = fixture();
+  const result = await createDeployManager(dependencies).install({ remoteUrl, ref: 'master' });
+
+  assert.deepEqual(calls, [
+    'preflight', 'ensureRepository', 'fetch', 'resolveRef', 'createCandidate',
+    'testCandidate', 'renderService', 'validateService', 'backupService',
+    'stopOldService', 'activateCandidate', 'installService', 'startService',
+    'serviceHealth', 'applicationHealth', 'handoffLauncher', 'writeMetadataWithRestoreState',
+  ]);
+  assert.deepEqual(result, {
+    ok: true, partial: false, requestedRef: 'master', commit: candidate.commit,
+    releasePath: candidate.path, launcherPath: '/usr/local/bin/teamclaude',
+    npmCleanupPending: false,
+    npmRestore: { packageName: '@karpeleslab/teamclaude', version: '1.1.13', npmPath: '/absolute/npm' },
+    serviceBackup: {
+      source: backup.source, backupPath: backup.backupPath, sha256: backup.sha256,
+      wasRunning: true, restoreOnUninstall: true,
+    },
+  });
+  assert.equal(Object.hasOwn(metadataWrites[0].serviceBackup, 'contents'), false);
+  assert.equal(metadataWrites[0].nodePath, '/absolute/node');
+  assert.equal(metadataWrites[0].requestedRef, 'master');
+});
+
+test('install compensates every failed takeover boundary and rechecks restored health', async () => {
+  const boundaries = [
+    { name: 'stopOldService', target: 'service', method: 'stop', activationExpected: false, serviceRestoreExpected: true },
+    { name: 'activateCandidate', target: 'store', method: 'activate', activationExpected: false, serviceRestoreExpected: true },
+    { name: 'installService', target: 'service', method: 'install', activationExpected: true, serviceRestoreExpected: true },
+    { name: 'startService', target: 'service', method: 'start', activationExpected: true, serviceRestoreExpected: true },
+    { name: 'serviceHealth', target: 'service', method: 'status', activationExpected: true, serviceRestoreExpected: true },
+    { name: 'applicationHealth', target: 'manager', method: 'checkHealth', activationExpected: true, serviceRestoreExpected: true },
+    { name: 'handoffLauncher', target: 'manager', method: 'handoffLauncher', activationExpected: true, serviceRestoreExpected: true },
+  ];
+
+  for (const boundary of boundaries) {
+    const fx = fixture();
+    const failure = new Error(`candidate failed at ${boundary.name}`);
+    if (boundary.target === 'service') {
+      const original = fx.dependencies.service[boundary.method];
+      let failed = false;
+      fx.dependencies.service[boundary.method] = async (...args) => {
+        if (!failed) {
+          failed = true;
+          fx.calls.push(boundary.name);
+          throw failure;
+        }
+        return original(...args);
+      };
+    } else if (boundary.target === 'store') {
+      fx.dependencies.store[boundary.method] = async () => {
+        fx.calls.push(boundary.name);
+        throw failure;
+      };
+    } else {
+      const original = fx.dependencies[boundary.method];
+      let failed = false;
+      fx.dependencies[boundary.method] = async (...args) => {
+        if (!failed) {
+          failed = true;
+          fx.calls.push(boundary.name);
+          throw failure;
+        }
+        return original(...args);
+      };
+    }
+
+    await assert.rejects(
+      createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' }),
+      error => error === failure,
+      boundary.name,
+    );
+    assert.equal(fx.metadataWrites.length, 0, boundary.name);
+    assert.equal(fx.calls.includes('restoreSelection'), boundary.activationExpected, boundary.name);
+    assert.equal(fx.calls.includes('restoreService'), boundary.serviceRestoreExpected, boundary.name);
+    if (boundary.serviceRestoreExpected) {
+      const restoreIndex = fx.calls.lastIndexOf('restoreService');
+      const selectionIndex = fx.calls.lastIndexOf('restoreSelection');
+      if (boundary.activationExpected) assert.ok(restoreIndex < selectionIndex, boundary.name);
+      assert.ok(fx.calls.lastIndexOf('serviceHealth') > restoreIndex, boundary.name);
+      assert.ok(fx.calls.lastIndexOf('applicationHealth') > restoreIndex, boundary.name);
+    }
+  }
+});
+
+test('rollback failure reports both candidate and compensation errors', async () => {
+  const fx = fixture();
+  fx.dependencies.service.start = async () => { fx.calls.push('startService'); throw new Error('candidate start exploded'); };
+  fx.dependencies.service.restore = async () => { fx.calls.push('restoreService'); throw new Error('old service restore exploded'); };
+  await assert.rejects(
+    createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' }),
+    error => {
+      assert.match(error.message, /candidate start exploded/);
+      assert.match(error.message, /old service restore exploded/);
+      assert.match(error.message, /logs/i);
+      return true;
+    },
+  );
+});
+
+test('pending npm cleanup is recorded as the only partial install result', async () => {
+  const fx = fixture({
+    handoffLauncher: async () => {
+      fx.calls.push('handoffLauncher');
+      return {
+        launcherPath: '/usr/local/bin/teamclaude', npmCleanupPending: true,
+        npmRestore: { packageName: '@karpeleslab/teamclaude', version: '1.1.13', npmPath: '/absolute/npm' },
+        warning: 'Run npm uninstall -g @karpeleslab/teamclaude',
+      };
+    },
+  });
+  const result = await createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' });
+  assert.equal(result.ok, false);
+  assert.equal(result.partial, true);
+  assert.equal(result.npmCleanupPending, true);
+  assert.match(result.warning, /npm uninstall -g/);
+  assert.equal(fx.metadataWrites[0].npmCleanupPending, true);
+  assert.equal(fx.calls.includes('restoreSelection'), false);
+  assert.equal(fx.calls.includes('restoreService'), false);
+});
+
+test('idempotent install reuses a healthy current commit and preserves original restore metadata', async () => {
+  const fx = fixture();
+  const originalBackup = {
+    source: fx.layout.serviceFile,
+    backupPath: '/opt/teamclaude/backups/original/teamclaude.service',
+    sha256: 'c'.repeat(64), wasRunning: true, restoreOnUninstall: true,
+  };
+  const existing = {
+    schemaVersion: 1, remoteUrl, requestedRef: 'master', nodePath: '/old/node',
+    launcherPath: '/usr/local/bin/teamclaude', configPath: fx.layout.configPath,
+    serviceKind: 'systemd', installedAt: '2026-08-26T10:00:00.000Z', npmCleanupPending: false,
+    npmRestore: { packageName: '@karpeleslab/teamclaude', version: '1.1.12', npmPath: '/old/npm' },
+    serviceBackup: originalBackup,
+  };
+  fx.dependencies.readDeployment = async () => existing;
+  fx.dependencies.store.ensureRepository = async () => { fx.calls.push('ensureRepository'); return { cloned: false, remoteUrl }; };
+  fx.dependencies.store.readSelection = async () => ({ current: candidate.path, previous: oldRelease });
+  fx.dependencies.store.describeRelease = async path => ({ path, commit: path === candidate.path ? candidate.commit : 'b'.repeat(40) });
+
+  const result = await createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' });
+  assert.equal(fx.calls.includes('createCandidate'), false);
+  assert.equal(result.releasePath, candidate.path);
+  assert.deepEqual(result.npmRestore, existing.npmRestore);
+  assert.deepEqual(result.serviceBackup, originalBackup);
+  assert.equal(fx.metadataWrites[0].installedAt, existing.installedAt);
+});
+
+test('an installed deployment with another remote refuses before fetch or takeover', async () => {
+  const fx = fixture({
+    readDeployment: async () => ({ remoteUrl: 'https://example.test/other.git' }),
+  });
+  await assert.rejects(
+    createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' }),
+    /different remote/i,
+  );
+  assert.equal(fx.calls.includes('ensureRepository'), false);
+  assert.equal(fx.calls.includes('fetch'), false);
+  assert.equal(fx.calls.includes('backupService'), false);
+});
+
+test('legacy Git layout is adopted without clone, release deletion, or npm-version invention', async () => {
+  const fx = fixture();
+  fx.dependencies.store.ensureRepository = async () => { fx.calls.push('ensureRepository'); return { cloned: false, remoteUrl }; };
+  fx.dependencies.store.readSelection = async () => ({ current: candidate.path, previous: oldRelease });
+  fx.dependencies.store.describeRelease = async path => ({ path, commit: path === candidate.path ? candidate.commit : 'b'.repeat(40) });
+  let handoffBootstrap;
+  fx.dependencies.handoffLauncher = async options => {
+    fx.calls.push('handoffLauncher');
+    handoffBootstrap = options.bootstrap;
+    return {
+      launcherPath: '/usr/local/bin/teamclaude', npmCleanupPending: false,
+      npmRestore: { packageName: '@karpeleslab/teamclaude', version: null, npmPath: options.bootstrap.npmPath },
+    };
+  };
+
+  const result = await createDeployManager(fx.dependencies).install({ remoteUrl, ref: 'master' });
+  assert.equal(fx.calls.includes('createCandidate'), false);
+  assert.equal(fx.calls.some(call => /clone|remove|nginx/i.test(call)), false);
+  assert.equal(result.releasePath, candidate.path);
+  assert.equal(handoffBootstrap.installKind, 'git');
+  assert.equal(handoffBootstrap.packageVersion, null);
+  assert.deepEqual(fx.metadataWrites[0].npmRestore, {
+    packageName: '@karpeleslab/teamclaude', version: null, npmPath: '/absolute/npm',
+  });
+});
+
+test('deployRef tests an immutable candidate before activation and updates only requestedRef', async () => {
+  const fx = fixture();
+  const metadata = deploymentMetadata(fx.layout);
+  fx.dependencies.readDeployment = async () => metadata;
+  const result = await createDeployManager(fx.dependencies).deployRef({ ref: 'feature/deploy' });
+  assert.deepEqual(fx.calls, [
+    'ensureRepository', 'fetch', 'resolveRef', 'createCandidate', 'testCandidate',
+    'activateCandidate', 'restartService', 'serviceHealth', 'applicationHealth',
+    'writeMetadataWithRestoreState',
+  ]);
+  assert.equal(result.ok, true);
+  assert.equal(result.requestedRef, 'feature/deploy');
+  assert.equal(result.commit, candidate.commit);
+  assert.deepEqual(fx.metadataWrites[0], { ...metadata, requestedRef: 'feature/deploy' });
+});
+
+test('deployRef test failure never activates or restarts', async () => {
+  const fx = fixture();
+  fx.dependencies.readDeployment = async () => deploymentMetadata(fx.layout);
+  fx.dependencies.runCandidateTests = async () => { fx.calls.push('testCandidate'); throw new Error('test failure'); };
+  await assert.rejects(createDeployManager(fx.dependencies).deployRef({ ref: 'broken' }), /test failure/);
+  assert.equal(fx.calls.includes('activateCandidate'), false);
+  assert.equal(fx.calls.includes('restartService'), false);
+  assert.equal(fx.metadataWrites.length, 0);
+});
+
+test('deployRef restores selection and old runtime after post-activation failure', async () => {
+  const fx = fixture();
+  fx.dependencies.readDeployment = async () => deploymentMetadata(fx.layout);
+  let restarts = 0;
+  fx.dependencies.service.restart = async () => {
+    fx.calls.push('restartService');
+    restarts += 1;
+    if (restarts === 1) throw new Error('candidate restart failed');
+  };
+  await assert.rejects(createDeployManager(fx.dependencies).deployRef({ ref: 'broken' }), /candidate restart failed/);
+  assert.ok(fx.calls.indexOf('restoreSelection') > fx.calls.indexOf('activateCandidate'));
+  assert.ok(fx.calls.lastIndexOf('restartService') > fx.calls.indexOf('restoreSelection'));
+  assert.ok(fx.calls.lastIndexOf('serviceHealth') > fx.calls.indexOf('restoreSelection'));
+  assert.ok(fx.calls.lastIndexOf('applicationHealth') > fx.calls.indexOf('restoreSelection'));
+  assert.equal(fx.metadataWrites.length, 0);
+});
+
+test('rollback swaps releases, verifies them, and restores the exact pair on failure', async () => {
+  const success = fixture();
+  success.dependencies.readDeployment = async () => deploymentMetadata(success.layout);
+  const result = await createDeployManager(success.dependencies).rollback();
+  assert.deepEqual(success.calls, ['swapForRollback', 'restartService', 'serviceHealth', 'applicationHealth']);
+  assert.deepEqual(result, { ok: true, current: oldRelease, previous: candidate.path });
+
+  const failed = fixture();
+  failed.dependencies.readDeployment = async () => deploymentMetadata(failed.layout);
+  let checks = 0;
+  failed.dependencies.checkHealth = async () => {
+    failed.calls.push('applicationHealth');
+    checks += 1;
+    return checks > 20;
+  };
+  const manager = createDeployManager(failed.dependencies);
+  await assert.rejects(manager.rollback(), /deployment did not become healthy/);
+  assert.ok(failed.calls.indexOf('restoreSelection') > failed.calls.indexOf('swapForRollback'));
+  assert.ok(failed.calls.lastIndexOf('restartService') > failed.calls.indexOf('restoreSelection'));
+  assert.equal(failed.metadataWrites.length, 0);
+});
+
+test('restart checks health without touching Git, links, or metadata', async () => {
+  const fx = fixture();
+  fx.dependencies.readDeployment = async () => deploymentMetadata(fx.layout);
+  assert.deepEqual(await createDeployManager(fx.dependencies).restart(), { ok: true });
+  assert.deepEqual(fx.calls, ['restartService', 'serviceHealth', 'applicationHealth']);
+  assert.equal(fx.metadataWrites.length, 0);
+});
+
+test('logs validates bounded integer line counts and delegates follow mode', async () => {
+  const fx = fixture();
+  fx.dependencies.readDeployment = async () => deploymentMetadata(fx.layout);
+  fx.dependencies.service.logs = options => { fx.calls.push(`logs:${options.lines}:${options.follow}`); return { code: 0 }; };
+  const manager = createDeployManager(fx.dependencies);
+  for (const lines of [0, -1, 1.5, 100001]) {
+    await assert.rejects(manager.logs({ lines }), /lines/i);
+  }
+  assert.deepEqual(await manager.logs(), { ok: true, code: 0 });
+  assert.deepEqual(await manager.logs({ lines: 25, follow: false }), { ok: true, code: 0 });
+  assert.deepEqual(fx.calls, ['logs:100:true', 'logs:25:false']);
+});
+
+test('status is JSON-safe and describes actual release commits', async () => {
+  const fx = fixture();
+  const backup = {
+    source: fx.layout.serviceFile,
+    backupPath: '/opt/teamclaude/backups/20260827T103003Z/teamclaude.service',
+    sha256: 'd'.repeat(64), wasRunning: true, restoreOnUninstall: false,
+  };
+  const metadata = deploymentMetadata(fx.layout, { serviceBackup: backup });
+  fx.dependencies.readDeployment = async () => metadata;
+  fx.dependencies.store.readSelection = async () => ({ current: candidate.path, previous: oldRelease });
+  fx.dependencies.store.describeRelease = async path => ({
+    path,
+    commit: path === candidate.path ? candidate.commit : 'b'.repeat(40),
+  });
+  const status = await createDeployManager(fx.dependencies).status();
+  assert.deepEqual(status, {
+    schemaVersion: 1,
+    platform: 'linux',
+    root: '/opt/teamclaude',
+    remoteUrl,
+    requestedRef: 'master',
+    current: { path: candidate.path, commit: candidate.commit },
+    previous: { path: oldRelease, commit: 'b'.repeat(40) },
+    service: { kind: 'systemd', running: true },
+    nodePath: '/absolute/node',
+    launcherPath: '/usr/local/bin/teamclaude',
+    configPath: fx.layout.configPath,
+    npmCleanupPending: false,
+    npmRestore: metadata.npmRestore,
+    serviceBackup: backup,
+  });
+
+  const absent = fixture({ readDeployment: async () => null });
+  assert.deepEqual(await createDeployManager(absent.dependencies).status(), {
+    installed: false, platform: 'linux', root: '/opt/teamclaude', detail: 'not installed',
+  });
+  assert.deepEqual(absent.calls, []);
+});
+
+test('operations other than status explain how to install when metadata is absent', async () => {
+  const fx = fixture({ readDeployment: async () => null });
+  const manager = createDeployManager(fx.dependencies);
+  for (const operation of [
+    () => manager.deployRef({ ref: 'master' }),
+    () => manager.rollback(),
+    () => manager.restart(),
+    () => manager.logs(),
+  ]) await assert.rejects(operation(), /teamclaude deploy install <git-url>/i);
+  assert.deepEqual(fx.calls, []);
+});

--- a/test/deploy-service.test.js
+++ b/test/deploy-service.test.js
@@ -1,0 +1,193 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEPLOYMENT_OWNER,
+  createDeployServiceAdapter,
+  isDeploymentOwnedDefinition,
+  renderLaunchAgent,
+  renderSystemdService,
+} from '../src/deploy/service.js';
+
+function layout(home, platform) {
+  const root = join(home, 'deploy');
+  return {
+    platform,
+    kind: platform === 'linux' ? 'systemd' : 'launchd',
+    root,
+    repo: join(root, 'repo'),
+    releases: join(root, 'releases'),
+    current: join(root, 'current'),
+    backups: join(root, 'backups'),
+    configPath: join(home, '.config', 'teamclaude.json'),
+    serviceFile: platform === 'linux'
+      ? join(home, 'teamclaude.service')
+      : join(home, 'Library', 'LaunchAgents', 'com.karpeleslab.teamclaude.plist'),
+    logFile: platform === 'darwin' ? join(home, 'Library', 'Logs', 'teamclaude.log') : null,
+  };
+}
+
+function recorder(responses = {}) {
+  const calls = [];
+  const run = (command, argv, options = {}) => {
+    const call = [command, ...argv].join(' ');
+    calls.push({ call, options });
+    const key = Object.keys(responses).find(candidate => call.includes(candidate));
+    return responses[key] || { code: 0, stdout: '', stderr: '' };
+  };
+  return { calls, run };
+}
+
+test('systemd definition is boot-persistent and deployment-owned', () => {
+  const l = layout('/root', 'linux');
+  const unit = renderSystemdService({ layout: l, nodePath: '/absolute/node' });
+  assert.match(unit, new RegExp(`TeamClaude-Owner: ${DEPLOYMENT_OWNER}`));
+  assert.match(unit, /WorkingDirectory=\/root\/deploy\/current/);
+  assert.match(unit, /ExecStart=\/absolute\/node \/root\/deploy\/current\/src\/index\.js server --headless/);
+  assert.match(unit, /Restart=always/);
+  assert.match(unit, /Environment=TEAMCLAUDE_DISABLE_AUTOUPDATE=1/);
+  assert.match(unit, /WantedBy=multi-user\.target/);
+  assert.equal(isDeploymentOwnedDefinition(unit), true);
+});
+
+test('LaunchAgent is owner-marked, escaped, and starts at login', () => {
+  const l = layout('/Users/a&b', 'darwin');
+  const plist = renderLaunchAgent({ layout: l, nodePath: '/opt/homebrew/bin/node' });
+  assert.match(plist, new RegExp(`<key>TeamClaudeOwner</key>\\s*<string>${DEPLOYMENT_OWNER}</string>`));
+  assert.match(plist, /<key>RunAtLoad<\/key>\s*<true\/>/);
+  assert.match(plist, /<key>KeepAlive<\/key>\s*<true\/>/);
+  assert.match(plist, /\/opt\/homebrew\/bin\/node/);
+  assert.match(plist, /current\/src\/index\.js/);
+  assert.match(plist, /a&amp;b/);
+  assert.match(plist, /TEAMCLAUDE_DISABLE_AUTOUPDATE/);
+  assert.equal(isDeploymentOwnedDefinition(plist), true);
+});
+
+test('definition validation delegates to platform validators', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const linuxRun = recorder();
+  const linux = createDeployServiceAdapter({ layout: layout(home, 'linux'), run: linuxRun.run });
+  await linux.validateDefinition(renderSystemdService({ layout: layout(home, 'linux'), nodePath: '/node' }));
+  assert.match(linuxRun.calls[0].call, /^systemd-analyze verify /);
+
+  const macRun = recorder();
+  const mac = createDeployServiceAdapter({ layout: layout(home, 'darwin'), run: macRun.run, uid: 501 });
+  await mac.validateDefinition(renderLaunchAgent({ layout: layout(home, 'darwin'), nodePath: '/node' }));
+  assert.match(macRun.calls[0].call, /^plutil -lint /);
+});
+
+test('systemd install separates enable from start and reports state', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const l = layout(home, 'linux');
+  const rec = recorder({
+    'is-enabled': { code: 0, stdout: 'enabled\n', stderr: '' },
+    'is-active': { code: 0, stdout: 'active\n', stderr: '' },
+  });
+  const adapter = createDeployServiceAdapter({ layout: l, run: rec.run });
+  const unit = renderSystemdService({ layout: l, nodePath: '/node' });
+  await adapter.install(unit);
+  await adapter.start();
+  assert.deepEqual(rec.calls.map(c => c.call), [
+    'systemctl daemon-reload',
+    'systemctl enable teamclaude.service',
+    'systemctl start teamclaude.service',
+  ]);
+  assert.equal(await readFile(l.serviceFile, 'utf8'), unit);
+  assert.deepEqual(await adapter.status(), {
+    kind: 'systemd', installed: true, enabled: true, running: true, detail: 'active',
+  });
+});
+
+test('LaunchAgent stop, start, restart, status, and logs use the user domain', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const l = layout(home, 'darwin');
+  const rec = recorder({
+    'launchctl print': { code: 0, stdout: 'state = running\n\tpid = 4242\n', stderr: '' },
+  });
+  const adapter = createDeployServiceAdapter({ layout: l, run: rec.run, uid: 501 });
+  await mkdir(join(home, 'Library', 'LaunchAgents'), { recursive: true });
+  await writeFile(l.serviceFile, renderLaunchAgent({ layout: l, nodePath: '/node' }));
+  await adapter.stop();
+  await adapter.start();
+  await adapter.restart();
+  const status = await adapter.status();
+  await adapter.logs({ lines: 25, follow: false });
+  assert.deepEqual(status, {
+    kind: 'launchd', installed: true, enabled: true, running: true, pid: '4242', detail: 'loaded',
+  });
+  assert.deepEqual(rec.calls.map(c => c.call), [
+    'launchctl bootout gui/501/com.karpeleslab.teamclaude',
+    `launchctl bootstrap gui/501 ${l.serviceFile}`,
+    'launchctl kickstart -k gui/501/com.karpeleslab.teamclaude',
+    'launchctl print gui/501/com.karpeleslab.teamclaude',
+    `tail -n 25 ${l.logFile}`,
+  ]);
+});
+
+test('backup records hash, running state, and whether uninstall may restore it', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const l = layout(home, 'linux');
+  const npmUnit = '[Service]\nExecStart=/node /usr/local/bin/teamclaude server --headless\n';
+  await writeFile(l.serviceFile, npmUnit);
+  const rec = recorder({ 'is-active': { code: 0, stdout: 'active\n', stderr: '' } });
+  const adapter = createDeployServiceAdapter({
+    layout: l, run: rec.run, now: () => new Date('2026-08-27T10:30:03.000Z'),
+  });
+  const backup = await adapter.backupExisting();
+  assert.equal(backup.contents, npmUnit);
+  assert.match(backup.sha256, /^[a-f0-9]{64}$/);
+  assert.equal(backup.wasRunning, true);
+  assert.equal(backup.restoreOnUninstall, true);
+  assert.equal((await adapter.validateBackup(backup)).contents, npmUnit);
+
+  await writeFile(l.serviceFile, `[Service]\nExecStart=/node ${l.current}/src/index.js server --headless\n`);
+  const gitBackup = await adapter.backupExisting();
+  assert.equal(gitBackup.restoreOnUninstall, false);
+});
+
+test('owned definition removal refuses an operator-owned file', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const l = layout(home, 'linux');
+  await writeFile(l.serviceFile, '[Service]\nExecStart=/operator/teamclaude\n');
+  const rec = recorder();
+  const adapter = createDeployServiceAdapter({ layout: l, run: rec.run });
+  await assert.rejects(adapter.removeOwnedDefinition(), /not deployment-owned/i);
+  assert.equal(await readFile(l.serviceFile, 'utf8'), '[Service]\nExecStart=/operator/teamclaude\n');
+  assert.equal(rec.calls.length, 0);
+});
+
+test('service backup and removal never follow a service-definition symlink', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const l = layout(home, 'linux');
+  const target = join(home, 'operator-owned-target');
+  await writeFile(target, renderSystemdService({ layout: l, nodePath: '/node' }));
+  await symlink(target, l.serviceFile);
+  const rec = recorder();
+  const adapter = createDeployServiceAdapter({ layout: l, run: rec.run });
+  await assert.rejects(adapter.backupExisting(), /regular file|symbolic link/i);
+  await assert.rejects(adapter.removeOwnedDefinition(), /regular file|symbolic link/i);
+  assert.match(await readFile(target, 'utf8'), /TeamClaude-Owner/);
+  assert.equal(rec.calls.length, 0);
+});
+
+test('systemd logs follow by default and use no-pager for finite output', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'tc-deploy-service-'));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const rec = recorder();
+  const adapter = createDeployServiceAdapter({ layout: layout(home, 'linux'), run: rec.run });
+  await adapter.logs({ lines: 100, follow: true });
+  await adapter.logs({ lines: 20, follow: false });
+  assert.deepEqual(rec.calls.map(c => c.call), [
+    'journalctl --unit teamclaude.service --lines 100 --follow',
+    'journalctl --unit teamclaude.service --lines 20 --no-pager',
+  ]);
+  assert.equal(rec.calls.every(c => c.options.stdio === 'inherit'), true);
+});

--- a/test/deploy-uninstall.test.js
+++ b/test/deploy-uninstall.test.js
@@ -26,7 +26,7 @@ function uninstallFixture({ version = '1.1.13', restoreOnUninstall = true, wasRu
   };
   const resolved = {
     packageSpec: `${packageName}@${version ?? 'latest'}`,
-    npmPath: '/absolute/npm', commandPath: '/npm-prefix/bin/teamclaude',
+    nodePath: '/absolute/node', npmPath: '/absolute/npm', commandPath: '/npm-prefix/bin/teamclaude',
   };
   const dependencies = {
     layout,
@@ -112,6 +112,22 @@ test('uninstall does not restore a legacy Git service rooted in the removed depl
   assert.equal(fx.calls.includes('restorePriorService'), false);
   assert.equal(fx.calls.includes('verifyPriorService'), false);
   assert.equal(result.restoredService, false);
+});
+
+test('restored npm command verification uses the selected Node when PATH has no node', async () => {
+  const fx = uninstallFixture();
+  delete fx.dependencies.verifyRestoredCommand;
+  fx.dependencies.run = (command, argv) => {
+    if (command === fx.resolved.commandPath) return { code: 127, stderr: '/usr/bin/env: node: not found' };
+    if (command === fx.resolved.nodePath && argv[0] === fx.resolved.commandPath && argv[1] === 'version') {
+      return { code: 0, stdout: '1.1.13\n', stderr: '' };
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  };
+
+  const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: true });
+  assert.equal(result.ok, true);
+  assert.equal(result.partial, false);
 });
 
 test('no-restore uninstall removes only deployment-owned resources', async () => {

--- a/test/deploy-uninstall.test.js
+++ b/test/deploy-uninstall.test.js
@@ -1,0 +1,205 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDeployManager } from '../src/deploy/manager.js';
+
+const packageName = '@karpeleslab/teamclaude';
+
+function uninstallFixture({ version = '1.1.13', restoreOnUninstall = true, wasRunning = true } = {}) {
+  const calls = [];
+  const layout = {
+    platform: 'linux', kind: 'systemd', root: '/opt/teamclaude', repo: '/opt/teamclaude/repo',
+    releases: '/opt/teamclaude/releases', current: '/opt/teamclaude/current', previous: '/opt/teamclaude/previous',
+    backups: '/opt/teamclaude/backups', metadataFile: '/opt/teamclaude/deployment.json',
+    serviceFile: '/etc/systemd/system/teamclaude.service', defaultLauncher: '/usr/local/bin/teamclaude',
+    configPath: '/root/.config/teamclaude.json',
+  };
+  const backup = {
+    source: layout.serviceFile,
+    backupPath: '/opt/teamclaude/backups/original/teamclaude.service',
+    sha256: 'a'.repeat(64), wasRunning, restoreOnUninstall,
+  };
+  const metadata = {
+    schemaVersion: 1, remoteUrl: 'https://github.com/dzamataev/teamclaude.git', requestedRef: 'master',
+    nodePath: '/absolute/node', launcherPath: '/usr/local/bin/teamclaude', configPath: layout.configPath,
+    serviceKind: 'systemd', installedAt: '2026-08-27T10:30:03.000Z', npmCleanupPending: false,
+    npmRestore: { packageName, version, npmPath: '/absolute/npm' }, serviceBackup: backup,
+  };
+  const resolved = {
+    packageSpec: `${packageName}@${version ?? 'latest'}`,
+    npmPath: '/absolute/npm', commandPath: '/npm-prefix/bin/teamclaude',
+  };
+  const dependencies = {
+    layout,
+    uid: 0,
+    readDeployment: async () => { calls.push('readMetadata'); return metadata; },
+    validateUninstallLayout: async () => calls.push('validateLayout'),
+    assertSafeRootRemoval: async () => {},
+    store: {
+      readSelection: async () => { calls.push('validateLinks'); return { current: '/opt/teamclaude/releases/current', previous: null }; },
+    },
+    readServiceDefinition: async () => { calls.push('validateOwnedService'); return '# TeamClaude-Owner: teamclaude-git-deploy-v1\n'; },
+    validateLauncher: async () => ({ exists: true, owned: true, symlink: false }),
+    service: {
+      validateBackup: async value => { calls.push('validateBackup'); return { ...value, contents: '[Service]\nExecStart=/npm/teamclaude\n' }; },
+      stop: async () => calls.push('stopDeploymentService'),
+      removeOwnedDefinition: async () => { calls.push('removeDeploymentService'); return { removed: true }; },
+      restore: async () => { calls.push('restorePriorService'); return { restored: true, running: wasRunning }; },
+      status: async () => { calls.push('verifyPriorService'); return { installed: true, running: wasRunning }; },
+      install: async () => calls.push('restoreDeploymentDefinition'),
+      start: async () => calls.push('restartDeploymentService'),
+    },
+    resolveNpmRestore: async () => { calls.push('resolveNpmRestore'); return resolved; },
+    stageLauncher: async () => { calls.push('stageOwnedLauncher'); return { path: '/tmp/staged-teamclaude' }; },
+    restoreGlobalNpm: async () => { calls.push('restoreGlobalNpm'); return resolved; },
+    removeOwnedLauncher: async () => { calls.push('removeOwnedLauncherIfStillPresent'); return { removed: false, preserved: true }; },
+    removeDeploymentRoot: async () => calls.push('removeDeploymentRoot'),
+    verifyRestoredCommand: async () => calls.push('verifyRestoredNpmCommand'),
+    restoreStagedLauncher: async () => calls.push('restoreStagedLauncher'),
+    cleanupStagedLauncher: async () => calls.push('cleanupStagedLauncher'),
+    checkHealth: async () => { calls.push('verifyDeploymentHealth'); return true; },
+    sleep: async () => {},
+    run: () => ({ code: 0, stdout: '', stderr: '' }),
+  };
+  return { calls, dependencies, metadata, layout, backup, resolved };
+}
+
+test('uninstall preflight rejects unsafe states before teardown mutation', async () => {
+  const cases = [
+    ['restoreNpm type', { restoreNpm: 'yes' }, {}, /boolean/i],
+    ['missing metadata', { restoreNpm: true }, { readDeployment: async () => null }, /not installed/i],
+    ['non-root Linux', { restoreNpm: true }, { uid: 501 }, /require root/i],
+    ['unsafe root', { restoreNpm: true }, { validateUninstallLayout: async () => { throw new Error('unsafe deployment root'); } }, /unsafe deployment root/],
+    ['unsafe links', { restoreNpm: true }, { store: { readSelection: async () => { throw new Error('current outside releases'); } } }, /outside releases/],
+    ['unowned service', { restoreNpm: true }, { readServiceDefinition: async () => '# operator service\n' }, /not deployment-owned/i],
+    ['bad backup', { restoreNpm: true }, { service: { validateBackup: async () => { throw new Error('backup hash mismatch'); } } }, /hash mismatch/],
+  ];
+  const mutationCalls = new Set([
+    'resolveNpmRestore', 'stageOwnedLauncher', 'restoreGlobalNpm', 'stopDeploymentService',
+    'removeDeploymentService', 'restorePriorService', 'removeOwnedLauncherIfStillPresent', 'removeDeploymentRoot',
+  ]);
+  for (const [name, options, override, pattern] of cases) {
+    const fx = uninstallFixture();
+    Object.assign(fx.dependencies, override);
+    await assert.rejects(createDeployManager(fx.dependencies).uninstall(options), pattern, name);
+    assert.deepEqual(fx.calls.filter(call => mutationCalls.has(call)), [], name);
+  }
+});
+
+test('restore-first uninstall supports exact and latest npm package restoration', async () => {
+  for (const version of ['1.1.13', null]) {
+    const fx = uninstallFixture({ version });
+    const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: true });
+    assert.deepEqual(fx.calls.slice(0, -1), [
+      'readMetadata', 'validateLayout', 'validateLinks', 'validateOwnedService',
+      'validateBackup', 'resolveNpmRestore', 'stageOwnedLauncher', 'restoreGlobalNpm',
+      'stopDeploymentService', 'removeDeploymentService', 'restorePriorService',
+      'verifyPriorService', 'removeOwnedLauncherIfStillPresent', 'removeDeploymentRoot',
+      'verifyRestoredNpmCommand',
+    ]);
+    assert.equal(fx.calls.at(-1), 'cleanupStagedLauncher');
+    assert.deepEqual(result, {
+      ok: true, partial: false, restoredNpm: true,
+      packageSpec: `${packageName}@${version ?? 'latest'}`,
+      commandPath: '/npm-prefix/bin/teamclaude', restoredService: true,
+      launcherRemoved: false, removedRoot: true, remainingPaths: [],
+    });
+  }
+});
+
+test('uninstall does not restore a legacy Git service rooted in the removed deployment', async () => {
+  const fx = uninstallFixture({ restoreOnUninstall: false });
+  const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: true });
+  assert.equal(fx.calls.includes('restorePriorService'), false);
+  assert.equal(fx.calls.includes('verifyPriorService'), false);
+  assert.equal(result.restoredService, false);
+});
+
+test('no-restore uninstall removes only deployment-owned resources', async () => {
+  const fx = uninstallFixture();
+  fx.dependencies.removeOwnedLauncher = async () => {
+    fx.calls.push('removeOwnedLauncherIfStillPresent');
+    return { removed: true, preserved: false };
+  };
+  const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: false });
+  assert.equal(fx.calls.some(call => /Npm|PriorService/.test(call)), false);
+  assert.deepEqual(fx.calls, [
+    'readMetadata', 'validateLayout', 'validateLinks', 'validateOwnedService', 'validateBackup',
+    'stageOwnedLauncher', 'stopDeploymentService', 'removeDeploymentService',
+    'removeOwnedLauncherIfStillPresent', 'removeDeploymentRoot', 'cleanupStagedLauncher',
+  ]);
+  assert.deepEqual(result, {
+    ok: true, partial: false, restoredNpm: false, packageSpec: null, commandPath: null,
+    restoredService: false, launcherRemoved: true, removedRoot: true, remainingPaths: [],
+    warning: 'TeamClaude was intentionally left uninstalled; the config, state, nginx, and retained logs were preserved.',
+  });
+  assert.deepEqual(fx.calls.filter(call => call.includes('/root/.config') || call.includes('nginx') || call.includes('Logs')), []);
+});
+
+test('teardown failures compensate deployment service and launcher in reverse order', async () => {
+  for (const boundary of ['stop', 'removeOwnedDefinition', 'restore', 'status', 'removeOwnedLauncher']) {
+    const fx = uninstallFixture();
+    const original = fx.dependencies.service[boundary] || fx.dependencies[boundary];
+    let failed = false;
+    const replacement = async (...args) => {
+      if (!failed) {
+        failed = true;
+        throw new Error(`failed ${boundary}`);
+      }
+      return original?.(...args);
+    };
+    if (Object.hasOwn(fx.dependencies.service, boundary)) fx.dependencies.service[boundary] = replacement;
+    else fx.dependencies[boundary] = replacement;
+
+    await assert.rejects(createDeployManager(fx.dependencies).uninstall({ restoreNpm: true }), new RegExp(`failed ${boundary}`));
+    assert.equal(fx.calls.includes('removeDeploymentRoot'), false, boundary);
+    assert.equal(fx.calls.includes('restoreDeploymentDefinition'), true, boundary);
+    assert.equal(fx.calls.includes('restoreStagedLauncher'), true, boundary);
+    assert.equal(fx.calls.includes('restartDeploymentService'), true, boundary);
+    assert.equal(fx.calls.includes('verifyDeploymentHealth'), true, boundary);
+  }
+});
+
+test('npm restore failure stops before service or root mutation with an exact recovery command', async () => {
+  const fx = uninstallFixture();
+  fx.dependencies.restoreGlobalNpm = async () => { fx.calls.push('restoreGlobalNpm'); throw new Error('registry unavailable'); };
+  await assert.rejects(
+    createDeployManager(fx.dependencies).uninstall({ restoreNpm: true }),
+    /npm install --global @karpeleslab\/teamclaude@1\.1\.13/,
+  );
+  assert.equal(fx.calls.includes('stopDeploymentService'), false);
+  assert.equal(fx.calls.includes('removeDeploymentRoot'), false);
+});
+
+test('root removal failure returns committed partial state without destructive compensation', async () => {
+  const fx = uninstallFixture();
+  fx.dependencies.removeDeploymentRoot = async () => {
+    fx.calls.push('removeDeploymentRoot');
+    throw new Error('filesystem busy');
+  };
+  const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: true });
+  assert.equal(result.ok, false);
+  assert.equal(result.partial, true);
+  assert.equal(result.restoredNpm, true);
+  assert.equal(result.restoredService, true);
+  assert.equal(result.removedRoot, false);
+  assert.deepEqual(result.remainingPaths, ['/opt/teamclaude']);
+  assert.match(result.warning, /filesystem busy/);
+  assert.equal(fx.calls.includes('restoreDeploymentDefinition'), false);
+  assert.equal(fx.calls.includes('restoreStagedLauncher'), false);
+});
+
+test('final npm command verification failure is partial after root removal', async () => {
+  const fx = uninstallFixture();
+  fx.dependencies.verifyRestoredCommand = async () => {
+    fx.calls.push('verifyRestoredNpmCommand');
+    throw new Error('restored command is unavailable');
+  };
+  const result = await createDeployManager(fx.dependencies).uninstall({ restoreNpm: true });
+  assert.equal(result.ok, false);
+  assert.equal(result.partial, true);
+  assert.equal(result.removedRoot, true);
+  assert.equal(result.restoredNpm, true);
+  assert.deepEqual(result.remainingPaths, ['/npm-prefix/bin/teamclaude']);
+  assert.match(result.warning, /restored command is unavailable/);
+  assert.equal(fx.calls.includes('restoreDeploymentDefinition'), false);
+});

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,8 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   serviceKind, launchAgentPath, systemdUnitPath, logPath, resolveExec, servicePath,
   renderLaunchAgent, renderSystemdUnit, installService, uninstallService, serviceStatus, LABEL,
@@ -207,6 +207,37 @@ test('uninstall unloads before deleting the unit file', async () => {
     await assert.rejects(readFile(launchAgentPath(home), 'utf8'));
   } finally {
     await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('simple service install and uninstall preserve deployment-owned definitions', async (t) => {
+  for (const kind of ['launchd', 'systemd']) {
+    const home = await mkdtemp(join(tmpdir(), `tc-owned-${kind}-`));
+    t.after(() => rm(home, { recursive: true, force: true }));
+    const file = kind === 'launchd' ? launchAgentPath(home) : systemdUnitPath(home, null);
+    const definition = kind === 'launchd'
+      ? '<key>TeamClaudeOwner</key>\n<string>teamclaude-git-deploy-v1</string>\n'
+      : '# TeamClaude-Owner: teamclaude-git-deploy-v1\n[Service]\n';
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, definition);
+    const rec = recorder();
+    const common = { kind, home, run: rec.run, log: () => {}, xdgConfig: null };
+
+    for (const result of [
+      await installService({
+        ...common, platform: kind === 'launchd' ? 'darwin' : 'linux',
+        exec: { node: '/node', entry: '/teamclaude' },
+      }),
+      await uninstallService(common),
+    ]) {
+      assert.deepEqual(result, {
+        ok: false,
+        error: 'This service is managed by teamclaude deploy. Use: teamclaude deploy status',
+        deploymentOwned: true,
+      });
+    }
+    assert.equal(await readFile(file, 'utf8'), definition);
+    assert.deepEqual(rec.calls, []);
   }
 });
 


### PR DESCRIPTION
## Summary

- add `teamclaude deploy install/ref/restart/logs/rollback/status/uninstall`
- install immutable Git releases behind atomic `current` and `previous` links
- manage boot-persistent systemd services on Linux and launchd agents on macOS
- validate refs, repository URLs, ownership markers, configuration placement, rollback health, and npm restoration before destructive transitions
- document installation, daily operation, rollback, uninstall, and migration

The deployment keeps account configuration and runtime state outside the release root. Candidate releases must pass the full test suite before activation, and a failed activation restores and verifies the previous release.

## Verification

- `PATH=/opt/homebrew/Cellar/node@22/22.23.2_1/bin:$PATH npm test -- --test-reporter=dot`
- `npm run lint`
- `git diff --check upstream/master...HEAD`