### PR TITLE
Bump to 1.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release 1.1.15 — 27 commits since 1.1.14.

Merging this triggers `publish.yml`: npm publish via Trusted Publishing, plus a `v1.1.15` tag and GitHub release.

## Behaviour change worth reading before upgrading

A **rate-limit 429 or an upstream 5xx now takes one failover hop** to an idle account, where before it never rotated (#271). Quota rejections rotate exactly as they always have.

This revisits #84 deliberately. That argument — moving a shared burst to the next account throttles it too and discards the KV cache — holds under load, and does not hold when a sibling is idle, which is what #137, #156 and #165 all reported. The hop is bounded to **one**: if the second account is rate-limited too, the limit is scoped to the egress IP rather than to either account, so rotating further pays a cold cache to learn nothing. After the hop the existing paths take over unchanged (sx.org fresh-IP retry, inline wait, or a 429 with `retry-after`).

## Features

- **#246** — pool **Codex** subscriptions alongside Claude accounts. A provider seam with passthrough forwarding: each provider speaks its own protocol, only the credential and destination change.
- **#188** — browser status dashboard at `/teamclaude/dashboard`
- **#194** — attribute usage by configured request headers (`proxy.usageDimensions`)
- **#252** — timezone-aware rolling warmup schedules, plus `GET /teamclaude/quota` for machine-readable fleet capacity
- **#247** — per-account usage caps (`maxUsage`), enforced where the switch threshold deliberately is not
- **#243** — warn when an account bills real money rather than burning subscription quota
- **#256** — set `switchThreshold` and `distributeSessions` headlessly
- **#244** — `stripRequestFields`, for third-party upstreams that reject fields Claude Code sends
- **#272** — `mitm.http1Only`, for Remote Control from the Claude Code Desktop app

## Correctness

Accounts and config, mostly one theme — the config list and the running fleet were paired **by position**, and `resolveAccounts` drops credential-less entries, so from the first drop the two named different accounts:

- **#199** pairs by entry id instead, across seven crossing sites
- **#273** resolves the token write by id, and stops the save dropping rows added to disk since the last reload
- **#267** stops the save mirroring an API key or a delegated token onto entries that do not own them
- **#266**, **#264**, **#261**, **#209** — upsert, reload duplication, stale local logins, client auth bootstrap

Server, quota and TUI: **#191** (family gating), **#270** (the synthetic 429 message), **#245** (`/api/oauth/*` relay), **#248** and **#263** (activity-log injection and permissions), **#265** (expired windows on the read path), **#262** (entitlement refusals now explain themselves), **#268** (row overflow).

Tests: **#260** (fixtures that expired on the calendar), **#269** (a network test that could borrow the shell's proxy), plus `test/README.md` writing the conventions down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
