### PR TITLE
fix(run): do not fall back to the bootstrap key for a merely expired or stale local login

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ teamclaude run       # in another terminal: Claude Code through the proxy
 Already logged into Claude Code? `teamclaude import` takes its credentials instead of a fresh OAuth round. API keys, and one email holding accounts in several orgs, are covered in [docs/accounts.md](docs/accounts.md).
 
 `teamclaude run` does not require a separate Claude Code login for normal API
-requests. When local Claude OAuth is unavailable or expired, proxy credential
-mode supplies a local-only bootstrap key; the proxy replaces that placeholder
+requests. When there is no usable local Claude OAuth (no login, or one that can
+no longer be refreshed), proxy credential mode supplies a local-only bootstrap
+key; the proxy replaces that placeholder
 with the selected TeamClaude account credential before forwarding.
 
 ## What it does

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,7 +119,7 @@ eval "$(teamclaude env --no-mitm)" # base-URL: ANTHROPIC_BASE_URL only
 claude
 ```
 
-Only the export lines go to stdout (so `eval` is safe); a short summary and any hints go to stderr. When local Claude OAuth is valid, no `ANTHROPIC_API_KEY` is emitted and Claude Code stays in subscription mode. When local OAuth is missing or expired, TeamClaude switches to proxy credential mode and emits a harmless local bootstrap key so Claude Code can start; the proxy replaces it with the selected account credential for normal API requests.
+Only the export lines go to stdout (so `eval` is safe); a short summary and any hints go to stderr. When local Claude OAuth is usable, no `ANTHROPIC_API_KEY` is emitted and Claude Code stays in subscription mode. An access token that has merely expired still counts as usable while its refresh token is valid, because Claude Code refreshes it itself at startup. Only when there is no local OAuth at all — no tokens, or a refresh token that has expired too — does TeamClaude switch to proxy credential mode and emit a harmless local bootstrap key so Claude Code can start; the proxy replaces it with the selected account credential for normal API requests. On macOS the Keychain (Claude Code's live store) is consulted before `~/.claude/.credentials.json`, which can be a stale snapshot from an earlier login.
 
 The bootstrap mode does not authenticate the passthrough endpoints used by Remote Control and claude.ai file transfers, which intentionally retain the client's own headers. Run `claude /login` if those features are needed. A remote (non-loopback) client must override the bootstrap key with the real proxy key.
 

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -67,22 +67,48 @@ export async function readKeychainCredentials({ exec = execFileAsync, username =
 
 /**
  * Import OAuth credentials from a Claude Code credentials file.
- * On macOS the default credentials location is the Keychain, not a file, so
- * when the default path is missing the Keychain is tried before giving up.
+ *
+ * On macOS Claude Code keeps its live login in the Keychain, and
+ * ~/.claude/.credentials.json — when it exists at all — is a snapshot from an
+ * earlier login that Claude Code never refreshes. So for the default path on
+ * darwin the Keychain is asked first, and the file is only the fallback for a
+ * Keychain that carries no token or cannot be read. Reading the file first made
+ * a days-old snapshot look like an expired login while Claude Code itself was
+ * still signed in. Any other path is a plain file read.
  */
 export async function importCredentials(filePath, {
   home = homedir(), platform = process.platform, readKeychain = readKeychainCredentials } = {}) {
   const resolvedPath = filePath.replace(/^~/, home);
-  let raw;
-  try {
-    raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
-  } catch (err) {
-    const isDefaultPath = resolvedPath === DEFAULT_CREDENTIALS_PATH.replace(/^~/, home);
-    if (err.code !== 'ENOENT' || platform !== 'darwin' || !isDefaultPath) throw err;
+  const isDefaultPath = resolvedPath === DEFAULT_CREDENTIALS_PATH.replace(/^~/, home);
+  const useKeychain = platform === 'darwin' && isDefaultPath;
+
+  let raw = null;
+  let keychainBlank = null; // a Keychain payload that parsed but carried no token
+  let keychainErr = null;
+  if (useKeychain) {
     try {
-      raw = await readKeychain();
-    } catch (kcErr) {
-      throw new Error(`${err.message}; macOS Keychain lookup for "${KEYCHAIN_SERVICE}" also failed: ${kcErr.message}`);
+      const payload = await readKeychain();
+      if (hasToken(payload)) raw = payload;
+      else keychainBlank = payload;
+    } catch (err) {
+      keychainErr = err;
+    }
+  }
+
+  if (!raw) {
+    try {
+      raw = JSON.parse(await readFile(resolvedPath, 'utf-8'));
+    } catch (err) {
+      if (!useKeychain || err.code !== 'ENOENT') throw err;
+      // No file either. A token-less Keychain payload still goes back to the
+      // caller, whose own "no credentials" reporting stays in charge; only a
+      // Keychain that could not be read at all is an error here.
+      if (keychainBlank) {
+        raw = keychainBlank;
+      } else {
+        const detail = keychainErr ? keychainErr.message : 'no item carried a token';
+        throw new Error(`${err.message}; macOS Keychain lookup for "${KEYCHAIN_SERVICE}" also failed: ${detail}`);
+      }
     }
   }
 
@@ -92,6 +118,9 @@ export async function importCredentials(filePath, {
     accessToken: data.accessToken,
     refreshToken: data.refreshToken,
     expiresAt: data.expiresAt,
+    // Only Claude Code's own store carries this; leave the key out rather than
+    // put an undefined one on every imported account.
+    ...(data.refreshTokenExpiresAt != null && { refreshTokenExpiresAt: data.refreshTokenExpiresAt }),
     subscriptionType: data.subscriptionType,
     rateLimitTier: data.rateLimitTier,
   };
@@ -204,10 +233,23 @@ export function isTokenExpired(expiresAt) {
   return Date.now() >= normalizeExpiresAt(expiresAt);
 }
 
+/**
+ * Whether Claude Code has to start in proxy credential mode (on the bootstrap
+ * key) because it has no usable OAuth of its own.
+ *
+ * "Usable" is deliberately loose. An access token that has already expired is
+ * fine as long as a refresh token is there: Claude Code refreshes the pair
+ * itself at startup, and the proxy relays that refresh untouched. Counting an
+ * expired access token as "no OAuth" put Claude Code into API-key mode — which
+ * drops subscription mode and disables Claude in Chrome — whenever the
+ * credentials it read were a stale snapshot. Only a missing, or itself
+ * expired, refresh token means Claude Code cannot sign in on its own.
+ */
 export function needsProxyClientCredential(credentials, now = Date.now()) {
-  if (!credentials?.accessToken) return true;
-  if (!credentials.expiresAt) return false;
-  return normalizeExpiresAt(credentials.expiresAt) <= now;
+  if (!credentials) return true;
+  const { accessToken, expiresAt, refreshToken, refreshTokenExpiresAt } = credentials;
+  const live = (token, expiry) => Boolean(token) && (!expiry || normalizeExpiresAt(expiry) > now);
+  return !live(accessToken, expiresAt) && !live(refreshToken, refreshTokenExpiresAt);
 }
 
 /** Normalize the OAuth profile fields TeamClaude persists and exposes. */

--- a/test/client-auth.test.js
+++ b/test/client-auth.test.js
@@ -7,10 +7,43 @@ test('proxy client credential is needed without a local access token', () => {
   assert.equal(needsProxyClientCredential({}, 2_000_000_000_000), true);
 });
 
-test('proxy client credential is needed for an expired local access token', () => {
+// Claude Code refreshes an expired access token itself at startup, so only a
+// login that cannot be refreshed counts as unavailable.
+
+test('an expired local access token with a refresh token keeps subscription mode', () => {
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    refreshToken: 'refresh',
+    expiresAt: 1_999_999_999_999,
+  }, 2_000_000_000_000), false);
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    refreshToken: 'refresh',
+    expiresAt: 1_999_999_999_999,
+    refreshTokenExpiresAt: 2_000_000_000_001,
+  }, 2_000_000_000_000), false);
+});
+
+test('proxy client credential is needed for an expired local access token with no refresh token', () => {
   assert.equal(needsProxyClientCredential({
     accessToken: 'token',
     expiresAt: 1_999_999_999_999,
+  }, 2_000_000_000_000), true);
+});
+
+test('proxy client credential is needed when the refresh token has expired too', () => {
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    refreshToken: 'refresh',
+    expiresAt: 1_999_999_999_999,
+    refreshTokenExpiresAt: 1_999_999_999_999,
+  }, 2_000_000_000_000), true);
+  // Seconds-based expiry is normalised the same way as expiresAt.
+  assert.equal(needsProxyClientCredential({
+    accessToken: 'token',
+    refreshToken: 'refresh',
+    expiresAt: 1_999_999_999,
+    refreshTokenExpiresAt: 1_999_999_999,
   }, 2_000_000_000_000), true);
 });
 

--- a/test/import-credentials.test.js
+++ b/test/import-credentials.test.js
@@ -15,10 +15,20 @@ test('reads nested claudeAiOauth credentials from file', async () => {
   const home = await tmpHome();
   await mkdir(join(home, '.claude'), { recursive: true });
   await writeFile(join(home, '.claude', '.credentials.json'), JSON.stringify({ claudeAiOauth: CREDS }));
+  const readKeychain = async () => { throw new Error('no keychain here'); };
 
-  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin' });
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
   assert.equal(creds.accessToken, 'at');
   assert.equal(creds.refreshToken, 'rt');
+  assert.equal('refreshTokenExpiresAt' in creds, false, 'absent in the source, absent in the result');
+});
+
+test('passes refreshTokenExpiresAt through when the source carries it', async () => {
+  const home = await tmpHome();
+  await writeFile(join(home, 'creds.json'), JSON.stringify({ ...CREDS, refreshTokenExpiresAt: 1760000000000 }));
+
+  const creds = await importCredentials(join(home, 'creds.json'), { home, platform: 'linux' });
+  assert.equal(creds.refreshTokenExpiresAt, 1760000000000);
 });
 
 test('reads flat credentials from file', async () => {
@@ -38,6 +48,62 @@ test('falls back to Keychain on macOS when default file is missing', async () =>
   assert.equal(called, 1);
   assert.equal(creds.accessToken, 'at');
   assert.equal(creds.expiresAt, CREDS.expiresAt);
+});
+
+// On macOS the Keychain is Claude Code's live store; the default file, when it
+// exists, is a snapshot from an earlier login that nothing keeps fresh.
+
+test('prefers the Keychain over a stale default file on macOS', async () => {
+  const home = await tmpHome();
+  await mkdir(join(home, '.claude'), { recursive: true });
+  await writeFile(join(home, '.claude', '.credentials.json'), JSON.stringify({
+    claudeAiOauth: { accessToken: 'stale', refreshToken: 'stale-rt', expiresAt: 1 },
+  }));
+  const readKeychain = async () => ({ claudeAiOauth: { ...CREDS, accessToken: 'fresh' } });
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
+  assert.equal(creds.accessToken, 'fresh');
+  assert.equal(creds.expiresAt, CREDS.expiresAt);
+});
+
+test('uses the default file on macOS when the Keychain carries no token', async () => {
+  const home = await tmpHome();
+  await mkdir(join(home, '.claude'), { recursive: true });
+  await writeFile(join(home, '.claude', '.credentials.json'), JSON.stringify({ claudeAiOauth: CREDS }));
+  const readKeychain = async () => ({ claudeAiOauth: { accessToken: '', refreshToken: '' } });
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
+  assert.equal(creds.accessToken, 'at');
+});
+
+test('uses the default file on macOS when the Keychain lookup throws', async () => {
+  const home = await tmpHome();
+  await mkdir(join(home, '.claude'), { recursive: true });
+  await writeFile(join(home, '.claude', '.credentials.json'), JSON.stringify({ claudeAiOauth: CREDS }));
+  const readKeychain = async () => { throw new Error('item not found in keychain'); };
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
+  assert.equal(creds.accessToken, 'at');
+});
+
+test('hands back a token-less Keychain payload when the default file is missing too', async () => {
+  const home = await tmpHome();
+  const readKeychain = async () => ({ claudeAiOauth: { accessToken: '', refreshToken: '' } });
+
+  const creds = await importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain });
+  assert.equal(creds.accessToken, '');
+});
+
+test('a non-ENOENT file error on macOS is reported as-is', async () => {
+  const home = await tmpHome();
+  await mkdir(join(home, '.claude'), { recursive: true });
+  await writeFile(join(home, '.claude', '.credentials.json'), '{not json');
+  const readKeychain = async () => { throw new Error('item not found in keychain'); };
+
+  await assert.rejects(
+    importCredentials('~/.claude/.credentials.json', { home, platform: 'darwin', readKeychain }),
+    SyntaxError,
+  );
 });
 
 test('does not touch Keychain on non-macOS platforms', async () => {


### PR DESCRIPTION
The bootstrap-key path from #209 misfires on macOS. `teamclaude run` and `teamclaude env` read `~/.claude/.credentials.json` before the Keychain, but on macOS that file is a snapshot from an earlier login that Claude Code never refreshes; the live token lives in the "Claude Code-credentials" Keychain item. A days-old file therefore reads as "expired", and `needsProxyClientCredential` treated an expired access token as no OAuth at all, even with a refresh token present. Claude Code then starts in API-key mode (after its "Detected a custom API key" prompt): subscription mode is lost and Claude in Chrome is disabled, on a machine that is signed in perfectly well.

This change:
- consults the Keychain first for the default path on darwin, keeping the file as the fallback when the Keychain has no token or cannot be read;
- treats an expired access token as usable while a refresh token is present and not itself expired (`refreshTokenExpiresAt` honoured), since Claude Code refreshes at startup and the proxy relays `/v1/oauth/token` untouched;
- passes `refreshTokenExpiresAt` through `importCredentials` so that check can see it.

Tests cover both behaviours; docs updated to say "no usable OAuth" instead of "missing or expired". Note that `teamclaude import` and accounts using the default `importFrom` path now take the live Keychain login on macOS instead of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
