### PR TITLE
fix(routing): give each provider its own cursor, and partition only subscriptions

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,5 +1,5 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired, formatMoney } from './oauth.js';
-import { providerOf, DEFAULT_PROVIDER } from './provider.js';
+import { providerOf, DEFAULT_PROVIDER, isSubscriptionAccount } from './provider.js';
 import { refreshCodexToken } from './codex-auth.js';
 import { parseCodexQuota, parseCodexPlanType } from './codex-quota.js';
 import { sameIdentity } from './identity.js';
@@ -226,6 +226,15 @@ export class AccountManager {
     // it. Each such switch arms the ramp below, so steady interleaved traffic
     // holds both accounts at the ramp floor while nothing has failed over.
     this.routeCursors = new Map();
+    // One cursor per provider. `currentIndex` is a single slot, and a request
+    // only another provider can serve would otherwise drag it across: a Codex
+    // request moved it onto a Codex account and the next Anthropic request moved
+    // it straight back, flapping the TUI's current-account marker and re-arming
+    // storm control on every alternation. A provider partition is the purest
+    // form of "barred for THIS request only" — an Anthropic account serves every
+    // Anthropic request perfectly well — so it must not move the fleet, exactly
+    // as a spent family bucket does not (#276).
+    this.providerCursors = new Map();
     this.switchThreshold = switchThreshold;
     this.setRoutes(routes);
     // Storm control: when rotation switches to a fresh account, a burst of
@@ -506,12 +515,43 @@ export class AccountManager {
    * request keeps flowing (upstream then fails just the advisor call).
    */
   getActiveAccount(exclude = null, model = null, advisorModel = null, sessionId = null, provider = DEFAULT_PROVIDER) {
-    const account = this._pickActiveAccount(this._excludeOtherProviders(exclude, provider), model, advisorModel, sessionId);
+    // Selection reads this.currentIndex as "where the fleet is". With more than
+    // one provider that is a single slot for several fleets, so a request whose
+    // provider does not own it borrows the slot for the walk and hands it back.
+    //
+    // With one provider — every config that predates #246 — `borrowed` is always
+    // false and this is the same code it was.
+    const owner = providerOf(this.accounts[this.currentIndex]);
+    const borrowed = !!this.accounts.length && owner !== provider;
+    const saved = this.currentIndex;
+    if (borrowed) {
+      const own = this.providerCursors.get(provider);
+      if (own != null && this.accounts[own] && providerOf(this.accounts[own]) === provider) this.currentIndex = own;
+    }
+
+    let account;
+    // Scoped rather than threaded through _select/_selectNext/_divertedFor: the
+    // whole walk is synchronous, so nothing can interleave and observe it, and
+    // the alternative is a provider argument on six private methods that exist
+    // to answer a different question.
+    this._selectingProvider = provider;
+    try {
+      account = this._pickActiveAccount(this._excludeOtherProviders(exclude, provider), model, advisorModel, sessionId);
+    } finally {
+      this._selectingProvider = null;
+      // Hand the slot back before anything can observe it moved. Only the
+      // provider that owns currentIndex gets to change it.
+      if (borrowed) this.currentIndex = saved;
+    }
+
     // Record where this route now sits, whatever path chose it — the steady-state
     // path returns the account the cursor already names and never reaches the
     // rotation code, so recording there alone would leave the cursor unset and
     // the next real failover unpaced.
-    if (account) this.routeCursors.set(this._cursorKey(model, advisorModel), account.index);
+    if (account) {
+      this.routeCursors.set(this._cursorKey(model, advisorModel, provider), account.index);
+      this.providerCursors.set(providerOf(account), account.index);
+    }
     return account;
   }
 
@@ -530,7 +570,13 @@ export class AccountManager {
    * the common single-provider case allocates nothing.
    */
   _excludeOtherProviders(exclude, provider) {
-    const foreign = this.accounts.filter(a => providerOf(a) !== provider);
+    // Only SUBSCRIPTION accounts are partitioned. A Claude Max token is issued
+    // to Claude and a ChatGPT token to Codex; neither plan can be spent by the
+    // other's client, so crossing them is never right. An API key carries no
+    // such tie — it is metered capacity, not a seat — so it stays eligible for
+    // whichever app is asking, which is what keeps a third-party backend usable
+    // from both.
+    const foreign = this.accounts.filter(a => providerOf(a) !== provider && isSubscriptionAccount(a));
     if (foreign.length === 0) return exclude;
     const combined = new Set(exclude || []);
     for (const account of foreign) combined.add(account.index);
@@ -1179,11 +1225,20 @@ export class AccountManager {
    * executor's, and sharing a cursor with plain requests for the executor's
    * model would have each overwrite the other's and re-log the diversion.
    */
-  _cursorKey(model, advisorModel = null) {
+  _cursorKey(model, advisorModel = null, provider = this._selectingProvider || DEFAULT_PROVIDER) {
     const own = this._routeForModel(model)?.name || (model ? this._weeklyBucketFor(model) : '');
-    if (!advisorModel) return own;
-    const adv = this._routeForModel(advisorModel)?.name || this._weeklyBucketFor(advisorModel);
-    return adv === own ? own : `${own}+${adv}`;
+    const base = (() => {
+      if (!advisorModel) return own;
+      const adv = this._routeForModel(advisorModel)?.name || this._weeklyBucketFor(advisorModel);
+      return adv === own ? own : `${own}+${adv}`;
+    })();
+    // Namespaced by provider so a diversion recorded for one provider is never
+    // read back as another's. Model names do not have to differ between
+    // providers, and a bucket key certainly does not — an unprefixed key would
+    // hand a Codex request the account an Anthropic request was diverted to.
+    // The default provider keeps the bare key, so existing cursors and every
+    // single-provider config are unchanged.
+    return provider === DEFAULT_PROVIDER ? base : `${provider}\u0000${base}`;
   }
 
   /**

--- a/src/provider.js
+++ b/src/provider.js
@@ -49,6 +49,24 @@ export function providerOf(account) {
   return (id && PROVIDERS[id]) ? id : DEFAULT_PROVIDER;
 }
 
+/**
+ * Whether an account is a SUBSCRIPTION, and therefore tied to the app whose plan
+ * it belongs to.
+ *
+ * An OAuth login is one: a Claude Max token is issued to Claude and a ChatGPT
+ * token to Codex, and neither plan can be spent by the other's client. Those
+ * accounts are partitioned by provider, strictly.
+ *
+ * An API key is not. It is metered capacity rather than a seat — nothing about
+ * it says which app may spend it — so it stays eligible for any caller. That is
+ * what lets a third-party backend (a `upstream` + `modelMap` account) serve
+ * whichever app is asking, instead of being fenced off by a provider field it
+ * never set.
+ */
+export function isSubscriptionAccount(account) {
+  return account?.type === 'oauth';
+}
+
 /** Whether `id` names a provider we know how to talk to. */
 export function isKnownProvider(id) {
   return Object.hasOwn(PROVIDERS, id);

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@ import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
 import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter, truncationNote } from './request-log.js';
 import { upstreamFetch } from './upstream-fetch.js';
-import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath } from './provider.js';
+import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath, providerOf, isSubscriptionAccount, DEFAULT_PROVIDER } from './provider.js';
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
@@ -1384,9 +1384,31 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   const pinned = ctx.pinnedIndex != null && !ctx.tried.has(ctx.pinnedIndex)
     ? accountManager.accounts[ctx.pinnedIndex]
     : null;
+  // A pin bypasses selection entirely, so the provider partition has to be
+  // enforced here too — otherwise TC_ACCT aimed at a Claude subscription would
+  // serve a Codex request from it, sending an OpenAI-shaped body to
+  // api.anthropic.com with a Claude token. Subscriptions only: an API-key
+  // account is metered capacity with no tie to a caller, so a pin to one stands.
+  const pinnedWrongProvider = pinned
+    && isSubscriptionAccount(pinned)
+    && providerOf(pinned) !== (ctx.provider || DEFAULT_PROVIDER);
   const account = ctx.pinnedIndex != null
-    ? (pinned && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
+    ? (pinned && !pinnedWrongProvider && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
     : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider);
+  if (pinnedWrongProvider && !res.headersSent && !clientGone(res)) {
+    // Named plainly: a pin that cannot serve is a configuration mistake, and the
+    // exhausted-account response would send the operator looking at quota.
+    ctx.status = 400;
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: `Pinned account "${pinned.name}" is a ${providerOf(pinned)} subscription and cannot serve a ${ctx.provider} request.`,
+      },
+    }));
+    return;
+  }
   if (!account) {
     // Every candidate was refused by upstream (403). Waiting will not help — the
     // account needs attention, not a retry — so say so plainly rather than

--- a/test/pinned-provider.test.js
+++ b/test/pinned-provider.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// A pin bypasses selection entirely, so the provider partition has to be
+// enforced on that path too. Without it, TC_ACCT aimed at a Claude subscription
+// served a Codex request from it — an OpenAI-shaped body sent to
+// api.anthropic.com with a Claude token.
+
+const HOUR = 3600_000;
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+
+async function proxyWith(accounts) {
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.headers.authorization || req.headers['x-api-key']);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(accounts, 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+  return { am, port, seen, close: () => { proxy.close(); upstream.close(); } };
+}
+
+const post = (port, path, name) => fetch(`http://127.0.0.1:${port}${path}`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', 'x-api-key': 'k', ...(name ? { TC_ACCT: name } : {}) },
+  body: JSON.stringify({ model: 'm', messages: [] }),
+});
+
+test('a Codex request pinned to a Claude subscription is refused, not served', async () => {
+  const ctx = await proxyWith([
+    { name: 'claude-sub', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+  ]);
+  try {
+    const res = await post(ctx.port, '/tc-acct/claude-sub/backend-api/codex/responses');
+    await res.text();
+    assert.notEqual(res.status, 200, 'the request must not have been served');
+    assert.deepEqual(ctx.seen, [], 'nothing should have reached upstream');
+  } finally {
+    ctx.close();
+  }
+});
+
+test('a Claude request pinned to a Claude subscription still works', async () => {
+  const ctx = await proxyWith([
+    { name: 'claude-sub', type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+  ]);
+  try {
+    const res = await post(ctx.port, '/tc-acct/claude-sub/v1/messages');
+    await res.text();
+    assert.equal(res.status, 200);
+    assert.equal(ctx.seen.length, 1);
+  } finally {
+    ctx.close();
+  }
+});
+
+// An API key is not a seat, so a pin to one stands whoever is calling.
+test('a pin to an API-key account stands for either caller', async () => {
+  const ctx = await proxyWith([{ name: 'shared', type: 'apikey', apiKey: 'k-shared' }]);
+  try {
+    const a = await post(ctx.port, '/tc-acct/shared/v1/messages');
+    await a.text();
+    assert.equal(a.status, 200);
+    const b = await post(ctx.port, '/tc-acct/shared/backend-api/codex/responses');
+    await b.text();
+    assert.equal(b.status, 200);
+    assert.equal(ctx.seen.length, 2);
+  } finally {
+    ctx.close();
+  }
+});

--- a/test/provider-cursor.test.js
+++ b/test/provider-cursor.test.js
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { isSubscriptionAccount, providerOf } from '../src/provider.js';
+
+// Two rules, and they pull in opposite directions:
+//
+//  1. A SUBSCRIPTION is tied to the app whose plan it is. A Claude Max token is
+//     issued to Claude and a ChatGPT token to Codex; neither plan may be spent
+//     by the other's client, ever.
+//  2. currentIndex is one slot shared by every provider. A request only another
+//     provider can serve must NOT drag it across, or a Codex request moves the
+//     cursor onto a Codex account and the next Anthropic request moves it back —
+//     flapping the current-account marker and re-arming storm control each time.
+
+const HOUR = 3600_000;
+const claude = (name) => ({ name, type: 'oauth', accessToken: `t-${name}`, refreshToken: 'r', expiresAt: Date.now() + HOUR });
+const codex = (name) => ({ ...claude(name), provider: 'codex', accountId: `acct-${name}` });
+const apikey = (name, over = {}) => ({ name, type: 'apikey', apiKey: `k-${name}`, ...over });
+
+// ── the partition ────────────────────────────────────────────
+
+test('a Codex request never lands on a Claude subscription', () => {
+  const am = new AccountManager([claude('a'), codex('c')], 0.98);
+  for (let i = 0; i < 10; i++) {
+    const picked = am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex');
+    assert.equal(providerOf(picked), 'codex', `picked ${picked?.name}`);
+  }
+});
+
+test('a Claude request never lands on a Codex subscription', () => {
+  const am = new AccountManager([codex('c'), claude('a')], 0.98);
+  am.currentIndex = 0;
+  for (let i = 0; i < 10; i++) {
+    const picked = am.getActiveAccount(null, 'claude-opus-5', null, null, 'anthropic');
+    assert.equal(providerOf(picked), 'anthropic', `picked ${picked?.name}`);
+  }
+});
+
+test('a Codex fleet with no Codex account serves nothing rather than crossing over', () => {
+  const am = new AccountManager([claude('a'), claude('b')], 0.98);
+  assert.equal(am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex'), null);
+});
+
+// An API key is metered capacity, not a seat — nothing about it says which app
+// may spend it, so it stays eligible for any caller.
+test('an API-key account may serve any caller', () => {
+  const am = new AccountManager([apikey('shared')], 0.98);
+  assert.ok(am.getActiveAccount(null, 'claude-opus-5', null, null, 'anthropic'));
+  assert.ok(am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex'));
+});
+
+test('isSubscriptionAccount separates a seat from metered capacity', () => {
+  assert.equal(isSubscriptionAccount({ type: 'oauth' }), true);
+  assert.equal(isSubscriptionAccount({ type: 'apikey' }), false);
+  assert.equal(isSubscriptionAccount(null), false);
+});
+
+// ── the cursor ───────────────────────────────────────────────
+
+test('a Codex request does not move the Anthropic cursor', () => {
+  const am = new AccountManager([claude('a'), claude('b'), codex('c')], 0.98);
+  am.currentIndex = 0;
+
+  am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex');
+
+  assert.equal(am.currentIndex, 0, 'the Codex request dragged the shared cursor across');
+  assert.equal(providerOf(am.accounts[am.currentIndex]), 'anthropic');
+});
+
+test('alternating providers does not thrash the cursor', () => {
+  const am = new AccountManager([claude('a'), codex('c')], 0.98);
+  am.currentIndex = 0;
+  const seen = new Set();
+  for (let i = 0; i < 8; i++) {
+    am.getActiveAccount(null, 'claude-opus-5', null, null, 'anthropic');
+    seen.add(am.currentIndex);
+    am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex');
+    seen.add(am.currentIndex);
+  }
+  assert.deepEqual([...seen], [0], `currentIndex visited ${[...seen]}`);
+});
+
+test('each provider keeps its own cursor across calls', () => {
+  const am = new AccountManager([claude('a'), codex('c1'), codex('c2')], 0.98);
+  am.currentIndex = 0;
+  const first = am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex');
+  const again = am.getActiveAccount(null, 'gpt-5.6-sol', null, null, 'codex');
+  assert.equal(again.name, first.name, 'Codex should stay on its own account, not restart the walk');
+  assert.equal(am.currentIndex, 0, 'and still without touching the Anthropic cursor');
+});
+
+// A single-provider fleet — every config predating the provider seam — must
+// behave exactly as it did.
+test('a single-provider fleet still moves its cursor normally', () => {
+  const am = new AccountManager([claude('a'), claude('b')], 0.98);
+  am.currentIndex = 0;
+  am.accounts[0].quota.unified5h = 0.99;      // over threshold: must rotate
+  am.accounts[0].quota.unified5hReset = Date.now() + HOUR;
+  const picked = am.getActiveAccount(null, 'claude-opus-5', null, null, 'anthropic');
+  assert.equal(picked.name, 'b');
+  assert.equal(am.currentIndex, 1, 'a same-provider rotation must still move the cursor');
+});


### PR DESCRIPTION
Two problems left over from the provider seam in #246. No issue filed — spotted while reviewing #277, which supplied the mechanism that makes the first one fixable.

## The cursor thrashed between providers

`currentIndex` is a single slot shared by every provider. A request only another provider could serve dragged it across: a Codex request moved it onto a Codex account, the next Anthropic request moved it straight back. That flaps the TUI's current-account marker and **re-arms storm control on every alternation**, pacing requests that never needed pacing.

A provider partition is the purest case of "barred for THIS request only" — an Anthropic account serves every Anthropic request perfectly well — so it must not move the fleet, exactly as a spent family bucket must not (#276). Each provider now keeps its own cursor; the request's provider borrows the slot for the walk and hands it back in a `finally`.

**With one provider the borrow never happens**, so every config predating #246 takes the same path it did. There is a test asserting a same-provider rotation still moves the cursor, because that is the thing this could plausibly have broken.

## The partition was too wide

Per the maintainer: **only subscriptions are tied to an app.** A Claude Max token is issued to Claude and a ChatGPT token to Codex, and neither plan can be spent by the other's client. An API key carries no such tie — it is metered capacity, not a seat — so it stays eligible for whichever app is asking, which keeps a third-party backend (`upstream` + `modelMap`) usable from both.

`_excludeOtherProviders` now excludes foreign **subscription** accounts only.

## A pin could cross providers

`TC_ACCT` bypasses selection entirely, so the partition was not enforced on that path at all: a pin aimed at a Claude subscription would serve a Codex request from it — an OpenAI-shaped body sent to `api.anthropic.com` with a Claude token, since `upstreamFor` follows the account. Now refused with a message naming the mismatch, rather than the exhausted-account response, which would send the operator looking at quota.

## One thing to sanity-check

The subscription rule means a Codex request *can* now select an Anthropic API-key account. That is what you asked for and it is right for a third-party backend, but a plain Anthropic API key cannot answer an OpenAI Responses body — it will fail at the wire rather than being routed away from. Say the word if you would rather API keys were eligible only when they carry an explicit `upstream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)