### PR TITLE
fix(accounts): prefer the UUID match over an earlier namesake on upsert

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -63,6 +63,20 @@ export function distinctAccounts(a, b) {
  * hard to trace back to the login that caused it.
  */
 export function findUpsertTarget(accounts, incoming) {
+  // A UUID match is evidence; a name match is a guess, and sameIdentity makes
+  // both in one pass — it compares UUIDs only when BOTH records carry one and
+  // falls back to the name otherwise. So an entry with no UUID matched any
+  // incoming record sharing its name, and if it sat earlier in the list it won
+  // over the entry whose account+org actually matched, landing the credential on
+  // the namesake row (#236). Two entries with one name where the earlier has no
+  // UUID is just a hand-added entry beside a logged-in one, or an account added
+  // before its first probe.
+  //
+  // So look for the evidence before accepting the guess.
+  if (incoming?.accountUuid) {
+    const byUuid = accounts.findIndex(a => a?.accountUuid && sameIdentity(a, incoming));
+    if (byUuid >= 0) return byUuid;
+  }
   const byIdentity = accounts.findIndex(a => sameIdentity(a, incoming));
   if (byIdentity >= 0) return byIdentity;
   return accounts.findIndex(a => a.name === incoming.name && !distinctAccounts(a, incoming));

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -214,3 +214,34 @@ test('an upsert keeps the existing id even when the incoming record carries one'
   const merged = updateAccountEntry({ id: 'entry-0', name: 'a' }, { id: 'minted-elsewhere', name: 'a' });
   assert.equal(merged.id, 'entry-0');
 });
+
+// A UUID match is evidence; a name match is a guess. sameIdentity makes both in
+// one pass, so a namesake entry carrying no UUID used to win purely by sitting
+// earlier in the list — and the incoming credential landed on it (#236).
+test('findUpsertTarget prefers the UUID match over an earlier namesake', () => {
+  const accounts = [
+    { name: 'a@x.com' },                                  // hand-added, no UUID
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o1' }, // the real one
+  ];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o1' }), 1);
+});
+
+test('findUpsertTarget still backfills a namesake when nothing contradicts it', () => {
+  // No UUID anywhere else to prefer, so the bare name match remains the answer —
+  // this is the legacy-entry backfill, which must keep working.
+  const accounts = [{ name: 'a@x.com' }];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o1' }), 0);
+});
+
+test('findUpsertTarget does not let a UUID match cross organizations', () => {
+  const accounts = [
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-personal' },
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' },
+  ];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' }), 1);
+});
+
+test('findUpsertTarget still adds a genuinely new account', () => {
+  const accounts = [{ name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o1' }];
+  assert.equal(findUpsertTarget(accounts, { name: 'b@x.com', accountUuid: 'u2', orgUuid: 'o2' }), -1);
+});


### PR DESCRIPTION
Closes #236 (lexfrei).

`findUpsertTarget` took the first `sameIdentity` hit, and `sameIdentity` compares UUIDs only when **both** records carry one, falling back to the name otherwise. So an entry with no UUID matched any incoming record sharing its name, and sitting earlier in the list was enough to beat the entry whose account+org actually matched — the imported credential landed on the namesake row. Both callers write through it: the CLI login/import and the TUI import.

As the issue notes, reaching it needs nothing exotic: two entries with one name where the earlier has no UUID is a hand-added entry beside a logged-in one, or an account added before its first probe.

Scans for a UUID match first, then falls back to the existing passes — so the legacy backfill (an entry with no UUID adopting an incoming one) keeps working, which a test pins alongside the multi-org case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)