### PR TITLE
fix(tui): stop a blocked-family row overrunning the terminal

### DIFF
--- a/src/tui.js
+++ b/src/tui.js
@@ -1329,7 +1329,6 @@ export class TUI {
         : '  No accounts configured. Press [g] → Add account.'));
     } else {
       lines.push('');
-      const showBoth = W >= 70;
 
       // Routes drive the inline markers; general (non-family) routes get a stable
       // column each at the row start so the marker's position identifies the route.
@@ -1365,9 +1364,22 @@ export class TUI {
       // fit even at BAR_MIN they would push the row past the edge, and a row cut
       // mid-bar reads worse than one that simply doesn't draw them (the `⊘` tag
       // still says which family is barred).
+      // The second shared bar answers to roomFor too, not just to a width
+      // threshold. `W >= 70` alone let the reservations (a 16-column blocked-family
+      // tag on two families, plus route cells) leave less than BAR_MIN per bar,
+      // and the floor below then overrode the budget: two accounts blocked on both
+      // families drew 72 columns at W=70, which fitLine silently cut (#234).
+      const showBoth = W >= 70 && roomFor(2);
       const showFamily = showBoth && (anyFable || anySonnet) && roomFor(2 + (anyFable ? 1 : 0) + (anySonnet ? 1 : 0));
       const nbars = (showBoth ? 2 : 1) + (showFamily ? (anyFable ? 1 : 0) + (anySonnet ? 1 : 0) : 0);
-      const bw = Math.max(BAR_MIN, Math.min(BAR_MAX, Math.floor((W - fixed - 6 * (nbars - 1)) / nbars)));
+      // Backstop for the case no count of bars can fix: when even one bar at
+      // BAR_MIN overruns the row, the floor has to yield. A narrow bar reads
+      // worse than a wide one; a row cut mid-bar loses the reset countdown its
+      // tail carries, and does it without saying so.
+      const avail = Math.floor((W - fixed - 6 * (nbars - 1)) / nbars);
+      const bw = avail < BAR_MIN
+        ? Math.max(1, avail)
+        : Math.min(BAR_MAX, avail);
 
       // Whatever the chrome and the capped bars leave over goes to the name
       // column, up to the longest name in the fleet, so a wide terminal shows

--- a/test/tui-row-width.test.js
+++ b/test/tui-row-width.test.js
@@ -17,9 +17,9 @@ function oauth(name) {
 
 /** Render the dashboard at `width` and return the account rows, ANSI stripped,
  * exactly as _renderAcct produced them (before fitLine pads or truncates). */
-function renderRows(width, { fable = [], sonnet = [], accounts = 6 } = {}) {
+function renderRows(width, { fable = [], sonnet = [], accounts = 6, routes = [] } = {}) {
   const names = Array.from({ length: accounts }, (_, i) => `acct${i}@example.com`);
-  const am = new AccountManager(names.map(oauth), 0.98);
+  const am = new AccountManager(names.map(oauth), 0.98, routes.length ? { routes } : {});
   const h = 3600_000;
   am.accounts.forEach((a, i) => {
     a.quota.unified5h = 0.4;
@@ -37,7 +37,7 @@ function renderRows(width, { fable = [], sonnet = [], accounts = 6 } = {}) {
   });
 
   const tui = new TUI({
-    accountManager: am, config: { proxy: { port: 1 }, accounts: [], routes: [] }, sx: null,
+    accountManager: am, config: { proxy: { port: 1 }, accounts: [], routes }, sx: null,
     saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {}, probeQuota: () => {},
   });
 
@@ -122,4 +122,47 @@ test('blockedFamilies reports the families barred by their own weekly bucket', (
   assert.deepEqual(blockedFamilies({ unified7dFable: 0.99, unified7dSonnet: 1 }, 0.98), ['Sonnet', 'Fable']);
   assert.deepEqual(blockedFamilies({ unified7dFable: 0.5 }, 0.98), []);
   assert.deepEqual(blockedFamilies({}, 0.98), []);
+});
+
+// The `⊘ Sonnet Fable` tag is 16 columns, and until #234 nothing checked that
+// what the reservations left could still afford BAR_MIN per bar: `showBoth` was
+// a bare `W >= 70`, and the bar-width floor then overrode the budget. The
+// fixtures above never produce this because every family bucket in them is far
+// below the threshold — they only ever draw the 9-column `⊘ Fable`.
+const SPENT = 0.99;   // over the 0.98 switch threshold, so the family is barred
+
+test('a row blocked on BOTH families does not overflow', () => {
+  // #234's first repro: two accounts, no routes, W=70 drew 72 columns.
+  for (const w of [70, 72, 73, 76, 80, 100]) {
+    const rows = renderRows(w, {
+      accounts: 2,
+      fable: [SPENT, SPENT],
+      sonnet: [SPENT, SPENT],
+    });
+    assert.ok(widest(rows) <= w, `W=${w}: widest row is ${widest(rows)} columns`);
+  }
+});
+
+test('a blocked row with general routes does not overflow', () => {
+  // #234's second repro: two accounts, three shared routes, W=73 drew 76.
+  const routes = [
+    { match: ['claude-opus-*'], accounts: ['acct0@example.com'] },
+    { match: ['claude-haiku-*'], accounts: ['acct1@example.com'] },
+    { match: ['claude-3-*'], accounts: ['acct0@example.com'] },
+  ];
+  for (const w of [70, 73, 76, 80, 90, 120]) {
+    const rows = renderRows(w, {
+      accounts: 2, routes,
+      fable: [SPENT, SPENT],
+      sonnet: [SPENT, SPENT],
+    });
+    assert.ok(widest(rows) <= w, `W=${w}: widest row is ${widest(rows)} columns`);
+  }
+});
+
+// The blocked tag is the point of the row at that moment, so dropping a bar to
+// make room must not drop the tag with it.
+test('the blocked tag survives the narrowing', () => {
+  const rows = renderRows(70, { accounts: 2, fable: [SPENT, SPENT], sonnet: [SPENT, SPENT] });
+  assert.ok(rows.some(r => r.includes('⊘')), 'the blocked tag was dropped to fit');
 });


### PR DESCRIPTION
Addresses the **third** case in #234 (lexfrei). The other two are a design call — see below.

`showBoth` was a bare `W >= 70` while only the family bars answered to `roomFor`, so the reservations could leave less than `BAR_MIN` per bar and the width floor then overrode the budget. Both reported repros:

- two accounts blocked on both families: **72 columns at W=70**
- the same with three shared routes: **76 at W=73**

`fitLine` cuts the tail, and the tail is where the bars carry their reset countdown — so the row lost information without saying so.

Two changes: the second shared bar now answers to `roomFor` too, and the bar width yields below `BAR_MIN` when even a single bar would overrun. A narrow bar reads worse than a wide one; a silently truncated row reads *wrong*.

**On the test gap** — the issue is right that `no account row overflows the terminal` could not catch this. Every family bucket in its fixtures sits far below the threshold, so it only ever produces the 9-column `⊘ Fable`, never the 16-column `⊘ Sonnet Fable`. New fixtures cover both repros, plus a check that the tag itself is not what gets dropped to make room.

## Not fixed here

The two **underfill** cases (`nbars` and `tagW` reserved fleet-wide, so an API-key row pays for an `F7` column it never draws, and one blocked account shortens every unblocked row by ~16). As the issue says, fixing those means deciding `nbars` and `tagW` per row — which produces rows of differing width in one table, and I think that reads worse than the wasted columns. It is a judgement about how the table should look rather than a correctness bug, so I have left it to you rather than picking. Happy to do it if you want the columns back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)