### PR TITLE
fix(reload): stop duplicating a config entry that has no running account

### DIFF
--- a/src/sync-accounts.js
+++ b/src/sync-accounts.js
@@ -42,20 +42,39 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
 
   for (const diskAcct of diskConfig.accounts) {
     const mgrIdx = claim(diskAcct);
+    // Claimed once per disk entry and reused below. Calling claimConfig twice
+    // for one entry would consume two different config rows.
+    const cfgAcct = claimConfig(diskAcct);
 
     if (mgrIdx < 0) {
-      // New account discovered on disk — add to running server. Both lists take
-      // the same object, so the account is built carrying its entry's id and the
-      // two pair from the moment they exist. ensureAccountIds runs between the
-      // two: a hand-copied section arrives holding an id this list already uses,
-      // and re-minting it before the account is built keeps the pair correct.
-      memConfig.accounts.push(diskAcct);
-      ensureAccountIds(memConfig.accounts);
+      // No manager account — which is NOT the same as "not yet known".
+      // resolveAccounts drops every entry without a usable credential (an oauth
+      // entry with no token, or an importFrom whose file has gone away — what
+      // logging out of Claude Code produces), so such an entry has no account
+      // for the life of the process. Pushing a config row for it on every pass
+      // grew the list without bound: the save carried the duplicate to disk, the
+      // next reload found another unclaimable row, and the pair compounded
+      // (#200, #235).
+      //
+      // The account is still added, so an entry whose credential reappears heals
+      // on the next reload rather than needing a restart. Only the duplicate
+      // config row is suppressed.
+      if (!cfgAcct) {
+        // Genuinely new. Both lists take the same object, so the account is
+        // built carrying its entry's id and the two pair from the moment they
+        // exist. ensureAccountIds runs between the two: a hand-copied section
+        // arrives holding an id this list already uses, and re-minting it before
+        // the account is built keeps the pair correct.
+        memConfig.accounts.push(diskAcct);
+        ensureAccountIds(memConfig.accounts);
+        cfgClaimed.add(memConfig.accounts.length - 1);
+      }
       accountManager.addAccount(diskAcct);
       claimed.add(accountManager.accounts.length - 1);
-      cfgClaimed.add(memConfig.accounts.length - 1);
       added++;
-      console.log(`[TeamClaude] Picked up new account "${diskAcct.name}" from config`);
+      console.log(cfgAcct
+        ? `[TeamClaude] Re-admitting known account "${diskAcct.name}" from config`
+        : `[TeamClaude] Picked up new account "${diskAcct.name}" from config`);
       continue;
     }
 
@@ -87,7 +106,6 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     // disk edit on the next save — and the following reload would then revert
     // the running account too. Delete-on-absence keeps the saved JSON clean,
     // the same shape a hand edit produces.
-    const cfgAcct = claimConfig(diskAcct);
     if (cfgAcct) {
       if (diskAcct.upstream) cfgAcct.upstream = diskAcct.upstream; else delete cfgAcct.upstream;
       if (diskAcct.modelMap) cfgAcct.modelMap = diskAcct.modelMap; else delete cfgAcct.modelMap;

--- a/test/reload-duplication.test.js
+++ b/test/reload-duplication.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { syncAccountsFromDisk } from '../src/sync-accounts.js';
+import { ensureAccountIds } from '../src/account-id.js';
+
+// resolveAccounts drops every entry without a usable credential, so such an
+// entry has no manager account for the life of the process. syncAccountsFromDisk
+// read "no manager account" as "new", pushed another config row on every pass,
+// and the save/reload pair compounded it — 1, 2, 4, 8 — from nothing more exotic
+// than an importFrom whose file went away, which is what logging out of Claude
+// Code produces (#200, #235).
+
+// A credential-less oauth entry beside one live API-key account.
+function fixture() {
+  const disk = {
+    accounts: [
+      { name: 'live@example.com', type: 'apikey', apiKey: 'k' },
+      { name: 'gone@example.com', type: 'oauth', importFrom: '/nonexistent/creds.json' },
+    ],
+  };
+  ensureAccountIds(disk.accounts);
+  // memConfig starts as a copy of disk, as loadConfig would produce it.
+  const memConfig = { accounts: disk.accounts.map(a => ({ ...a })) };
+  // The manager is built only from entries that resolved a credential.
+  const am = new AccountManager([{ name: 'live@example.com', type: 'apikey', apiKey: 'k', id: disk.accounts[0].id }], 0.98);
+  return { disk, memConfig, am };
+}
+
+// Model the save the TUI performs: memConfig is written to disk verbatim.
+const save = (memConfig) => ({ accounts: memConfig.accounts.map(a => ({ ...a })) });
+
+test('a credential-less entry is not duplicated by repeated reloads', async () => {
+  const { disk, memConfig, am } = fixture();
+  for (let i = 0; i < 5; i++) await syncAccountsFromDisk(disk, memConfig, am);
+  assert.equal(memConfig.accounts.length, 2, 'config gained a row per reload');
+  assert.equal(am.accounts.length, 2, 'the manager gained an account per reload');
+});
+
+// The compounding case from #235: a save carries any duplicate to disk, and the
+// next reload sees a row it cannot claim.
+test('save-and-reload cycles do not grow the lists', async () => {
+  let { disk, memConfig, am } = fixture();
+  for (let cycle = 0; cycle < 4; cycle++) {
+    await syncAccountsFromDisk(disk, memConfig, am);
+    disk = save(memConfig);
+  }
+  assert.equal(memConfig.accounts.length, 2, `config grew to ${memConfig.accounts.length}`);
+  assert.equal(disk.accounts.length, 2, `disk grew to ${disk.accounts.length}`);
+  assert.equal(am.accounts.length, 2, `manager grew to ${am.accounts.length}`);
+  assert.deepEqual(
+    memConfig.accounts.map(a => a.name).sort(),
+    ['gone@example.com', 'live@example.com'],
+  );
+});
+
+// The suppression must not cost the recovery: an entry whose credential comes
+// back should start serving on a reload, not need a restart.
+test('an entry whose credential reappears is picked up on reload', async () => {
+  const { disk, memConfig, am } = fixture();
+  await syncAccountsFromDisk(disk, memConfig, am);
+  assert.equal(memConfig.accounts.length, 2);
+
+  // The operator logs back in: the entry now carries a token directly.
+  const revived = disk.accounts.find(a => a.name === 'gone@example.com');
+  delete revived.importFrom;
+  revived.accessToken = 'fresh-token';
+  revived.refreshToken = 'r';
+  revived.expiresAt = Date.now() + 3600_000;
+
+  await syncAccountsFromDisk(disk, memConfig, am);
+
+  assert.equal(memConfig.accounts.length, 2, 'still no duplicate row');
+  const mgr = am.accounts.find(a => a.name === 'gone@example.com');
+  assert.ok(mgr, 'the revived entry has a running account');
+  assert.equal(mgr.credential, 'fresh-token', 'and it picked up the credential');
+});
+
+// A genuinely new entry must still be added — the guard keys on "already has a
+// config row", not on "has no credential".
+test('a genuinely new account is still picked up', async () => {
+  const { disk, memConfig, am } = fixture();
+  await syncAccountsFromDisk(disk, memConfig, am);
+  const before = memConfig.accounts.length;
+
+  disk.accounts.push({ name: 'new@example.com', type: 'apikey', apiKey: 'k2' });
+  ensureAccountIds(disk.accounts);
+  const added = await syncAccountsFromDisk(disk, memConfig, am);
+
+  assert.equal(added, 1);
+  assert.equal(memConfig.accounts.length, before + 1);
+  assert.ok(am.accounts.some(a => a.name === 'new@example.com'));
+});


### PR DESCRIPTION
Closes #200. Closes #235. Both are lexfrei's, diagnosed to the line — #200 has the exponential growth and #235 the measured save/reload table.

`resolveAccounts` drops every entry without a usable credential, so such an entry has no manager account for the life of the process. `syncAccountsFromDisk` read that as "new" and pushed another config row every pass; the save carried it to disk and the next reload duplicated both. Reaching it needs no unusual configuration — an `importFrom` whose credentials file has gone away is enough, which is what logging out of Claude Code produces.

The fix suppresses only the duplicate **row**. The account is still added, so an entry whose credential reappears still heals on the next reload instead of needing a restart — there is a test for that, because a naive `continue` would have traded one bug for a quieter one.

Also: `claimConfig` is now called once per disk entry and the result reused. The new branch would otherwise have called it twice for one entry, consuming two different config rows — the greedy claim makes that a real hazard rather than a style point.

Tests model the save as a JSON round trip and run four save-and-reload cycles, which is the shape that compounded.

**Not fixed here, deliberately:** #205 (a save drops disk-only entries) and #203 (the disk row is resolved by first identity match). Both live on the config↔disk axis that #199 documented as still open, and #205 in particular has a trap — adopting disk-only entries at save time would resurrect an account the operator just removed, because removal *is* a save. That needs removal tracking, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)