### PR TITLE
feat(routing): one bounded failover hop on a rate limit or upstream 5xx

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -37,6 +37,32 @@ If every configured account returns that exact denial, TeamClaude's terminal `50
 
 An explicit [`TC_ACCT` pin](#pin-a-session-to-one-account) continues to target exactly the requested account and never fails over, even while that account is excluded from automatic rotation.
 
+## One failover hop on a rate limit
+
+A **quota rejection** (a 429 carrying `...unified-*-status: rejected`) is durable
+exhaustion and rotates, as it always has. A plain **rate-limit 429** does not
+rotate as a policy — moving a shared burst to the next account just throttles
+that one too and discards the first account's prompt cache.
+
+That reasoning holds under load. It does not hold when a sibling is sitting
+idle, which is the common shape for a small fleet of personal subscriptions: one
+account throttled, another at 9% weekly, and the whole proxy stalling for 60s at
+a time.
+
+So a rate-limit 429 takes **one** failover hop, onto an account that is not
+already tried and not inside its own 429 pause. The same single hop applies to
+an upstream **5xx** (`529 Overloaded` above all), which is the provider
+declining to serve rather than anything about the account.
+
+One hop, not a walk of the fleet, and the reason is worth knowing: **if the
+second account is rate-limited too, the limit is almost certainly scoped to the
+egress IP rather than to either account** — every account leaves from the same
+address. Continuing to rotate would prove nothing and pay a cold cache for each
+attempt. After the hop the existing behaviour takes over: the sx.org fresh-IP
+retry if `sx.mode` is `429`, otherwise the inline wait, otherwise a 429 to the
+client with its `retry-after`. An IP-scoped limit is logged as such, since that
+is what an operator chasing a fleet-wide throttle is looking for.
+
 ## Storm control
 
 When you run many agents at once and the active account runs out, every in-flight request fails over to the next account **at the same instant** — a thundering herd that can spend a big chunk of the fresh account's quota (large contexts) and instantly throttle it, cascading down the fleet ([#84](https://github.com/KarpelesLab/teamclaude/issues/84)).

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -446,6 +446,14 @@ export class AccountManager {
    * window (storm control) so they trickle out rather than flood. Extends an
    * existing pause rather than shortening it.
    */
+  /** True while an account is inside a rate-limit pause (see pauseAccount). The
+   * pause deliberately does NOT mark the account throttled, so selection still
+   * offers it — a caller choosing a failover target has to ask. */
+  isPaused(index, now = Date.now()) {
+    const account = this.accounts[index];
+    return !!(account?.pausedUntil && now < account.pausedUntil);
+  }
+
   pauseAccount(index, seconds) {
     const account = this.accounts[index];
     if (!account) return;

--- a/src/server.js
+++ b/src/server.js
@@ -1647,6 +1647,48 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // selection keeps choosing it.
       accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
 
+      // ONE bounded failover hop to an idle sibling (#137, #165, #156).
+      //
+      // #84's argument against rotating on a rate-limit 429 is that moving a
+      // shared burst to the next account just throttles that one too and throws
+      // away this account's KV cache. That holds under load. It does not hold
+      // when a sibling is sitting idle, which is the case every reporter hit: a
+      // three-account fleet stalling for 60s at a time on one throttled account
+      // while another was at 9% weekly.
+      //
+      // So the hop is deliberately not a rotation policy: at most once per
+      // request, never onto an account already tried, and never onto one inside
+      // its own 429 pause — pauseAccount does not mark an account throttled, so
+      // selection would otherwise happily hand back an account that is itself
+      // waiting out a 429.
+      //
+      // The budget is one hop for a specific reason. If the SECOND account is
+      // rate-limited too, the limit is almost certainly scoped to the egress IP
+      // rather than to either account: every account leaves from the same
+      // address, which is the premise the sx.org path below is built on. Hopping
+      // further would prove nothing and pay a cold cache each time. After the
+      // hop ctx.rateLimitHopped is set, this branch does not run again for this
+      // request, and the sx fresh-IP retry and the inline wait take over —
+      // which is the right response to an IP-scoped limit.
+      if (!ctx.rateLimitHopped && retryCount < maxRetries) {
+        const alt = accountManager.getActiveAccount(
+          new Set([...ctx.tried, account.index]), ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider,
+        );
+        if (alt && !accountManager.isPaused(alt.index)) {
+          ctx.rateLimitHopped = true;
+          ctx.tried.add(account.index);
+          console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — failing over once to idle account "${alt.name}"`);
+          if (clientGone(res)) return;
+          return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+        }
+      } else if (ctx.rateLimitHopped) {
+        // Second 429 this request, on a different account. Say so once: the
+        // operator chasing "why is my fleet throttled" is looking for exactly
+        // this, and it points at the egress IP rather than at the accounts.
+        console.log('[TeamClaude] Second account rate-limited too — the limit looks IP-scoped, not per-account'
+          + (sx?.useOn429() ? '' : ' (sx.org mode "429" would retry from a fresh egress IP)'));
+      }
+
       // sx fresh-IP retry (still the same account) takes precedence over waiting.
       // Bounded by retryCount like the inline-wait path below, so a persistently
       // 429ing upstream can't loop forever through sx.
@@ -1690,6 +1732,31 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // retry's status check rotates to another account. Bounded to one re-auth
     // per account per request, so a genuinely dead credential surfaces the 401
     // instead of looping.
+    // Upstream 5xx — 529 "Overloaded" above all (#156). This is the provider
+    // saying it cannot serve right now, not anything about this account'"'"'s quota,
+    // so surfacing it to the client turns a provider-side transient into a
+    // client-visible failure — and Claude Code'"'"'s own retry loop then re-piles the
+    // same load onto the same account.
+    //
+    // One hop, on the same budget and for the same reason as the 429 path above:
+    // if a second account is overloaded too, it is the provider that is
+    // overloaded, not the account, and walking the fleet would just spend every
+    // account'"'"'s cache discovering that. After the hop the response goes to the
+    // client as it does today, with its own retry-after intact.
+    if (upstreamRes.status >= 500 && !res.headersSent && !ctx.serverErrorHopped && retryCount < maxRetries) {
+      const alt = accountManager.getActiveAccount(
+        new Set([...ctx.tried, account.index]), ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider,
+      );
+      if (alt && !accountManager.isPaused(alt.index)) {
+        await upstreamRes.body?.cancel();
+        ctx.serverErrorHopped = true;
+        ctx.tried.add(account.index);
+        console.log(`[TeamClaude] Upstream ${upstreamRes.status} on "${account.name}" — failing over once to "${alt.name}"`);
+        if (clientGone(res)) return;
+        return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
+      }
+    }
+
     // A 403 ("Request not allowed") is upstream refusing THIS account outright —
     // not a stale token a refresh could fix, and not anything the client sent.
     // The client never sees the credential we inject, so it cannot act on the

--- a/test/bounded-failover.test.js
+++ b/test/bounded-failover.test.js
@@ -1,0 +1,152 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// One bounded failover hop when the current account cannot serve but a sibling
+// can (#137, #165, #156).
+//
+// #84's argument — moving a shared burst to the next account just throttles it
+// too and discards the KV cache — holds under load and not when a sibling is
+// idle, which is what every reporter hit. So: at most one hop, never onto an
+// account already tried or inside its own 429 pause.
+
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+const HOUR = 3600_000;
+
+const accounts = () => ([
+  { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+  { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+]);
+
+const tokenOf = (req) => (req.headers.authorization || '').replace(/^Bearer /, '');
+
+async function post(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'claude-x', messages: [] }),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+async function withFleet(handler, fn, extraConfig = {}) {
+  const seen = [];
+  const upstream = http.createServer((req, res) => { seen.push(tokenOf(req)); handler(req, res, seen); });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(accounts(), 0.98, { refreshFn: async () => { throw new Error('no refresh'); } });
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}`, ...extraConfig });
+  const proxyPort = await listen(proxy);
+  try { await fn({ am, proxyPort, seen }); } finally { proxy.close(); upstream.close(); }
+}
+
+// A rate-limit 429 (no `rejected` status) used to wait 60s and retry the SAME
+// account, never touching the idle sibling.
+test('a rate-limit 429 fails over once to an idle sibling', async () => {
+  await withFleet((req, res) => {
+    if (tokenOf(req) === 't-a') {
+      res.writeHead(429, { 'retry-after': '60', 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  }, async ({ proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200, 'the idle sibling should have served it');
+    assert.deepEqual(seen, ['t-a', 't-b']);
+  });
+});
+
+// #165: a headerless 429 — no anthropic-ratelimit-* at all — is the same shape.
+test('a headerless 429 fails over rather than retrying the same account', async () => {
+  await withFleet((req, res) => {
+    if (tokenOf(req) === 't-a') {
+      res.writeHead(429, { 'content-type': 'application/json', 'x-should-retry': 'true' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  }, async ({ proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200);
+    assert.deepEqual(seen, ['t-a', 't-b']);
+  });
+});
+
+// The maintainer's point: if the second account is throttled too, the limit is
+// scoped to the egress IP, not to either account. Hopping further would prove
+// nothing and pay a cold cache each time, so the budget is one hop — the request
+// must not walk the fleet.
+test('a fleet-wide 429 stops after one hop instead of walking every account', async () => {
+  await withFleet((req, res) => {
+    res.writeHead(429, { 'retry-after': '300', 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+  }, async ({ proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 429, 'a 429 the fleet cannot escape belongs to the client');
+    assert.equal(seen.length, 2, `expected one hop, upstream saw ${seen.length} attempts`);
+    assert.deepEqual(seen, ['t-a', 't-b']);
+  });
+});
+
+// #156: a 529 is the provider saying it is overloaded, not a statement about
+// this account. Surfacing it turned a provider transient into a client failure.
+test('an upstream 529 fails over instead of reaching the client', async () => {
+  await withFleet((req, res) => {
+    if (tokenOf(req) === 't-a') {
+      res.writeHead(529, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'overloaded_error' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  }, async ({ proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200);
+    assert.deepEqual(seen, ['t-a', 't-b']);
+  });
+});
+
+test('a provider-wide 529 stops after one hop and reaches the client', async () => {
+  await withFleet((req, res) => {
+    res.writeHead(529, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'overloaded_error' } }));
+  }, async ({ proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 529);
+    assert.equal(seen.length, 2, `expected one hop, upstream saw ${seen.length}`);
+  });
+});
+
+// A quota rejection is durable exhaustion and already rotates; the hop must not
+// change that path or double-count against it.
+test('a quota-rejection 429 still rotates as before', async () => {
+  await withFleet((req, res) => {
+    if (tokenOf(req) === 't-a') {
+      res.writeHead(429, {
+        'retry-after': '60',
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'content-type': 'application/json',
+      });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  }, async ({ am, proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200);
+    assert.deepEqual(seen, ['t-a', 't-b']);
+    assert.equal(am.accounts[0].status, 'throttled', 'a quota rejection still throttles the account');
+  });
+});
+
+test('isPaused reports the rate-limit pause selection does not model', () => {
+  const am = new AccountManager(accounts(), 0.98);
+  assert.equal(am.isPaused(0), false);
+  am.pauseAccount(0, 30);
+  assert.equal(am.isPaused(0), true);
+  assert.equal(am.isPaused(1), false);
+});

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -150,9 +150,13 @@ test('a rate-limit 429 rotates at most once, never into a carousel', async () =>
     // fleet. When the second account is throttled too the limit is scoped to
     // the egress IP, not the accounts, so continuing would pay a cold cache per
     // attempt to learn nothing.
+    // One hop means two DISTINCT accounts. The attempt count is higher than two
+    // on purpose: this upstream answers `retry-after: 1`, inside the inline
+    // absorb cap, so after the hop the same-account wait-and-retry still runs —
+    // pre-existing behaviour that the hop does not replace. What must not happen
+    // is a third account being drawn in.
     const accounts = new Set(seen);
-    assert.equal(accounts.size, 2, `expected one hop, saw ${[...accounts].length} accounts`);
-    assert.equal(seen.length, 2, `expected exactly two upstream attempts, saw ${seen.length}`);
+    assert.equal(accounts.size, 2, `expected one hop, saw ${accounts.size} accounts`);
     // Still no throttling: a rate-limit 429 is not quota exhaustion, so neither
     // account is marked, and both stay selectable once their pause lapses.
     assert.equal(am.accounts[0].status, 'active', 'a rate limit must not throttle the account');

--- a/test/server-429.test.js
+++ b/test/server-429.test.js
@@ -118,7 +118,7 @@ test('long upstream Retry-After is surfaced without sleeping in client request',
 // A rate-limit 429 (no quota-rejected status) must NOT rotate to another
 // account — every retry stays on the same one (#84: rotating just moves the
 // burst and drops the KV cache).
-test('a rate-limit 429 never rotates to another account', async () => {
+test('a rate-limit 429 rotates at most once, never into a carousel', async () => {
   const seen = [];
   const upstream = http.createServer((req, res) => {
     seen.push(req.headers.authorization);
@@ -141,11 +141,22 @@ test('a rate-limit 429 never rotates to another account', async () => {
     });
     await res.text();
     assert.equal(res.status, 429);
+    // The invariant changed deliberately. #84 argued that rotating on a
+    // rate-limit 429 moves the burst and discards the KV cache, and this test
+    // used to assert no rotation at all. That was too strong: it also stalled a
+    // fleet whose sibling was idle, which is what #137, #165 and #156 reported.
+    //
+    // What has to hold now is the bounded version — ONE hop, not a walk of the
+    // fleet. When the second account is throttled too the limit is scoped to
+    // the egress IP, not the accounts, so continuing would pay a cold cache per
+    // attempt to learn nothing.
     const accounts = new Set(seen);
-    assert.equal(accounts.size, 1, `all hits should be on one account, saw ${[...accounts]}`);
-    assert.equal(am.accounts[0].status, 'active', 'current account not throttled');
+    assert.equal(accounts.size, 2, `expected one hop, saw ${[...accounts].length} accounts`);
+    assert.equal(seen.length, 2, `expected exactly two upstream attempts, saw ${seen.length}`);
+    // Still no throttling: a rate-limit 429 is not quota exhaustion, so neither
+    // account is marked, and both stay selectable once their pause lapses.
+    assert.equal(am.accounts[0].status, 'active', 'a rate limit must not throttle the account');
     assert.equal(am.accounts[1].status, 'active');
-    assert.equal(am.accounts[1].pausedUntil, null, 'the other account is untouched — no rotation');
   } finally {
     proxy.close();
     upstream.close();


### PR DESCRIPTION
Closes #137 (lawrns). Closes #165 (herrozim-ship-it). Closes #156 (songwunil). Three reports of one problem.

Today a rate-limit 429 never rotates, per #84: moving a shared burst to the next account throttles that one too and discards the first account's prompt cache. **That argument holds under load and does not hold when a sibling is idle** — which is what all three reporters hit. #137 measured it: a three-account fleet stalling 60s at a time on one throttled account while another sat at 9% weekly. #165 is the same shape via a headerless 429, retried four times against the same account. #156 is a 529 surfaced straight to the client, turning a provider transient into a client-visible failure that Claude Code's retry loop then piles back onto the same account.

## The mechanism

**One** hop per request, onto an account that is not already tried and **not inside its own 429 pause** — `pauseAccount` deliberately does not mark an account throttled, so selection would otherwise hand back an account that is itself waiting out a 429. The same single hop covers upstream 5xx.

Quota rejections (`...unified-*-status: rejected`) are durable exhaustion and rotate exactly as they always have. A test pins that, including that the account is still throttled.

## Why exactly one hop

This is the maintainer's point and it is the load-bearing part of the design: **if the second account is rate-limited too, the limit is almost certainly scoped to the egress IP rather than to either account** — every account leaves from the same address, which is the premise sx.org's `429` mode is already built on. Continuing to rotate proves nothing and pays a cold cache per attempt.

So after the hop the existing behaviour takes over unchanged: the sx.org fresh-IP retry when `sx.mode` is `429`, otherwise the inline wait, otherwise a 429 to the client with its `retry-after`. The IP-scoped conclusion is logged once — an operator chasing "why is my whole fleet throttled" is looking for exactly that line, and it points at the egress rather than at the accounts.

Two tests cover the stop: a fleet-wide 429 and a provider-wide 529 must each reach the client after exactly **two** upstream attempts, not one per account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)