### PR TITLE
fix(log): create the activity log 0600 like every sibling file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -450,7 +450,8 @@ async function serverCommand() {
 
   // In headless mode, wire activity-log writes directly via hooks + console.
   if (!tui && activityLogPath) {
-    const aStream = createWriteStream(activityLogPath, { flags: 'a' });
+    // 0600, matching the request log and the config (see tui.js for why).
+    const aStream = createWriteStream(activityLogPath, { flags: 'a', mode: 0o600 });
     aStream.on('error', err => process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`));
     const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
     const writeActivity = msg => {

--- a/src/tui.js
+++ b/src/tui.js
@@ -397,16 +397,32 @@ export class TUI {
 
   // ── lifecycle ──────────────────────────────────────
 
+  /**
+   * Open the activity log, if one is configured.
+   *
+   * Split out of start() so it can be exercised without entering the alt screen
+   * or putting stdin in raw mode — neither of which a test process can do.
+   *
+   * 0600 like every sibling (config, state, request log and its directory): the
+   * activity log names which client made each call, so on a shared host it is
+   * the record that says who was working on what and when (#259). Mode applies
+   * on creation only, so a file the operator already placed keeps the
+   * permissions they chose rather than being chmod'ed underneath them.
+   */
+  _openActivityLog() {
+    if (!this.activityLogPath) return null;
+    this._activityStream = createWriteStream(this.activityLogPath, { flags: 'a', mode: 0o600 });
+    this._activityStream.on('error', err => {
+      // Swallow write errors — can't log them to the TUI without recursion
+      this._activityStream = null;
+      process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`);
+    });
+    return this._activityStream;
+  }
+
   start() {
     this.running = true;
-    if (this.activityLogPath) {
-      this._activityStream = createWriteStream(this.activityLogPath, { flags: 'a' });
-      this._activityStream.on('error', err => {
-        // Swallow write errors — can't log them to the TUI without recursion
-        this._activityStream = null;
-        process.stderr.write(`[TeamClaude] activity log error: ${err.message}\n`);
-      });
-    }
+    this._openActivityLog();
     process.stdout.write(`${ESC}?1049h${ESC}?25l`);
     process.stdin.setRawMode(true);
     process.stdin.resume();

--- a/test/activity-log-mode.test.js
+++ b/test/activity-log-mode.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, stat, writeFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { once } from 'node:events';
+import { createWriteStream } from 'node:fs';
+import { TUI } from '../src/tui.js';
+
+// The activity log names which client made each call, so on a shared host it is
+// the record that says who was working on what and when. Every sibling file —
+// config, state, request log and its directory — is already 0600; this one was
+// left at the process umask, typically 0644 (#259).
+//
+// The mode is asserted through the same createWriteStream call the server makes,
+// under an umask that would otherwise widen it.
+
+const MODE = 0o600;
+
+async function withUmask(mask, fn) {
+  const prev = process.umask(mask);
+  try { return await fn(); } finally { process.umask(prev); }
+}
+
+test('a new activity log is created 0600 even under a permissive umask', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-act-'));
+  try {
+    const path = join(dir, 'activity.log');
+    await withUmask(0o000, async () => {
+      const s = createWriteStream(path, { flags: 'a', mode: 0o600 });
+      s.write('x\n');
+      s.end();
+      await once(s, 'close');
+    });
+    const mode = (await stat(path)).mode & 0o777;
+    assert.equal(mode, MODE, `expected 0600, got 0${mode.toString(8)}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the TUI opens its activity log 0600', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-act-'));
+  try {
+    const path = join(dir, 'tui-activity.log');
+    const am = {
+      accounts: [{ name: 'a', index: 0, type: 'oauth', credential: 't' }],
+      currentIndex: 0, switchThreshold: 0.98,
+      getRoutes: () => [], sessionStats: () => ({ active: 0, total: 0 }),
+      getStatus: () => ({ accounts: [] }), refreshExpiredQuotas: () => {},
+    };
+    const tui = new TUI({
+      accountManager: am,
+      config: { proxy: { port: 1 }, accounts: [], routes: [], blockedModels: [] },
+      saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {},
+      activityLogPath: path,
+    });
+    await withUmask(0o000, async () => { tui._openActivityLog(); });
+    assert.ok(tui._activityStream, 'the TUI should have opened its activity stream');
+    tui._activityStream.end();
+    await once(tui._activityStream, 'close');
+    const mode = (await stat(path)).mode & 0o777;
+    assert.equal(mode, MODE, `expected 0600, got 0${mode.toString(8)}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Mode applies on creation only. A file the operator already placed keeps the
+// permissions they chose, rather than being silently chmod'ed underneath them.
+test('an existing log file is not re-chmoded', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-act-'));
+  try {
+    const path = join(dir, 'existing.log');
+    await writeFile(path, 'old\n');
+    await chmod(path, 0o644);
+    const s = createWriteStream(path, { flags: 'a', mode: 0o600 });
+    s.write('new\n'); s.end();
+    await once(s, 'close');
+    assert.equal((await stat(path)).mode & 0o777, 0o644);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #259. Frozen666's diagnosis, including the table of what was already hardened.

The config, state file, request log and its directory are all created `0600`/`0700`. The activity log was the one left at the process umask, typically `0644` — at both call sites (the TUI and headless `--activity-log`).

It is not incidental output: with `proxy.clientKeys` configured, each line carries a `[name]` prefix, so it records which person or CI job made each call, alongside session id, path, model, serving account, status and duration. No credentials are in it, so this is a confidentiality nit rather than a leak — but on a shared host every local user could read it, and the neighbouring files were fixed in 1.1.14.

Mode applies on creation only, so a file the operator already placed keeps the permissions they chose rather than being chmod'ed underneath them. A test covers that case explicitly.

**One structural change:** `TUI._openActivityLog` is split out of `start()`, because `start()` also enters the alt screen and puts stdin in raw mode — neither of which a test process can do, so the real path was otherwise untestable. Tests assert the mode under `umask(0o000)`, which would otherwise widen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)