### PR TITLE
Add read-only terminal status dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Already logged into Claude Code? `teamclaude import` takes its credentials inste
 ```bash
 teamclaude accounts          # accounts with tier and token status
 teamclaude status            # live proxy status, needs a running server
+teamclaude watch             # read-only terminal dashboard, refreshes every minute
 teamclaude disable <name>    # pause an account without removing it
 teamclaude priority <name> 1 # rotation order, lower = preferred
 teamclaude alias --install   # make plain `claude` go through the proxy
@@ -51,6 +52,17 @@ teamclaude help              # everything else
 
 Full reference: [docs/usage.md](docs/usage.md).
 
+## Terminal dashboard
+
+Run the read-only dashboard in a terminal connected to the TeamClaude host:
+
+```bash
+teamclaude watch
+```
+
+It shows the same account, routing, quota, probe, and keep-warm details as `teamclaude status`, together with a short summary from Anthropic's public service-status page. The dashboard fetches both views once a minute, builds the complete frame before repainting, and preserves the colored quota bars without clearing and flashing the terminal. The previous frame stays visible while each refresh is in progress; `Ctrl+C` exits and restores the cursor.
+
+Unlike `teamclaude attach`, `watch` is deliberately read-only and has no keyboard controls or activity stream. Use `attach` when you need the interactive dashboard and `watch` for a compact operational overview over SSH. No commands beyond the installed TeamClaude package are required.
 ## Configuration
 
 Config is at `~/.config/teamclaude.json` (`$XDG_CONFIG_HOME` honoured) and is meant to be hand-editable. A proxy API key is generated on first use. Observed quota goes to a separate `teamclaude.state.json` next to it, safe to delete since quota gets re-learned from traffic.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,6 +143,7 @@ teamclaude env               # Print export lines for routing claude yourself
 teamclaude alias             # Print/install a `claude` alias that routes via the proxy
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude status            # Show live proxy status (requires running server)
+teamclaude watch             # Open the read-only terminal dashboard
 teamclaude attach            # Open the live dashboard against a running server
 teamclaude switch [name]     # Prefer an account; no name lists them (needs server)
 teamclaude remove <name>     # Remove an account (by name or email)
@@ -159,6 +160,8 @@ teamclaude help              # Show all commands
 ```
 
 `teamclaude status` prints the same picture as the TUI, once, as text. Handy over SSH or in a script; `--json` for machine-readable output.
+
+`teamclaude watch` opens a read-only terminal dashboard that refreshes every minute. It combines the color account, routing, quota, probe, and keep-warm output from `teamclaude status` with a one-line summary from Anthropic's public service-status page. Each complete frame replaces the previous one without clearing the terminal, so the display does not flash while either status is being fetched. If Anthropic's page cannot be read, its line reports `UNKNOWN`; if the local proxy is temporarily unreachable, the TeamClaude line reports `UNAVAILABLE` and the next scheduled refresh tries again. Press `Ctrl+C` to exit.
 
 `teamclaude attach` opens the dashboard itself against a server that is already running, which is how you get interactive control back when the proxy runs as a background service. It polls the same status endpoint every second and can do the two things the control plane exposes: `s` switches account, `R` reloads config. Settings editing, quota probing and the request activity stream stay in the server's own TUI — they need state that only that process has. When contact with the server drops, the header marker turns from `▲` to `▼` and what is on screen is the last snapshot, not the current state.
 

