### PR TITLE
fix(routing): do not let a status read consume the session-reset switch

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1403,6 +1403,14 @@ export class AccountManager {
     // Clear expired unified quotas
     if (q.unified5h != null && q.unified5hReset && now >= q.unified5hReset) {
       console.log(`[TeamClaude] Account "${account.name}" session quota reset`);
+      // Recorded on the account, not just returned. _clearExpiredQuotas is
+      // reached from two directions — refreshExpiredQuotas on the request path,
+      // which runs the session-reset switch rule, and _isNearQuota via
+      // unavailableReason, which getStatus calls for every account on every
+      // read. Whichever noticed first used to consume the event, so with a
+      // dashboard polling every 5s the rule almost never ran (#275). The flag
+      // outlives the observation; only the request path clears it.
+      account.sessionResetPending = true;
       q.unified5h = null;
       q.unified5hReset = null;
       // `rejected` describes the shared buckets and this is one of them: a
@@ -1529,7 +1537,13 @@ export class AccountManager {
     for (const account of this.accounts) {
       const r = this._clearExpiredQuotas(account);
       if (r.changed) changed = true;
-      if (r.session) sessionReset.push(account);
+      // The flag, not r.session: a status read may have cleared the window
+      // seconds earlier, and the rule still has to run. Cleared here because
+      // this is the only path that acts on it.
+      if (account.sessionResetPending) {
+        account.sessionResetPending = false;
+        sessionReset.push(account);
+      }
     }
     if (sessionReset.length) this._switchOnSessionReset(sessionReset);
     return changed;

--- a/test/session-reset-race.test.js
+++ b/test/session-reset-race.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// _switchOnSessionReset — "session quota reset and weekly expires sooner,
+// switch to it" — used to run only when refreshExpiredQuotas was the path that
+// first observed the 5-hour reset. getStatus reaches _clearExpiredQuotas too,
+// through unavailableReason → _isNearQuota, so a status poll landing between
+// the reset and the next proxied request consumed the event and the rule never
+// ran. With the dashboard polling every 5s that was nearly every time (#275).
+//
+// These pin the observed order: status first, then a request.
+
+const HOUR = 3600_000;
+const oauth = (name) => ({ name, type: 'oauth', accessToken: `t-${name}`, refreshToken: 'r', expiresAt: Date.now() + HOUR });
+
+// A: 5h window just reset, weekly lapses soon — the account the rule exists to
+// move traffic onto. B: current, weekly resets much later.
+function fleet() {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  const [a, b] = am.accounts;
+  a.quota.unified5h = 0.99;
+  a.quota.unified5hReset = Date.now() - 1000;        // rolled a second ago
+  a.quota.unified7d = 0.5;
+  a.quota.unified7dReset = Date.now() + 6 * HOUR;    // lapses soon
+  b.quota.unified5h = 0.2;
+  b.quota.unified5hReset = Date.now() + 4 * HOUR;
+  b.quota.unified7d = 0.1;
+  b.quota.unified7dReset = Date.now() + 58 * HOUR;   // plenty of runway
+  am.currentIndex = 1;                                // current = B
+  return am;
+}
+
+test('a status poll before the next request does not consume the reset', () => {
+  const am = fleet();
+  am.getStatus();                       // the poll that used to swallow it
+  assert.equal(am.currentIndex, 1, 'a status read must not switch on its own');
+
+  am.refreshExpiredQuotas();            // the next proxied request
+  assert.equal(am.currentIndex, 0, 'the switch rule should have run for A');
+});
+
+test('the rule still runs when the request path observes the reset first', () => {
+  const am = fleet();
+  am.refreshExpiredQuotas();
+  assert.equal(am.currentIndex, 0);
+});
+
+// Many polls, not just one — the flag must survive all of them.
+test('repeated polling does not wear the event down', () => {
+  const am = fleet();
+  for (let i = 0; i < 12; i++) am.getStatus();
+  assert.equal(am.currentIndex, 1);
+  am.refreshExpiredQuotas();
+  assert.equal(am.currentIndex, 0);
+});
+
+// And it must fire once, not on every later request.
+test('the reset is consumed once', () => {
+  const am = fleet();
+  am.getStatus();
+  am.refreshExpiredQuotas();
+  assert.equal(am.currentIndex, 0);
+
+  // Someone switches back by hand; a later request must not drag it away again
+  // on the strength of a reset that was already acted on.
+  am.currentIndex = 1;
+  am.refreshExpiredQuotas();
+  assert.equal(am.currentIndex, 1, 'the reset fired twice');
+});
+
+test('an account with no reset pending leaves the cursor alone', () => {
+  const am = fleet();
+  am.accounts[0].quota.unified5hReset = Date.now() + HOUR;   // not rolled
+  am.accounts[0].quota.unified5h = 0.4;
+  am.getStatus();
+  am.refreshExpiredQuotas();
+  assert.equal(am.currentIndex, 1);
+});


### PR DESCRIPTION
Closes #275 (Frozen666), whose diagnosis and suggested shape this implements.

`_switchOnSessionReset` ran only when `refreshExpiredQuotas` was the path that first observed the 5-hour reset. But `getStatus` reaches `_clearExpiredQuotas` too — through `unavailableReason` → `_isNearQuota`, for every account on every read — so a status poll landing between the reset and the next proxied request consumed the event and the rule never ran. With the #188 dashboard polling every 5s, that is nearly every time.

The reporter caught it in the logs: `Account "A" session quota reset` at 12:10:01 with no `switching to it` line, the reverse proxy showing a status poll in that exact second, and no proxied request for another 53 seconds.

The reset is now recorded on the account and cleared by the request path, so it no longer matters which caller noticed the window had rolled.

**I took the sticky flag rather than the alternative** the issue also offered (having `getStatus` call `refreshExpiredQuotas`), for the reason the issue itself gives: that makes a read endpoint drive a rotation. A dashboard poll should not move the fleet. This is also why #265 added a read-only sweep in the first place — the flag is what makes that sweep safe rather than lossy.

Tests pin the observed order (status first, then a request), repeated polling, and that the event fires exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)