### PR TITLE
fix(probe): never send a third-party backend's key to Anthropic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `accounts[].accountUuid` | Anthropic account (person) id; set automatically from the OAuth profile |
 | `accounts[].orgUuid` / `orgName` | Organization the account is scoped to — lets one email hold multiple org accounts |
 | `accounts[].priority` | Rotation preference, lower = preferred (default 0) |
+| `accounts[].maxUsage` | Hard per-account usage cap: a number, or a per-bucket table like `{ "unified7d": 0.6, "unified7dFable": 0.8 }` (same keys as `switchThreshold`; `default` covers unlisted buckets, anything else is uncapped). At the cap the account receives **no** requests — rotation skips it, the all-exhausted revalidation probe skips it, and a pin gets the exhausted answer. Model-scoped like the thresholds, applied live on reload. See [Per-account usage caps](quota.md#per-account-usage-caps) |
 | `accounts[].disabled` | If `true`, the account is excluded from rotation until re-enabled |
 | `accounts[].upstream` | Alternative upstream base URL for this account (e.g. `https://api.deepseek.com/anthropic`). Overrides the global `upstream` for this account only — see [third-party backends](accounts.md#third-party-backend-accounts) |
 | `accounts[].modelMap` | Object mapping Anthropic model names to this backend's model names (e.g. `{"claude-sonnet-4-6": "deepseek-v4-pro[1m]"}`). Applied automatically when requests are routed to this account |

--- a/docs/quota.md
+++ b/docs/quota.md
@@ -87,6 +87,18 @@ At the cap, that account receives **nothing**:
 
 Caps are model-scoped exactly like thresholds. `unified5h` and `unified7d` stop every model; `unified7dFable` stops only Fable, so the example above keeps serving Opus and Sonnet from the same account after Fable is done. The cap binds at the level you set (`>=`), and a window that has reset is never capped on the old reading.
 
+A cap shows on the status screen before it binds — marked on the bar it applies to, named in percent beside it, and reflected in the `Models` row:
+
+```
+  Session  [██░░░░░░░░░┃░░░░░░] 10% cap 60%
+  Weekly   [███████████┃░░░░░░] 62% cap 60%
+  Fable    [██░░░░░░░░░░░░┃░░░] 10% cap 80%
+  Models   Opus ✗   Fable ✗
+  Blocked  account usage cap reached (maxUsage)
+```
+
+The mark stays inside the bar rather than widening it, so capped and uncapped rows still line up. In the TUI the bar reddens at the cap instead of at the switch threshold.
+
 Edits apply live on config reload — no restart.
 
 ## Hold on exhaustion

--- a/docs/quota.md
+++ b/docs/quota.md
@@ -64,6 +64,31 @@ That conflates two different risks, though: 98% of a 5-hour window that refills 
 
 Keys are the quota field names — `unified5h`, `unified7d`, `unified7dFable`, `unified7dSonnet`, `tokens`, `requests`. Anything unlisted takes `default`, and a bare number behaves exactly as before. The TUI's ±1% control edits the single-number form; when a table is configured the settings row shows it read-only, so the ± control can't silently flatten your per-bucket values.
 
+## Per-account usage caps
+
+`switchThreshold` is fleet-wide, and it is a *preference*: at that level rotation prefers another account, but when every account is over it the proxy still sends one revalidating request, because a threshold decision can rest on a stale reading and refusing forever is worse. That makes it the wrong tool for "this account may spend only part of its quota".
+
+`accounts[].maxUsage` is that tool. Same shapes, per account:
+
+```json
+{
+  "name": "spare@example.com",
+  "maxUsage": { "unified5h": 0.6, "unified7d": 0.6, "unified7dFable": 0.8 }
+}
+```
+
+A bare number caps every bucket. Keys are the same quota field names as `switchThreshold`, and `default` covers the ones a table does not list — but a bucket that is neither listed nor covered by `default` is **uncapped**, so a cap is only ever what you asked for.
+
+At the cap, that account receives **nothing**:
+
+- rotation skips it, reporting `capped` (or `advisor-capped`) in `teamclaude status`;
+- the all-exhausted revalidation probe skips it, unlike a `switchThreshold` decision;
+- a pinned request (`TC_ACCT`, `/tc-acct/<name>`) gets the exhausted answer rather than spending past the cap. A pin still never leaks to another account.
+
+Caps are model-scoped exactly like thresholds. `unified5h` and `unified7d` stop every model; `unified7dFable` stops only Fable, so the example above keeps serving Opus and Sonnet from the same account after Fable is done. The cap binds at the level you set (`>=`), and a window that has reset is never capped on the old reading.
+
+Edits apply live on config reload — no restart.
+
 ## Hold on exhaustion
 
 By default, when all accounts are exhausted TeamClaude returns a `429` immediately, which causes Claude Code to abort the current task. With `holdSeconds` set, the proxy **holds the HTTP connection open** instead and polls silently every ~60 seconds; the instant any account's quota resets, the request is forwarded and Claude Code resumes — the interruption never happens.

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -96,6 +96,7 @@ function makeAccount(acct, index) {
     orgName: acct.orgName || null,
     priority: acct.priority || 0,
     disabled: acct.disabled || false,
+    maxUsage: acct.maxUsage ?? null,
     upstream: acct.upstream || null,
     modelMap: acct.modelMap || null,
     models: acct.models || null,
@@ -271,6 +272,95 @@ export class AccountManager {
    * places that show one (status header, TUI settings row). */
   get effectiveThreshold() {
     return this.thresholdFor('default');
+  }
+
+  /**
+   * A per-account usage cap, or null when that bucket is uncapped.
+   *
+   * `switchThreshold` is a rotation preference: at that level the fleet PREFERS
+   * another account, but the all-exhausted probe path deliberately overrides it,
+   * because a threshold decision can rest on a stale reading and refusing
+   * forever is worse than one revalidating request. A budget is not that. An
+   * operator who says "this account stops at 60% of its weekly" wants zero
+   * requests past 60%, so `accounts[].maxUsage` is a separate, harder setting —
+   * see capExceeded.
+   *
+   * Same shapes as switchThreshold, per account:
+   *
+   *   "maxUsage": 0.6
+   *   "maxUsage": { "unified5h": 0.6, "unified7d": 0.6, "unified7dFable": 0.8 }
+   *
+   * Bucket keys are the quota field names (unified5h, unified7d, unified7dFable,
+   * unified7dSonnet, tokens, requests). A bare number caps every bucket; in the
+   * map form, a bucket that is neither listed nor covered by `default` is
+   * uncapped, so a cap is only ever what was asked for.
+   */
+  capFor(bucket, account) {
+    const m = account?.maxUsage;
+    if (typeof m === 'number' && Number.isFinite(m)) return m;
+    if (m && typeof m === 'object') {
+      const v = m[bucket] ?? m.default;
+      if (typeof v === 'number' && Number.isFinite(v)) return v;
+    }
+    return null;
+  }
+
+  /**
+   * The bucket that has reached this account's cap for `model`, or null.
+   *
+   * The shared buckets (unified5h, unified7d) cap every request; a family bucket
+   * caps only the family it meters, so a Fable cap stops Fable and leaves Opus
+   * alone. Both apply: a Fable request is capped by whichever binds first.
+   */
+  capExceeded(account, model = null) {
+    if (!account?.maxUsage) return null;
+    const q = account.quota;
+    // Same reason _isNearQuota does this first: a window that has already reset
+    // must not read as capped on a value that no longer applies.
+    this._clearExpiredQuotas(account);
+
+    const cap5h = this.capFor('unified5h', account);
+    if (cap5h != null && q.unified5h != null && q.unified5h >= cap5h) return 'unified5h';
+
+    // The shared weekly bucket caps every request, family requests included:
+    // family spend meters into BOTH its own bucket and the shared one (#175), so
+    // a budget written against the shared weekly is one that Fable can overrun
+    // if only the governing bucket is checked. This is not _isNearQuota's rule —
+    // a threshold gates on the governing bucket alone — but a threshold is a
+    // preference and a cap is a total.
+    const capWeekly = this.capFor('unified7d', account);
+    if (capWeekly != null && q.unified7d != null && q.unified7d >= capWeekly) return 'unified7d';
+
+    // …and on top of it, the family bucket that meters THIS model, when the
+    // family has one. A Fable cap stops Fable and leaves Opus alone.
+    const familyKey = this._weeklyBucketFor(model);
+    if (familyKey !== 'unified7d') {
+      const familyCap = this.capFor(familyKey, account);
+      const familyVal = q[familyKey];
+      if (familyCap != null && familyVal != null && familyVal >= familyCap) return familyKey;
+    }
+
+    const tokensCap = this.capFor('tokens', account);
+    if (tokensCap != null && q.tokensLimit != null && q.tokensRemaining != null
+      && 1 - q.tokensRemaining / q.tokensLimit >= tokensCap) return 'tokens';
+
+    const requestsCap = this.capFor('requests', account);
+    if (requestsCap != null && q.requestsLimit != null && q.requestsRemaining != null
+      && 1 - q.requestsRemaining / q.requestsLimit >= requestsCap) return 'requests';
+
+    return null;
+  }
+
+  /** The family weekly bucket that has reached its cap for `model`, or null.
+   * The advisor check needs this narrower form: the shared buckets were already
+   * decided for the executor model, and only the advisor's own family is new. */
+  _familyCapExceeded(account, model) {
+    if (!account?.maxUsage) return null;
+    const key = this._weeklyBucketFor(model);
+    if (key === 'unified7d') return null;
+    const cap = this.capFor(key, account);
+    const val = account.quota[key];
+    return cap != null && val != null && val >= cap ? key : null;
   }
 
   /** Start (or restart) the ramp window for an account that just became current,
@@ -720,6 +810,10 @@ export class AccountManager {
       // would just 429 again — so skip it (Fable/Sonnet) and let the caller emit
       // the synthetic 429 when no other account is available.
       if (model && this._modelWeeklyExhausted(account, model)) continue;
+      // A cap is the operator's own decision, not a reading that a live request
+      // might refresh, so the exhausted-fleet probe does not get to override it.
+      // Checked here rather than in _isProbeable because a cap is model-scoped.
+      if (this.capExceeded(account, model)) continue;
       // Same for routing/ownership: a probe for a routed or owned model must not
       // land on an ineligible account (it would just reject the unknown model id).
       if (model && !this._routeAllows(account, model)) continue;
@@ -765,6 +859,12 @@ export class AccountManager {
     // Manually disabled accounts are skipped entirely until re-enabled.
     if (account.disabled) return 'disabled';
 
+    // An operator budget cap. Checked here, above every transient state, because
+    // it is a decision rather than an estimate — and unlike the switch threshold
+    // nothing overrides it: _selectProbe skips a capped account too, so an
+    // account at its cap receives no requests at all.
+    if (this.capExceeded(account, model)) return 'capped';
+
     // A structured organization-policy 403 means this account cannot serve OAuth
     // requests right now. Skip it across requests until the short cooldown ends.
     if (this._entitlementDenied(account)) return false;
@@ -804,6 +904,7 @@ export class AccountManager {
     // already checked above for the executor) and any route/ownership rule for
     // it must allow this account.
     if (advisorModel) {
+      if (this._familyCapExceeded(account, advisorModel)) return 'advisor-capped';
       if (this._modelWeeklyExhausted(account, advisorModel)) return 'advisor-quota';
       if (!this._routeAllows(account, advisorModel)) return 'advisor-route';
     }
@@ -1911,6 +2012,7 @@ export class AccountManager {
         orgName: a.orgName || null,
         priority: a.priority || 0,
         disabled: a.disabled || false,
+        maxUsage: a.maxUsage ?? null,
         status: a.status,
         // Why the account is out of rotation right now (null = it can serve).
         // Distinguishes a local threshold decision from an upstream rejection —

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,6 +1,6 @@
 import { refreshAccessToken, isTokenExpiringSoon, isTokenExpired } from './oauth.js';
 import { sameIdentity } from './identity.js';
-import { weeklyBucketForModel, modelGlobMatches, modelFamily } from './model.js';
+import { weeklyBucketForModel, modelGlobMatches, modelFamily, resolveMaxUsage } from './model.js';
 import { SessionTracker } from './session-tracker.js';
 
 // Re-exported for callers that import these model helpers from here.
@@ -296,13 +296,7 @@ export class AccountManager {
    * uncapped, so a cap is only ever what was asked for.
    */
   capFor(bucket, account) {
-    const m = account?.maxUsage;
-    if (typeof m === 'number' && Number.isFinite(m)) return m;
-    if (m && typeof m === 'object') {
-      const v = m[bucket] ?? m.default;
-      if (typeof v === 'number' && Number.isFinite(v)) return v;
-    }
-    return null;
+    return resolveMaxUsage(account?.maxUsage, bucket);
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -454,7 +454,9 @@ async function serverCommand() {
       running: false,
       accounts: accountManager.accounts.map(account => ({
         name: account.name,
-        status: account.type === 'oauth' ? 'never' : 'not-applicable',
+        // Same rule as Prober._isProbeTarget: a third-party backend has no
+        // Anthropic usage to read, so it is not-applicable rather than pending.
+        status: (account.type === 'oauth' && !account.upstream) ? 'never' : 'not-applicable',
         lastProbedAt: null,
         startedAt: null,
         durationMs: null,

--- a/src/model.js
+++ b/src/model.js
@@ -31,6 +31,20 @@ const FAMILY_WEEKLY_BUCKET = {
   sonnet: 'unified7dSonnet',
 };
 
+// A per-account usage cap (accounts[].maxUsage) for one quota bucket, or null
+// when that bucket is uncapped. Shapes mirror switchThreshold: a bare number
+// caps every bucket, a table caps the buckets it lists, and `default` covers the
+// rest. Lives here, beside the bucket keys, so the status renderer can draw a
+// cap without importing the account manager (it renders remote JSON too).
+export function resolveMaxUsage(maxUsage, bucket) {
+  if (typeof maxUsage === 'number' && Number.isFinite(maxUsage)) return maxUsage;
+  if (maxUsage && typeof maxUsage === 'object') {
+    const v = maxUsage[bucket] ?? maxUsage.default;
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
 // The weekly quota bucket key that governs a model, e.g. a Fable request is
 // gated by 'unified7dFable' rather than the shared 'unified7d'. Used by account
 // selection so a spent family bucket only bars that family's requests.

--- a/src/prober.js
+++ b/src/prober.js
@@ -60,12 +60,27 @@ export class Prober {
     this.lastRunStartedAt = Date.now();
     this.nextRunAt = this.intervalMs > 0 ? this.lastRunStartedAt + this.intervalMs : null;
     try {
-      const accounts = this.am.accounts.filter(account => account.type === 'oauth' && account.credential);
+      const accounts = this.am.accounts.filter(account => this._isProbeTarget(account));
       await Promise.all(accounts.map(account => this.probeAccount(account)));
     } finally {
       this.lastRunFinishedAt = Date.now();
       this._running = false;
     }
+  }
+
+  /**
+   * Whether this account has Anthropic subscription usage to read.
+   *
+   * `/api/oauth/usage` is Anthropic's own endpoint, and its URL is fixed — a
+   * third-party backend account (`upstream` set) carries a DIFFERENT provider's
+   * key, which the probe would send to api.anthropic.com every cycle. That
+   * leaks the key to a party it was never issued for, and the answer it gets
+   * back (429) is recorded as a permanent probe error against an account that
+   * is serving traffic perfectly well. The keep-warm scheduler already draws
+   * this line (warmer.js `_isWarmTarget`); the probe did not.
+   */
+  _isProbeTarget(account) {
+    return !!account && account.type === 'oauth' && !!account.credential && !account.upstream;
   }
 
   async probeAccount(account) {

--- a/src/prober.js
+++ b/src/prober.js
@@ -140,7 +140,7 @@ export class Prober {
         const status = this.accountStatus.get(account.name);
         return {
           name: account.name,
-          status: account.type === 'oauth' ? (status?.status || 'never') : 'not-applicable',
+          status: this._isProbeTarget(account) ? (status?.status || 'never') : 'not-applicable',
           lastProbedAt: iso(status?.finishedAt),
           startedAt: iso(status?.startedAt),
           durationMs: status?.durationMs ?? null,

--- a/src/server.js
+++ b/src/server.js
@@ -1295,8 +1295,15 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // A pinned request (via /tc-acct/<name>) forces one exact account and never
   // rotates or fails over: once that account has been tried, `account` is null
   // and the caller gets the exhausted response rather than leaking to another.
+  // A cap outranks the pin. Rotation checks it through unavailableReason, but a
+  // pinned request never reaches that walk, and a budget a pin can spend past is
+  // not a budget. The request gets the exhausted response, exactly as it would
+  // for an already-tried pin — it still never leaks to another account.
+  const pinned = ctx.pinnedIndex != null && !ctx.tried.has(ctx.pinnedIndex)
+    ? accountManager.accounts[ctx.pinnedIndex]
+    : null;
   const account = ctx.pinnedIndex != null
-    ? (ctx.tried.has(ctx.pinnedIndex) ? null : accountManager.accounts[ctx.pinnedIndex])
+    ? (pinned && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
     : accountManager.getActiveAccount(ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId);
   if (!account) {
     // Every candidate was refused by upstream (403). Waiting will not help — the

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -1,4 +1,4 @@
-import { findFamilyBlock, modelGlobOverlaps } from './model.js';
+import { findFamilyBlock, modelGlobOverlaps, resolveMaxUsage } from './model.js';
 
 const ESC = '\x1b[';
 const RESET = `${ESC}0m`;
@@ -205,25 +205,37 @@ function modelRoutingLine(account, threshold, blocked, now, paint) {
   const q = account.quota || {};
   if (q.unified7dSonnet == null && q.unified7dFable == null) return null;
   const t = Number(threshold);
-  const fiveOver = q.unified5h != null && !Number.isNaN(t) && q.unified5h >= t;
+  const overThreshold = v => v != null && !Number.isNaN(t) && v >= t;
+  // A per-account cap is the other ceiling a family can be over. Without it a
+  // capped family reads ✓ on the very line that exists to say where a model can
+  // still run, right beside the Blocked line saying it cannot.
+  const overCap = (v, bucket) => {
+    const cap = resolveMaxUsage(account.maxUsage, bucket);
+    return cap != null && v != null && v >= cap;
+  };
+  // Blocks every family: the shared 5-hour bucket, and the shared weekly at its
+  // CAP — family spend meters into the shared bucket, so a cap written against
+  // it stops the families too (see AccountManager.capExceeded).
+  const sharedOver = overThreshold(q.unified5h) || overCap(q.unified5h, 'unified5h')
+    || overCap(q.unified7d, 'unified7d');
 
-  const cell = (label, weekly, reset) => {
+  const cell = (label, weekly, reset, bucket) => {
     // The blocklist outranks quota: a blocked family cannot be served however
     // much headroom the account has, so it must not read ✓. Reporting quota
     // alone is what made a fully-blocked model look available.
     if (findFamilyBlock(blocked, label)) {
       return `${label} ${paint.red('⊘')}${paint.dim(' blocked')}`;
     }
-    const weeklyOver = weekly != null && !Number.isNaN(t) && weekly >= t;
-    const mark = fiveOver || weeklyOver ? paint.red('✗') : paint.green('✓');
+    const weeklyOver = overThreshold(weekly) || overCap(weekly, bucket);
+    const mark = sharedOver || weeklyOver ? paint.red('✗') : paint.green('✓');
     const resetTs = parseTs(reset);
     const when = weeklyOver && resetTs && resetTs > now ? paint.dim(` ${formatDuration(resetTs - now)}`) : '';
     return `${label} ${mark}${when}`;
   };
 
-  const cells = [cell('Opus', q.unified7d, q.unified7dReset)];
-  if (q.unified7dSonnet != null) cells.push(cell('Sonnet', q.unified7dSonnet, q.unified7dSonnetReset));
-  if (q.unified7dFable != null) cells.push(cell('Fable', q.unified7dFable, q.unified7dFableReset));
+  const cells = [cell('Opus', q.unified7d, q.unified7dReset, 'unified7d')];
+  if (q.unified7dSonnet != null) cells.push(cell('Sonnet', q.unified7dSonnet, q.unified7dSonnetReset, 'unified7dSonnet'));
+  if (q.unified7dFable != null) cells.push(cell('Fable', q.unified7dFable, q.unified7dFableReset, 'unified7dFable'));
   return `${paint.dim('Models'.padEnd(8))} ${cells.join('   ')}`;
 }
 
@@ -231,46 +243,64 @@ function quotaLines(account, now, paint) {
   const quota = account.quota || {};
   const lines = [];
 
+  // A configured cap (accounts[].maxUsage) is drawn on the bucket it caps, so the
+  // budget is visible before it binds rather than only as a Blocked line after.
+  const cap = bucket => resolveMaxUsage(account.maxUsage, bucket);
+
   if (quota.unified5h != null || quota.unified7d != null || quota.unified7dSonnet != null || quota.unified7dFable != null) {
-    lines.push(formatQuotaLine('Session', quota.unified5h, quota.unified5hReset, now, paint));
-    lines.push(formatQuotaLine('Weekly', quota.unified7d, quota.unified7dReset, now, paint));
+    lines.push(formatQuotaLine('Session', quota.unified5h, quota.unified5hReset, now, paint, cap('unified5h')));
+    lines.push(formatQuotaLine('Weekly', quota.unified7d, quota.unified7dReset, now, paint, cap('unified7d')));
     if (quota.unified7dSonnet != null) {
-      lines.push(formatQuotaLine('Sonnet', quota.unified7dSonnet, quota.unified7dSonnetReset, now, paint));
+      lines.push(formatQuotaLine('Sonnet', quota.unified7dSonnet, quota.unified7dSonnetReset, now, paint, cap('unified7dSonnet')));
     }
     if (quota.unified7dFable != null) {
-      lines.push(formatQuotaLine('Fable', quota.unified7dFable, quota.unified7dFableReset, now, paint));
+      lines.push(formatQuotaLine('Fable', quota.unified7dFable, quota.unified7dFableReset, now, paint, cap('unified7dFable')));
     }
     return lines;
   }
 
   if (quota.tokensLimit != null && quota.tokensRemaining != null) {
     const ratio = 1 - quota.tokensRemaining / quota.tokensLimit;
-    lines.push(formatQuotaLine('Tokens', ratio, quota.resetsAt, now, paint));
+    lines.push(formatQuotaLine('Tokens', ratio, quota.resetsAt, now, paint, cap('tokens')));
   }
   if (quota.requestsLimit != null && quota.requestsRemaining != null) {
     const ratio = 1 - quota.requestsRemaining / quota.requestsLimit;
-    lines.push(formatQuotaLine('Requests', ratio, quota.resetsAt, now, paint));
+    lines.push(formatQuotaLine('Requests', ratio, quota.resetsAt, now, paint, cap('requests')));
   }
   if (lines.length === 0) lines.push(`${paint.dim('Quota'.padEnd(8))} ${paint.gray('unknown')}`);
   return lines;
 }
 
-function formatQuotaLine(label, ratio, resetAt, now, paint) {
+function formatQuotaLine(label, ratio, resetAt, now, paint, cap = null) {
   const resetTs = parseTs(resetAt);
   const reset = resetTs && resetTs > now ? ` reset ${formatDuration(resetTs - now)}` : '';
-  return `${paint.dim(label.padEnd(8))} ${usageBar(ratio, paint)} ${formatPercent(ratio)}${reset}`;
+  // Name the cap in words as well as marking it on the bar: one bar cell is ~6%,
+  // so the mark alone cannot say 60% rather than 61%.
+  const reached = cap != null && ratio != null && Number(ratio) >= cap;
+  const capText = cap == null ? ''
+    : ` ${(reached ? paint.red : paint.yellow)(`cap ${formatPercent(cap)}`)}`;
+  return `${paint.dim(label.padEnd(8))} ${usageBar(ratio, paint, cap)} ${formatPercent(ratio)}${capText}${reset}`;
 }
 
-function usageBar(ratio, paint) {
+const BAR_WIDTH = 18;
+
+function usageBar(ratio, paint, cap = null) {
   if (ratio == null || Number.isNaN(Number(ratio))) return `[${paint.gray('??????????????????')}]`;
-  const width = 18;
+  const width = BAR_WIDTH;
   const safeRatio = Math.max(0, Math.min(1, Number(ratio)));
   const full = Math.round(safeRatio * width);
-  const fill = Array.from({ length: full }, (_, i) => {
+  const cells = Array.from({ length: width }, (_, i) => {
+    if (i >= full) return paint.gray('░');
     const [r, g, b] = gradientColor(i, width);
     return paint.rgb(r, g, b, '█');
-  }).join('');
-  return `[${fill}${paint.gray('░'.repeat(width - full))}]`;
+  });
+  // The cap sits where the bar may not pass. Drawn INSIDE the bar rather than
+  // inserted, so a capped row still lines up with an uncapped one.
+  if (cap != null && cap > 0 && cap < 1) {
+    const at = Math.min(width - 1, Math.round(cap * width));
+    cells[at] = (safeRatio >= cap ? paint.red : paint.yellow)('┃');
+  }
+  return `[${cells.join('')}]`;
 }
 
 function gradientColor(index, width) {

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -78,6 +78,8 @@ const UNAVAILABLE_TEXT = {
   error: 'account error (see logs)',
   'upstream-rejected': 'upstream reports quota rejected',
   quota: 'local switch threshold reached',
+  capped: 'account usage cap reached (maxUsage)',
+  'advisor-capped': "advisor model's usage cap reached (maxUsage)",
   route: 'no route allows this account',
   'advisor-quota': "advisor model's weekly bucket spent",
   'advisor-route': 'no route allows the advisor model',

--- a/src/sync-accounts.js
+++ b/src/sync-accounts.js
@@ -61,6 +61,10 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     if (diskAcct.orgName && !mgr.orgName) mgr.orgName = diskAcct.orgName;
     if (diskAcct.name && mgr.name !== diskAcct.name) mgr.name = diskAcct.name;
     if (diskAcct.priority != null && mgr.priority !== diskAcct.priority) mgr.priority = diskAcct.priority;
+    // A cap edit applies live for the same reason priority does: it is an
+    // operator decision about a running fleet, and waiting for a restart to
+    // honour a budget defeats the budget.
+    mgr.maxUsage = diskAcct.maxUsage ?? null;
     // Third-party-backend bindings are read per request off this object
     // (`account.upstream || upstream`, `account.modelMap` in server.js), so a
     // disk edit must land here to take effect on reload. `|| null` mirrors the
@@ -78,6 +82,7 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     if (cfgAcct) {
       if (diskAcct.upstream) cfgAcct.upstream = diskAcct.upstream; else delete cfgAcct.upstream;
       if (diskAcct.modelMap) cfgAcct.modelMap = diskAcct.modelMap; else delete cfgAcct.modelMap;
+      if (diskAcct.maxUsage != null) cfgAcct.maxUsage = diskAcct.maxUsage; else delete cfgAcct.maxUsage;
     }
     // Pick up enable/disable toggles; re-enabling clears a stuck error state.
     const wantDisabled = !!diskAcct.disabled;

--- a/src/tui.js
+++ b/src/tui.js
@@ -7,6 +7,7 @@ import {
   oauthIdentityFields,
 } from './identity.js';
 import { formatPercent } from './status-renderer.js';
+import { resolveMaxUsage } from './model.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, describeSelfProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
@@ -1439,8 +1440,18 @@ export class TUI {
     // the weekly one lower than the 5-hour one); the attach-mode manager
     // mirrors thresholdFor, so both dashboards agree with the gate.
     const thFor = (k) => (typeof this.am.thresholdFor === 'function' ? this.am.thresholdFor(k) : this.am.switchThreshold);
-    const th1 = thFor(r1 === q.unified5h ? 'unified5h' : 'tokens');
-    const th2 = thFor(r2 === q.unified7d ? 'unified7d' : 'requests');
+    // A per-account cap (accounts[].maxUsage) is the lower ceiling when it is
+    // set, and it is the harder one — past it the account is sent nothing at
+    // all. Reddening at the cap keeps the bar honest about where this account
+    // actually stops. Read straight off the account so the attached dashboard,
+    // which has the payload but no AccountManager, agrees with the server.
+    const limFor = (k) => {
+      const cap = resolveMaxUsage(a.maxUsage, k);
+      const th = thFor(k);
+      return cap == null ? th : (typeof th === 'number' ? Math.min(th, cap) : cap);
+    };
+    const th1 = limFor(r1 === q.unified5h ? 'unified5h' : 'tokens');
+    const th2 = limFor(r2 === q.unified7d ? 'unified7d' : 'requests');
 
     let line = ` ${sel}${cur} ${startSlot}${name} ${type} ${status} ${l1} ${bar(r1, bw, t1, w1, th1)}`;
     if (showBoth) {
@@ -1448,18 +1459,18 @@ export class TUI {
       // Sonnet weekly bar — only shown when the usage probe has populated it. A
       // leading ► (in place of a padding space) marks a Sonnet route on this account.
       if (showFamily && q.unified7dSonnet != null) {
-        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, thFor('unified7dSonnet'))}`;
+        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, limFor('unified7dSonnet'))}`;
       }
       // Fable weekly bar — only shown when the usage probe has populated it.
       if (showFamily && q.unified7dFable != null) {
-        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, thFor('unified7dFable'))}`;
+        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, limFor('unified7dFable'))}`;
       }
     }
     // Explicit "disabled for these models" tag (issue #85): a family whose own
     // weekly bucket is over the switch threshold can't serve that model even
     // while the account is otherwise active. A spent shared 5h blocks everything
     // and is already conveyed by the Ses bar + status, so it's not repeated here.
-    const blocked = blockedFamilies(q, key => this.am.thresholdFor(key));
+    const blocked = blockedFamilies(q, limFor);
     if (blocked.length) line += `  ${red('⊘ ' + blocked.join(' '))}`;
     return line;
   }

--- a/test/account-max-usage.test.js
+++ b/test/account-max-usage.test.js
@@ -1,0 +1,224 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+const OPUS = 'claude-opus-5';
+const FABLE = 'claude-fable-5-1';
+
+// The case the feature exists for: one account in a fleet is allowed to spend
+// only part of its quota, and must receive nothing past that point.
+function fleet(maxUsage) {
+  const am = new AccountManager([oauth('a'), oauth('capped', { maxUsage })], 0.98);
+  return am;
+}
+
+function setQuota(account, q) {
+  Object.assign(account.quota, q);
+}
+
+// ── capFor ───────────────────────────────────────────────────
+
+test('a bare number caps every bucket, a map caps the listed ones', () => {
+  const am = fleet(0.6);
+  const capped = am.accounts[1];
+  for (const b of ['unified5h', 'unified7d', 'unified7dFable', 'tokens']) {
+    assert.equal(am.capFor(b, capped), 0.6, b);
+  }
+
+  const am2 = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const c2 = am2.accounts[1];
+  assert.equal(am2.capFor('unified7d', c2), 0.6);
+  assert.equal(am2.capFor('unified7dFable', c2), 0.8);
+  // Not listed and no `default`: uncapped. A cap is only ever what was asked for.
+  assert.equal(am2.capFor('unified5h', c2), null);
+  // An account with no maxUsage at all is uncapped everywhere.
+  assert.equal(am2.capFor('unified7d', am2.accounts[0]), null);
+});
+
+test('`default` covers the buckets a map does not list', () => {
+  const am = fleet({ default: 0.5, unified7dFable: 0.8 });
+  const c = am.accounts[1];
+  assert.equal(am.capFor('unified5h', c), 0.5);
+  assert.equal(am.capFor('unified7dFable', c), 0.8);
+});
+
+// ── capExceeded: model scoping ───────────────────────────────
+
+test('a family cap stops that family and leaves the others alone', () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified5h: 0.1, unified7d: 0.2, unified7dFable: 0.8 });
+
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7dFable');
+  assert.equal(am.capExceeded(capped, OPUS), null);      // Opus is metered elsewhere
+  assert.equal(am.capExceeded(capped, null), null);
+});
+
+test('the session and weekly caps stop every model', () => {
+  const am = fleet({ unified5h: 0.6, unified7d: 0.6 });
+  const capped = am.accounts[1];
+
+  setQuota(capped, { unified5h: 0.6, unified7d: 0.1 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified5h');
+  assert.equal(am.capExceeded(capped, FABLE), 'unified5h');
+
+  setQuota(capped, { unified5h: 0.1, unified7d: 0.61 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+  // Family spend meters into the shared weekly too (#175), so a shared cap that
+  // Fable could walk past would not be a cap. This is where a cap parts company
+  // with switchThreshold, which gates on the governing bucket alone.
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+});
+
+test('the shared and family caps both apply to a family request', () => {
+  const am = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+
+  // Under both: serving.
+  setQuota(capped, { unified7d: 0.5, unified7dFable: 0.7 });
+  assert.equal(am.capExceeded(capped, FABLE), null);
+
+  // Family bucket alone is over: Fable stops, Opus keeps going.
+  setQuota(capped, { unified7d: 0.5, unified7dFable: 0.8 });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7dFable');
+  assert.equal(am.capExceeded(capped, OPUS), null);
+
+  // Shared bucket alone is over: everything stops, Fable included.
+  setQuota(capped, { unified7d: 0.6, unified7dFable: 0.1 });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+});
+
+// An unreported family bucket used to fall back to the shared VALUE while being
+// compared against the FAMILY cap — 60% of the shared weekly read as under an
+// 80% Fable cap, and the request went through.
+test('an unreported family bucket does not escape the shared cap', () => {
+  const am = fleet({ unified7d: 0.6, unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.6, unified7dFable: null });
+  assert.equal(am.capExceeded(capped, FABLE), 'unified7d');
+});
+
+// The cap is a ceiling, not a target: at exactly the configured level the
+// account is done, matching how switchThreshold reads (>=).
+test('the cap binds at the configured level, not past it', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.59 });
+  assert.equal(am.capExceeded(capped, OPUS), null);
+  setQuota(capped, { unified7d: 0.6 });
+  assert.equal(am.capExceeded(capped, OPUS), 'unified7d');
+});
+
+test('a window that has already reset is not capped on a stale reading', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.9, unified7dReset: Date.now() - 1000 });
+  assert.equal(am.capExceeded(capped, OPUS), null);
+  assert.equal(capped.quota.unified7d, null);
+});
+
+// ── selection: zero requests past the cap ────────────────────
+
+test('a capped account is not selected and says why', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7d: 0.7 });
+  am.currentIndex = 1;
+
+  assert.equal(am.unavailableReason(capped, OPUS), 'capped');
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'a');
+});
+
+// The whole point of the setting. switchThreshold is a preference the
+// exhausted-fleet probe deliberately overrides; a budget is not.
+test('the exhausted-fleet probe does not override a cap', () => {
+  const am = fleet({ unified7d: 0.6 });
+  const [normal, capped] = am.accounts;
+  setQuota(normal, { unified7d: 0.99 });      // over the switch threshold
+  setQuota(capped, { unified7d: 0.7 });       // over its own cap
+
+  // Every account is out: the normal one may still be probed, the capped one
+  // must not be. With the normal account excluded, nothing is left at all.
+  assert.equal(am.getActiveAccount(new Set([normal.index]), OPUS), null);
+});
+
+test('a capped account still serves the models its cap does not meter', () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7dFable: 0.9 });
+  am.currentIndex = 1;
+
+  assert.equal(am.getActiveAccount(null, FABLE).name, 'a');
+  // Selection stays on whichever account it just moved to, so put it back
+  // before asking the other question (as the Fable-exhaustion test does).
+  am.currentIndex = 1;
+  assert.equal(am.getActiveAccount(null, OPUS).name, 'capped');
+});
+
+test("an advisor model's cap is checked too", () => {
+  const am = fleet({ unified7dFable: 0.8 });
+  const capped = am.accounts[1];
+  setQuota(capped, { unified7dFable: 0.85 });
+  // Executing Opus while advising with Fable still touches the capped bucket.
+  assert.equal(am.unavailableReason(capped, OPUS, FABLE), 'advisor-capped');
+});
+
+test('an uncapped fleet behaves exactly as before', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  setQuota(am.accounts[0], { unified7d: 0.7, unified7dFable: 0.9 });
+  assert.equal(am.capExceeded(am.accounts[0], FABLE), null);
+  assert.equal(am.unavailableReason(am.accounts[0], FABLE), null);
+});
+
+test('the cap is visible in status output', () => {
+  const am = fleet({ unified7d: 0.6 });
+  setQuota(am.accounts[1], { unified7d: 0.7 });
+  const status = am.getStatus();
+  assert.deepEqual(status.accounts[1].maxUsage, { unified7d: 0.6 });
+  assert.equal(status.accounts[1].unavailable, 'capped');
+  assert.equal(status.accounts[0].maxUsage, null);
+});
+
+// ── the pinned path ──────────────────────────────────────────
+
+// A pinned request never enters the selection walk, so the cap has to be
+// enforced where the pin is resolved. Without this, `TC_ACCT` (or a
+// /tc-acct/<name> URL) would spend straight past a budget.
+test('a pinned request to a capped account reaches no upstream at all', async () => {
+  const http = await import('node:http');
+  const { createProxyServer } = await import('../src/server.js');
+  const seen = [];
+  const upstream = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise(r => upstream.listen(0, '127.0.0.1', r));
+
+  const am = new AccountManager([oauth('alpha'), oauth('beta', { maxUsage: { unified7d: 0.6 } })], 0.98);
+  setQuota(am.accounts[1], { unified7d: 0.7 });
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k' },
+    upstream: `http://127.0.0.1:${upstream.address().port}`,
+  });
+  await new Promise(r => proxy.listen(0, '127.0.0.1', r));
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${proxy.address().port}/tc-acct/beta/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+    });
+    await res.text();
+    assert.equal(res.status, 429);      // the exhausted answer, as for a spent pin
+    assert.deepEqual(seen, []);         // and nothing was sent, to beta or anyone else
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -279,6 +279,24 @@ test('prober probes oauth accounts and applies the usage data', async () => {
   assert.equal(am.accounts[0].quota.unified7d, 0.2);
 });
 
+// A third-party backend account is typed `oauth` with a static token (the
+// documented DeepSeek/GLM pattern), so a type check alone sends THAT provider's
+// key to api.anthropic.com every cycle — which answers 429, leaving a permanent
+// probe error on an account that is serving traffic normally.
+test('prober never sends a third-party key to the Anthropic usage endpoint', async () => {
+  const am = new AccountManager([
+    oauth('claude'),
+    { ...oauth('deepseek'), upstream: 'https://api.deepseek.com/anthropic' },
+  ], 0.98);
+  const probed = [];
+  const probeFn = async (token) => { probed.push(token); return { fiveHour: { utilization: 0.1, resetAt: 1 } }; };
+  await new Prober(am, { intervalMs: 0, probeFn, log: () => {} }).probeAll();
+
+  assert.deepEqual(probed, ['t-claude']);
+  // …and the backend's own quota is left untouched rather than recorded as an error.
+  assert.equal(am.accounts[1].quota.unified5h, null);
+});
+
 test('prober skips API-key accounts', async () => {
   const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
   let calls = 0;

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -297,6 +297,16 @@ test('prober never sends a third-party key to the Anthropic usage endpoint', asy
   assert.equal(am.accounts[1].quota.unified5h, null);
 });
 
+test('a third-party backend reads not-applicable, not a pending probe', () => {
+  const am = new AccountManager([
+    oauth('claude'),
+    { ...oauth('deepseek'), upstream: 'https://api.deepseek.com/anthropic' },
+  ], 0.98);
+  const rows = new Prober(am, { intervalMs: 300_000, log: () => {} }).getStatus().accounts;
+  assert.equal(rows[0].status, 'never');            // probed, just not yet
+  assert.equal(rows[1].status, 'not-applicable');   // nothing to probe, ever
+});
+
 test('prober skips API-key accounts', async () => {
   const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
   let calls = 0;

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -221,3 +221,61 @@ test('renderStatus still lists accounts for a route the blocklist does not cover
   const output = renderStatus(status, { color: false, now });
   assert.match(output, /\*sonnet\*\s+→ a \(auto\)/);
 });
+
+// ── per-account usage caps (accounts[].maxUsage) ──────────────
+
+function cappedStatus(quota, maxUsage) {
+  return {
+    currentAccount: 'a',
+    switchThreshold: 0.98,
+    accounts: [{
+      name: 'a', type: 'oauth', priority: 0, status: 'active',
+      quota, maxUsage, usage: {},
+    }],
+  };
+}
+
+test('renderStatus marks the cap on the bar and names it', () => {
+  const out = renderStatus(cappedStatus({ unified5h: 0.1, unified7d: 0.1 },
+    { unified5h: 0.6, unified7d: 0.6 }), { color: false, now });
+  // The mark sits where the bar may not pass, and the number says which percent
+  // it is — one cell is ~6%, so the mark alone cannot tell 60% from 61%.
+  assert.match(out, /Session\s+\[██░░░░░░░░░┃░░░░░░\] 10% cap 60%/);
+});
+
+test('a capped bar is the same width as an uncapped one', () => {
+  const capped = renderStatus(cappedStatus({ unified7d: 0.1 }, { unified7d: 0.6 }), { color: false, now });
+  const plain = renderStatus(cappedStatus({ unified7d: 0.1 }, null), { color: false, now });
+  const width = out => out.match(/Weekly\s+\[([^\]]*)\]/)[1].length;
+  assert.equal(width(capped), width(plain));   // rows still line up
+  assert.doesNotMatch(plain, /cap /);          // and nothing is drawn without a cap
+});
+
+test('an uncapped bucket on a capped account is left alone', () => {
+  const out = renderStatus(cappedStatus({ unified5h: 0.1, unified7d: 0.1 },
+    { unified7d: 0.6 }), { color: false, now });
+  assert.match(out, /Session\s+\[██░░░░░░░░░░░░░░░░\] 10%$/m);
+  assert.match(out, /Weekly\s+.*cap 60%/);
+});
+
+test('a family over its cap reads ✗ while the others keep serving', () => {
+  const out = renderStatus(cappedStatus(
+    { unified5h: 0.1, unified7d: 0.1, unified7dFable: 0.85 },
+    { unified7d: 0.6, unified7dFable: 0.8 }), { color: false, now });
+  assert.match(out, /Models\s+Opus ✓\s+Fable ✗/);
+});
+
+// The shared weekly bucket meters family spend too, so a cap on it stops every
+// family — the Models line must not advertise one as available.
+test('a shared weekly cap marks every family unavailable', () => {
+  const out = renderStatus(cappedStatus(
+    { unified5h: 0.1, unified7d: 0.62, unified7dFable: 0.1 },
+    { unified7d: 0.6, unified7dFable: 0.8 }), { color: false, now });
+  assert.match(out, /Models\s+Opus ✗\s+Fable ✗/);
+});
+
+test('the blocked line names the cap as the reason', () => {
+  const status = cappedStatus({ unified7d: 0.7 }, { unified7d: 0.6 });
+  status.accounts[0].unavailable = 'capped';
+  assert.match(renderStatus(status, { color: false, now }), /Blocked\s+account usage cap reached \(maxUsage\)/);
+});


### PR DESCRIPTION
`Prober.probeAll` selected accounts with `account.type === 'oauth'`, and `fetchUsage` posts to a fixed `https://api.anthropic.com/api/oauth/usage`.

A third-party backend account is typed `oauth` with a static token — that is the documented pattern in [accounts.md](docs/accounts.md#third-party-backend-accounts), which is how DeepSeek and GLM are meant to be added. So with the probe enabled, every cycle sent **that provider's API key to api.anthropic.com**.

Observed on a fleet with a DeepSeek backend and one other Anthropic-compatible provider, both added exactly as documented:

```
deepseek (oauth, prio 200) active
  Probe    error 2m ago, 55ms, HTTP 429: Rate limited. Please try again later.
```

Reproduced directly: a third-party key against `/api/oauth/usage` returns `HTTP 429`.

Two costs:

- **The key leaves the machine for a party it was never issued to**, on a timer, for as long as the probe is on.
- The 429 is recorded as a permanent probe error against an account that is serving traffic perfectly well — so the one row an operator reads to judge a backend's health says it is broken when it is not. Routing is unaffected; only the readout and the outbound request are wrong.

## The fix

Probing now requires the account to carry no `upstream`. That is the same line `warmer.js` already draws in `_isWarmTarget`: an account with its own base URL has no Anthropic subscription usage to read. The rule moves into a named `_isProbeTarget` so the reason is stated once.

`index.js` built its pre-probe status view with the looser test (`type === 'oauth'`) while the warm view beside it already excluded `upstream`. It now matches, so a backend reads `not-applicable` instead of pending a probe that will never come.

One regression test: a fleet of one Claude account and one `upstream` account, asserting only the Claude token is ever handed to the probe function, and that the backend's quota is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
