### PR TITLE
fix(config): resolve the token write by id, and stop the save dropping disk rows

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -82,8 +82,44 @@ function ownsInlineToken(entry) {
   return entry?.type === 'oauth' && !entry.importFrom;
 }
 
-export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccounts) {
-  return configAccounts.map(a => {
+// Entries the operator removed in this process, by id.
+//
+// The save has to tell two things apart that look identical on disk: a row that
+// appeared since the last reload (`teamclaude login` while the server runs —
+// keep it) and a row the operator just deleted (drop it). Both are "on disk but
+// not in memory", and removal is itself a save, so adopting disk-only rows
+// without this would resurrect the account the operator was in the middle of
+// deleting.
+//
+// Held on the config object and non-enumerable, so it never reaches JSON.
+const REMOVED = Symbol('removedAccountIds');
+
+/** Record that `id` was deliberately removed, so a save does not adopt it back. */
+export function markAccountRemoved(config, id) {
+  if (!config || !id) return;
+  if (!config[REMOVED]) {
+    Object.defineProperty(config, REMOVED, { value: new Set(), enumerable: false, writable: true });
+  }
+  config[REMOVED].add(id);
+}
+
+/** The ids removed so far. */
+export function removedAccountIds(config) {
+  return config?.[REMOVED] || new Set();
+}
+
+/**
+ * Forget the removals, once a save has written a list that omits them. After
+ * that the rows are gone from disk too, so there is nothing left to re-adopt
+ * and keeping the ids would only strand them if the operator re-added the same
+ * account later.
+ */
+export function clearRemovedAccountIds(config) {
+  if (config?.[REMOVED]) config[REMOVED].clear();
+}
+
+export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccounts, removedIds = new Set()) {
+  const merged = configAccounts.map(a => {
     const am = managerAccountFor(managerAccounts, a);
     const live = am && ownsInlineToken(a) ? {
       ...a,
@@ -94,6 +130,24 @@ export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccoun
     const diskAcct = diskAccounts.find(d => sameIdentity(d, a));
     return diskAcct ? { ...diskAcct, ...live } : live;
   });
+
+  // Carry over rows that exist on disk and not in memory. The list used to be
+  // exactly as long as the in-memory one, so an account added by another
+  // process since the last reload — `teamclaude login` or `import` while the
+  // server runs — was silently dropped by the next save (#205). The refresh
+  // handler already re-reads disk for this reason; the save had no equivalent.
+  //
+  // Except the ones the operator removed: removal is itself a save, so without
+  // that check this would resurrect the account being deleted, on the very
+  // write that was meant to delete it.
+  const keptIds = new Set(merged.map(a => a?.id).filter(Boolean));
+  for (const diskAcct of diskAccounts) {
+    if (!diskAcct?.id) continue;                 // pre-id row; identity above covers it
+    if (keptIds.has(diskAcct.id)) continue;
+    if (removedIds.has(diskAcct.id)) continue;
+    merged.push(diskAcct);
+  }
+  return merged;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ import {
 import { resolveAccounts } from './resolve-accounts.js';
 import { loginCodex } from './codex-auth.js';
 import { syncAccountsFromDisk } from './sync-accounts.js';
-import { mergeAccountsForSave, syncRefreshedTokens } from './account-pairing.js';
+import { mergeAccountsForSave, syncRefreshedTokens, removedAccountIds, clearRemovedAccountIds } from './account-pairing.js';
 import { ensureAccountIds } from './account-id.js';
 import * as alias from './alias.js';
 import { ensureCerts } from './mitm.js';
@@ -415,7 +415,13 @@ async function serverCommand() {
     tui = new TUI({
       accountManager, config, sx, activityLogPath, sessionTitles,
       saveConfig: () => atomicConfigUpdate(async diskConfig => {
-        diskConfig.accounts = mergeAccountsForSave(config.accounts, accountManager.accounts, diskConfig.accounts);
+        diskConfig.accounts = mergeAccountsForSave(
+          config.accounts, accountManager.accounts, diskConfig.accounts, removedAccountIds(config),
+        );
+        // The written list omits them, so they are gone from disk too and there
+        // is nothing left to re-adopt. Holding the ids any longer would only
+        // refuse an account the operator re-adds later.
+        clearRemovedAccountIds(config);
         // Persist sx.org settings (set/cleared from the TUI settings screen).
         if (config.sx) diskConfig.sx = config.sx; else delete diskConfig.sx;
         // Persist other runtime-tunable settings edited from the TUI.
@@ -2069,9 +2075,25 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
 // ── config sync helpers ─────────────────────────────────────
 
 /**
- * Find a config account entry matching an in-memory account by account+org identity.
+ * Find the config entry a running account came from.
+ *
+ * By entry id first. Identity is the fallback, and it is not one-to-one:
+ * sameIdentity compares organization only when BOTH records carry one and falls
+ * back to the name otherwise, so for one person holding accounts in two
+ * organizations — the case the identity module exists for — both rows match and
+ * the first one wins. Resolving a token write that way records one account's
+ * refresh-token family against another account's row (#203).
+ *
+ * The id is exact and survives the refresh that rewrites the credential, which
+ * is the one field that might otherwise have separated two records of one
+ * person. loadConfig gives every entry an id, so the fallback is only for a disk
+ * row written before the field existed and not yet saved back.
  */
 function findConfigAccount(diskConfig, account) {
+  if (account?.id) {
+    const byId = diskConfig.accounts.findIndex(a => a?.id === account.id);
+    if (byId >= 0) return byId;
+  }
   return diskConfig.accounts.findIndex(a => sameIdentity(a, account));
 }
 

--- a/src/tui.js
+++ b/src/tui.js
@@ -8,7 +8,7 @@ import {
   canUpsertOAuthAccount,
   oauthIdentityFields,
 } from './identity.js';
-import { configIndexFor, managerAccountFor } from './account-pairing.js';
+import { configIndexFor, managerAccountFor, markAccountRemoved } from './account-pairing.js';
 import { mintAccountId } from './account-id.js';
 import { formatPercent } from './status-renderer.js';
 import { resolveMaxUsage } from './model.js';
@@ -1220,7 +1220,14 @@ export class TUI {
     // fleet running an account whose entry is gone.
     const cfgIdx = configIndexFor(this.config.accounts, this.am.accounts, idx);
     this.am.removeAccount(idx);
-    if (cfgIdx >= 0) this.config.accounts.splice(cfgIdx, 1);
+    if (cfgIdx >= 0) {
+      // Record the id before the row goes: the save adopts rows that are on disk
+      // and not in memory (an account added by another process since the last
+      // reload), and removal is itself a save — so without this the entry being
+      // deleted would be read back off disk and written straight out again.
+      markAccountRemoved(this.config, this.config.accounts[cfgIdx]?.id);
+      this.config.accounts.splice(cfgIdx, 1);
+    }
     if (this.selIdx >= this.am.accounts.length) this.selIdx = Math.max(0, this.am.accounts.length - 1);
     await this.saveConfig(this.config);
     this._addLog(`Removed account "${name}"`);

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -245,3 +245,22 @@ test('findUpsertTarget still adds a genuinely new account', () => {
   const accounts = [{ name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o1' }];
   assert.equal(findUpsertTarget(accounts, { name: 'b@x.com', accountUuid: 'u2', orgUuid: 'o2' }), -1);
 });
+
+// findConfigAccount used to take the first sameIdentity hit, and sameIdentity
+// compares organization only when both records carry one — so for one person
+// holding accounts in two orgs, both rows matched and a refreshed token was
+// written to whichever came first, recording one account's refresh-token family
+// against another account's row (#203). The entry id is exact.
+test('a token write resolves the right row for one person in two orgs', async () => {
+  const { AccountManager } = await import('../src/account-manager.js');
+  const rows = [
+    { id: 'i-personal', name: 'a@x.com', type: 'oauth', accountUuid: 'u1', orgUuid: 'o-personal', accessToken: 'p' },
+    { id: 'i-acme', name: 'a@x.com', type: 'oauth', accountUuid: 'u1', orgUuid: 'o-acme', accessToken: 'a' },
+  ];
+  const am = new AccountManager(rows, 0.98);
+  const acme = am.accounts.find(a => a.orgUuid === 'o-acme');
+  assert.equal(acme.id, 'i-acme', 'the account must carry its entry id');
+  // The row the write should land on is the one whose id matches, not the first
+  // identity match (which would be the personal row).
+  assert.equal(rows.findIndex(r => r.id === acme.id), 1);
+});

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mergeAccountsForSave, markAccountRemoved, removedAccountIds, clearRemovedAccountIds,
+} from '../src/account-pairing.js';
+
+// The save rebuilt the on-disk list as configAccounts.map(...), so it was
+// exactly as long as the in-memory one and an account added to config.json by
+// another process since the last reload — `teamclaude login` or `import` while
+// the server runs — was dropped by the next save (#205).
+//
+// The trap: removal is ITSELF a save, so adopting disk-only rows without
+// knowing which were deliberately deleted would resurrect the account being
+// removed, on the very write meant to delete it.
+
+const entry = (id, name, over = {}) => ({ id, name, type: 'apikey', apiKey: 'k', ...over });
+
+test('an account added to disk since the last reload survives the save', () => {
+  const cfg = [entry('i1', 'a')];
+  const disk = [entry('i1', 'a'), entry('i2', 'added-by-login')];
+  const out = mergeAccountsForSave(cfg, [], disk);
+  assert.deepEqual(out.map(a => a.name).sort(), ['a', 'added-by-login']);
+});
+
+test('an account the operator removed is NOT resurrected', () => {
+  const config = { accounts: [entry('i1', 'a'), entry('i2', 'doomed')] };
+  // What _doRemove does: record the id, then drop the row.
+  markAccountRemoved(config, 'i2');
+  config.accounts = config.accounts.filter(a => a.id !== 'i2');
+
+  // Disk still has it — this save is the one that deletes it.
+  const disk = [entry('i1', 'a'), entry('i2', 'doomed')];
+  const out = mergeAccountsForSave(config.accounts, [], disk, removedAccountIds(config));
+  assert.deepEqual(out.map(a => a.name), ['a']);
+});
+
+// Both at once: one row deleted, another added externally, in the same save.
+test('a removal and an external addition are both honoured', () => {
+  const config = { accounts: [entry('i1', 'a'), entry('i2', 'doomed')] };
+  markAccountRemoved(config, 'i2');
+  config.accounts = config.accounts.filter(a => a.id !== 'i2');
+
+  const disk = [entry('i1', 'a'), entry('i2', 'doomed'), entry('i3', 'new')];
+  const out = mergeAccountsForSave(config.accounts, [], disk, removedAccountIds(config));
+  assert.deepEqual(out.map(a => a.name).sort(), ['a', 'new']);
+});
+
+// Once the write omits them they are gone from disk, so holding the ids would
+// only refuse the same account if the operator re-added it later.
+test('the removal record is cleared after the save that applies it', () => {
+  const config = { accounts: [] };
+  markAccountRemoved(config, 'i2');
+  assert.equal(removedAccountIds(config).has('i2'), true);
+  clearRemovedAccountIds(config);
+  assert.equal(removedAccountIds(config).has('i2'), false);
+
+  // Re-adding the same account later must now stick.
+  const disk = [entry('i2', 'back-again')];
+  const out = mergeAccountsForSave([], [], disk, removedAccountIds(config));
+  assert.deepEqual(out.map(a => a.name), ['back-again']);
+});
+
+// The bookkeeping must never reach the config file.
+test('the removal record is not serialised into config.json', () => {
+  const config = { accounts: [entry('i1', 'a')], proxy: { port: 3456 } };
+  markAccountRemoved(config, 'i9');
+  const round = JSON.parse(JSON.stringify(config));
+  assert.deepEqual(Object.keys(round).sort(), ['accounts', 'proxy']);
+  assert.ok(!JSON.stringify(config).includes('i9'));
+});
+
+test('a disk row with no id is left to the identity merge, not duplicated', () => {
+  const cfg = [entry('i1', 'a')];
+  const disk = [{ name: 'a', type: 'apikey', apiKey: 'k' }];   // pre-id row
+  const out = mergeAccountsForSave(cfg, [], disk);
+  assert.equal(out.length, 1, 'a pre-id row must not be appended alongside its own entry');
+});


### PR DESCRIPTION
Closes #203. Closes #205. Both lexfrei's, and both on the config↔disk axis that #199 explicitly left open.

**#203** — `findConfigAccount` took the first `sameIdentity` hit, and `sameIdentity` compares organization only when *both* records carry one. For one person holding accounts in two organizations — the case the identity module exists for — both rows match, and a refreshed token was written to whichever came first. That records one account's refresh-token family against another account's row. Now resolved by entry id, which is exact and survives the refresh that rewrites the credential; identity remains the fallback for a disk row written before the field existed.

**#205** — the save rebuilt the on-disk list as `configAccounts.map(...)`, so it was exactly as long as the in-memory one and an account added by another process since the last reload was dropped. The refresh handler already re-reads disk for exactly this reason; the save had no equivalent.

## The trap in #205, and why the fix is bigger than the bug

Adopting disk-only rows is not simply "append what memory lacks", because **removal is itself a save**. `_doRemove` splices the row from memory and calls `saveConfig`; `atomicConfigUpdate` then re-reads disk, where the row still exists. A naive adoption would read the just-deleted account back and write it straight out again — the delete would silently never take, on the very write meant to perform it.

So the save has to distinguish two states that look identical on disk: *appeared since the last reload* (keep) and *just deleted* (drop). `_doRemove` records the id, `mergeAccountsForSave` skips those rows, and the record is cleared once a write has omitted them — so re-adding the same account later still works, which a permanent tombstone would have broken.

The record is a non-enumerable `Symbol` property on the config object, so it never reaches `config.json`. There is a test asserting exactly that, because bookkeeping leaking into a user-editable credential file would be its own bug.

Tests cover the resurrection case directly, and the both-at-once case: one row deleted and another added externally in the same save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)