### PR TITLE
test: re-date two fixtures that expired on the calendar

### DIFF
--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -191,9 +191,9 @@ test('a failed probe is not evidence', () => {
 test('a probe that reports the family still spent keeps it spent', () => {
   const am = new AccountManager([oauth('a')], 0.98);
   const q = sealFable(am);
-  const at = Date.parse('2026-09-04T10:00:00Z');
+  const at = Math.floor((Date.now() + 48 * 3600_000) / 1000) * 1000;
   am.applyUsageData(0, normalizeUsagePayload({ limits: [
-    { kind: 'weekly_scoped', group: 'weekly', percent: 99, resets_at: '2026-09-04T10:00:00Z',
+    { kind: 'weekly_scoped', group: 'weekly', percent: 99, resets_at: new Date(at).toISOString(),
       scope: { model: { display_name: 'Fable' } } },
   ]}));
   assert.equal(q.unified7dFable, 0.99);

--- a/test/scoped-weekly.test.js
+++ b/test/scoped-weekly.test.js
@@ -30,7 +30,8 @@ test('every scoped weekly limit is read, keyed by the name upstream used', () =>
   assert.deepEqual(Object.keys(scoped).sort(), ['fable', 'opus']);
   assert.equal(scoped.fable.utilization, 0);
   assert.equal(scoped.opus.utilization, 0.95, 'percent is normalized to a 0-1 fraction');
-  assert.ok(scoped.opus.resetAt > Date.now(), 'reset parses to a timestamp');
+  assert.equal(scoped.opus.resetAt, Date.parse('2026-09-05T00:00:00Z'),
+    'reset parses to a timestamp');
 });
 
 test('unscoped and non-weekly entries are not mistaken for family buckets', () => {


### PR DESCRIPTION
`test/scoped-weekly.test.js` and `test/quota-probe.test.js` fail on master with no source change, because the fixtures they rest on expired on the calendar.

`test/scoped-weekly.test.js` asserted that a hard-coded reset instant was still in the future, so the result depended on the wall clock rather than on the parser the assertion names; it now compares the parsed value against `Date.parse` of the same string the fixture sets.

`test/quota-probe.test.js` set a weekly window at a fixed instant that has since passed, so the expiry sweep cleared the bucket the assertion was about and the account read as eligible again; that window is now dated 48 hours from the current time.

With both, `npm test` on master is green at 858 tests, and #190 includes both of these changes, so a maintainer merging both should expect the overlap.
