### PR TITLE
fix(routing): divert only the family the current account cannot serve

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -511,7 +511,7 @@ export class AccountManager {
     // path returns the account the cursor already names and never reaches the
     // rotation code, so recording there alone would leave the cursor unset and
     // the next real failover unpaced.
-    if (account) this.routeCursors.set(this._cursorKey(model), account.index);
+    if (account) this.routeCursors.set(this._cursorKey(model, advisorModel), account.index);
     return account;
   }
 
@@ -602,7 +602,10 @@ export class AccountManager {
       const betterExists = this._preemptedBy(current, model, advisorModel, exclude);
       return betterExists ? this._selectNext(exclude, model, advisorModel) : current;
     }
-    const diverted = this._divertedFor(model, advisorModel, exclude);
+    // Barred for this request only: keep the family where it was diverted.
+    // Barred outright (disabled, throttled, spent): rotate, as before.
+    const diverted = this._currentBarredOnlyFor(model, advisorModel, exclude)
+      ? this._divertedFor(model, advisorModel, exclude) : null;
     if (diverted) return diverted;
     const next = this._selectNext(exclude, model, advisorModel);
     if (next) return next;
@@ -749,6 +752,13 @@ export class AccountManager {
       const better = this.accounts.some(a =>
         this._isAvailable(a, model) && (a.priority || 0) < (current.priority || 0));
       if (!better) return current.index;
+    }
+    // Mirror _select's diversion cursor, so the preview names the account a
+    // diverted family will actually land on rather than the one a fresh walk
+    // would pick.
+    if (this._currentBarredOnlyFor(model)) {
+      const diverted = this._divertedFor(model);
+      if (diverted) return diverted.index;
     }
     const best = this._pickBestAvailable(null, model);
     return best ? best.index : null;
@@ -1160,25 +1170,46 @@ export class AccountManager {
     this.routeCursors?.clear();
   }
 
