### PR TITLE
test: stop a network-shaped test borrowing the shell's proxy

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,50 @@
+# Test conventions
+
+Short list. Each entry is here because breaking it produced a test that passed
+while checking nothing.
+
+## A network-shaped test must not be able to reach a proxy
+
+Any test that expects a **connection-level** outcome — refused, unresolvable,
+reset, timed out — has to opt out of the ambient proxy configuration:
+
+```js
+import { setUpstreamProxy, resolveUpstreamProxy, resetUpstreamProxy } from '../src/upstream-proxy.js';
+
+test.beforeEach(() => setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: false }, {})));
+test.afterEach(() => resetUpstreamProxy());
+```
+
+Both halves matter. `upstreamProxy: false` is the explicit opt-out, and the
+empty second argument stops `resolveUpstreamProxy` falling back to
+`process.env`.
+
+Without it, a developer with `HTTPS_PROXY` or `ALL_PROXY` exported — common, and
+the default on plenty of corporate machines — has the request tunneled rather
+than refused. The proxy answers, the test asserts against a completely different
+error shape, and it still passes. It fails to check the thing it was written
+for, silently, and only on some machines.
+
+`NO_PROXY=127.0.0.1` is the same hazard pointing the other way: it makes a test
+that *wants* to go through a mock proxy quietly go direct. That is what
+`87a7f78` fixed for the upstream-proxy e2e tests.
+
+**A test that spawns a child process must scrub the variables too** — the child
+inherits the shell, so the in-process guard does not reach it. See
+`connect-error-message.test.js`.
+
+## Clean up in `finally`
+
+A failed assertion must not leave a server listening. A leaked handle keeps the
+child's event loop alive and hangs the whole `node --test` run, not just the
+file that leaked it — so one broken test costs the entire suite rather than one
+red line. `remote-control-relay.test.js` has the pattern, including
+`closeAllConnections()` for a server whose response deliberately never ends.
+
+## Do not pin a date that will pass
+
+A fixture asserting a timestamp is in the future stops testing anything the day
+it goes stale, and the failure lands on whoever happens to run the suite next
+rather than on whoever wrote it. Derive the value from `Date.now()`, or assert
+the parse rather than the ordering. Both forms are in `quota-probe.test.js` and
+`scoped-weekly.test.js` after #260.

--- a/test/connect-error-message.test.js
+++ b/test/connect-error-message.test.js
@@ -7,6 +7,18 @@ import { fileURLToPath } from 'node:url';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer, describeConnectError } from '../src/server.js';
 import { createConnectHandler } from '../src/mitm.js';
+import { setUpstreamProxy, resolveUpstreamProxy, resetUpstreamProxy } from '../src/upstream-proxy.js';
+
+// A test that expects a CONNECTION-LEVEL failure must not be able to reach a
+// proxy. With HTTPS_PROXY or ALL_PROXY set in the developer's shell — common,
+// and the default on plenty of corporate machines — the request is tunneled
+// instead of refused, the proxy answers, and the test asserts against a
+// completely different error shape while still passing (#207).
+//
+// `upstreamProxy: false` is the explicit opt-out, and the empty env argument
+// stops resolveUpstreamProxy falling back to process.env.
+test.beforeEach(() => setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: false }, {})));
+test.afterEach(() => resetUpstreamProxy());
 
 // A failed connect has its reason in one of two places, and the interesting one
 // is not where you would look.
@@ -216,7 +228,15 @@ function describeThroughGlobalFetch() {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, ['--input-type=module', '--eval', source], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH: '1' },
+      // The child inherits this shell, so the proxy variables are dropped for
+      // the same reason as the in-process guard above — otherwise it dials the
+      // developer's proxy instead of the closed port this test is about.
+      env: {
+        ...process.env,
+        TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH: '1',
+        HTTPS_PROXY: '', https_proxy: '', ALL_PROXY: '', all_proxy: '',
+        HTTP_PROXY: '', http_proxy: '', NO_PROXY: '*', no_proxy: '*',
+      },
     });
     const out = [];
     child.stdout.on('data', d => out.push(String(d)));


### PR DESCRIPTION
Closes #207 (lexfrei).

`connect-error-message.test.js` expects connection-level failures — a refused port and a closed one — and had no proxy guard. With `HTTPS_PROXY` or `ALL_PROXY` set in the shell the request is tunneled instead of refused: the proxy answers, and the test asserts against a different error shape while still passing. It checks nothing, silently, and only on some machines.

Two vectors, both closed:

- the in-process tests now opt out via `setUpstreamProxy(resolveUpstreamProxy({ upstreamProxy: false }, {}))`;
- the test also **spawns a child** to exercise the global-fetch path, and the child inherits the shell, so the in-process guard never reached it. Its env now drops the proxy variables.

**The audit result:** the other network-shaped tests already carry the guard — `unreachable-upstream` and `dns-transient` both do. This was the one that did not, so the exposure was narrower than it might have been.

Also writes the convention down, which is the half of the issue that stops it recurring: `test/README.md` states the rule and the two adjacent traps that have each already cost the suite once — cleanup in `finally` (a leaked handle hangs the whole run, not one file) and fixtures pinned to a date that passes (#260).

🤖 Generated with [Claude Code](https://claude.com/claude-code)