--- a/src/abort.js
+++ b/src/abort.js
@@ -1,0 +1,25 @@
+/** Combine an optional caller cancellation signal with a bounded timeout. */
+export function timeoutSignal(parent, timeoutMs) {
+  const controller = new AbortController();
+  const onAbort = () => controller.abort(parent.reason);
+  if (parent?.aborted) onAbort();
+  else parent?.addEventListener('abort', onAbort, { once: true });
+
+  let timer = null;
+  if (!controller.signal.aborted) {
+    timer = setTimeout(() => {
+      const error = new Error(`request timed out after ${timeoutMs}ms`);
+      error.name = 'TimeoutError';
+      controller.abort(error);
+    }, timeoutMs);
+    timer.unref?.();
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup() {
+      if (timer) clearTimeout(timer);
+      parent?.removeEventListener('abort', onAbort);
+    },
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
+import { resolveControlHost, runWatchDashboard } from './watch-dashboard.js';
 
 // These constants are referenced by routeCommand, which the dispatch below
 // reaches through a top-level `await`. The await suspends module evaluation at
@@ -77,6 +78,9 @@ switch (command) {
   case 'status':
     await statusCommand();
     process.exit(0);
+    break;
+  case 'watch':
+    process.exit(await runWatchDashboard());
     break;
   case 'attach':
     await attachCommand();
@@ -914,8 +918,7 @@ async function attachCommand() {
   // the config or the environment is not reachable as localhost, and reporting
   // "not running" for a server that is plainly up is the worst of the answers.
   // A wildcard bind is not an address to dial, so dial this machine instead.
-  const bound = process.env.TEAMCLAUDE_HOST || config.proxy.host || '127.0.0.1';
-  const host = (bound === '0.0.0.0' || bound === '::') ? '127.0.0.1' : bound;
+  const host = resolveControlHost(config);
 
   // Checked before connecting: the dashboard needs raw-mode input, and failing
   // on that after a successful poll would be a confusing order to report it in.
@@ -1564,6 +1567,8 @@ Commands:
                       'print' writes the unit to stdout without touching anything)
   status [--json]     Show rich proxy/account/probe status (live)
                       Use --color=always|never to control ANSI colors
+  watch               Open the read-only terminal dashboard with TeamClaude
+                      quota and Anthropic service status; refreshes every minute
   attach              Open the live dashboard against a running server; s
                       switches account, R reloads config, q leaves it running
   accounts            List configured accounts

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -1,6 +1,7 @@
 import { TUI } from './tui.js';
 import { SessionTitles } from './session-titles.js';
 import { modelGlobMatches } from './model.js';
+import { timeoutSignal } from './abort.js';
 
 // Attach mode — the dashboard against a server running somewhere else (a
 // background service, another terminal). The renderer is the same one the
@@ -27,8 +28,8 @@ export class RemoteControl {
   }
 
   /** The current status payload (the same one `teamclaude status` renders). */
-  async status() {
-    const payload = await this._call('GET', '/teamclaude/status');
+  async status({ signal = null } = {}) {
+    const payload = await this._call('GET', '/teamclaude/status', undefined, signal);
     // A status reply always carries an accounts array, even when it is empty.
     // Anything else answered on this port is not this control plane, and calling
     // that "connected with no accounts" would diagnose the wrong problem.
@@ -79,13 +80,15 @@ export class RemoteControl {
     return payload;
   }
 
-  async _call(method, path, body) {
+  async _call(method, path, body, signal = null) {
     const deadline = this.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const headers = {};
     if (this.apiKey) headers['x-api-key'] = this.apiKey;
     if (body !== undefined) headers['content-type'] = 'application/json';
 
     let res;
+    let text;
+    const request = timeoutSignal(signal, deadline);
     try {
       res = await this._fetch(`http://${this.host}:${this.port}${path}`, {
         method, headers,
@@ -93,15 +96,17 @@ export class RemoteControl {
         // A socket that is open but silent — the server stopped, the laptop
         // suspended mid-request — would otherwise hold this call for minutes
         // while the dashboard showed a live marker over a frozen snapshot.
-        signal: AbortSignal.timeout(deadline),
+        signal: request.signal,
       });
+      text = await res.text();
     } catch (err) {
       if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
         throw new Error(`no reply within ${deadline}ms`);
       }
       throw err;
+    } finally {
+      request.cleanup();
     }
-    const text = await res.text();
     let payload = null;
     try { payload = text ? JSON.parse(text) : null; } catch { /* not JSON — the status carries the meaning */ }
 

--- a/src/watch-dashboard.js
+++ b/src/watch-dashboard.js
@@ -1,0 +1,187 @@
+import { loadOrCreateConfig } from './config.js';
+import { renderStatus } from './status-renderer.js';
+import { RemoteControl } from './tui-remote.js';
+import { proxyFetch } from './upstream-fetch.js';
+import { timeoutSignal } from './abort.js';
+
+const ANTHROPIC_STATUS_URL = 'https://status.claude.com/api/v2/summary.json';
+const REFRESH_MS = 60_000;
+const timestampFormat = new Intl.DateTimeFormat('sv-SE', {
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+  hourCycle: 'h23',
+});
+
+/** Reduce the public Anthropic status summary to one terminal line. */
+export function formatAnthropicStatus(summary) {
+  const indicator = typeof summary?.status?.indicator === 'string'
+    ? cleanLine(summary.status.indicator, 32)
+    : '';
+  if (!indicator) return 'Anthropic: UNKNOWN';
+  if (indicator === 'none') return 'Anthropic: OPERATIONAL';
+
+  const label = indicator.toUpperCase();
+  const incident = Array.isArray(summary.incidents) ? summary.incidents[0] : null;
+  const incidentName = typeof incident?.name === 'string' ? cleanLine(incident.name) : '';
+  if (incidentName) {
+    const incidentStatus = typeof incident.status === 'string' ? cleanLine(incident.status, 48) : '';
+    const status = incidentStatus
+      ? ` (${incidentStatus})`
+      : '';
+    return cleanLine(`Anthropic: ${label} — ${incidentName}${status}`);
+  }
+  const description = typeof summary?.status?.description === 'string'
+    ? cleanLine(summary.status.description)
+    : '';
+  return description
+    ? cleanLine(`Anthropic: ${label} — ${description}`)
+    : `Anthropic: ${label}`;
+}
+
+/** Resolve the local control address from the same bind settings as attach. */
+export function resolveControlHost(config, env = process.env) {
+  const bound = env.TEAMCLAUDE_HOST || config.proxy.host || '127.0.0.1';
+  return bound === '0.0.0.0' || bound === '::' ? '127.0.0.1' : bound;
+}
+
+/** Build one complete dashboard repaint with color forced on. */
+export function renderWatchFrame({ teamClaudeStatus, teamClaudeError, anthropicStatus, now = Date.now() }) {
+  const timestamp = timestampFormat.format(new Date(now));
+  const status = teamClaudeStatus
+    ? renderStatus(teamClaudeStatus, { color: true, now })
+    : `TeamClaude: UNAVAILABLE${teamClaudeError ? ` — ${cleanLine(teamClaudeError)}` : ''}`;
+  return `TeamClaude dashboard — ${timestamp}\n\n${anthropicStatus}\n\n${status}`;
+}
+
+/** Read and reduce the public Anthropic status page without failing the dashboard. */
+export async function readAnthropicStatus({ fetchImpl = proxyFetch, timeoutMs = 5000, signal = null } = {}) {
+  const request = timeoutSignal(signal, timeoutMs);
+  try {
+    const response = await fetchImpl(ANTHROPIC_STATUS_URL, {
+      signal: request.signal,
+    });
+    if (!response.ok) {
+      await response.body?.cancel?.().catch(() => {});
+      return 'Anthropic: UNKNOWN';
+    }
+    return formatAnthropicStatus(await readJsonBody(response, request.signal));
+  } catch {
+    return 'Anthropic: UNKNOWN';
+  } finally {
+    request.cleanup();
+  }
+}
+
+/** Run the read-only terminal dashboard until its signal is aborted. */
+export async function runWatchDashboard({
+  stdout = process.stdout,
+  stderr = process.stderr,
+  signal = null,
+  readTeamClaude = null,
+  readAnthropic = readAnthropicStatus,
+  wait = waitFor,
+  now = Date.now,
+} = {}) {
+  if (!stdout.isTTY) {
+    stderr.write('teamclaude watch needs a terminal. For a one-shot readout use: teamclaude status\n');
+    return 1;
+  }
+
+  if (!readTeamClaude) {
+    const config = await loadOrCreateConfig();
+    const control = new RemoteControl({
+      port: config.proxy.port,
+      host: resolveControlHost(config),
+      apiKey: config.proxy.apiKey,
+      timeoutMs: 5000,
+    });
+    readTeamClaude = ({ signal }) => control.status({ signal });
+  }
+
+  const controller = signal ? null : new AbortController();
+  signal ||= controller.signal;
+  const stop = () => controller.abort();
+  if (controller) {
+    process.on('SIGINT', stop);
+    process.on('SIGTERM', stop);
+    process.on('SIGHUP', stop);
+  }
+
+  let painted = false;
+  try {
+    while (!signal.aborted) {
+      const cycleStartedAt = now();
+      const [teamClaude, anthropic] = await Promise.allSettled([
+        readTeamClaude({ signal }),
+        readAnthropic({ signal }),
+      ]);
+      if (signal.aborted) break;
+
+      const frameNow = now();
+      const frame = renderWatchFrame({
+        teamClaudeStatus: teamClaude.status === 'fulfilled' ? teamClaude.value : null,
+        teamClaudeError: teamClaude.status === 'rejected' ? teamClaude.reason?.message || teamClaude.reason : null,
+        anthropicStatus: anthropic.status === 'fulfilled' ? anthropic.value : 'Anthropic: UNKNOWN',
+        now: frameNow,
+      });
+      const prefix = painted ? '\x1b[H' : '\x1b[?25l\x1b[2J\x1b[H';
+      stdout.write(`${prefix}${frame}\n\x1b[J`);
+      painted = true;
+      const elapsed = Math.max(0, now() - cycleStartedAt);
+      await wait(Math.max(0, REFRESH_MS - elapsed), signal);
+    }
+    return 0;
+  } finally {
+    if (controller) {
+      process.off('SIGINT', stop);
+      process.off('SIGTERM', stop);
+      process.off('SIGHUP', stop);
+    }
+    if (painted) stdout.write('\x1b[?25h\n');
+  }
+}
+
+function waitFor(ms, signal) {
+  return new Promise(resolve => {
+    if (signal.aborted) { resolve(); return; }
+    const timer = setTimeout(done, ms);
+    signal.addEventListener('abort', done, { once: true });
+    function done() {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', done);
+      resolve();
+    }
+  });
+}
+
+async function readJsonBody(response, signal) {
+  if (!response.body?.getReader) return response.json();
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let bytes = 0;
+  const onAbort = () => { reader.cancel(signal.reason).catch(() => {}); };
+  signal.addEventListener('abort', onAbort, { once: true });
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (signal.aborted) throw signal.reason;
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > 1_000_000) {
+        await reader.cancel();
+        throw new Error('Anthropic status response is too large');
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return JSON.parse(text);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+    reader.releaseLock();
+  }
+}
+
+function cleanLine(value, maxLength = 240) {
+  return String(value).replace(/\p{C}+/gu, ' ').replace(/\s+/gu, ' ').trim().slice(0, maxLength);
+}

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -122,6 +122,24 @@ test('the status call carries the proxy API key and returns the payload', async 
   );
 });
 
+test('an external abort cancels an active status call before its timeout', async () => {
+  const controller = new AbortController();
+  let requestSignal = null;
+  const control = new RemoteControl({
+    port: 3456,
+    timeoutMs: 1000,
+    fetchImpl: (_url, { signal }) => new Promise((_resolve, reject) => {
+      requestSignal = signal;
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }),
+  });
+  const status = control.status({ signal: controller.signal });
+  controller.abort(new Error('stop dashboard'));
+
+  await assert.rejects(status, /stop dashboard/);
+  assert.equal(requestSignal?.aborted, true);
+});
+
 test('a non-2xx status reply is an error, not a half-empty dashboard', async (t) => {
   const { control } = await makeSession(t, {
     routes: { 'GET /teamclaude/status': (req, res) => { res.writeHead(500); res.end('boom'); } },

--- a/test/watch-dashboard.test.js
+++ b/test/watch-dashboard.test.js
@@ -1,0 +1,297 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import http from 'node:http';
+import { ReadableStream } from 'node:stream/web';
+import { TextEncoder } from 'node:util';
+import * as dashboard from '../src/watch-dashboard.js';
+import { resetUpstreamProxy, setUpstreamProxy } from '../src/upstream-proxy.js';
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+test('watch is a terminal command and explains when no terminal is attached', () => {
+  const result = spawnSync(process.execPath, [cliPath, 'watch'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /teamclaude watch needs a terminal/i);
+  assert.doesNotMatch(result.stderr, /unknown command/i);
+});
+
+test('top-level help presents watch as the read-only terminal dashboard', () => {
+  const result = spawnSync(process.execPath, [cliPath, 'help'], { encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /watch\s+Open the read-only terminal dashboard/);
+});
+
+test('Anthropic status summarizes operational, incident, and unavailable states', () => {
+  const operational = dashboard.formatAnthropicStatus?.({
+    status: { indicator: 'none', description: 'All Systems Operational' },
+    incidents: [],
+  });
+  const incident = dashboard.formatAnthropicStatus?.({
+    status: { indicator: 'minor', description: 'Minor Service Outage' },
+    incidents: [{ name: 'Elevated errors for multiple models', status: 'identified' }],
+  });
+
+  assert.equal(operational, 'Anthropic: OPERATIONAL');
+  assert.equal(incident, 'Anthropic: MINOR — Elevated errors for multiple models (identified)');
+  assert.equal(dashboard.formatAnthropicStatus?.(null), 'Anthropic: UNKNOWN');
+});
+
+test('external status text cannot inject terminal control characters', () => {
+  const line = dashboard.formatAnthropicStatus?.({
+    status: { indicator: 'minor\x1b[2J' },
+    incidents: [{ name: `bad\n\x1b[31mred\u202e${'x'.repeat(500)}`, status: 'identified\r' }],
+  });
+
+  assert.doesNotMatch(line || '', /\p{C}/u);
+  assert.ok((line || '').length <= 240, 'external status line must be bounded');
+});
+
+test('control host follows the configured bind and maps wildcards to loopback', () => {
+  assert.equal(dashboard.resolveControlHost?.({ proxy: { host: '192.0.2.4' } }, {}), '192.0.2.4');
+  assert.equal(dashboard.resolveControlHost?.({ proxy: { host: '0.0.0.0' } }, {}), '127.0.0.1');
+  assert.equal(dashboard.resolveControlHost?.({ proxy: { host: '::' } }, {}), '127.0.0.1');
+  assert.equal(
+    dashboard.resolveControlHost?.({ proxy: { host: '192.0.2.4' } }, { TEAMCLAUDE_HOST: '198.51.100.8' }),
+    '198.51.100.8',
+  );
+});
+
+test('Anthropic status uses the configured upstream proxy', async t => {
+  let connectTarget = null;
+  const proxy = http.createServer();
+  proxy.on('connect', (req, socket) => {
+    connectTarget = req.url;
+    socket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+  });
+  await new Promise(resolve => proxy.listen(0, '127.0.0.1', resolve));
+  t.after(() => {
+    resetUpstreamProxy();
+    proxy.close();
+  });
+  setUpstreamProxy({
+    proxy: { host: '127.0.0.1', port: proxy.address().port, username: null, password: null },
+    source: 'test',
+    noProxy: null,
+  });
+
+  assert.equal(await dashboard.readAnthropicStatus({ timeoutMs: 200 }), 'Anthropic: UNKNOWN');
+  assert.equal(connectTarget, 'status.claude.com:443');
+});
+
+test('aborting Anthropic status cancels its active request', async () => {
+  const controller = new AbortController();
+  let requestSignal = null;
+  const read = dashboard.readAnthropicStatus({
+    timeoutMs: 1000,
+    signal: controller.signal,
+    fetchImpl: (_url, { signal }) => new Promise((_resolve, reject) => {
+      requestSignal = signal;
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }),
+  });
+  controller.abort(new Error('stop dashboard'));
+
+  const outcome = await Promise.race([
+    read,
+    new Promise(resolve => setTimeout(() => resolve('still pending'), 50)),
+  ]);
+  assert.equal(outcome, 'Anthropic: UNKNOWN');
+  assert.equal(requestSignal?.aborted, true);
+});
+
+test('Anthropic timeout cancels a response body that stalls after headers', async () => {
+  let bodyCancelled = false;
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('{"status":'));
+    },
+    cancel() {
+      bodyCancelled = true;
+    },
+  });
+  const read = dashboard.readAnthropicStatus({
+    timeoutMs: 20,
+    fetchImpl: async () => ({ ok: true, body, json: () => new Promise(() => {}) }),
+  });
+
+  const outcome = await Promise.race([
+    read,
+    new Promise(resolve => setTimeout(() => resolve('still pending'), 100)),
+  ]);
+  assert.equal(outcome, 'Anthropic: UNKNOWN');
+  assert.equal(bodyCancelled, true);
+});
+
+test('an unsuccessful Anthropic response is discarded without retaining its socket', async () => {
+  let bodyCancelled = false;
+  const body = new ReadableStream({ cancel() { bodyCancelled = true; } });
+
+  const outcome = await dashboard.readAnthropicStatus({
+    fetchImpl: async () => ({ ok: false, body }),
+  });
+
+  assert.equal(outcome, 'Anthropic: UNKNOWN');
+  assert.equal(bodyCancelled, true);
+});
+
+test('the dashboard frame includes Anthropic health and colored TeamClaude quota bars', () => {
+  const now = Date.parse('2026-09-03T13:00:00Z');
+  const frame = dashboard.renderWatchFrame?.({
+    now,
+    anthropicStatus: 'Anthropic: OPERATIONAL',
+    teamClaudeStatus: {
+      currentAccount: 'a',
+      switchThreshold: 0.95,
+      probe: { enabled: false, intervalSeconds: 0, accounts: [] },
+      accounts: [{
+        name: 'a',
+        type: 'oauth',
+        status: 'active',
+        quota: { unified5h: 0.5, unified5hReset: now + 60_000 },
+        usage: {},
+      }],
+    },
+  });
+
+  assert.match(frame || '', /^TeamClaude dashboard — /);
+  assert.match(frame || '', /Anthropic: OPERATIONAL/);
+  assert.match(frame || '', /\x1b\[38;2;\d+;\d+;\d+m█/);
+});
+
+test('the dashboard repaints complete frames in place and restores the cursor', async () => {
+  const controller = new AbortController();
+  const writes = [];
+  const stdout = {
+    isTTY: true,
+    write(chunk) { writes.push(String(chunk)); return true; },
+  };
+  const teamClaudeStatus = {
+    currentAccount: 'a',
+    switchThreshold: 0.95,
+    probe: { enabled: false, intervalSeconds: 0, accounts: [] },
+    accounts: [],
+  };
+  const anthropicStatuses = [
+    'Anthropic: OPERATIONAL',
+    'Anthropic: MINOR — Elevated errors (identified)',
+  ];
+  let reads = 0;
+  let waits = 0;
+
+  const code = await dashboard.runWatchDashboard({
+    stdout,
+    stderr: { write() { return true; } },
+    signal: controller.signal,
+    readTeamClaude: async () => teamClaudeStatus,
+    readAnthropic: async () => anthropicStatuses[reads++],
+    wait: async () => {
+      waits++;
+      if (waits === 2) controller.abort();
+    },
+    now: () => Date.parse('2026-09-03T13:00:00Z'),
+  });
+
+  const output = writes.join('');
+  assert.equal(code, 0);
+  assert.equal((output.match(/\x1b\[H/g) || []).length, 2);
+  assert.equal((output.match(/\x1b\[2J/g) || []).length, 1);
+  assert.match(output, /Anthropic: OPERATIONAL/);
+  assert.match(output, /Anthropic: MINOR — Elevated errors \(identified\)/);
+  assert.ok(output.endsWith('\x1b[?25h\n'), 'cursor must be visible after exit');
+});
+
+test('the first frame replaces the screen only after both reads finish', async () => {
+  const controller = new AbortController();
+  const writes = [];
+  let finishTeamClaude;
+  let finishAnthropic;
+  const teamClaude = new Promise(resolve => { finishTeamClaude = resolve; });
+  const anthropic = new Promise(resolve => { finishAnthropic = resolve; });
+  const running = dashboard.runWatchDashboard({
+    stdout: { isTTY: true, write(chunk) { writes.push(String(chunk)); return true; } },
+    stderr: { write() { return true; } },
+    signal: controller.signal,
+    readTeamClaude: async () => teamClaude,
+    readAnthropic: async () => anthropic,
+    wait: async () => controller.abort(),
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(writes, [], 'the existing terminal must remain visible during the first fetch');
+
+  finishTeamClaude({ currentAccount: 'a', switchThreshold: 0.95, accounts: [] });
+  finishAnthropic('Anthropic: OPERATIONAL');
+  assert.equal(await running, 0);
+  assert.equal((writes.join('').match(/\x1b\[2J/g) || []).length, 1);
+});
+
+test('refresh timing subtracts fetch time instead of accumulating drift', async () => {
+  const controller = new AbortController();
+  const clock = [1000, 6000, 6000];
+  let requestedDelay = null;
+  await dashboard.runWatchDashboard({
+    stdout: { isTTY: true, write() { return true; } },
+    stderr: { write() { return true; } },
+    signal: controller.signal,
+    readTeamClaude: async () => ({ currentAccount: 'a', switchThreshold: 0.95, accounts: [] }),
+    readAnthropic: async () => 'Anthropic: OPERATIONAL',
+    now: () => clock.shift() ?? 6000,
+    wait: async delay => { requestedDelay = delay; controller.abort(); },
+  });
+
+  assert.equal(requestedDelay, 55_000);
+});
+
+test('SIGINT propagates to active readers in a real child process', async () => {
+  const moduleUrl = new URL('../src/watch-dashboard.js', import.meta.url).href;
+  const source = `
+    import { runWatchDashboard } from ${JSON.stringify(moduleUrl)};
+    const hold = setInterval(() => {}, 1000);
+    const pending = ({ signal }) => new Promise((_resolve, reject) => {
+      process.stderr.write('reader-ready\\n');
+      signal.addEventListener('abort', () => {
+        process.stderr.write('reader-aborted\\n');
+        reject(signal.reason);
+      }, { once: true });
+    });
+    const stdout = { isTTY: true, write: chunk => process.stdout.write(chunk) };
+    const code = await runWatchDashboard({ stdout, readTeamClaude: pending, readAnthropic: pending });
+    clearInterval(hold);
+    process.exit(code);
+  `;
+  const child = spawn(process.execPath, ['--input-type=module', '--eval', source], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => { stdout += chunk; });
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`child readers did not start: ${stderr}`)), 1000);
+    const ready = () => {
+      if ((stderr.match(/reader-ready/g) || []).length !== 2) return;
+      clearTimeout(timer);
+      child.stderr.off('data', ready);
+      resolve();
+    };
+    child.stderr.on('data', ready);
+  });
+  child.kill('SIGINT');
+  const code = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { child.kill('SIGKILL'); resolve('timeout'); }, 500);
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('exit', value => { clearTimeout(timer); resolve(value); });
+  });
+
+  assert.equal(code, 0, stderr);
+  assert.equal((stderr.match(/reader-aborted/g) || []).length, 2, stderr);
+  assert.doesNotMatch(stdout, /\x1b\[\?25l/, 'the cursor is untouched before the first frame');
+});


### PR DESCRIPTION
Supersedes #251 after renaming the fork branch.

## Summary

- add `teamclaude watch` as a compact read-only terminal dashboard
- show proxy state, Anthropic reachability, account quota bars, session activity, and recent failures
- update the screen in place without terminal flicker while preserving ANSI colors
- support one-shot and JSON output for scripts and non-interactive terminals
- share abort handling with the remote TUI and document the command as part of the normal CLI

The dashboard reads existing local TeamClaude status endpoints and does not alter routing or account state.

## Verification

- `PATH=/opt/homebrew/Cellar/node@22/22.23.2_1/bin:$PATH npm test -- --test-reporter=dot`
- `npm run lint`
- `git diff --check upstream/master...HEAD`