### PR TITLE
feat(mitm): intercept Codex in MITM mode, not just via a base-URL redirect

### DIFF
--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -129,6 +129,26 @@ base_url = "http://127.0.0.1:3456/backend-api/codex"
 wire_api = "responses"
 ```
 
+### Through the MITM proxy (no Codex config needed)
+
+MITM mode intercepts `chatgpt.com` as well as `api.anthropic.com`, so a Codex CLI
+launched behind the proxy is pooled with no `~/.codex/config.toml` change at all:
+
+```bash
+eval "$(teamclaude env)"   # HTTPS_PROXY + NODE_EXTRA_CA_CERTS
+codex
+```
+
+Two boundaries worth knowing:
+
+- `chatgpt.com` is intercepted **only when a Codex account is configured**. An
+  Anthropic-only fleet tunnels it untouched — intercepting a host nobody asked
+  the proxy to read is not a neutral default.
+- `ab.chatgpt.com` is never intercepted. It is OpenAI's telemetry endpoint,
+  carries no inference, and there is nothing there to rewrite.
+
+The base-URL route below still works and is the way to pool Codex without MITM.
+
 `OPENAI_BASE_URL` does **not** work for this — a ChatGPT-authenticated Codex
 ignores it. `model_providers` is the supported redirect.
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ import { syncAccountsFromDisk } from './sync-accounts.js';
 import { mergeAccountsForSave, syncRefreshedTokens, removedAccountIds, clearRemovedAccountIds } from './account-pairing.js';
 import { ensureAccountIds } from './account-id.js';
 import * as alias from './alias.js';
-import { ensureCerts } from './mitm.js';
+import { ensureCerts, mitmHosts } from './mitm.js';
 import { Prober } from './prober.js';
 import { Warmer } from './warmer.js';
 import { createRollingWarmupSchedule, formatWarmupScheduleConfirmation, resolveWarmupConfig, resolveWarmupSchedule } from './warmup-schedule.js';
@@ -863,7 +863,9 @@ async function envCommand() {
   const useMitm = !args.slice(1).includes('--no-mitm');
 
   let caPath = null;
-  if (useMitm) ({ caPath } = await ensureCerts(upstreamHost(config)));
+  // The leaf has to name every host MITM will intercept, or the CONNECT for
+  // a second provider fails the handshake instead of being served.
+  if (useMitm) ({ caPath } = await ensureCerts(mitmHosts(config)));
 
   // Same pin as `teamclaude run`, so `eval "$(teamclaude env)"` and `run` agree.
   const account = (process.env.TC_ACCT || '').trim();
@@ -944,8 +946,7 @@ async function runCommand() {
       // Route ALL of claude's traffic through us as an HTTPS forward proxy, so
       // even hardcoded api.anthropic.com endpoints (e.g. the design MCP) get the
       // real token injected. claude trusts our MITM leaf via NODE_EXTRA_CA_CERTS.
-      const host = upstreamHost(config);
-      const { caPath } = await ensureCerts(host);
+      const { caPath } = await ensureCerts(mitmHosts(config));
       // The pin rides in the proxy URL's userinfo, which the client forwards as
       // `Proxy-Authorization: Basic <acct>:<key>` on each CONNECT — the only pin
       // channel an HTTPS_PROXY env var can express. The password slot keeps the
@@ -2120,12 +2121,6 @@ function isLocalAccountPin(url, port) {
 function argValue(flag) {
   const i = args.indexOf(flag);
   return (i >= 0 && args[i + 1]) ? args[i + 1] : null;
-}
-
-// Hostname of the configured upstream (the host MITM-intercepts under `run`).
-function upstreamHost(config) {
-  try { return new URL(config.upstream || 'https://api.anthropic.com').hostname; }
-  catch { return 'api.anthropic.com'; }
 }
 
 // Keep the terminal title in sync with the active account (e.g. "teamclaude 2/4

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -21,6 +21,7 @@ import http2 from 'node:http2';
 import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { createProxyRequestListener, resolveClientAuth, isLoopbackAddr, relayUpgrade, resolveAccountPin, describeConnectError } from './server.js';
+import { interceptHostsFor, isNeverIntercepted } from './provider.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -71,7 +72,9 @@ function leafCovers(caCertPem, leafCertPem, hosts) {
  * Returns { caPath, caCertPem, leafCertPem, leafKeyPem }.
  */
 export async function ensureCerts(host) {
-  const hosts = host === TEST_HOST ? [TEST_HOST] : [host, TEST_HOST];
+  const named = Array.isArray(host) ? host : [host];
+  const hosts = [...new Set(named.filter(Boolean))];
+  if (!hosts.includes(TEST_HOST)) hosts.push(TEST_HOST);
   const [caCertPem, leafCertPem, leafKeyPem] = await Promise.all([
     readIf(fpath(CA_CERT)), readIf(fpath(LEAF_CERT)), readIf(fpath(LEAF_KEY)),
   ]);
@@ -98,10 +101,23 @@ function upstreamHostOf(config) {
   catch { return 'api.anthropic.com'; }
 }
 
+/** Every host the MITM leaf must be valid for, given this config. */
+export function mitmHosts(config) {
+  return [...new Set([upstreamHostOf(config), ...interceptHostsFor(config?.accounts || [])])];
+}
+
 /** Per-CONNECT behavior: 'rewrite' (intercept + token inject), 'test', or 'tunnel'. */
 export function hostMode(host, config) {
   if (host === TEST_HOST) return 'test';
+  // Explicitly never intercepted, even though it sits under a provider's domain
+  // — checked before anything else so no later rule can claim it.
+  if (isNeverIntercepted(host)) return 'tunnel';
   if (host === upstreamHostOf(config)) return 'rewrite';
+  // A second provider's host, and only when an account actually uses that
+  // provider. MITM is the mode that works without the client cooperating — a
+  // CLI that honours only HTTPS_PROXY has no base URL to redirect — so refusing
+  // to intercept here is the same as not supporting the provider at all.
+  if (interceptHostsFor(config?.accounts || []).includes(host)) return 'rewrite';
   return 'tunnel';
 }
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -67,6 +67,53 @@ export function isSubscriptionAccount(account) {
   return account?.type === 'oauth';
 }
 
+// The hosts each provider is reached on, for MITM interception.
+//
+// MITM is the mode that works without the client cooperating: a CLI that only
+// honours HTTPS_PROXY has no base-URL to redirect, so if the proxy will not
+// intercept the provider's host, that provider is simply unreachable through
+// it. Codex is exactly that case.
+const PROVIDER_HOSTS = { 'api.anthropic.com': 'anthropic', 'chatgpt.com': 'codex' };
+
+// Hosts adjacent to a provider that must NOT be intercepted.
+//
+// `ab.chatgpt.com` is OpenAI's own telemetry/experiment endpoint. It carries no
+// inference, nothing here would rewrite, and terminating it would mean
+// presenting our leaf for a host we have no reason to read — so it is
+// blind-tunnelled like any unrelated host. Listed rather than left to fall
+// through, because `chatgpt.com` matching by suffix would otherwise swallow it.
+const NEVER_INTERCEPT = new Set(['ab.chatgpt.com']);
+
+/**
+ * The provider reached on `host`, or null when the host is not one we intercept.
+ *
+ * Exact match, never a suffix: a subdomain of a provider is a different service
+ * (see NEVER_INTERCEPT), and matching loosely would have the proxy terminate TLS
+ * for hosts nobody asked it to read.
+ */
+export function providerForHost(host) {
+  if (!host || NEVER_INTERCEPT.has(host)) return null;
+  return PROVIDER_HOSTS[host] || null;
+}
+
+/** Whether `host` is one we deliberately refuse to intercept. */
+export function isNeverIntercepted(host) {
+  return NEVER_INTERCEPT.has(host);
+}
+
+/** Hosts to intercept for the providers this config actually uses. */
+export function interceptHostsFor(accounts = []) {
+  const wanted = new Set();
+  for (const [host, id] of Object.entries(PROVIDER_HOSTS)) {
+    // Anthropic is always intercepted — it is the default provider and the
+    // configured `upstream` may name a different host anyway. A non-default
+    // provider is intercepted only when an account actually uses it, so an
+    // Anthropic-only fleet never has its ChatGPT traffic terminated.
+    if (id === DEFAULT_PROVIDER || accounts.some(a => providerOf(a) === id)) wanted.add(host);
+  }
+  return [...wanted];
+}
+
 /** Whether `id` names a provider we know how to talk to. */
 export function isKnownProvider(id) {
   return Object.hasOwn(PROVIDERS, id);

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { createWriteStream, mkdirSync, writeSync } from 'node:fs';
 import { readdir, stat, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
-import { ensureCerts, createConnectHandler } from './mitm.js';
+import { ensureCerts, createConnectHandler, mitmHosts } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
 import { sanitizeToolPairs } from './tool-pair-sanitize.js';
 import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
@@ -363,12 +363,15 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
   // to the upstream host is a transparent MITM relay (rewrite only auth); the
   // test host is answered locally; anything else is blind-tunneled. Certs are
   // minted lazily on the first intercepted CONNECT.
-  const mitmHost = (() => { try { return new URL(upstream).hostname; } catch { return 'api.anthropic.com'; } })();
+  // Every host the leaf must cover, not just the Anthropic upstream: a Codex
+  // account is reached on chatgpt.com, and MITM cannot intercept a host its
+  // certificate does not name.
+  const mitmHostList = mitmHosts(config);
   let certsPromise = null;
   const ensureLeaf = async () => {
     // Reset the memo on failure so a transient cert error doesn't wedge the MITM
     // path permanently (a cached rejected promise would re-throw on every CONNECT).
-    certsPromise ||= ensureCerts(mitmHost).catch((err) => { certsPromise = null; throw err; });
+    certsPromise ||= ensureCerts(mitmHostList).catch((err) => { certsPromise = null; throw err; });
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };

--- a/test/mitm-provider-hosts.test.js
+++ b/test/mitm-provider-hosts.test.js
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { hostMode, mitmHosts, ensureCerts, TEST_HOST } from '../src/mitm.js';
+import { providerForHost, isNeverIntercepted, interceptHostsFor } from '../src/provider.js';
+import { X509Certificate } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// MITM is the mode that works without the client cooperating: a CLI that honours
+// only HTTPS_PROXY has no base URL to redirect. So a provider the proxy will not
+// intercept is a provider it does not support in its main mode. Codex was that
+// case — chatgpt.com fell through to a blind tunnel.
+
+const claude = (name) => ({ name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000 });
+const codex = (name) => ({ ...claude(name), provider: 'codex' });
+
+test('a Codex fleet intercepts chatgpt.com', () => {
+  const config = { accounts: [claude('a'), codex('c')] };
+  assert.equal(hostMode('chatgpt.com', config), 'rewrite');
+  assert.equal(hostMode('api.anthropic.com', config), 'rewrite');
+});
+
+// The safety half: a fleet with no Codex account must not have its ChatGPT
+// traffic terminated. Intercepting a host nobody asked us to read is not a
+// neutral default.
+test('an Anthropic-only fleet still tunnels chatgpt.com', () => {
+  const config = { accounts: [claude('a')] };
+  assert.equal(hostMode('chatgpt.com', config), 'tunnel');
+  assert.equal(hostMode('api.anthropic.com', config), 'rewrite');
+});
+
+// ab.chatgpt.com is OpenAI's telemetry endpoint: no inference, nothing to
+// rewrite, and terminating it would present our leaf for a host we have no
+// reason to read.
+test('ab.chatgpt.com is never intercepted, even with Codex accounts', () => {
+  const config = { accounts: [codex('c')] };
+  assert.equal(hostMode('ab.chatgpt.com', config), 'tunnel');
+  assert.equal(isNeverIntercepted('ab.chatgpt.com'), true);
+});
+
+test('host matching is exact, never a suffix', () => {
+  assert.equal(providerForHost('chatgpt.com'), 'codex');
+  assert.equal(providerForHost('api.anthropic.com'), 'anthropic');
+  assert.equal(providerForHost('ab.chatgpt.com'), null);
+  assert.equal(providerForHost('evil-chatgpt.com'), null);
+  assert.equal(providerForHost('chatgpt.com.evil.test'), null);
+  assert.equal(providerForHost(null), null);
+});
+
+test('unrelated hosts still tunnel, and the test host is still answered locally', () => {
+  const config = { accounts: [codex('c')] };
+  assert.equal(hostMode('example.com', config), 'tunnel');
+  assert.equal(hostMode(TEST_HOST, config), 'test');
+});
+
+test('interceptHostsFor only adds a provider an account actually uses', () => {
+  assert.deepEqual(interceptHostsFor([claude('a')]), ['api.anthropic.com']);
+  assert.deepEqual(interceptHostsFor([claude('a'), codex('c')]).sort(),
+    ['api.anthropic.com', 'chatgpt.com']);
+});
+
+// The leaf has to NAME every host we intercept, or the CONNECT fails the
+// handshake instead of being served — which is the failure this whole change
+// exists to avoid.
+test('mitmHosts covers the Anthropic upstream and every used provider host', () => {
+  assert.deepEqual(mitmHosts({ accounts: [claude('a')] }), ['api.anthropic.com']);
+  assert.deepEqual(mitmHosts({ accounts: [claude('a'), codex('c')] }).sort(),
+    ['api.anthropic.com', 'chatgpt.com']);
+  // A custom upstream is still covered alongside the provider hosts.
+  assert.deepEqual(
+    mitmHosts({ upstream: 'https://proxy.internal.test', accounts: [codex('c')] }).sort(),
+    ['api.anthropic.com', 'chatgpt.com', 'proxy.internal.test'].sort(),
+  );
+});
+
+test('the minted leaf is valid for every intercepted host', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-cert-'));
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = join(dir, 'teamclaude.json');
+  try {
+    const hosts = mitmHosts({ accounts: [claude('a'), codex('c')] });
+    const { leafCertPem } = await ensureCerts(hosts);
+    const names = (new X509Certificate(leafCertPem).subjectAltName || '')
+      .split(',').map(s => s.trim());
+    for (const h of [...hosts, TEST_HOST]) {
+      assert.ok(names.includes(`DNS:${h}`), `the leaf does not name ${h}: ${names.join(', ')}`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// A single host string must keep working — every existing caller passed one.
+test('ensureCerts still accepts a single host', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-cert-'));
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = join(dir, 'teamclaude.json');
+  try {
+    const { leafCertPem } = await ensureCerts('api.anthropic.com');
+    const names = (new X509Certificate(leafCertPem).subjectAltName || '').split(',').map(s => s.trim());
+    assert.ok(names.includes('DNS:api.anthropic.com'));
+    assert.ok(names.includes(`DNS:${TEST_HOST}`));
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
MITM is the proxy's main mode, and Codex was not supported in it.

`hostMode` rewrote exactly one host — the configured Anthropic upstream — and blind-tunnelled everything else, so `chatgpt.com` fell through. Codex was reachable only by editing `~/.codex/config.toml` to point `base_url` at the proxy. That works, but MITM is the mode that works **without the client cooperating**: a CLI that honours only `HTTPS_PROXY` has no base URL to redirect, which is exactly why the mode exists.

This is the piece of #95's Phase 0 design that never landed with #246, noted when I closed it.

## What changed

`hostMode` now also rewrites a provider host, and the MITM leaf **names every host it will intercept** — without that the CONNECT fails the TLS handshake rather than being served, which is the failure this whole change exists to avoid. `mitmHosts(config)` is the single source of that list and both cert call sites use it.

Routing past that point already worked: an intercepted request carries the *real* upstream path, so `providerForPath('/backend-api/codex/responses')` already picks the Codex pool and `upstreamFor` already sends it to `chatgpt.com`. The gap was purely that the CONNECT never got terminated.

```bash
eval "$(teamclaude env)"   # HTTPS_PROXY + NODE_EXTRA_CA_CERTS
codex                      # pooled, no ~/.codex/config.toml change
```

## Two boundaries, both deliberate

**`chatgpt.com` is intercepted only when an account actually uses that provider.** An Anthropic-only fleet tunnels it untouched. Terminating TLS for a host nobody asked the proxy to read is not a neutral default, and this keeps the blast radius to operators who opted into Codex.

**`ab.chatgpt.com` is never intercepted.** OpenAI's telemetry/experiment endpoint — no inference, nothing to rewrite, and no reason to present our leaf for it. It is listed explicitly rather than left to fall through, and host matching is **exact rather than suffix**, so neither a subdomain nor a lookalike (`evil-chatgpt.com`, `chatgpt.com.evil.test`) can claim interception. Tests cover all four.

Also removes `upstreamHost`, which `mitmHosts` supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)