### PR TITLE
fix(server): say what is actually blocked in the synthetic 429

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1325,6 +1325,39 @@ export function isTransientUpstreamError(err, { otherHostAvailable = false } = {
   return false;
 }
 
+/**
+ * The message behind the synthetic 429, when no account can serve the request.
+ *
+ * The old wording — `All N accounts exhausted. Retry in 60s.` — was wrong in
+ * three ways at once, and each one pushed the operator somewhere unhelpful
+ * (#168):
+ *
+ *   - N counted every configured account, including ones the operator had
+ *     disabled. An account deliberately out of rotation is not capacity that
+ *     ran out.
+ *   - it never named the model, so a family-specific refusal (Fable spent,
+ *     Opus fine) read as the whole proxy being out of capacity.
+ *   - "exhausted" reads terminal while "retry in 60s" reads transient, so the
+ *     operator retried by hand instead of looking at what was actually blocked.
+ *
+ * Counts only the accounts that were candidates, names the model when the
+ * request carried one, and says plainly that the wait is until a window resets.
+ */
+export function exhaustedMessage(accountManager, model, retryAfter) {
+  const accounts = accountManager.accounts || [];
+  const eligible = accounts.filter(a => !a.disabled);
+  const disabled = accounts.length - eligible.length;
+
+  const scope = model ? ` for ${model}` : '';
+  const pool = eligible.length === 1 ? '1 account' : `${eligible.length} accounts`;
+  const aside = disabled ? ` (${disabled} more disabled)` : '';
+  const when = retryAfter > 0
+    ? ` Quota resets in ${retryAfter}s.`
+    : ' Retry shortly.';
+
+  return `No account can serve this request${scope}: all ${pool}${aside} are at their quota or rate limit.${when}`;
+}
+
 export async function forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, useSx) {
   const maxRetries = accountManager.accounts.length;
   // This function is exported, so a caller may hand us a ctx built elsewhere.
@@ -1445,7 +1478,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       type: 'error',
       error: {
         type: 'rate_limit_error',
-        message: `All ${accountManager.accounts.length} accounts exhausted. Retry in ${retryAfter}s.`,
+        message: exhaustedMessage(accountManager, ctx.model, retryAfter),
       },
     }));
     return;

--- a/test/exhausted-message.test.js
+++ b/test/exhausted-message.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { exhaustedMessage } from '../src/server.js';
+
+// `All 3 accounts exhausted. Retry in 60s.` was wrong three ways at once, and
+// each one sent the operator somewhere unhelpful (#168).
+
+const oauth = (name, over = {}) => ({
+  name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...over,
+});
+
+const fleet = (...accts) => new AccountManager(accts, 0.98);
+
+test('a disabled account is not counted as capacity that ran out', () => {
+  const am = fleet(oauth('a'), oauth('b'), oauth('c', { disabled: true }));
+  const msg = exhaustedMessage(am, null, 60);
+  assert.match(msg, /2 accounts/, 'the disabled one was counted');
+  assert.doesNotMatch(msg, /3 accounts/);
+  assert.match(msg, /1 more disabled/, 'the operator should still be told it is there');
+});
+
+test('the model is named, so a family refusal does not read as a fleet outage', () => {
+  const am = fleet(oauth('a'));
+  const msg = exhaustedMessage(am, 'claude-fable-5', 60);
+  assert.match(msg, /claude-fable-5/);
+});
+
+test('a request with no model says nothing about one', () => {
+  const am = fleet(oauth('a'));
+  assert.doesNotMatch(exhaustedMessage(am, null, 60), /for (null|undefined)/);
+});
+
+// "exhausted" reads terminal, "retry in 60s" reads transient. Saying both at
+// once is what nudged the operator into retrying by hand instead of looking.
+test('the wording does not contradict itself', () => {
+  const am = fleet(oauth('a'), oauth('b'));
+  const msg = exhaustedMessage(am, 'claude-opus-4', 60);
+  assert.doesNotMatch(msg, /exhausted/i);
+  assert.match(msg, /quota or rate limit/i);
+  assert.match(msg, /resets in 60s/i);
+});
+
+test('singular reads correctly with one account', () => {
+  const am = fleet(oauth('a'));
+  const msg = exhaustedMessage(am, null, 30);
+  assert.match(msg, /all 1 account\b/);
+  assert.doesNotMatch(msg, /1 accounts/);
+});
+
+test('a fleet with no reset to name still says something actionable', () => {
+  const am = fleet(oauth('a'));
+  assert.match(exhaustedMessage(am, null, 0), /Retry shortly/);
+});


### PR DESCRIPTION
Closes #168 (herrozim-ship-it), who listed the three ways one sentence managed to mislead.

`All 3 accounts exhausted. Retry in 60s.` was wrong three ways at once:

- **it counted disabled accounts** — an account the operator had deliberately taken out of rotation is not capacity that ran out;
- **it never named the model** — a family-specific refusal (Fable spent, Opus fine) read as the whole proxy being out of capacity;
- **it contradicted itself** — "exhausted" reads terminal, "retry in 60s" reads transient. That combination is what nudged the operator into retrying by hand instead of diagnosing, which the reporter called out explicitly.

Now: counts only the accounts that were actually candidates (mentioning the disabled ones separately, since hiding them would be its own confusion), names the model when the request carried one, and says the wait is until a window resets.

```
No account can serve this request for claude-fable-5: all 2 accounts (1 more disabled) are at their quota or rate limit. Quota resets in 60s.
```

Message-only — no routing or retry behaviour changes here. The related rotation questions in #165, #137 and #156 are a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)