### PR TITLE
fix(status): give the entitlement refusal a reason, not `false`

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -942,7 +942,13 @@ export class AccountManager {
 
     // A structured organization-policy 403 means this account cannot serve OAuth
     // requests right now. Skip it across requests until the short cooldown ends.
-    if (this._entitlementDenied(account)) return false;
+    //
+    // A reason string, not `false`: this function's contract is "a reason, or
+    // null when it can serve", and getStatus surfaces the value verbatim. `false`
+    // read as available against that contract and, being falsy, made
+    // unavailableLine drop the row — so the one state added to make a refusal
+    // explainable was the only one that printed no explanation (#258).
+    if (this._entitlementDenied(account)) return 'entitlement';
 
     // Check rate limit expiry
     if (account.status === 'throttled' && account.rateLimitedUntil) {

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -104,6 +104,7 @@ export const UNAVAILABLE_TEXT = {
   quota: 'local switch threshold reached',
   capped: 'account usage cap reached (maxUsage)',
   'advisor-capped': "advisor model's usage cap reached (maxUsage)",
+  entitlement: 'upstream refused this account for the organization (cooldown)',
   route: 'no route allows this account',
   'advisor-quota': "advisor model's weekly bucket spent",
   'advisor-route': 'no route allows the advisor model',

--- a/test/entitlement-reason.test.js
+++ b/test/entitlement-reason.test.js
@@ -36,7 +36,10 @@ test('the reason survives into getStatus rather than reading as available', () =
 test('status prints a line for it, which is the whole point of the reason', () => {
   const am = denied();
   const status = am.getStatus();
-  const line = unavailableLine(status.accounts[0], { red: s => s, dim: s => s });
+  // A pass-through paint: renderStatus's real one exposes a colour per role, and
+  // a stub missing one fails as a TypeError rather than an assertion.
+  const paint = new Proxy({}, { get: () => (v => String(v)) });
+  const line = unavailableLine(status.accounts[0], paint);
   assert.ok(line, 'a refusal with a reason must render a line');
   assert.match(line, /organization/i);
 

--- a/test/entitlement-reason.test.js
+++ b/test/entitlement-reason.test.js
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { renderStatus, unavailableLine, UNAVAILABLE_TEXT } from '../src/status-renderer.js';
+
+// unavailableReason's contract is "a short reason string, or null when the
+// account can serve". The entitlement branch returned `false`, which read as
+// available against that contract and, being falsy, made unavailableLine drop
+// the row — so the one state added to make refusals explainable (#166) was the
+// only one that explained nothing (#258).
+
+const acct = (over = {}) => ({ name: 'a', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...over });
+
+function denied() {
+  const am = new AccountManager([acct(), acct({ name: 'b' })], 0.98);
+  am.accounts[0].entitlementDeniedUntil = Date.now() + 60_000;
+  return am;
+}
+
+test('an entitlement-denied account reports a reason string, not false', () => {
+  const am = denied();
+  const reason = am.unavailableReason(am.accounts[0]);
+  assert.equal(typeof reason, 'string', 'every other branch returns a string');
+  assert.equal(reason, 'entitlement');
+  // The contract's other half: null, and only null, means "can serve".
+  assert.equal(am.unavailableReason(am.accounts[1]), null);
+});
+
+test('the reason survives into getStatus rather than reading as available', () => {
+  const am = denied();
+  const status = am.getStatus();
+  assert.equal(status.accounts[0].unavailable, 'entitlement');
+  assert.notEqual(status.accounts[0].unavailable, false, '`false` reads as available');
+});
+
+test('status prints a line for it, which is the whole point of the reason', () => {
+  const am = denied();
+  const status = am.getStatus();
+  const line = unavailableLine(status.accounts[0], { red: s => s, dim: s => s });
+  assert.ok(line, 'a refusal with a reason must render a line');
+  assert.match(line, /organization/i);
+
+  const text = renderStatus(status, { color: false });
+  assert.match(text, /organization/i);
+});
+
+test('the reason has human text, like every other reason', () => {
+  assert.ok(UNAVAILABLE_TEXT.entitlement, 'an unmapped reason would print the bare key');
+});
+
+// Routing must not change: the account was already correctly excluded, because
+// _isAvailable tests === null and `false !== null` happened to hold too.
+test('the account is still kept out of rotation', () => {
+  const am = denied();
+  const picked = am.getActiveAccount();
+  assert.equal(picked.name, 'b', 'entitlement-denied must not be selected');
+});
+
+// _isProbeable is a different function with a boolean contract, and the same
+// helper feeds both — so a fix applied by search-and-replace would break it.
+test('the probe path keeps its boolean answer', () => {
+  const am = denied();
+  assert.equal(am._isProbeable(am.accounts[0]), false);
+  assert.equal(am._isProbeable(am.accounts[1]), true);
+});


### PR DESCRIPTION
Closes #258. Diagnosis and the `false` vs `null` contract argument are Frozen666's; this implements it.

`unavailableReason` returns a short reason string, or `null` when the account can serve. The entitlement branch returned `false`, so `/teamclaude/status` carried `"unavailable": false` — which reads as *available* against the field's own contract — and `unavailableLine` dropped the row because `false` is falsy. The one state added to make refusals explainable (#166) was the only one that explained nothing.

Now returns `'entitlement'`, with matching `UNAVAILABLE_TEXT`. Routing is unchanged: `_isAvailable` tests `=== null`, which both the old and new values already failed.

**The part worth reviewing:** `_isProbeable` has an identical-looking `if (this._entitlementDenied(account)) return false;` two hundred lines earlier, and that one is **correct** — it is a boolean predicate. So this is deliberately not a search-and-replace, and a test pins both contracts so a later cleanup does not "fix" the other one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)