-  /** Cursor key for a model: its route's name, or '' when no route matches. */
-  // Keyed by route name, or — with no route configured — by the weekly bucket
-  // the model spends, so Fable and Opus keep separate cursors in the default
-  // config too. One key for everything let a Fable diversion be read back as
-  // the Opus cursor (#276).
-  _cursorKey(model) {
-    const route = this._routeForModel(model);
-    if (route) return route.name;
-    return model ? this._weeklyBucketFor(model) : '';
+  /**
+   * Cursor key for a request: its route's name, or — with no route configured —
+   * the weekly bucket the model spends, so Fable and Opus keep separate cursors
+   * in the default config too (one key for everything let a Fable diversion be
+   * read back as the Opus cursor, #276). An advisor request is keyed by both
+   * families it needs: it is diverted for the advisor's sake as often as the
+   * executor's, and sharing a cursor with plain requests for the executor's
+   * model would have each overwrite the other's and re-log the diversion.
+   */
+  _cursorKey(model, advisorModel = null) {
+    const own = this._routeForModel(model)?.name || (model ? this._weeklyBucketFor(model) : '');
+    if (!advisorModel) return own;
+    const adv = this._routeForModel(advisorModel)?.name || this._weeklyBucketFor(advisorModel);
+    return adv === own ? own : `${own}+${adv}`;
   }
 
-  // Where this model's family was last diverted to, if that account can still
-  // serve it. Consulted only after the current account has been found unable
-  // to, so a family returns to the current account the moment it can (its
-  // bucket refreshed) rather than staying diverted out of habit. Yields to a
-  // higher-priority account the same way the current account does.
+  /**
+   * True when the current account can serve in general but not THIS request:
+   * its family bucket or cap is spent, a route excludes it, or the advisor
+   * model's family is spent. That is a per-request diversion, not a rotation,
+   * and the fleet stays where it is. False for disabled / error / throttled /
+   * 5h or shared weekly over threshold, which bar every request and must
+   * rotate the fleet as before.
+   */
+  _currentBarredOnlyFor(model, advisorModel = null, exclude = null) {
+    const current = this.accounts[this.currentIndex];
+    return !!model && !!current && !exclude?.has(current.index)
+      && this._isAvailable(current, null) && !this._isAvailable(current, model, advisorModel);
+  }
+
+  /**
+   * Where this request's family was last diverted to, if that account can still
+   * serve it. Consulted only once the current account has been found barred
+   * for this request alone, so a family returns to the current account the
+   * moment it can serve it again rather than staying diverted out of habit.
+   * Yields to a higher-priority account the same way the current account does.
+   */
   _divertedFor(model, advisorModel = null, exclude = null) {
     if (!model) return null;
-    const idx = this.routeCursors.get(this._cursorKey(model));
+    const idx = this.routeCursors.get(this._cursorKey(model, advisorModel));
     const account = idx != null ? this.accounts[idx] : null;
     if (!account || account.index === this.currentIndex || exclude?.has(account.index)) return null;
     if (!this._isAvailable(account, model, advisorModel)) return null;
@@ -1192,8 +1223,8 @@ export class AccountManager {
    * it names an account the route could have used: a cursor left on another
    * route's account was never this route's position, so moving off it is not a
    * rotation. */
-  _previousCursor(model) {
-    const recorded = this.routeCursors.get(this._cursorKey(model));
+  _previousCursor(model, advisorModel = null) {
+    const recorded = this.routeCursors.get(this._cursorKey(model, advisorModel));
     if (recorded != null) return recorded;
     const current = this.accounts[this.currentIndex];
     return current && this._routeAllows(current, model) ? current.index : null;
@@ -1632,23 +1663,23 @@ export class AccountManager {
   _selectNext(exclude = null, model = null, advisorModel = null) {
     const best = this._pickBestAvailable(exclude, model, advisorModel);
     if (best) {
-      const previous = this._previousCursor(model);
+      const previous = this._previousCursor(model, advisorModel);
       const switched = previous != null && previous !== best.index;
-      // A family-scoped exclusion — the current account serves everything but
-      // THIS model's family — diverts that family alone. The global cursor
-      // stays: the account was chosen (often by hand, for a weekly window about
-      // to lapse) to be spent by the families it can serve, and moving the whole
-      // fleet off it for one family's sake undid that on the next request (#276).
+      // A model-scoped exclusion — the current account serves everything but
+      // this request (family bucket, cap, route, or the advisor's family) —
+      // diverts this request alone. The global cursor stays: the account was
+      // chosen, often by hand for a weekly window about to lapse, to be spent by
+      // what it can serve, and moving the whole fleet off it for one family's
+      // sake undid that on the next request (#276).
       const current = this.accounts[this.currentIndex];
-      const familyOnly = !!model && !!current && !exclude?.has(current.index)
-        && this._isAvailable(current, null) && !this._isAvailable(current, model, advisorModel);
-      if (!familyOnly) this.currentIndex = best.index;
+      const scoped = this._currentBarredOnlyFor(model, advisorModel, exclude);
+      if (!scoped) this.currentIndex = best.index;
       // If we switched to an account whose weekly quota is still unknown, flag
       // it so we re-evaluate once that quota is learned (see updateQuota).
       best.probing = best.quota.unified7dReset == null;
       if (switched) {
         this._beginRamp(best);
-        console.log(familyOnly
+        console.log(scoped
           ? `[TeamClaude] Diverting "${model}" to "${best.name}" — "${current.name}" cannot serve it`
           : `[TeamClaude] Switched to account "${best.name}"`);
       }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -602,6 +602,8 @@ export class AccountManager {
       const betterExists = this._preemptedBy(current, model, advisorModel, exclude);
       return betterExists ? this._selectNext(exclude, model, advisorModel) : current;
     }
+    const diverted = this._divertedFor(model, advisorModel, exclude);
+    if (diverted) return diverted;
     const next = this._selectNext(exclude, model, advisorModel);
     if (next) return next;
     // No account is under the switch threshold. Before refusing locally, allow a
@@ -1159,8 +1161,28 @@ export class AccountManager {
   }
 
   /** Cursor key for a model: its route's name, or '' when no route matches. */
+  // Keyed by route name, or — with no route configured — by the weekly bucket
+  // the model spends, so Fable and Opus keep separate cursors in the default
+  // config too. One key for everything let a Fable diversion be read back as
+  // the Opus cursor (#276).
   _cursorKey(model) {
-    return this._routeForModel(model)?.name || '';
+    const route = this._routeForModel(model);
+    if (route) return route.name;
+    return model ? this._weeklyBucketFor(model) : '';
+  }
+
+  // Where this model's family was last diverted to, if that account can still
+  // serve it. Consulted only after the current account has been found unable
+  // to, so a family returns to the current account the moment it can (its
+  // bucket refreshed) rather than staying diverted out of habit. Yields to a
+  // higher-priority account the same way the current account does.
+  _divertedFor(model, advisorModel = null, exclude = null) {
+    if (!model) return null;
+    const idx = this.routeCursors.get(this._cursorKey(model));
+    const account = idx != null ? this.accounts[idx] : null;
+    if (!account || account.index === this.currentIndex || exclude?.has(account.index)) return null;
+    if (!this._isAvailable(account, model, advisorModel)) return null;
+    return this._preemptedBy(account, model, advisorModel, exclude) ? null : account;
   }
 
   /** The account this route was serving from before the current selection, or
@@ -1612,13 +1634,23 @@ export class AccountManager {
     if (best) {
       const previous = this._previousCursor(model);
       const switched = previous != null && previous !== best.index;
-      this.currentIndex = best.index;
+      // A family-scoped exclusion — the current account serves everything but
+      // THIS model's family — diverts that family alone. The global cursor
+      // stays: the account was chosen (often by hand, for a weekly window about
+      // to lapse) to be spent by the families it can serve, and moving the whole
+      // fleet off it for one family's sake undid that on the next request (#276).
+      const current = this.accounts[this.currentIndex];
+      const familyOnly = !!model && !!current && !exclude?.has(current.index)
+        && this._isAvailable(current, null) && !this._isAvailable(current, model, advisorModel);
+      if (!familyOnly) this.currentIndex = best.index;
       // If we switched to an account whose weekly quota is still unknown, flag
       // it so we re-evaluate once that quota is learned (see updateQuota).
       best.probing = best.quota.unified7dReset == null;
       if (switched) {
         this._beginRamp(best);
-        console.log(`[TeamClaude] Switched to account "${best.name}"`);
+        console.log(familyOnly
+          ? `[TeamClaude] Diverting "${model}" to "${best.name}" — "${current.name}" cannot serve it`
+          : `[TeamClaude] Switched to account "${best.name}"`);
       }
       return best;
     }

--- a/test/family-scoped-cursor.test.js
+++ b/test/family-scoped-cursor.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// Availability is scoped per model: an account whose Fable weekly bucket is
+// spent still serves every other family. A request that finds the current
+// account unable to serve ITS family must therefore divert that family alone,
+// not move the fleet — the account was chosen (often by hand, for a weekly
+// window about to lapse) precisely to be spent by the families it can serve.
+
+function oauth(name) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000 };
+}
+const OPUS = 'claude-opus-5';
+const FABLE = 'claude-fable-5-1';
+const H = 3600_000;
+
+// a: weekly lapses soon, Fable bucket spent, everything else fine.
+// b: fresh, weekly resets much later.
+function fleet() {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const now = Date.now();
+  Object.assign(am.accounts[0].quota, {
+    unified5h: 0.4, unified5hReset: now + 4 * H,
+    unified7d: 0.6, unified7dReset: now + 4 * H,
+    unified7dFable: 0.99, unified7dFableReset: now + 4 * H,
+  });
+  Object.assign(am.accounts[1].quota, {
+    unified5h: 0.05, unified5hReset: now + 4 * H,
+    unified7d: 0.1, unified7dReset: now + 100 * H,
+    unified7dFable: 0.1, unified7dFableReset: now + 100 * H,
+  });
+  return am;
+}
+
+function captureLog(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try { fn(); } finally { console.log = original; }
+  return lines;
+}
+
+test('a Fable-only exclusion diverts Fable and leaves the current account for everything else', () => {
+  const am = fleet();
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'a');
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b', 'a cannot serve Fable; Fable diverts');
+  // The observed defect: the Fable diversion had moved the global cursor, so
+  // this returned b although a was fully eligible for Opus.
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'a');
+  assert.equal(am.accounts[am.currentIndex].name, 'a', 'the current account did not move');
+  assert.equal(am.getStatus().currentAccount, 'a');
+});
+
+test('the diverted family stays put, and returns once the current account can serve it again', () => {
+  const am = fleet();
+  am.getActiveAccount(null, OPUS);
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  // a's Fable bucket refreshes: Fable comes back to the current account.
+  am.accounts[0].quota.unified7dFable = 0.1;
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'a');
+});
+
+test('a diversion is logged as one, once, and never as a global switch', () => {
+  const am = fleet();
+  am.getActiveAccount(null, OPUS);
+  const lines = captureLog(() => {
+    am.getActiveAccount(null, FABLE);
+    am.getActiveAccount(null, FABLE);
+  });
+  assert.equal(lines.length, 1, lines.join('\n'));
+  assert.match(lines[0], /Divert/);
+  assert.doesNotMatch(lines[0], /Switched to account/);
+});
+
+test('an exclusion that is not family-scoped still rotates the fleet', () => {
+  const am = fleet();
+  am.getActiveAccount(null, OPUS);
+  // a's 5-hour window is spent: a can serve nothing, so this is the ordinary
+  // rotation and the current account must move.
+  am.accounts[0].quota.unified5h = 0.99;
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  assert.equal(am.accounts[am.currentIndex].name, 'b');
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'b');
+});

--- a/test/family-scoped-cursor.test.js
+++ b/test/family-scoped-cursor.test.js
@@ -8,8 +8,11 @@ import { AccountManager } from '../src/account-manager.js';
 // not move the fleet — the account was chosen (often by hand, for a weekly
 // window about to lapse) precisely to be spent by the families it can serve.
 
-function oauth(name) {
-  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000 };
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+function apikey(name, extra = {}) {
+  return { name, type: 'apikey', apiKey: 'k-' + name, ...extra };
 }
 const OPUS = 'claude-opus-5';
 const FABLE = 'claude-fable-5-1';
@@ -17,8 +20,8 @@ const H = 3600_000;
 
 // a: weekly lapses soon, Fable bucket spent, everything else fine.
 // b: fresh, weekly resets much later.
-function fleet() {
-  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+function fleet(extra = [], opts = {}) {
+  const am = new AccountManager([oauth('a', opts.a), oauth('b', opts.b), ...extra], 0.98, opts.manager);
   const now = Date.now();
   Object.assign(am.accounts[0].quota, {
     unified5h: 0.4, unified5hReset: now + 4 * H,
@@ -72,6 +75,81 @@ test('a diversion is logged as one, once, and never as a global switch', () => {
   assert.equal(lines.length, 1, lines.join('\n'));
   assert.match(lines[0], /Divert/);
   assert.doesNotMatch(lines[0], /Switched to account/);
+  // The diversion paces the burst onto b once; a repeat does not re-arm it.
+  assert.notEqual(am.accounts[1].rampStartedAt, null);
+  am.accounts[1].rampStartedAt = null;
+  am.getActiveAccount(null, FABLE);
+  assert.equal(am.accounts[1].rampStartedAt, null);
+});
+
+test('advisor requests keep their own cursor, so interleaving with plain requests does not thrash', () => {
+  const am = fleet();
+  am.getActiveAccount(null, OPUS);
+  const lines = captureLog(() => {
+    for (let i = 0; i < 3; i++) {
+      // An Opus request whose advisor needs Fable: a cannot serve the pair.
+      assert.equal(am.getActiveAccount(null, OPUS, FABLE).name, 'b');
+      assert.equal(am.getActiveAccount(null, OPUS).name, 'a');
+    }
+  });
+  assert.equal(lines.length, 1, lines.join('\n'));
+  assert.equal(am.accounts[am.currentIndex].name, 'a');
+});
+
+test('a current account barred outright is abandoned, diversion cursor or not', () => {
+  const am = fleet();
+  am.getActiveAccount(null, OPUS);
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  am.setDisabled(0, true);
+  // Fable-only traffic: the sticky diversion must not keep a disabled account current.
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  assert.equal(am.accounts[am.currentIndex].name, 'b', 'the fleet moved off the disabled account');
+  assert.equal(am.getStatus().currentAccount, 'b');
+});
+
+test('the preview names the account a diverted family will actually land on', () => {
+  // c is barred at first (5h spent), then frees up with a sooner Fable reset
+  // than b. Selection keeps Fable on b; the preview must say the same.
+  const am = fleet([oauth('c')]);
+  const now = Date.now();
+  Object.assign(am.accounts[2].quota, {
+    unified5h: 0.99, unified5hReset: now + 4 * H,
+    unified7d: 0.1, unified7dReset: now + 2 * H,
+    unified7dFable: 0.1, unified7dFableReset: now + 2 * H,
+  });
+  am.getActiveAccount(null, OPUS);
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  am.accounts[2].quota.unified5h = 0.1;
+  const chosen = am.getActiveAccount(null, FABLE);
+  assert.equal(chosen.name, 'b');
+  assert.equal(am.previewRouteIndex(FABLE), chosen.index);
+});
+
+test('a diverted family yields to a higher-priority account that becomes available', () => {
+  const am = fleet([oauth('c', { priority: 0 })], { a: { priority: 1 }, b: { priority: 1 } });
+  const now = Date.now();
+  Object.assign(am.accounts[2].quota, {
+    unified5h: 0.99, unified5hReset: now + 4 * H,
+    unified7d: 0.1, unified7dReset: now + 50 * H,
+    unified7dFable: 0.1, unified7dFableReset: now + 50 * H,
+  });
+  am.getActiveAccount(null, OPUS);
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'b');
+  am.accounts[2].quota.unified5h = 0.1;
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'c');
+});
+
+test('a route exclusion is model-scoped too: a manual switch to a routed account holds', () => {
+  const routes = [
+    { name: 'backend', match: ['k3*'], accounts: ['backend'] },
+    { name: 'claude', match: ['*'], accounts: ['a', 'b'] },
+  ];
+  const am = fleet([apikey('backend', { priority: 100 })], { manager: { routes } });
+  am.currentIndex = 2; // POST /teamclaude/switch to the backend account
+  assert.equal(am.getActiveAccount(null, 'k3-large').name, 'backend');
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'a', 'Opus is routed away');
+  assert.equal(am.getActiveAccount(null, 'k3-large').name, 'backend');
+  assert.equal(am.getStatus().currentAccount, 'backend', 'the operator\'s switch was not undone');
 });
 
 test('an exclusion that is not family-scoped still rotates the fleet', () => {


### PR DESCRIPTION
Fixes #276. Branches off current master; independent of #188/#194/#248/#274. Two commits: the fix, and the changes from an independent review of it.

## The defect

`_select` scopes availability per model — its own comment: *"an account whose Fable weekly bucket is spent is still fully usable for other models."* But when a Fable request found the current account unable to serve it, `_selectNext` wrote the replacement into the **global** `currentIndex`, and the next Opus request followed. Observed sequence in #276: current = A (weekly lapsing in 4.5h, Fable 98%, shared 60%); one Fable request → `Switched to account "B"`; eight seconds later an Opus request also lands on B, and A's unspent weekly expires.

## The fix

- **`_selectNext` moves `currentIndex` only when the current account is barred outright** — `!_isAvailable(current, null)`: disabled, errored, throttled, 5h or shared weekly over threshold. When it can serve in general but not *this request* — a spent family bucket, a family cap, a route exclusion, or the advisor model's family — the request diverts alone, logged as `Diverting "<model>" to "B" — "A" cannot serve it`, and the cursor stays. That predicate is one helper, `_currentBarredOnlyFor`.
- **Route cursors are keyed by the model's weekly bucket when no route is configured**, instead of one `''` key for everything. #195's per-route cursor could not separate Fable from Opus in the default config because both resolved to the same key. An advisor request is keyed by both families it needs, so it does not share a cursor with plain requests for the executor's model (which would overwrite each other and re-log the diversion on every advisor call).
- **`_select` consults that cursor only when the current account is barred for this request alone**, so a diverted family stays where it went rather than re-walking the fleet per request — and returns to the current account the moment it can serve the family again, since the current check still comes first. It yields to a higher-priority account the same way the current account does (`_preemptedBy`). A current account barred outright still rotates the fleet, diversion cursor or not.
- **`previewRouteIndex` mirrors the diversion cursor**, so the TUI marker names the account a diverted family will actually land on.

Net effect: a manual `switch` to a soon-expiring account now holds for the families that can use it, instead of being undone by the first request of the family that cannot.

## One behaviour change to be aware of

The predicate treats a **route** exclusion as model-scoped too. For a route-split fleet: after `POST /teamclaude/switch` to a routed account, requests for other routes are served elsewhere and `currentAccount` stays on the operator's choice, where before the first such request moved the fleet back. That is #276's intent applied consistently — an operator's switch is not undone by a request the account cannot serve — and interleaved multi-route traffic no longer flips `currentAccount` per request. Pinned by a test so it is deliberate rather than incidental.

## Testing

`test/family-scoped-cursor.test.js`, nine cases: the observed sequence (current = a with `unified7dFable` over threshold; one Fable request lands on b; **the next Opus request must still land on a**); the diverted family stays on b and returns to a once a's bucket refreshes; the diversion logs once, arms the ramp once, and never as `Switched to account`; interleaved advisor/plain requests keep separate cursors and log once; a current account that becomes disabled is abandoned despite a live diversion; the preview agrees with selection when a sooner-reset account appears later; a diverted family yields to a higher-priority account; the route-split case above; and the negative control — a's 5h window spent — still rotates the fleet.

Repro-first: the three original positive cases fail on master (`actual: 'b', expected: 'a'`); the negative case passes before and after.

`npm run lint` clean, `npm test` 1163/1163.