### PR TITLE
Bump to 1.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Multi-account Claude proxy with automatic quota-based rotation",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release 1.1.16 — seven commits since 1.1.15.

Merging this triggers `publish.yml`: npm publish via Trusted Publishing, plus a `v1.1.16` tag and GitHub release.

## Read before upgrading — two routing behaviour changes

**#277 — a family-scoped exclusion no longer moves the whole fleet.** `_select` scoped availability per model, but `_selectNext` then wrote the replacement into the *global* cursor. One Fable request finding the current account's Fable bucket spent moved Opus and Sonnet with it, onto a fresh account — while the original's weekly quota expired unspent. Exactly the account you'd most want to drain. A family now diverts alone; an account barred outright still rotates the fleet as before.

**#281 — provider partition, corrected in three ways.** Each provider keeps its own cursor (a Codex request was dragging the shared `currentIndex` across and the next Anthropic request dragged it back, re-arming storm control on every alternation). The partition now applies to **subscription** accounts only — a Claude Max token is issued to Claude and a ChatGPT token to Codex, while an API key is metered capacity with no tie to a caller. And a `TC_ACCT` pin can no longer serve a Codex request from a Claude subscription: the pin bypasses selection entirely, so it was sending OpenAI-shaped bodies to `api.anthropic.com` with a Claude token.

## Features

- **#283** — **Codex works in MITM mode.** `chatgpt.com` is intercepted when a Codex account is configured, so a Codex CLI behind `HTTPS_PROXY` is pooled with no `~/.codex/config.toml` change. An Anthropic-only fleet tunnels it untouched, and `ab.chatgpt.com` (telemetry) is never intercepted.
- **#282** — expiry-pressure account selection: rank on governing weekly headroom per second until that bucket resets, so a window stops lapsing unspent while traffic drains a longer-dated account. **Opt-in** via `expiryRouting.enabled`, inert with the knob off.
- **#274** — switch the current account from the browser dashboard.
- **#279** — a routing table showing where each model family goes, which #277 made a genuinely separate question from "which account is current".

## Fixes

- **#280** — a status poll no longer consumes the session-reset switch. `getStatus` reached `_clearExpiredQuotas` through `unavailableReason`, so with the dashboard polling every 5s the rule that spends a soon-expiring window was effectively disabled whenever anyone had the page open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
