### PR TITLE
fix(config): stop the save mirroring credentials onto entries that do not own them

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -58,10 +58,34 @@ export function configIndexFor(configAccounts, managerAccounts, mgrIdx) {
  * its own and read another's credential a restart later. Pairing by id does not
  * reach this axis.
  */
+/**
+ * Whether this entry's OAuth token belongs in `config.json` at all.
+ *
+ * The save used to write `accessToken: am.credential` onto EVERY entry, which
+ * is right for an ordinary oauth account and wrong for the other two kinds:
+ *
+ *   - an API-KEY account's credential is its `apiKey`, so the save mirrored the
+ *     same secret into `accessToken` — and makeAccount reads
+ *     `acct.accessToken || acct.apiKey`, preferring the mirror. Rotating the key
+ *     in config.json was then ignored on the next cold start, while a running
+ *     server picked it up, so the failure looked like the provider rejecting a
+ *     key that reads correctly in the file (#202).
+ *   - an `importFrom` account delegates to a credentials file on purpose. One
+ *     save materialised the token into config.json, and from then on the copy
+ *     won over re-reading the file, so the entry stopped delegating in practice
+ *     (#204).
+ *
+ * Refreshed tokens for ordinary oauth entries still persist — that is the case
+ * this write exists for.
+ */
+function ownsInlineToken(entry) {
+  return entry?.type === 'oauth' && !entry.importFrom;
+}
+
 export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccounts) {
   return configAccounts.map(a => {
     const am = managerAccountFor(managerAccounts, a);
-    const live = am ? {
+    const live = am && ownsInlineToken(a) ? {
       ...a,
       accessToken: am.credential,
       refreshToken: am.refreshToken,

--- a/test/save-credential-mirroring.test.js
+++ b/test/save-credential-mirroring.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeAccountsForSave } from '../src/account-pairing.js';
+
+// The save wrote `accessToken: am.credential` onto every entry. That is right
+// for an ordinary oauth account and wrong for the other two kinds (#202, #204).
+
+const mgr = (over) => ({ id: 'i1', name: 'a', credential: 'live-secret', refreshToken: 'r', expiresAt: 123, ...over });
+
+test('an API-key entry does not get its key mirrored into accessToken', () => {
+  const cfg = [{ id: 'i1', name: 'a', type: 'apikey', apiKey: 'k-old' }];
+  const out = mergeAccountsForSave(cfg, [mgr({ credential: 'k-old' })], []);
+  assert.equal(out[0].accessToken, undefined,
+    'makeAccount reads accessToken||apiKey, so a mirror shadows a rotated key on the next cold start');
+  assert.equal(out[0].apiKey, 'k-old');
+});
+
+// The consequence, spelled out: rotate the key on disk and a cold start must use
+// the new one.
+test('a rotated API key is what a fresh AccountManager would read', async () => {
+  const cfg = [{ id: 'i1', name: 'a', type: 'apikey', apiKey: 'k-old' }];
+  const saved = mergeAccountsForSave(cfg, [mgr({ credential: 'k-old' })], [])[0];
+  const rotated = { ...saved, apiKey: 'k-new' };          // operator edits config.json
+  const { AccountManager } = await import('../src/account-manager.js');
+  const am = new AccountManager([rotated], 0.98);
+  assert.equal(am.accounts[0].credential, 'k-new');
+});
+
+test('an importFrom entry does not get its delegated token materialised', () => {
+  const cfg = [{ id: 'i1', name: 'a', type: 'oauth', importFrom: '~/.claude/.credentials.json' }];
+  const out = mergeAccountsForSave(cfg, [mgr()], []);
+  assert.equal(out[0].accessToken, undefined, 'the file is meant to stay authoritative');
+  assert.equal(out[0].importFrom, '~/.claude/.credentials.json');
+});
+
+// The case the write exists for must keep working.
+test('an ordinary oauth entry still persists its refreshed token', () => {
+  const cfg = [{ id: 'i1', name: 'a', type: 'oauth', accessToken: 'stale', refreshToken: 'old', expiresAt: 1 }];
+  const out = mergeAccountsForSave(cfg, [mgr()], []);
+  assert.equal(out[0].accessToken, 'live-secret');
+  assert.equal(out[0].refreshToken, 'r');
+  assert.equal(out[0].expiresAt, 123);
+});
+
+test('an entry with no running account is left exactly as it was', () => {
+  const cfg = [{ id: 'zz', name: 'gone', type: 'oauth', accessToken: 'kept' }];
+  const out = mergeAccountsForSave(cfg, [], []);
+  assert.equal(out[0].accessToken, 'kept');
+});


### PR DESCRIPTION
Closes #202. Closes #204. Both lexfrei's, and both trace to one line in the save.

`mergeAccountsForSave` wrote `accessToken: am.credential` onto **every** entry. That is right for an ordinary oauth account and wrong for the other two kinds:

- **#202** — an API-key account's credential *is* its `apiKey`, so the same secret was mirrored into `accessToken`. `makeAccount` reads `acct.accessToken || acct.apiKey` and prefers the mirror, so rotating the key in `config.json` was ignored on the next cold start while a running server picked it up. The failure presents as the provider rejecting a key that reads correctly in the file. A test walks the whole path: save, rotate on disk, construct a fresh `AccountManager`, assert it uses the new key.
- **#204** — an `importFrom` account delegates to a credentials file on purpose. One save materialised the token into `config.json`, and the copy then won over re-reading the file, so the entry stopped delegating in practice.

Refreshed tokens for ordinary oauth entries still persist — that is the case this write exists for, and it is covered.

## One thing I did not change, and want your call on

`syncRefreshedTokens` (the token-refresh path) also writes `accessToken` unconditionally, including onto `importFrom` entries. So #204's materialisation can still happen that way.

I left it alone deliberately, because the safe answer is not obvious: Anthropic **rotates the refresh token** on refresh, so if TeamClaude refreshes a delegated account and then declines to record the result, the credentials file is left holding a refresh token that has just been invalidated — and the account breaks on the next restart rather than merely losing its delegation. Suppressing that write is plausibly worse than the bug.

The options I see are (a) leave it, and document that a delegated account materialises on first refresh; (b) write back to the delegated file; (c) never refresh a delegated account and let the owning tool do it. That is a design decision rather than a fix, so I have not guessed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)