### PR TITLE
fix(status): sweep expired quota windows on the read path

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1444,6 +1444,18 @@ export class AccountManager {
    * account's (and it still has weekly quota), so we spend the quota closest to
    * refreshing first.
    */
+  /**
+   * Clear windows whose reset has passed, WITHOUT the session-reset switch.
+   *
+   * For read paths. refreshExpiredQuotas() also runs _switchOnSessionReset,
+   * which moves currentIndex — so calling that from getStatus would let a GET
+   * on /teamclaude/status rotate the fleet as a side effect of being read, and
+   * a polling dashboard would quietly drive routing.
+   */
+  sweepExpiredQuotas() {
+    for (const account of this.accounts) this._clearExpiredQuotas(account);
+  }
+
   refreshExpiredQuotas() {
     let changed = false;
     const sessionReset = [];
@@ -2173,6 +2185,12 @@ export class AccountManager {
   // client and dimension value to anyone who can read status, and on a shared
   // proxy that is every key holder.
   getStatus({ sessionDetail = false } = {}) {
+    // Sweep first: nothing else on the read path does, so an idle server kept
+    // reporting a window whose reset had already passed — at its old percentage,
+    // with a timestamp in the past — to `status --json`, anything scripted
+    // against the endpoint, and the attached TUI, whose own refresh is a no-op
+    // precisely because it trusts the server to have done this (#237).
+    this.sweepExpiredQuotas();
     const sessions = this.sessionTracker.stats(undefined, { detail: sessionDetail });
     return {
       currentAccount: this.accounts[this.currentIndex]?.name,

--- a/test/status-expired-windows.test.js
+++ b/test/status-expired-windows.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// getStatus copied each account's quota verbatim and nothing on the read path
+// swept expired windows, so an idle server reported a window whose reset had
+// passed at its old percentage with a timestamp in the past — to `status
+// --json`, to anything scripted against /teamclaude/status, and to the attached
+// TUI, whose own refresh is a no-op because it trusts the server to do this
+// (#237).
+
+const HOUR = 3600_000;
+const acct = (name) => ({ name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + HOUR });
+
+function withExpiredSession() {
+  const am = new AccountManager([acct('a'), acct('b')], 0.98);
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.97;
+  q.unified5hReset = Date.now() - HOUR;      // already rolled
+  return am;
+}
+
+test('getStatus does not report a window whose reset has passed', () => {
+  const am = withExpiredSession();
+  const status = am.getStatus();
+  const a = status.accounts.find(x => x.name === 'a');
+  assert.notEqual(a.quota.unified5h, 0.97, 'the expired window was reported at its old percentage');
+  assert.ok(a.quota.unified5hReset == null || a.quota.unified5hReset > Date.now(),
+    'a reset timestamp in the past was reported as current');
+});
+
+test('a live window is left alone', () => {
+  const am = new AccountManager([acct('a')], 0.98);
+  const q = am.accounts[0].quota;
+  q.unified5h = 0.42;
+  q.unified5hReset = Date.now() + HOUR;
+  const status = am.getStatus();
+  assert.equal(status.accounts[0].quota.unified5h, 0.42);
+});
+
+// The part that makes this safe: reading status must not rotate the fleet.
+// refreshExpiredQuotas() also runs _switchOnSessionReset, so wiring that into
+// getStatus would let a polling dashboard drive routing.
+test('reading status never moves the current account', () => {
+  const am = withExpiredSession();
+  // Give the current account a later weekly reset than the other, which is the
+  // shape _switchOnSessionReset acts on.
+  am.accounts[0].quota.unified7dReset = Date.now() + 6 * 24 * HOUR;
+  am.accounts[1].quota.unified7dReset = Date.now() + HOUR;
+  am.accounts[1].quota.unified7d = 0.1;
+  const before = am.currentIndex;
+
+  for (let i = 0; i < 5; i++) am.getStatus();
+
+  assert.equal(am.currentIndex, before, 'a status read rotated the fleet');
+});
+
+test('sweepExpiredQuotas clears without switching; refreshExpiredQuotas may switch', () => {
+  const am = withExpiredSession();
+  am.sweepExpiredQuotas();
+  assert.notEqual(am.accounts[0].quota.unified5h, 0.97);
+  // The mutating form still exists for the request path.
+  assert.equal(typeof am.refreshExpiredQuotas, 'function');
+});


### PR DESCRIPTION
Closes #237 (lexfrei).

`getStatus` copied each account's quota verbatim and nothing on the read path swept expired windows, so an idle server reported a window whose reset had already passed — at its old percentage, with a timestamp in the past. Everything reading the endpoint saw it: `status --json`, anything scripted against it, and the attached TUI, whose `RemoteAccountManager.refreshExpiredQuotas` is a no-op *precisely because* it trusts the server to have swept.

**The bit worth reviewing.** The obvious fix is to call `refreshExpiredQuotas()` from `getStatus`, and that would be wrong: it also runs `_switchOnSessionReset`, which moves `currentIndex`. A GET on `/teamclaude/status` would then be able to rotate the fleet, so a dashboard polling once a second would quietly drive routing.

So this adds a read-only `sweepExpiredQuotas()` beside it and calls that. A test pins that repeated status reads never move `currentIndex`, set up in the exact shape `_switchOnSessionReset` acts on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)