### PR TITLE
Fix proxy scheduling and harden request lifecycle under overload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,15 @@ and do not restart the live service just to experiment without authorization.
 - Do not immediately destroy an h1 request with unread upload bytes after
   writing a rejection: the reset can hide the 413/503 from its caller. Teardown
   must be bounded, while h2 rejection must close only the affected stream.
+
+### Privacy before publishing or merging
+
+- Audit the final diff, every new commit's content, and the PR description for
+  personal data and secrets before publishing or marking a PR ready. Removing
+  data only from the final tree does not remove it from earlier commits.
+- Keep real account emails/IDs, credentials, session identifiers, private local
+  paths, request payloads and raw operational logs out of source, fixtures and
+  PR text. Use clearly synthetic accounts and sanitized aggregate measurements.
+- If sensitive data was already published, stop and report it without repeating
+  the value. Coordinate credential revocation and history cleanup as appropriate;
+  do not silently force-push or rewrite contributor attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Agent guidance
+
+## Proxy reliability: preserve these findings
+
+TeamClaude is operational infrastructure. Diagnose with live evidence before
+changing scheduling, routing, timeouts, or concurrency. Preserve unrelated work
+and do not restart the live service just to experiment without authorization.
+
+### macOS service scheduling
+
+- Keep the user-facing HTTP LaunchAgent's `ProcessType` set to `Interactive`
+  in `src/service.js`. Do not change it to `Background` as a daemon convention.
+  Background scheduling was demonstrated to starve this proxy under host
+  resource pressure, causing local status timeouts and large event-loop lag.
+- `Adaptive` launchd scheduling relies on XPC activity for promotion; ordinary
+  HTTP clients do not provide that signal. This is unrelated to TeamClaude's
+  adaptive account-routing mode.
+- Preserve the service-rendering regression assertion in `test/service.test.js`.
+  A source change alone does not update an installed LaunchAgent: deployment
+  must regenerate its plist and reload the service, then verify the effective
+  policy with `launchctl print gui/$(id -u)/com.karpeleslab.teamclaude`.
+
+### Probe the correct layer
+
+- Use `teamclaude status` or `GET /teamclaude/status` for local proxy status.
+  **Do not use `/status`: it is forwarded upstream, not a local health check.**
+  Respect configured authentication; never expose credentials in diagnostics.
+- Separate connection refusal, local status timeout/event-loop lag, and upstream
+  first-byte latency. They are different failure modes, not interchangeable
+  evidence of an Anthropic outage.
+- Upstream 429s and quota retry holds can delay API responses while local status
+  remains healthy. An account's `active` credential state does not necessarily
+  mean it is eligible for routing below the configured quota threshold.
+- Before attributing a stall to JavaScript hot loops, inspect process CPU time
+  alongside wall time, host memory pressure, effective service scheduling,
+  event-loop metrics, and time-correlated logs. A sampled busy stack alone does
+  not prove that the process is receiving enough CPU time.
+
+### Verification and change discipline
+
+- Capture evidence before a restart when possible. Restarts destroy the stalled
+  state and transient recovery is not proof of a fix.
+- Verify under concurrent traffic with repeated bounded status probes; report
+  sample count, observation duration, latency distribution, failures, and
+  event-loop stalls. Check API first-byte/streaming behavior separately.
+- The scheduling fix passed a 60-probe live window with zero failures and zero
+  event-loop stalls, but that is historical evidence, not an indefinite health
+  guarantee. Do not claim all streaming failures are fixed from status alone.
+- Do not treat longer timeouts, more memory, a runtime switch, or smaller socket
+  pools as proven fixes without a controlled comparison. Socket limits can add
+  queue latency to long-lived streams.
+- The experimental ingress gate is disabled by default and explicitly enabled
+  only by a positive `TEAMCLAUDE_INGRESS_CONCURRENCY`. Do not enable it by default
+  until cancellation, queue-wait deadlines, body size/time bounds, permit
+  cleanup, and overload/recovery behavior are covered by tests.
+- For code changes, run targeted regression tests, `npm test`, `npm run lint`,
+  and `git diff --check`. Distinguish tested source, committed/pushed code, and
+  the version/configuration actually running in the installed service.
+
+### Follow-up hardening
+
+- Read `docs/reliability.md` for limit scope, defaults, diagnostics and rollout.
+- Acquire bounded, cancellable upstream admission before constructing a Node
+  ClientRequest. Destroying a request already waiting in the Agent queue can
+  defer its error until socket assignment; a headers timer alone is insufficient.
+- Keep upstream slots for the response-body lifetime; separate the queue wait
+  deadline from the headers deadline. Never retry local saturation on another
+  account. Disconnects must cancel queued work, silent reads and quota timers.
+- Do not locate request metadata using an unscoped substring search. Nested
+  metadata and differently escaped duplicate strings can fool a unique-match
+  check. Preserve the regression cases in `test/account-uuid-rewrite.test.js`.
+- Do not immediately destroy an h1 request with unread upload bytes after
+  writing a rejection: the reset can hide the 413/503 from its caller. Teardown
+  must be bounded, while h2 rejection must close only the affected stream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code guidance
+
+Read and follow [AGENTS.md](AGENTS.md) before working on this repository. It is
+the canonical shared agent guidance, including the macOS scheduling incident,
+the correct local status endpoint, and reliability verification requirements.
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Step-by-step lifecycle: [docs/routing.md](docs/routing.md#request-lifecycle).
 | [Routing](docs/routing.md) | Rotation, the two kinds of 429, storm control, model routes, session spreading, pinning, prompt cache |
 | [Quota](docs/quota.md) | Quota probe, keep-warm, holding on exhaustion |
 | [Configuration](docs/configuration.md) | Config format, every field, environment variables, network tuning |
+| [Reliability](docs/reliability.md) | Status diagnostics, resource limits, overload handling, regression and rollout checks |
 | [Proxy modes](docs/proxy-modes.md) | MITM forward proxy, sx.org residential egress |
 | [Compliance](docs/compliance.md) | Terms of service notes |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,12 @@ The defaults are meant to be left alone; these exist for the rare case where the
 | --- | --- | --- |
 | `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS` | `120000` | Max wait for upstream **response headers** (time-to-first-byte). Cleared the instant headers arrive, so a long streaming body is never cut. Streamed completions deliver first byte in seconds; a non-streaming (`stream:false`) request that legitimately generates for longer than this could trip it — raise it for such callers |
 | `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS` | `120000` | Max **idle** gap between response-body chunks. Resets on every chunk, so a slow-but-healthy stream is fine; it fires only when the socket goes silent mid-stream (a drop after headers), turning a hang into a fast, retryable failure |
-| `TEAMCLAUDE_UPSTREAM_MAX_SOCKETS` | `256` | Max concurrent upstream connections **per origin** in the pooled path. Requests beyond this queue (raise it if you run more concurrent sessions than this against one host) |
+| `TEAMCLAUDE_UPSTREAM_MAX_SOCKETS` | `256` | Max concurrent upstream connections **per origin** in the pooled path. Long streams retain slots; additional requests enter bounded admission with a separate wait deadline |
 | `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH` | _(off)_ | Set to `1` to route upstream requests through Node's global `fetch` (single HTTP/2 connection) instead of the pooled H1 transport — an escape hatch, not recommended under concurrency |
 | `TEAMCLAUDE_REFRESH_TIMEOUT_MS` | `30000` | Max wait for an OAuth token refresh. A hung refresh is coalesced across all callers, so it would otherwise wedge every request for that account |
 | `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS` | `60` | Longest `retry-after` absorbed inline on the same account before a rate-limit 429 is surfaced to the client — see [the two kinds of 429](routing.md#the-two-kinds-of-429) |
+
+See [Reliability limits](reliability.md#limits) for the upstream queue limit and
+deadline, opt-in ingestion admission, upload and buffered-response limits, and
+the scope of each safeguard. Local queue overflow/expiry returns `503` with
+`Retry-After: 1`; it is not an account failure or a reason to rotate credentials.

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -1,0 +1,89 @@
+# Proxy reliability and incident checks
+
+## Check the correct layer
+
+Use `teamclaude status --json` or authenticated `GET /teamclaude/status`.
+`/status` is an upstream request, not a health endpoint. A quick local status
+response does not establish upstream API health. Separate connection refusal,
+event-loop stalls, upstream headers waits, body stalls, and quota retry holds.
+
+On macOS, keep the LaunchAgent `ProcessType` set to `Interactive`. Verify the
+effective policy with `launchctl print gui/$(id -u)/com.karpeleslab.teamclaude`.
+Changing source does not update an installed plist. Use `teamclaude service
+install` during an approved restart window and verify the running service.
+
+Before restarting a stalled service, capture status timings, process CPU time
+and uptime, host memory pressure, effective launchd policy, and the service log
+(`~/Library/Logs/teamclaude.log`). Avoid recording request bodies or credentials.
+The event-loop watchdog can report a stall only after the event loop resumes;
+external status checks remain necessary to detect a continuously wedged process.
+
+## Limits
+
+All values below are environment variables read by the service process. Exporting
+them in a separate shell does not reconfigure an already-running LaunchAgent.
+Changing limits requires an intentional restart and verification. Invalid values
+fall back to defaults; use positive integers, except queue length may be zero.
+
+| Variable | Default | Scope |
+| --- | --- | --- |
+| `TEAMCLAUDE_INGRESS_CONCURRENCY` | off | Opt-in shared HTTP/MITM request-body ingestion slots. A positive value enables admission. |
+| `TEAMCLAUDE_INGRESS_QUEUE` | 64 | Maximum waiting ingestion requests; zero rejects instead of queuing. |
+| `TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS` | 5000 | Absolute maximum ingestion-queue wait. |
+| `TEAMCLAUDE_REQUEST_BODY_MAX_BYTES` | 33554432 | Maximum buffered request body, also when ingestion admission is off. |
+| `TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS` | 120000 | Absolute upload deadline after admission; trickled bytes do not renew it. |
+| `TEAMCLAUDE_UPSTREAM_MAX_SOCKETS` | 256 | Per-origin upstream concurrency. Long-lived response bodies retain their slots. |
+| `TEAMCLAUDE_UPSTREAM_MAX_QUEUE` | 64 | Maximum waiting upstream requests per origin; zero rejects instead of queuing. |
+| `TEAMCLAUDE_UPSTREAM_QUEUE_TIMEOUT_MS` | 5000 | Upstream admission deadline, separate from the headers deadline. |
+| `TEAMCLAUDE_UPSTREAM_HEADERS_TIMEOUT_MS` | 120000 | Deadline after upstream admission until response headers. |
+| `TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS` | 120000 | Inactivity deadline for SSE reads and buffered response reads. |
+| `TEAMCLAUDE_RESPONSE_BODY_MAX_BYTES` | 33554432 | Maximum buffered non-streaming response. |
+
+Queue overflow/expiry returns 503 with `Retry-After: 1`; oversized request bodies
+return 413; upload expiry returns 408. These local failures do not establish bad
+account credentials. Local upstream saturation must not cause account rotation.
+An incomplete response is terminated, not reported as a successful complete body.
+
+`status --json` includes `ingress` occupancy (or `enabled: false`), `upstreamPool`
+aggregate occupancy, and `server.eventLoop` when the headless service installs
+its watchdog. Upstream queue slots are acquired before creating Node requests;
+cancelled/expired waiters are removed instead of waiting in Node's agent queue.
+Disconnects also cancel upstream work and quota-hold timers.
+
+The upstream cap covers the Node HTTP transport, including tunneled requests.
+The legacy `TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH` escape hatch bypasses that cap.
+OAuth/Remote Control, attachments, forward-proxy traffic and WebSockets have
+separate relay paths; the buffered ingestion limits are not universal limits
+for every endpoint. The ingestion gate does not cap total retained retry bodies
+or total concurrent sessions. These are not a global process-memory guarantee.
+
+## Regression and rollout checks
+
+Run `npm test` and `npm run lint`. Targeted reliability tests:
+
+```sh
+node --test test/admission-gate.test.js test/ingress-safety.test.js \
+  test/upstream-pool.test.js test/upstream-timeout.test.js \
+  test/account-uuid-rewrite.test.js
+```
+
+Coverage includes FIFO/overflow, queue expiry/cancellation, slow and oversized
+uploads, exactly-once activity cleanup, HTTP/2 stream isolation, repeated 1 MiB
+bursts with concurrent status calls, cancellation before headers/during silent
+streams/during quota holds, bounded buffered responses, and metadata rewrite
+scope. The long-stream regression verifies twelve streams can start without
+waiting for another to end; eight sockets is not a suitable default for that
+workload. Existing fairness yields remain, but their optimal batch size is not
+established by these tests.
+
+Before deploying: record the current executable, commit, service configuration
+and rollback target; run an isolated load test, then schedule an approved service
+restart. Verify correct status, effective scheduling, queue recovery and actual
+API first-byte/streaming behavior with representative concurrent sessions. Keep
+the ingestion gate opt-in pending sustained production-like testing. Do not
+infer permanent health from a restart, passing unit tests, or a short live check.
+
+Remaining validation: a longer representative soak, peak/steady-state memory
+measurements, mixed-account fairness under quota pressure, and operational alert
+thresholds. A generic circuit breaker must not classify local overload or an
+account-specific quota failure as a fleet-wide outage.

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -22,8 +22,8 @@ external status checks remain necessary to detect a continuously wedged process.
 
 All values below are environment variables read by the service process. Exporting
 them in a separate shell does not reconfigure an already-running LaunchAgent.
-Changing limits requires an intentional restart and verification. Invalid values
-fall back to defaults; use positive integers, except queue length may be zero.
+Changing limits requires an intentional restart and verification. Use positive
+integers for these settings, except queue length may be zero.
 
 | Variable | Default | Scope |
 | --- | --- | --- |
@@ -83,7 +83,18 @@ API first-byte/streaming behavior with representative concurrent sessions. Keep
 the ingestion gate opt-in pending sustained production-like testing. Do not
 infer permanent health from a restart, passing unit tests, or a short live check.
 
-Remaining validation: a longer representative soak, peak/steady-state memory
-measurements, mixed-account fairness under quota pressure, and operational alert
-thresholds. A generic circuit breaker must not classify local overload or an
-account-specific quota failure as a fleet-wide outage.
+The pre-merge isolated soak ran for 60 seconds with 12 concurrent clients,
+one-MiB requests and three pinned synthetic accounts. One account began returning
+429s after 20 seconds. All 1,608 activity entries closed, both unaffected accounts
+completed 536 requests, and all 585 status probes succeeded (p95 5.92 ms); the
+event-loop monitor recorded zero stalls. The throttled account returned four
+429s and had 204 requests cancelled during its existing per-account pause.
+Post-GC heap was approximately 11–12 MiB; sampled RSS peaked near 311 MiB for the
+combined proxy, fake upstream and load generator. This is a short synthetic
+memory sample, not a process-memory limit or proof against long-term leaks.
+
+For broader rollout, continue multi-hour real-workload observation and establish
+operational alert thresholds. Pinned synthetic-account progress does not validate
+adaptive routing fairness, which belongs to the separate adaptive-routing work.
+A generic circuit breaker must not classify local overload or an account-specific
+quota failure as a fleet-wide outage.

--- a/src/account-uuid-rewrite.js
+++ b/src/account-uuid-rewrite.js
@@ -14,6 +14,19 @@
 // Byte sequence of `account_uuid":"` as it appears INSIDE the (escaped) user_id
 // string: account_uuid \ " : \ "
 const PREFIX = Buffer.from('account_uuid\\":\\"', 'latin1');
+const CANONICAL_METADATA_USER_ID = Buffer.from('"metadata":{"user_id":"', 'latin1');
+let lastSlowFallbackWarning = 0;
+
+function hasOuterStringEndBefore(buf, start, limit) {
+  let at = start;
+  while ((at = buf.indexOf(0x22, at)) >= 0 && at < limit) {
+    let slashes = 0;
+    for (let i = at - 1; i >= start && buf[i] === 0x5c; i--) slashes++;
+    if (slashes % 2 === 0) return true;
+    at++;
+  }
+  return false;
+}
 
 export class AccountUuidPatcher {
   constructor(newUuid) {
@@ -109,7 +122,69 @@ export class AccountUuidPatcher {
 
 /** One-shot convenience (whole-buffer); returns the same instance if unchanged. */
 export function patchAccountUuid(buf, newUuid) {
+  if (typeof newUuid !== 'string' || newUuid.length !== 36) return buf;
+  // Most proxied request bodies do not carry this optional metadata at all.
+  // A native scan can prove the rewrite is a no-op without walking every JSON
+  // key in JavaScript.
+  if (!buf.includes(PREFIX)) return buf;
+  let fallbackReason = 'noncanonical-metadata';
+  // Claude Code emits compact JSON with this structural key sequence. Quotes
+  // inside prompt strings are escaped, so the unescaped sequence cannot be a
+  // user-content false positive. Native Buffer searches skip the potentially
+  // multi-megabyte messages array without executing JavaScript once per byte.
+  const metadataAt = buf.indexOf(CANONICAL_METADATA_USER_ID);
+  if (metadataAt >= 0 && buf.indexOf(CANONICAL_METADATA_USER_ID, metadataAt + 1) < 0) {
+    const valueStart = metadataAt + CANONICAL_METADATA_USER_ID.length;
+    const prefixAt = buf.indexOf(PREFIX, valueStart);
+    if (prefixAt >= valueStart && !hasOuterStringEndBefore(buf, valueStart, prefixAt)) {
+      const uuidAt = prefixAt + PREFIX.length;
+      const oldUuid = buf.toString('latin1', uuidAt, uuidAt + 36);
+      if (oldUuid.length === 36) {
+        if (oldUuid === newUuid) return buf;
+        const out = Buffer.from(buf);
+        out.write(newUuid, uuidAt, 36, 'latin1');
+        return out;
+      }
+    }
+  }
+  // Whole request bodies are already buffered by the retry layer. Let V8's
+  // native JSON parser validate the exact metadata value, then locate that
+  // serialized string with native Buffer searches. This avoids calling the JS
+  // byte-state-machine once per byte/key across multi-megabyte conversations.
+  // If the value is encoded unusually or appears more than once, retain the
+  // structural streaming patcher as the conservative compatibility fallback.
+  try {
+    const outer = JSON.parse(Buffer.from(buf).toString('utf8'));
+    const userId = outer?.metadata?.user_id;
+    if (typeof userId === 'string') {
+      fallbackReason = 'ambiguous-serialization';
+      const serialized = Buffer.from(JSON.stringify(userId), 'utf8');
+      const valueAt = buf.indexOf(serialized);
+      const uniqueValue = valueAt >= 0 && buf.indexOf(serialized, valueAt + 1) < 0;
+      const prefixAt = serialized.indexOf(PREFIX);
+      const uniquePrefix = prefixAt >= 0 && serialized.indexOf(PREFIX, prefixAt + 1) < 0;
+      const uuidAt = prefixAt + PREFIX.length;
+      const oldUuid = serialized.toString('latin1', uuidAt, uuidAt + 36);
+      if (valueAt < 0) fallbackReason = 'serialized-value-not-found';
+      else if (!uniqueValue) fallbackReason = 'serialized-value-duplicate';
+      else if (prefixAt < 0) fallbackReason = 'uuid-prefix-not-found';
+      else if (!uniquePrefix) fallbackReason = 'uuid-prefix-duplicate';
+      else if (oldUuid.length !== 36) fallbackReason = 'account-id-not-36-bytes';
+      if (uniqueValue && uniquePrefix && oldUuid.length === 36) {
+        if (oldUuid === newUuid) return buf;
+        const out = Buffer.from(buf);
+        out.write(newUuid, valueAt + uuidAt, 36, 'latin1');
+        return out;
+      }
+    }
+  } catch { /* malformed/unusual JSON: preserve the exact structural fallback */ }
+  const fallbackStarted = Date.now();
   const p = new AccountUuidPatcher(newUuid);
   const out = p.push(buf);
+  const fallbackMs = Date.now() - fallbackStarted;
+  if (fallbackMs >= 100 && Date.now() - lastSlowFallbackWarning >= 60_000) {
+    lastSlowFallbackWarning = Date.now();
+    console.error(`[TeamClaude] Slow account UUID rewrite fallback: ${fallbackMs}ms, ${buf.length} bytes, reason=${fallbackReason}`);
+  }
   return p.changed ? out : buf;
 }

--- a/src/account-uuid-rewrite.js
+++ b/src/account-uuid-rewrite.js
@@ -14,19 +14,6 @@
 // Byte sequence of `account_uuid":"` as it appears INSIDE the (escaped) user_id
 // string: account_uuid \ " : \ "
 const PREFIX = Buffer.from('account_uuid\\":\\"', 'latin1');
-const CANONICAL_METADATA_USER_ID = Buffer.from('"metadata":{"user_id":"', 'latin1');
-let lastSlowFallbackWarning = 0;
-
-function hasOuterStringEndBefore(buf, start, limit) {
-  let at = start;
-  while ((at = buf.indexOf(0x22, at)) >= 0 && at < limit) {
-    let slashes = 0;
-    for (let i = at - 1; i >= start && buf[i] === 0x5c; i--) slashes++;
-    if (slashes % 2 === 0) return true;
-    at++;
-  }
-  return false;
-}
 
 export class AccountUuidPatcher {
   constructor(newUuid) {
@@ -122,69 +109,45 @@ export class AccountUuidPatcher {
 
 /** One-shot convenience (whole-buffer); returns the same instance if unchanged. */
 export function patchAccountUuid(buf, newUuid) {
-  if (typeof newUuid !== 'string' || newUuid.length !== 36) return buf;
-  // Most proxied request bodies do not carry this optional metadata at all.
-  // A native scan can prove the rewrite is a no-op without walking every JSON
-  // key in JavaScript.
-  if (!buf.includes(PREFIX)) return buf;
-  let fallbackReason = 'noncanonical-metadata';
-  // Claude Code emits compact JSON with this structural key sequence. Quotes
-  // inside prompt strings are escaped, so the unescaped sequence cannot be a
-  // user-content false positive. Native Buffer searches skip the potentially
-  // multi-megabyte messages array without executing JavaScript once per byte.
-  const metadataAt = buf.indexOf(CANONICAL_METADATA_USER_ID);
-  if (metadataAt >= 0 && buf.indexOf(CANONICAL_METADATA_USER_ID, metadataAt + 1) < 0) {
-    const valueStart = metadataAt + CANONICAL_METADATA_USER_ID.length;
-    const prefixAt = buf.indexOf(PREFIX, valueStart);
-    if (prefixAt >= valueStart && !hasOuterStringEndBefore(buf, valueStart, prefixAt)) {
-      const uuidAt = prefixAt + PREFIX.length;
-      const oldUuid = buf.toString('latin1', uuidAt, uuidAt + 36);
-      if (oldUuid.length === 36) {
-        if (oldUuid === newUuid) return buf;
-        const out = Buffer.from(buf);
-        out.write(newUuid, uuidAt, 36, 'latin1');
-        return out;
-      }
-    }
-  }
-  // Whole request bodies are already buffered by the retry layer. Let V8's
-  // native JSON parser validate the exact metadata value, then locate that
-  // serialized string with native Buffer searches. This avoids calling the JS
-  // byte-state-machine once per byte/key across multi-megabyte conversations.
-  // If the value is encoded unusually or appears more than once, retain the
-  // structural streaming patcher as the conservative compatibility fallback.
+  if (typeof newUuid !== 'string' || !/^[\w-]{36}$/.test(newUuid)) return buf;
+  // Validate the actual top-level value before searching bytes. A unique
+  // "metadata" substring can still belong to a nested tool, not the request.
   try {
-    const outer = JSON.parse(Buffer.from(buf).toString('utf8'));
+    const text = buf.toString('utf8');
+    const outer = JSON.parse(text);
     const userId = outer?.metadata?.user_id;
-    if (typeof userId === 'string') {
-      fallbackReason = 'ambiguous-serialization';
-      const serialized = Buffer.from(JSON.stringify(userId), 'utf8');
-      const valueAt = buf.indexOf(serialized);
-      const uniqueValue = valueAt >= 0 && buf.indexOf(serialized, valueAt + 1) < 0;
-      const prefixAt = serialized.indexOf(PREFIX);
-      const uniquePrefix = prefixAt >= 0 && serialized.indexOf(PREFIX, prefixAt + 1) < 0;
-      const uuidAt = prefixAt + PREFIX.length;
-      const oldUuid = serialized.toString('latin1', uuidAt, uuidAt + 36);
-      if (valueAt < 0) fallbackReason = 'serialized-value-not-found';
-      else if (!uniqueValue) fallbackReason = 'serialized-value-duplicate';
-      else if (prefixAt < 0) fallbackReason = 'uuid-prefix-not-found';
-      else if (!uniquePrefix) fallbackReason = 'uuid-prefix-duplicate';
-      else if (oldUuid.length !== 36) fallbackReason = 'account-id-not-36-bytes';
-      if (uniqueValue && uniquePrefix && oldUuid.length === 36) {
-        if (oldUuid === newUuid) return buf;
-        const out = Buffer.from(buf);
-        out.write(newUuid, valueAt + uuidAt, 36, 'latin1');
-        return out;
+    if (typeof userId !== 'string') return buf;
+    let replacement;
+    try {
+      const inner = JSON.parse(userId);
+      if (typeof inner?.account_uuid !== 'string' || !/^[\w-]{36}$/.test(inner.account_uuid)) return buf;
+      if (inner.account_uuid === newUuid) return buf;
+      inner.account_uuid = newUuid;
+      replacement = JSON.stringify(inner);
+    } catch {
+      // Older clients use an opaque user_id. Replace only a complete 36-byte
+      // marker; never consume its delimiters or the next field's bytes.
+      replacement = userId.replace(/(account_uuid":")([\w-]{36})(?="|;|$)/, `$1${newUuid}`);
+    }
+    if (replacement === userId) return buf;
+    // Locate the top-level property with a
+    // native JSON-token scan. Preserve every byte outside this string; do not
+    // reserialize the request (large numeric values and whitespace may matter).
+    const frames = [];
+    let span;
+    for (const match of text.matchAll(/"(?:\\.|[^"\\])*"|[{}\[\]:,]/g)) {
+      const token = match[0], top = frames.at(-1);
+      if (token === '{' || token === '[') {
+        frames.push({ object: token === '{', key: null, awaitingKey: token === '{', name: top?.key });
+      } else if (token === '}' || token === ']') frames.pop();
+      else if (token === ':') { if (top) top.awaitingKey = false; }
+      else if (token === ',') { if (top) top.awaitingKey = top.object; }
+      else if (top?.awaitingKey) top.key = JSON.parse(token);
+      else if (frames.length === 2 && top?.name === 'metadata' && top.key === 'user_id' && JSON.parse(token) === userId) {
+        span = [match.index, match.index + token.length];
       }
     }
-  } catch { /* malformed/unusual JSON: preserve the exact structural fallback */ }
-  const fallbackStarted = Date.now();
-  const p = new AccountUuidPatcher(newUuid);
-  const out = p.push(buf);
-  const fallbackMs = Date.now() - fallbackStarted;
-  if (fallbackMs >= 100 && Date.now() - lastSlowFallbackWarning >= 60_000) {
-    lastSlowFallbackWarning = Date.now();
-    console.error(`[TeamClaude] Slow account UUID rewrite fallback: ${fallbackMs}ms, ${buf.length} bytes, reason=${fallbackReason}`);
-  }
-  return p.changed ? out : buf;
+    if (span) return Buffer.from(text.slice(0, span[0]) + JSON.stringify(replacement) + text.slice(span[1]));
+  } catch { /* Invalid request JSON is never rewritten. */ }
+  return buf;
 }

--- a/src/admission-gate.js
+++ b/src/admission-gate.js
@@ -1,23 +1,96 @@
 export const DEFAULT_INGRESS_CONCURRENCY = 4;
 export const DEFAULT_INGRESS_QUEUE = 64;
+export const DEFAULT_QUEUE_TIMEOUT_MS = 5_000;
+
+export class IngressError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export function ingressOptions(env = process.env) {
+  return {
+    queueTimeoutMs: positiveInt(env.TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS, DEFAULT_QUEUE_TIMEOUT_MS),
+    bodyTimeoutMs: positiveInt(env.TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS, 120_000),
+    maxBodyBytes: positiveInt(env.TEAMCLAUDE_REQUEST_BODY_MAX_BYTES, 32 * 1024 * 1024),
+  };
+}
+
+// An absolute deadline, not an idle timer: a trickling peer cannot renew it.
+// Do not destroy the request here; the caller must first send its 408/413.
+export function readRequestBody(req, { maxBodyBytes, bodyTimeoutMs, signal, onChunk }) {
+  return new Promise((resolve, reject) => {
+    let bytes = 0;
+    const chunks = [];
+    let timer;
+    const cleanup = () => {
+      clearTimeout(timer);
+      req.off('data', data);
+      req.off('end', end);
+      req.off('error', error);
+      req.off('aborted', abort);
+      signal?.removeEventListener('abort', abort);
+    };
+    const error = err => { req.pause(); cleanup(); reject(err); };
+    const abort = () => error(new IngressError(499, 'Client disconnected during upload.'));
+    const end = () => { cleanup(); resolve(Buffer.concat(chunks, bytes)); };
+    const data = chunk => {
+      bytes += chunk.length;
+      if (bytes > maxBodyBytes) {
+        error(new IngressError(413, 'Request body exceeds TeamClaude byte limit.'));
+        return;
+      }
+      chunks.push(chunk);
+      try { onChunk?.(chunk); } catch (err) { error(err); }
+    };
+    if (signal?.aborted || req.destroyed) { abort(); return; }
+    if (Number(req.headers['content-length']) > maxBodyBytes) {
+      error(new IngressError(413, 'Request body exceeds TeamClaude byte limit.'));
+      return;
+    }
+    timer = setTimeout(() => error(new IngressError(408, 'Request body upload deadline exceeded.')), bodyTimeoutMs);
+    timer.unref?.();
+    req.on('data', data);
+    req.once('end', end);
+    req.once('error', error);
+    req.once('aborted', abort);
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}
 
 // Small FIFO semaphore used only while request bodies are being ingested and
 // parsed. Long upstream streams and quota holds do not retain a permit.
 export class AdmissionGate {
   constructor(limit = DEFAULT_INGRESS_CONCURRENCY, maxQueue = DEFAULT_INGRESS_QUEUE) {
     this.limit = positiveInt(limit, DEFAULT_INGRESS_CONCURRENCY);
-    this.maxQueue = positiveInt(maxQueue, DEFAULT_INGRESS_QUEUE);
+    this.maxQueue = Number.isSafeInteger(Number(maxQueue)) && Number(maxQueue) >= 0 ? Number(maxQueue) : DEFAULT_INGRESS_QUEUE;
     this.active = 0;
     this.queue = [];
   }
 
-  enter() {
+  enter({ signal, timeoutMs = DEFAULT_QUEUE_TIMEOUT_MS } = {}) {
+    if (signal?.aborted) return Promise.resolve(false);
     if (this.active < this.limit) {
       this.active += 1;
       return Promise.resolve(true);
     }
     if (this.queue.length >= this.maxQueue) return Promise.resolve(false);
-    return new Promise(resolve => this.queue.push(resolve));
+    return new Promise(resolve => {
+      let timer;
+      const settle = admitted => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', cancel);
+        const index = this.queue.indexOf(settle);
+        if (index !== -1) this.queue.splice(index, 1);
+        resolve(admitted);
+      };
+      const cancel = () => settle(false);
+      this.queue.push(settle);
+      signal?.addEventListener('abort', cancel, { once: true });
+      timer = setTimeout(cancel, positiveInt(timeoutMs, DEFAULT_QUEUE_TIMEOUT_MS));
+      timer.unref?.();
+    });
   }
 
   leave() {
@@ -33,5 +106,5 @@ export class AdmissionGate {
 
 function positiveInt(value, fallback) {
   const n = Number(value);
-  return Number.isInteger(n) && n > 0 ? n : fallback;
+  return Number.isSafeInteger(n) && n > 0 && n <= 2 ** 31 - 1 ? n : fallback;
 }

--- a/src/admission-gate.js
+++ b/src/admission-gate.js
@@ -59,8 +59,8 @@ export function readRequestBody(req, { maxBodyBytes, bodyTimeoutMs, signal, onCh
   });
 }
 
-// Small FIFO semaphore used only while request bodies are being ingested and
-// parsed. Long upstream streams and quota holds do not retain a permit.
+// FIFO semaphore shared by ingestion and upstream admission. Each caller owns
+// its permit lifetime: ingestion releases after parsing, upstream after close.
 export class AdmissionGate {
   constructor(limit = DEFAULT_INGRESS_CONCURRENCY, maxQueue = DEFAULT_INGRESS_QUEUE) {
     this.limit = positiveInt(limit, DEFAULT_INGRESS_CONCURRENCY);

--- a/src/admission-gate.js
+++ b/src/admission-gate.js
@@ -1,0 +1,37 @@
+export const DEFAULT_INGRESS_CONCURRENCY = 4;
+export const DEFAULT_INGRESS_QUEUE = 64;
+
+// Small FIFO semaphore used only while request bodies are being ingested and
+// parsed. Long upstream streams and quota holds do not retain a permit.
+export class AdmissionGate {
+  constructor(limit = DEFAULT_INGRESS_CONCURRENCY, maxQueue = DEFAULT_INGRESS_QUEUE) {
+    this.limit = positiveInt(limit, DEFAULT_INGRESS_CONCURRENCY);
+    this.maxQueue = positiveInt(maxQueue, DEFAULT_INGRESS_QUEUE);
+    this.active = 0;
+    this.queue = [];
+  }
+
+  enter() {
+    if (this.active < this.limit) {
+      this.active += 1;
+      return Promise.resolve(true);
+    }
+    if (this.queue.length >= this.maxQueue) return Promise.resolve(false);
+    return new Promise(resolve => this.queue.push(resolve));
+  }
+
+  leave() {
+    const next = this.queue.shift();
+    if (next) next(true); // transfer this permit; active does not change
+    else if (this.active > 0) this.active -= 1;
+  }
+
+  status() {
+    return { active: this.active, queued: this.queue.length, limit: this.limit, maxQueue: this.maxQueue };
+  }
+}
+
+function positiveInt(value, fallback) {
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}

--- a/src/event-loop-monitor.js
+++ b/src/event-loop-monitor.js
@@ -1,0 +1,47 @@
+import { performance } from 'node:perf_hooks';
+
+const DEFAULT_INTERVAL_MS = 1_000;
+const DEFAULT_WARN_LAG_MS = 500;
+const DEFAULT_WARN_COOLDOWN_MS = 30_000;
+
+// A deliberately small watchdog for a failure an HTTP health endpoint cannot
+// report: if the event loop is wedged, the endpoint itself cannot run. The
+// delayed timer writes one bounded warning after JavaScript becomes schedulable
+// again, leaving evidence in the service log without emitting request content.
+export function startEventLoopMonitor({
+  intervalMs = DEFAULT_INTERVAL_MS,
+  warnLagMs = DEFAULT_WARN_LAG_MS,
+  warnCooldownMs = DEFAULT_WARN_COOLDOWN_MS,
+  now = () => performance.now(),
+  schedule = setInterval,
+  cancel = clearInterval,
+  log = (message) => console.error(message),
+} = {}) {
+  let expectedAt = now() + intervalMs;
+  let lastLagMs = 0;
+  let maxLagMs = 0;
+  let stallCount = 0;
+  let lastStallAt = null;
+  let lastWarningClock = -Infinity;
+
+  const timer = schedule(() => {
+    const current = now();
+    const lag = Math.max(0, current - expectedAt);
+    expectedAt = current + intervalMs;
+    lastLagMs = Math.round(lag);
+    maxLagMs = Math.max(maxLagMs, lastLagMs);
+    if (lag < warnLagMs) return;
+
+    stallCount += 1;
+    lastStallAt = new Date().toISOString();
+    if (current - lastWarningClock < warnCooldownMs) return;
+    lastWarningClock = current;
+    log(`[TeamClaude] Event loop stalled: lag=${Math.round(lag)}ms (threshold=${warnLagMs}ms, stalls=${stallCount})`);
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    status: () => ({ lastLagMs, maxLagMs, stallCount, lastStallAt, warnLagMs }),
+    stop: () => cancel(timer),
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
+import { startEventLoopMonitor } from './event-loop-monitor.js';
 
 // These constants are referenced by routeCommand, which the dispatch below
 // reaches through a top-level `await`. The await suspends module evaluation at
@@ -208,6 +209,7 @@ async function serverCommand() {
   // overnight leaves nothing behind to explain why.
   const crashLog = getCrashLogPath();
   installCrashHandlers(crashLog);
+  const eventLoopMonitor = startEventLoopMonitor();
 
   const config = await loadOrCreateConfig();
 
@@ -516,6 +518,7 @@ async function serverCommand() {
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),
       port,
       upstream: config.upstream || 'https://api.anthropic.com',
+      eventLoop: eventLoopMonitor.status(),
     },
     probe: prober?.getStatus() || {
       enabled: false,
@@ -640,6 +643,7 @@ async function serverCommand() {
     if (!tui) console.log('\n[TeamClaude] Shutting down...');
     prober?.stop();
     warmer?.stop();
+    eventLoopMonitor.stop();
     if (quotaSaveInterval) clearInterval(quotaSaveInterval);
     await persistQuotaState();
     // Don't linger waiting on keep-alive / streaming connections: actively
@@ -1046,9 +1050,14 @@ async function statusCommand() {
   const colorArg = argValue('--color') || args.find(arg => arg.startsWith('--color='))?.slice('--color='.length);
   const color = colorArg === 'always'
     || (colorArg !== 'never' && process.stdout.isTTY);
+  const configuredTimeout = Number(process.env.TEAMCLAUDE_STATUS_TIMEOUT_MS);
+  const timeoutMs = configuredTimeout > 0 ? configuredTimeout : 5_000;
 
   try {
-    const res = await fetch(url, { headers: { 'x-api-key': config.proxy.apiKey } });
+    const res = await fetch(url, {
+      headers: { 'x-api-key': config.proxy.apiKey },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
     const data = await res.json();
     if (json) {
       console.log(JSON.stringify(data, null, 2));
@@ -1056,6 +1065,12 @@ async function statusCommand() {
     }
     console.log(renderStatus(data, { color }));
   } catch (err) {
+    if (err?.name === 'TimeoutError') {
+      console.error(`Proxy at localhost:${config.proxy.port} did not answer status within ${timeoutMs}ms.`);
+      console.error('The process may be overloaded or its event loop may be stalled.');
+      console.error(`Check the service log: ${logPath()}`);
+      process.exit(1);
+    }
     console.error('Cannot connect to proxy at localhost:' + config.proxy.port);
     console.error('Is the server running? Start with: teamclaude server');
     if (err?.message) console.error(`Details: ${err.message}`);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -126,7 +126,7 @@ export function hostMode(host, config) {
  * the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
  */
-export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null, clientUsage = null, dimensionUsage = null }) {
+export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null, clientUsage = null, dimensionUsage = null, ingressGate = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
 
@@ -169,7 +169,7 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
       key, cert, allowHTTP1: true,
       ...(http1Only ? { ALPNProtocols: ['http/1.1'] } : {}),
     });
-    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null, egress, clientUsage, forcedClient: client, dimensionUsage }));
+    srv.on('request', createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, forcedPin: pin || null, egress, clientUsage, forcedClient: client, dimensionUsage, ingressGate }));
     // Remote Control's real-time channel is a WebSocket (Upgrade handshake),
     // which never fires 'request' — only 'upgrade', with a raw socket instead
     // of a response object (h1-only; falls back to blind h2 passthrough is not

--- a/src/model.js
+++ b/src/model.js
@@ -210,14 +210,16 @@ export class TopLevelFieldFinder {
 }
 
 // Extract the requested model id from a JSON request body (Buffer or string).
-// Uses the streaming top-level finder so it is exact (never matches a `model`
-// key nested in conversation content) and cheap on large bodies (it stops as
-// soon as the top-level field resolves). Returns null if absent.
+// Whole-body callers use native JSON parsing: it is exact (never matches a
+// nested `model`) without a JavaScript loop over every byte of a large context.
+// TopLevelFieldFinder remains available to the interactive TUI, which is the
+// only caller that needs a result before the request body has finished.
 export function parseRequestModel(body) {
   if (!body) return null;
   try {
     const buf = Buffer.isBuffer(body) ? body : Buffer.from(String(body), 'utf8');
-    return new TopLevelFieldFinder('model').push(buf);
+    const payload = JSON.parse(buf.toString('utf8'));
+    return payload && typeof payload.model === 'string' ? payload.model : null;
   } catch { return null; }
 }
 

--- a/src/model.js
+++ b/src/model.js
@@ -324,6 +324,19 @@ export function parseAdvisorModel(body) {
   try {
     const buf = Buffer.isBuffer(body) ? body : Buffer.from(String(body), 'utf8');
     if (!buf.includes('advisor')) return null;
-    return new AdvisorModelFinder().push(buf);
+    // This function always receives the complete request body. JSON.parse runs
+    // in native code and is dramatically faster than feeding hundreds of KB
+    // through AdvisorModelFinder one JavaScript byte at a time. Keep the finder
+    // for callers that genuinely need incremental/chunked parsing; for a whole
+    // body, inspect only direct fields of direct tools[] entries, preserving the
+    // same decoy/nesting boundary as the state machine.
+    const payload = JSON.parse(buf.toString('utf8'));
+    if (!payload || !Array.isArray(payload.tools)) return null;
+    for (const tool of payload.tools) {
+      if (!tool || typeof tool !== 'object' || Array.isArray(tool)) continue;
+      if (typeof tool.type === 'string' && /^advisor/i.test(tool.type)
+          && typeof tool.model === 'string' && tool.model) return tool.model;
+    }
+    return null;
   } catch { return null; }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -976,7 +976,7 @@ export function relayFair(source, destination) {
       chunks += 1;
       if (chunks >= STREAM_FAIRNESS_CHUNKS) {
         chunks = 0;
-        setImmediate(callback);
+        setTimeout(callback, STREAM_FAIRNESS_DELAY_MS);
       } else {
         callback();
       }
@@ -2045,13 +2045,13 @@ const DEFAULT_BODY_IDLE_TIMEOUT_MS = 120_000;
 // buffered. With a busy upstream, repeatedly awaiting those ready reads never
 // returns to the event-loop poll phase, so the listener can accept a status
 // connection in the kernel while JavaScript never runs its request handler.
-// Yield after every chunk even when neither socket applies backpressure. Under
-// a reconnect storm many TLS sockets can stay readable at once; batching even
-// 32 chunks per response lets that poll/microtask traffic starve a newly
-// accepted status request for seconds. A streamed model response naturally has
-// sizeable gaps between chunks, so one check-phase hop per chunk has negligible
-// user-visible cost and keeps the control plane responsive under saturation.
-const STREAM_FAIRNESS_CHUNKS = 1;
+// Yield briefly every small batch even when neither socket applies
+// backpressure. Under a reconnect storm many TLS sockets can stay readable at
+// once; the old 32-chunk batch let poll/microtask traffic starve a newly
+// accepted status request for seconds. Eight keeps bulk relays efficient while
+// regularly leaving a real scheduling window for the control plane.
+const STREAM_FAIRNESS_CHUNKS = 8;
+const STREAM_FAIRNESS_DELAY_MS = 1;
 
 function resolveBodyIdleTimeout() {
   const env = Number(process.env.TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS);
@@ -2142,7 +2142,7 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
       chunksSinceYield += 1;
       if (chunksSinceYield >= STREAM_FAIRNESS_CHUNKS) {
         chunksSinceYield = 0;
-        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setTimeout(resolve, STREAM_FAIRNESS_DELAY_MS));
         if (clientGone(res)) break;
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -18,7 +18,7 @@ import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
 import { renderDashboardHtml } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
-import { AdmissionGate } from './admission-gate.js';
+import { AdmissionGate, IngressError, ingressOptions, readRequestBody } from './admission-gate.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -242,7 +242,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
         const status = accountManager.getStatus({ sessionDetail: config.proxy?.sessionDetail === true });
         const extra = hooks.getStatusExtra?.() || {};
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ...extra, ...status }, null, 2));
+        res.end(JSON.stringify({ ...extra, ...status, ingress: ingressGate?.status() ?? { enabled: false } }, null, 2));
         return;
       }
 
@@ -569,6 +569,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/'];
  */
 export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null, dimensionUsage = null, ingressGate = null }) {
   let counter = 0;
+  const limits = ingressOptions();
   return async (req, res) => {
     // The activity entry this request opened, while it is still open. Every
     // consumer holds the row until it is told the request ended, so exactly one
@@ -703,32 +704,32 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       let model;
       let advisorModel;
       let admitted = false;
+      const uploadAbort = new AbortController();
+      const onUploadClose = () => uploadAbort.abort();
+      res.once('close', onUploadClose);
       try {
+        if (clientGone(res)) throw new IngressError(499, 'Client disconnected.');
         if (ingressGate) {
-          admitted = await ingressGate.enter();
+          admitted = await ingressGate.enter({ signal: uploadAbort.signal, timeoutMs: limits.queueTimeoutMs });
           if (!admitted) {
-            res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '1' });
-            res.end(JSON.stringify({ type: 'error', error: { type: 'overloaded_error', message: 'TeamClaude request queue is full; retry shortly.' } }));
-            return;
+            throw new IngressError(clientGone(res) ? 499 : 503, 'TeamClaude request queue is full or its wait deadline expired; retry shortly.');
           }
-          if (clientGone(res)) return;
+          if (clientGone(res)) throw new IngressError(499, 'Client disconnected.');
         }
-        const bodyChunks = [];
         // A headless service has no live model hook, so an incremental byte scan
         // buys it nothing. Defer to parseRequestModel's native whole-body path in
         // that case; this keeps large reconnect uploads from blocking status.
         const modelFinder = hooks.onRequestModel ? new TopLevelFieldFinder('model') : null;
-        for await (const chunk of req) {
-          bodyChunks.push(chunk);
+        body = await readRequestBody(req, { ...limits, signal: uploadAbort.signal, onChunk: chunk => {
           if (modelFinder && !modelFinder.done) {
             const found = modelFinder.push(chunk);
             if (found && !hideActivity) hooks.onRequestModel?.(reqId, { model: found });
           }
-        }
-        body = Buffer.concat(bodyChunks);
+        } });
         model = modelFinder?.done ? modelFinder.value : parseRequestModel(body);
         advisorModel = parseAdvisorModel(body);
       } finally {
+        res.off('close', onUploadClose);
         if (admitted) ingressGate.leave();
       }
       // An advisor request (Claude Code's advisor tool) carries a SECOND model
@@ -802,7 +803,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: ctx.account, status: ctx.status, model: ctx.model, sessionId, pinned: ctx.pinnedIndex != null, client });
       }
     } catch (err) {
-      reportFailure('[TeamClaude] Unhandled error:', err);
+      if (!(err instanceof IngressError)) reportFailure('[TeamClaude] Unhandled error:', err);
       // Close the activity entry. Only the inner path has a `finally`, so a
       // throw above it opens a row that nothing else will ever close, and every
       // consumer holds an open row indefinitely: the TUI keeps it in `active`
@@ -814,7 +815,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         // 499 when nothing was sent and nothing will be, either because the
         // client is gone or because the response is past the point of saying
         // anything; 502 is what the answer below is about to write.
-        const status = res.headersSent || clientGone(res) ? 499 : 502;
+        const status = res.headersSent || clientGone(res) ? 499 : err instanceof IngressError ? err.status : 502;
         const entry = openEntry;
         openEntry = null;
         // Guarded, because the throw that landed here may be this hook. Escaping
@@ -835,7 +836,19 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // buffering, the activity hooks) runs outside the 502 that guards
       // forwardRequest, and the inner `finally` calls onRequestEnd after the
       // response has streamed.
-      answerUnhandled(res);
+      if (err instanceof IngressError) {
+        if (!clientGone(res) && !res.headersSent) {
+          const headers = { 'Content-Type': 'application/json' };
+          if (err.status === 503) headers['Retry-After'] = '1';
+          // Unread h1 bodies must not become the next keep-alive request.
+          // On h2 close only this stream, never its shared connection.
+          if (req.httpVersionMajor !== 2) headers.Connection = 'close';
+          res.writeHead(err.status, headers);
+          res.end(JSON.stringify({ type: 'error', error: { type: err.status === 503 ? 'overloaded_error' : 'invalid_request_error', message: err.message } }), () => {
+            if (!req.complete) req.destroy();
+          });
+        }
+      } else answerUnhandled(res);
     }
   };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@ import { sanitizeToolPairs } from './tool-pair-sanitize.js';
 import { parseRequestModel, parseAdvisorModel } from './account-manager.js';
 import { TopLevelFieldFinder, modelGlobMatches } from './model.js';
 import { BodyWriter, truncationNote } from './request-log.js';
-import { upstreamFetch } from './upstream-fetch.js';
+import { upstreamFetch, upstreamPoolStatus } from './upstream-fetch.js';
 import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath, providerOf, isSubscriptionAccount, DEFAULT_PROVIDER } from './provider.js';
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
@@ -58,7 +58,7 @@ async function readErrorBody(body, limit = ERROR_BODY_INSPECTION_LIMIT) {
   let length = 0;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout(reader, resolveBodyIdleTimeout());
       if (done) return Buffer.concat(chunks, length);
       length += value.byteLength;
       if (length > limit) {
@@ -242,7 +242,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
         const status = accountManager.getStatus({ sessionDetail: config.proxy?.sessionDetail === true });
         const extra = hooks.getStatusExtra?.() || {};
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ...extra, ...status, ingress: ingressGate?.status() ?? { enabled: false } }, null, 2));
+        res.end(JSON.stringify({ ...extra, ...status, ingress: ingressGate?.status() ?? { enabled: false }, upstreamPool: upstreamPoolStatus() }, null, 2));
         return;
       }
 
@@ -781,6 +781,11 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         client,
         dimensions: Object.fromEntries(usageDimensions.map(d => [d.name, d.key])),
       });
+      const requestAbort = new AbortController();
+      const onRequestClose = () => requestAbort.abort();
+      ctx.signal = requestAbort.signal;
+      res.once('close', onRequestClose);
+      if (clientGone(res)) onRequestClose();
       try {
         await forwardRequest(req, res, body, accountManager, upstream, 0, hooks, reqId, ctx, logDir, sx);
       } catch (err) {
@@ -795,6 +800,8 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           res.end(JSON.stringify({ type: 'error', error: { type: 'proxy_error', message: 'Internal proxy error' } }));
         }
       } finally {
+        res.off('close', onRequestClose);
+        if (requestAbort.signal.aborted) ctx.status = 499;
         accountManager.endSession(sessionId);
         // Cleared BEFORE the hook, because the hook can throw: leaving the entry
         // marked open would send the outer catch to call that same throwing hook
@@ -845,7 +852,17 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           if (req.httpVersionMajor !== 2) headers.Connection = 'close';
           res.writeHead(err.status, headers);
           res.end(JSON.stringify({ type: 'error', error: { type: err.status === 503 ? 'overloaded_error' : 'invalid_request_error', message: err.message } }), () => {
-            if (!req.complete) req.destroy();
+            if (!req.complete) {
+              if (req.httpVersionMajor === 2) { req.destroy(); return; }
+              // An immediate destroy with unread upload bytes can reset h1
+              // before the peer receives the 413/503. Discard (never buffer)
+              // briefly to allow the reply through, then bound the teardown.
+              const timer = setTimeout(() => req.destroy(), 1000);
+              timer.unref?.();
+              const cleanup = () => { clearTimeout(timer); req.off('end', cleanup); req.off('close', cleanup); };
+              req.once('end', cleanup); req.once('close', cleanup);
+              req.resume();
+            }
           });
         }
       } else answerUnhandled(res);
@@ -903,6 +920,15 @@ function reportFailure(...args) {
  * `drain` or a `close` that has already happened and will not happen again, so
  * the handler never returns and its activity entry never closes.
  */
+function waitForRetry(ms, signal) {
+  return new Promise(resolve => {
+    if (signal?.aborted) { resolve(); return; }
+    const finish = () => { clearTimeout(timer); signal?.removeEventListener('abort', finish); resolve(); };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener('abort', finish, { once: true });
+  });
+}
+
 function clientGone(res) {
   return !!res.destroyed || !!res.stream?.destroyed;
 }
@@ -1560,7 +1586,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       const waitMs = Math.min(retryAfter * 1000, ctx.holdBudgetMs, 60_000);
       ctx.holdBudgetMs -= waitMs;
       console.log(`[TeamClaude] All accounts exhausted — holding connection, retry in ${Math.ceil(waitMs / 1000)}s (${Math.ceil(ctx.holdBudgetMs / 1000)}s budget left)`);
-      await new Promise(resolve => setTimeout(resolve, waitMs));
+      await waitForRetry(waitMs, ctx.signal);
       if (clientGone(res)) return;
       return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
     }
@@ -1569,7 +1595,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     if (exhaustedRetries < 1 && retryAfter <= INLINE_RETRY_AFTER_MAX_SECONDS) {
       ctx.exhaustedRetries = exhaustedRetries + 1;
       console.log(`[TeamClaude] All accounts exhausted — waiting ${retryAfter}s before retry`);
-      await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+      await waitForRetry(retryAfter * 1000, ctx.signal);
       if (clientGone(res)) return;
       return forwardRequest(req, res, body, accountManager, upstream, retryCount, hooks, reqId, ctx, logDir, sx, route);
     }
@@ -1705,6 +1731,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       upstreamRes = await upstreamFetch(upstreamUrl, {
         method,
         headers,
+        signal: ctx.signal,
         body: ['GET', 'HEAD'].includes(method) ? undefined : sendBody,
         redirect: 'manual',
       }, sx, route);
@@ -1843,7 +1870,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // rate-limited account can't loop forever tying up the connection.
       if (retryAfter <= RATE_LIMIT_ABSORB_MAX_SECONDS && retryCount < maxRetries) {
         console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — waiting ${retryAfter}s, retrying same account (no switch)`);
-        await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+        await waitForRetry(retryAfter * 1000, ctx.signal);
         if (clientGone(res)) return;
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
       }
@@ -1981,13 +2008,22 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       }
       l?.end();
     } else {
-      const buf = Buffer.from(await upstreamRes.arrayBuffer());
+      const buf = await readBufferedResponse(upstreamRes.body);
       extractUsageFromBody(buf, account.index, accountManager, ctx.onUsage, ctx.sessionId, ctx.model);
       const l = getLog();
       if (l) { l.body('RESPONSE BODY', buf, contentType); l.end(); }
       res.end(buf);
     }
   } catch (err) {
+    if (clientGone(res)) { ctx.status = 499; return; }
+    // Local saturation is not an account error and must not rotate credentials
+    // or amplify load with another upstream attempt.
+    if (err.code === 'TEAMCLAUDE_UPSTREAM_OVERLOADED' && !res.headersSent) {
+      ctx.status = 503;
+      res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '1' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'overloaded_error', message: err.message } }));
+      return;
+    }
     console.error(`[TeamClaude] Upstream error (account "${account.name}"):`, describeConnectError(err));
 
     logRequestHead();
@@ -2094,6 +2130,27 @@ function resolveBodyIdleTimeout() {
   return env > 0 ? env : DEFAULT_BODY_IDLE_TIMEOUT_MS;
 }
 
+async function readBufferedResponse(body) {
+  const configured = Number(process.env.TEAMCLAUDE_RESPONSE_BODY_MAX_BYTES);
+  const limit = Number.isSafeInteger(configured) && configured > 0 ? configured : 32 * 1024 * 1024;
+  const reader = body.getReader();
+  const chunks = [];
+  let bytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await readWithIdleTimeout(reader, resolveBodyIdleTimeout());
+      if (done) return Buffer.concat(chunks, bytes);
+      bytes += value.byteLength;
+      if (bytes > limit) {
+        const err = new Error('Buffered upstream response exceeds TeamClaude byte limit');
+        err.code = 'TEAMCLAUDE_RESPONSE_TOO_LARGE';
+        throw err;
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally { await reader.cancel().catch(() => {}); reader.releaseLock(); }
+}
+
 // Race a single reader.read() against an inactivity deadline. Resolves to the
 // read result, or rejects with a transient TEAMCLAUDE_BODY_TIMEOUT if no chunk
 // arrives within `ms`. The pending read is abandoned on timeout; the caller
@@ -2120,6 +2177,11 @@ export function readWithIdleTimeout(reader, ms) {
  */
 export async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, onUsage = null, sessionId = null, model = null) {
   const reader = webStream.getReader();
+  // A disconnected client must cancel a pending read, even when the upstream
+  // is silent. Checking clientGone only after a chunk cannot release that slot.
+  const onClose = () => { reader.cancel().catch(() => {}); };
+  res.once?.('close', onClose);
+  if (clientGone(res)) onClose();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
   let sseBuffer = '';
@@ -2196,6 +2258,7 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
     errored = true;
     throw err;
   } finally {
+    res.off?.('close', onClose);
     // Record the message once, on every exit path. A stream that died after
     // `message_start` still spent the input it reported, so the merge is written
     // even when no `message_delta` ever arrived. An empty merge is written

--- a/src/server.js
+++ b/src/server.js
@@ -693,17 +693,20 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // TUI can show it the instant it appears in the stream — usually the first
       // frame — rather than waiting for the whole body and the request to finish.
       const bodyChunks = [];
-      const modelFinder = new TopLevelFieldFinder('model');
+      // A headless service has no live model hook, so an incremental byte scan
+      // buys it nothing. Defer to parseRequestModel's native whole-body path in
+      // that case; this keeps large reconnect uploads from blocking status.
+      const modelFinder = hooks.onRequestModel ? new TopLevelFieldFinder('model') : null;
       for await (const chunk of req) {
         bodyChunks.push(chunk);
-        if (!modelFinder.done) {
+        if (modelFinder && !modelFinder.done) {
           const found = modelFinder.push(chunk);
           if (found && !hideActivity) hooks.onRequestModel?.(reqId, { model: found });
         }
       }
       const body = Buffer.concat(bodyChunks);
 
-      const model = modelFinder.done ? modelFinder.value : parseRequestModel(body);
+      const model = modelFinder?.done ? modelFinder.value : parseRequestModel(body);
       // An advisor request (Claude Code's advisor tool) carries a SECOND model
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).

--- a/src/server.js
+++ b/src/server.js
@@ -150,10 +150,12 @@ export function resolveClientAuth(proxyConfig, presented) {
 export function createProxyServer(accountManager, config, hooks = {}, sx = null, clientUsage = null, dimensionUsage = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
-  const ingressGate = new AdmissionGate(
+  // Experimental until cancellation, queue deadlines and slow-upload bounds
+  // are covered. Do not activate this draft gate on a routine service restart.
+  const ingressGate = Number(process.env.TEAMCLAUDE_INGRESS_CONCURRENCY) > 0 ? new AdmissionGate(
     process.env.TEAMCLAUDE_INGRESS_CONCURRENCY,
     process.env.TEAMCLAUDE_INGRESS_QUEUE,
-  );
+  ) : null;
 
   // The log directory is made up front and synchronously, so a path that
   // cannot be a directory (a file sitting there, no permission) is reported

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { createWriteStream, mkdirSync, writeSync } from 'node:fs';
 import { readdir, stat, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Transform } from 'node:stream';
 import { ensureCerts, createConnectHandler, mitmHosts } from './mitm.js';
 import { patchAccountUuid } from './account-uuid-rewrite.js';
 import { sanitizeToolPairs } from './tool-pair-sanitize.js';
@@ -930,7 +931,7 @@ function relayStream(req, res, upstream, sx) {
       responseHeaders[key] = value;
     }
     res.writeHead(upstreamRes.statusCode, responseHeaders);
-    upstreamRes.pipe(res);
+    relayFair(upstreamRes, res);
     // pipe() only propagates 'end'. If the upstream leg dies mid-response
     // (network blip, upstream restart), upstreamRes emits 'aborted'/'error'
     // and the pipe just stops — the client's long-poll stays open forever and
@@ -960,6 +961,26 @@ function relayStream(req, res, upstream, sx) {
 
   if (['GET', 'HEAD'].includes(req.method)) upstreamReq.end();
   else req.pipe(upstreamReq);
+}
+
+// Kept as a named seam so raw long-poll relay fairness can be regression-tested
+// independently of a real upstream socket.
+export function relayFair(source, destination) {
+  let chunks = 0;
+  const fairness = new Transform({
+    transform(chunk, encoding, callback) {
+      this.push(chunk);
+      chunks += 1;
+      if (chunks >= STREAM_FAIRNESS_CHUNKS) {
+        chunks = 0;
+        setImmediate(callback);
+      } else {
+        callback();
+      }
+    },
+  });
+  source.pipe(fairness).pipe(destination);
+  return fairness;
 }
 
 /**
@@ -2021,9 +2042,13 @@ const DEFAULT_BODY_IDLE_TIMEOUT_MS = 120_000;
 // buffered. With a busy upstream, repeatedly awaiting those ready reads never
 // returns to the event-loop poll phase, so the listener can accept a status
 // connection in the kernel while JavaScript never runs its request handler.
-// Yield periodically even when neither socket applies backpressure. Thirty-two
-// chunks keeps the relay hot while bounding how long control-plane requests wait.
-const STREAM_FAIRNESS_CHUNKS = 32;
+// Yield after every chunk even when neither socket applies backpressure. Under
+// a reconnect storm many TLS sockets can stay readable at once; batching even
+// 32 chunks per response lets that poll/microtask traffic starve a newly
+// accepted status request for seconds. A streamed model response naturally has
+// sizeable gaps between chunks, so one check-phase hop per chunk has negligible
+// user-visible cost and keeps the control plane responsive under saturation.
+const STREAM_FAIRNESS_CHUNKS = 1;
 
 function resolveBodyIdleTimeout() {
   const env = Number(process.env.TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS);

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,7 @@ import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
 import { renderDashboardHtml } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
+import { AdmissionGate } from './admission-gate.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -149,6 +150,10 @@ export function resolveClientAuth(proxyConfig, presented) {
 export function createProxyServer(accountManager, config, hooks = {}, sx = null, clientUsage = null, dimensionUsage = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
+  const ingressGate = new AdmissionGate(
+    process.env.TEAMCLAUDE_INGRESS_CONCURRENCY,
+    process.env.TEAMCLAUDE_INGRESS_QUEUE,
+  );
 
   // The log directory is made up front and synchronously, so a path that
   // cannot be a directory (a file sitting there, no permission) is reported
@@ -335,7 +340,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
   // Opt-in egress pin: null unless config.egress.pin is set, and then shared by
   // the base listener and the MITM one so both honour the same hold.
   const egress = createEgressGuard(config, console.error);
-  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, egress, clientUsage, dimensionUsage });
+  const forward = createProxyRequestListener({ accountManager, upstream, logDir, hooks, sx, holdMs, config, egress, clientUsage, dimensionUsage, ingressGate });
   const server = http.createServer(requestHandler);
 
   // What bounds a directory of one-shot dumps is deleting the expired ones, not
@@ -376,7 +381,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
     const c = await certsPromise;
     return { key: c.leafKeyPem, cert: c.leafCertPem };
   };
-  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx, egress, clientUsage, dimensionUsage }));
+  server.on('connect', createConnectHandler({ config, accountManager, ensureLeaf, logDir, hooks, log: console.error, sx, egress, clientUsage, dimensionUsage, ingressGate }));
   // Remote Control's real-time channel is a WebSocket, not a request/response
   // call — Node fires 'upgrade' for that handshake, never 'request', so it
   // needs its own listener (base-URL routing path; the MITM path wires the
@@ -560,7 +565,7 @@ const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/'];
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
  */
-export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null, dimensionUsage = null }) {
+export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null, dimensionUsage = null, ingressGate = null }) {
   let counter = 0;
   return async (req, res) => {
     // The activity entry this request opened, while it is still open. Every
@@ -692,25 +697,41 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // Peek the top-level `model` field incrementally as chunks arrive so the
       // TUI can show it the instant it appears in the stream — usually the first
       // frame — rather than waiting for the whole body and the request to finish.
-      const bodyChunks = [];
-      // A headless service has no live model hook, so an incremental byte scan
-      // buys it nothing. Defer to parseRequestModel's native whole-body path in
-      // that case; this keeps large reconnect uploads from blocking status.
-      const modelFinder = hooks.onRequestModel ? new TopLevelFieldFinder('model') : null;
-      for await (const chunk of req) {
-        bodyChunks.push(chunk);
-        if (modelFinder && !modelFinder.done) {
-          const found = modelFinder.push(chunk);
-          if (found && !hideActivity) hooks.onRequestModel?.(reqId, { model: found });
+      let body;
+      let model;
+      let advisorModel;
+      let admitted = false;
+      try {
+        if (ingressGate) {
+          admitted = await ingressGate.enter();
+          if (!admitted) {
+            res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '1' });
+            res.end(JSON.stringify({ type: 'error', error: { type: 'overloaded_error', message: 'TeamClaude request queue is full; retry shortly.' } }));
+            return;
+          }
+          if (clientGone(res)) return;
         }
+        const bodyChunks = [];
+        // A headless service has no live model hook, so an incremental byte scan
+        // buys it nothing. Defer to parseRequestModel's native whole-body path in
+        // that case; this keeps large reconnect uploads from blocking status.
+        const modelFinder = hooks.onRequestModel ? new TopLevelFieldFinder('model') : null;
+        for await (const chunk of req) {
+          bodyChunks.push(chunk);
+          if (modelFinder && !modelFinder.done) {
+            const found = modelFinder.push(chunk);
+            if (found && !hideActivity) hooks.onRequestModel?.(reqId, { model: found });
+          }
+        }
+        body = Buffer.concat(bodyChunks);
+        model = modelFinder?.done ? modelFinder.value : parseRequestModel(body);
+        advisorModel = parseAdvisorModel(body);
+      } finally {
+        if (admitted) ingressGate.leave();
       }
-      const body = Buffer.concat(bodyChunks);
-
-      const model = modelFinder?.done ? modelFinder.value : parseRequestModel(body);
       // An advisor request (Claude Code's advisor tool) carries a SECOND model
       // nested in tools[]; the advisor sub-inference runs on the selected
       // account, so selection must be eligible for it too (issue #98).
-      const advisorModel = parseAdvisorModel(body);
 
       // Model blocklist (issue #116): reject a request for a blocked model right
       // here instead of forwarding it. A model no account can serve (e.g. Fable

--- a/src/server.js
+++ b/src/server.js
@@ -2017,6 +2017,13 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
 // the sx-tunnel path, since both hand back a web ReadableStream). Override with
 // TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS.
 const DEFAULT_BODY_IDLE_TIMEOUT_MS = 120_000;
+// A web-stream read resolves as a microtask when undici already has bytes
+// buffered. With a busy upstream, repeatedly awaiting those ready reads never
+// returns to the event-loop poll phase, so the listener can accept a status
+// connection in the kernel while JavaScript never runs its request handler.
+// Yield periodically even when neither socket applies backpressure. Thirty-two
+// chunks keeps the relay hot while bounding how long control-plane requests wait.
+const STREAM_FAIRNESS_CHUNKS = 32;
 
 function resolveBodyIdleTimeout() {
   const env = Number(process.env.TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS);
@@ -2047,12 +2054,13 @@ export function readWithIdleTimeout(reader, ms) {
 /**
  * Stream an SSE response to the client, parsing usage data along the way.
  */
-async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, onUsage = null, sessionId = null, model = null) {
+export async function streamResponse(webStream, res, accountIndex, accountManager, bodyWriter, onUsage = null, sessionId = null, model = null) {
   const reader = webStream.getReader();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
   let sseBuffer = '';
   let errored = false;
+  let chunksSinceYield = 0;
   // The message's usage, merged across its two reports and recorded once below.
   const merged = {};
 
@@ -2097,6 +2105,16 @@ async function streamResponse(webStream, res, accountIndex, accountManager, body
           res.once('drain', done);
           res.once('close', done);
         });
+        if (clientGone(res)) break;
+      }
+
+      // `reader.read()` may stay immediately ready for the entire response.
+      // Awaiting an already-settled promise only drains more microtasks; it does
+      // not give the HTTP listener a turn to answer status/reload/dashboard.
+      chunksSinceYield += 1;
+      if (chunksSinceYield >= STREAM_FAIRNESS_CHUNKS) {
+        chunksSinceYield = 0;
+        await new Promise(resolve => setImmediate(resolve));
         if (clientGone(res)) break;
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -150,8 +150,8 @@ export function resolveClientAuth(proxyConfig, presented) {
 export function createProxyServer(accountManager, config, hooks = {}, sx = null, clientUsage = null, dimensionUsage = null) {
   const upstream = config.upstream || 'https://api.anthropic.com';
   const holdMs = (config.holdSeconds || 0) * 1000;
-  // Experimental until cancellation, queue deadlines and slow-upload bounds
-  // are covered. Do not activate this draft gate on a routine service restart.
+  // Opt-in admission: cancellation, deadlines and byte bounds are tested, but
+  // operators must size ingestion concurrency for their actual workload.
   const ingressGate = Number(process.env.TEAMCLAUDE_INGRESS_CONCURRENCY) > 0 ? new AdmissionGate(
     process.env.TEAMCLAUDE_INGRESS_CONCURRENCY,
     process.env.TEAMCLAUDE_INGRESS_QUEUE,
@@ -920,6 +920,11 @@ function reportFailure(...args) {
  * `drain` or a `close` that has already happened and will not happen again, so
  * the handler never returns and its activity entry never closes.
  */
+function clientGone(res) {
+  return !!res.destroyed || !!res.stream?.destroyed;
+}
+
+// Stop retaining a cancelled request while a quota retry timer is pending.
 function waitForRetry(ms, signal) {
   return new Promise(resolve => {
     if (signal?.aborted) { resolve(); return; }
@@ -927,10 +932,6 @@ function waitForRetry(ms, signal) {
     const timer = setTimeout(finish, ms);
     signal?.addEventListener('abort', finish, { once: true });
   });
-}
-
-function clientGone(res) {
-  return !!res.destroyed || !!res.stream?.destroyed;
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -86,6 +86,9 @@ const xmlEscape = (s) => String(s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 export function renderLaunchAgent({ node, entry, log, path, configPath = null }) {
+  // User-facing HTTP streaming depends on this service receiving CPU promptly.
+  // Background applies a QoS clamp that can starve it under host contention;
+  // Adaptive only promotes via XPC activity, which our HTTP clients do not use.
   const args = [node, entry, 'server', '--headless'];
   const env = [`    <key>PATH</key>\n    <string>${xmlEscape(path)}</string>`];
   if (configPath) env.push(`    <key>TEAMCLAUDE_CONFIG</key>\n    <string>${xmlEscape(configPath)}</string>`);
@@ -104,7 +107,7 @@ ${args.map(a => `    <string>${xmlEscape(a)}</string>`).join('\n')}
   <key>KeepAlive</key>
   <true/>
   <key>ProcessType</key>
-  <string>Background</string>
+  <string>Interactive</string>
   <key>StandardOutPath</key>
   <string>${xmlEscape(log)}</string>
   <key>StandardErrorPath</key>

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -14,6 +14,7 @@ import https from 'node:https';
 import { ReadableStream } from 'node:stream/web';
 import { tunnelTls } from './sx.js';
 import { proxyForHost, proxyAgent } from './upstream-proxy.js';
+import { AdmissionGate } from './admission-gate.js';
 
 // Pooled keep-alive agents for the direct (non-sx) path. Node's global fetch
 // multiplexes ALL requests to an origin over a SINGLE HTTP/2 connection; under
@@ -26,15 +27,18 @@ import { proxyForHost, proxyAgent } from './upstream-proxy.js';
 // socket at TCP speed, exactly like N direct Claude Code processes. maxSockets is
 // per-origin and bounds the fan-out. Escape hatch:
 // TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH=1 reverts to the old global-fetch path.
-// A proxy has one JavaScript event loop, unlike N independent Claude Code
-// processes. Letting a reconnect storm fan out to hundreds of readable TLS
-// sockets can spend whole poll turns draining upstream data and starve even the
-// local status listener. Eight preserves useful parallelism (and fixes the old
-// single-h2 flow-control bottleneck) while applying backpressure before the
-// relay becomes unresponsive. Operators with measured headroom can override it.
-export const DEFAULT_UPSTREAM_MAX_SOCKETS = 8;
+// Long-lived streams occupy sockets until their body ends. A small default
+// (eight) serializes unrelated sessions behind those streams. Preserve the
+// original pool width; explicit bounded admission below limits waiting work.
+export const DEFAULT_UPSTREAM_MAX_SOCKETS = 256;
 const configuredMaxSockets = Number(process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS);
-const MAX_SOCKETS = configuredMaxSockets > 0 ? configuredMaxSockets : DEFAULT_UPSTREAM_MAX_SOCKETS;
+const MAX_SOCKETS = Number.isSafeInteger(configuredMaxSockets) && configuredMaxSockets > 0 ? configuredMaxSockets : DEFAULT_UPSTREAM_MAX_SOCKETS;
+const admissionByOrigin = new Map();
+export function upstreamPoolStatus() {
+  let active = 0, queued = 0;
+  for (const gate of admissionByOrigin.values()) { active += gate.active; queued += gate.queue.length; }
+  return { active, queued, origins: admissionByOrigin.size, perOriginLimit: MAX_SOCKETS };
+}
 const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
 const httpAgent = new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
 const USE_GLOBAL_FETCH = /^(1|true|yes|on)$/i.test(process.env.TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH || '');
@@ -145,7 +149,8 @@ function directFetch(url, opts, timeoutMs) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(headersTimeoutError(timeoutMs)), timeoutMs);
   timer.unref?.();
-  return fetch(url, { ...opts, signal: ctrl.signal }).then(
+  const signal = opts.signal ? AbortSignal.any([opts.signal, ctrl.signal]) : ctrl.signal;
+  return fetch(url, { ...opts, signal }).then(
     (res) => { clearTimeout(timer); return res; },
     (err) => { clearTimeout(timer); throw err; },
   );
@@ -176,12 +181,48 @@ function proxiedFetch(url, opts, sx, timeoutMs) {
 // minutes is never cut. `req` is created BEFORE the timer so a synchronous
 // throw (e.g. an invalid client header) can't leave a scheduled timer that later
 // fires against an uninitialized binding.
-function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
+async function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
+  // Admit before constructing ClientRequest. Destroying a request in Node's
+  // internal Agent queue need not emit error until it receives a socket.
+  // Our queue can expire/cancel and drop its retained body immediately.
+  let gate = admissionByOrigin.get(u.origin);
+  if (!gate) {
+    gate = new AdmissionGate(MAX_SOCKETS, process.env.TEAMCLAUDE_UPSTREAM_MAX_QUEUE);
+    admissionByOrigin.set(u.origin, gate);
+  }
+  const admitted = await gate.enter({ signal: opts.signal,
+    timeoutMs: opts.queueTimeoutMs ?? process.env.TEAMCLAUDE_UPSTREAM_QUEUE_TIMEOUT_MS });
+  if (!admitted) {
+    if (!gate.active && !gate.queue.length) admissionByOrigin.delete(u.origin);
+    if (opts.signal?.aborted) throw opts.signal.reason ?? new Error('aborted');
+    const err = new Error('TeamClaude upstream queue is full or its wait deadline expired');
+    err.code = 'TEAMCLAUDE_UPSTREAM_OVERLOADED';
+    throw err;
+  }
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    gate.leave();
+    if (!gate.active && !gate.queue.length) admissionByOrigin.delete(u.origin);
+  };
+  try {
+    return await sendNodeRequest(u, opts, timeoutMs, { transport, agent }, release);
+  } catch (err) { release(); throw err; }
+}
+
+function sendNodeRequest(u, opts, timeoutMs, { transport, agent }, release) {
   return new Promise((resolve, reject) => {
     const req = transport.request(
       u,
       { method: opts.method || 'GET', headers: opts.headers || {}, agent },
-      (res) => { clearTimeout(timer); cleanupAbort(); resolve(makeResponse(res)); },
+      (res) => {
+        clearTimeout(timer);
+        const finish = () => { cleanupAbort(); release(); };
+        res.once('end', finish);
+        res.once('close', finish);
+        resolve(makeResponse(res));
+      },
     );
     const timer = setTimeout(() => req.destroy(headersTimeoutError(timeoutMs)), timeoutMs);
     timer.unref?.();
@@ -192,12 +233,11 @@ function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
     const signal = opts.signal;
     const onAbort = () => req.destroy(signal?.reason ?? new Error('aborted'));
     const cleanupAbort = () => signal?.removeEventListener?.('abort', onAbort);
+    req.once('error', (err) => { clearTimeout(timer); cleanupAbort(); release(); reject(err); });
     if (signal) {
       if (signal.aborted) { clearTimeout(timer); req.destroy(); reject(signal.reason ?? new Error('aborted')); return; }
       signal.addEventListener?.('abort', onAbort, { once: true });
     }
-
-    req.once('error', (err) => { clearTimeout(timer); cleanupAbort(); reject(err); });
 
     const body = opts.body;
     const method = (opts.method || 'GET').toUpperCase();

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -26,7 +26,15 @@ import { proxyForHost, proxyAgent } from './upstream-proxy.js';
 // socket at TCP speed, exactly like N direct Claude Code processes. maxSockets is
 // per-origin and bounds the fan-out. Escape hatch:
 // TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH=1 reverts to the old global-fetch path.
-const MAX_SOCKETS = Number(process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS) || 256;
+// A proxy has one JavaScript event loop, unlike N independent Claude Code
+// processes. Letting a reconnect storm fan out to hundreds of readable TLS
+// sockets can spend whole poll turns draining upstream data and starve even the
+// local status listener. Eight preserves useful parallelism (and fixes the old
+// single-h2 flow-control bottleneck) while applying backpressure before the
+// relay becomes unresponsive. Operators with measured headroom can override it.
+export const DEFAULT_UPSTREAM_MAX_SOCKETS = 8;
+const configuredMaxSockets = Number(process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS);
+const MAX_SOCKETS = configuredMaxSockets > 0 ? configuredMaxSockets : DEFAULT_UPSTREAM_MAX_SOCKETS;
 const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
 const httpAgent = new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS });
 const USE_GLOBAL_FETCH = /^(1|true|yes|on)$/i.test(process.env.TEAMCLAUDE_UPSTREAM_GLOBAL_FETCH || '');

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -226,7 +226,7 @@ export function writeRequestBody(req, body) {
     // the socket has room, otherwise several multi-megabyte Claude context
     // uploads can monopolise that thread and keep status connections waiting in
     // the kernel. Backpressure remains authoritative when the socket is full.
-    if (ready) setImmediate(pump);
+    if (ready) setTimeout(pump, 1);
     else req.once('drain', pump);
   };
   pump();

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -194,9 +194,34 @@ function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
     const body = opts.body;
     const method = (opts.method || 'GET').toUpperCase();
     if (body == null || method === 'GET' || method === 'HEAD') req.end();
-    else if (typeof body === 'string' || Buffer.isBuffer(body) || body instanceof Uint8Array) req.end(Buffer.from(body));
-    else req.end(String(body));
+    else writeRequestBody(req, body);
   });
+}
+
+// Named seam for the potentially expensive upload path. Large Claude requests
+// commonly carry megabytes of context, so its scheduling behaviour is tested
+// independently of a real TLS socket.
+export function writeRequestBody(req, body) {
+  const bytes = typeof body === 'string' || Buffer.isBuffer(body) || body instanceof Uint8Array
+    ? Buffer.from(body)
+    : Buffer.from(String(body));
+  const chunkBytes = 64 * 1024;
+  let offset = 0;
+
+  const pump = () => {
+    if (req.destroyed) return;
+    if (offset >= bytes.length) { req.end(); return; }
+    const end = Math.min(offset + chunkBytes, bytes.length);
+    const ready = req.write(bytes.subarray(offset, end));
+    offset = end;
+    // A TLS write encrypts synchronously on Node's main thread. Yield even when
+    // the socket has room, otherwise several multi-megabyte Claude context
+    // uploads can monopolise that thread and keep status connections waiting in
+    // the kernel. Backpressure remains authoritative when the socket is full.
+    if (ready) setImmediate(pump);
+    else req.once('drain', pump);
+  };
+  pump();
 }
 
 // Adapt a Node IncomingMessage to a web ReadableStream. Done by hand rather than

--- a/test/account-uuid-rewrite.test.js
+++ b/test/account-uuid-rewrite.test.js
@@ -62,3 +62,62 @@ test('no-op when already the target / no user_id / bad uuid length', () => {
   const body = Buffer.from(inner(OLD));
   assert.equal(patchAccountUuid(body, 'not-a-uuid'), body);    // wrong length → no-op
 });
+
+test('canonical whole bodies avoid the per-byte fallback', () => {
+  const body = Buffer.from(JSON.stringify({
+    messages: Array.from({ length: 1_000 }, (_, i) => ({ role: 'user', content: String(i) })),
+    metadata: { user_id: JSON.stringify({ account_uuid: OLD }) },
+  }));
+  const original = AccountUuidPatcher.prototype.push;
+  AccountUuidPatcher.prototype.push = () => { throw new Error('slow byte fallback used'); };
+  try {
+    const out = patchAccountUuid(body, NEW);
+    assert.equal(JSON.parse(JSON.parse(out).metadata.user_id).account_uuid, NEW);
+  } finally {
+    AccountUuidPatcher.prototype.push = original;
+  }
+});
+
+test('non-JSON metadata.user_id also avoids the per-byte fallback', () => {
+  const body = Buffer.from(JSON.stringify({
+    messages: [{ role: 'user', content: 'ordinary prompt' }],
+    metadata: { source: 'cli', user_id: `device=abc;account_uuid":"${OLD};session=xyz` },
+  }));
+  const original = AccountUuidPatcher.prototype.push;
+  AccountUuidPatcher.prototype.push = () => { throw new Error('slow byte fallback used'); };
+  try {
+    const out = patchAccountUuid(body, NEW);
+    assert.equal(JSON.parse(out).metadata.user_id,
+      `device=abc;account_uuid":"${NEW};session=xyz`);
+  } finally {
+    AccountUuidPatcher.prototype.push = original;
+  }
+});
+
+test('opaque 36-byte account identifiers use the validated fast path', () => {
+  const opaque = 'user_account_identifier_123456789012';
+  assert.equal(opaque.length, 36);
+  const body = Buffer.from(JSON.stringify({
+    metadata: { source: 'cli', user_id: `account_uuid":"${opaque}` },
+  }));
+  const original = AccountUuidPatcher.prototype.push;
+  AccountUuidPatcher.prototype.push = () => { throw new Error('slow byte fallback used'); };
+  try {
+    assert.match(JSON.parse(patchAccountUuid(body, NEW)).metadata.user_id, new RegExp(NEW));
+  } finally {
+    AccountUuidPatcher.prototype.push = original;
+  }
+});
+
+test('bodies without an account marker never enter the per-byte fallback', () => {
+  const body = Buffer.from(JSON.stringify({
+    messages: Array.from({ length: 1_000 }, (_, i) => ({ content: String(i) })),
+  }));
+  const original = AccountUuidPatcher.prototype.push;
+  AccountUuidPatcher.prototype.push = () => { throw new Error('slow byte fallback used'); };
+  try {
+    assert.equal(patchAccountUuid(body, NEW), body);
+  } finally {
+    AccountUuidPatcher.prototype.push = original;
+  }
+});

--- a/test/account-uuid-rewrite.test.js
+++ b/test/account-uuid-rewrite.test.js
@@ -5,6 +5,32 @@ import { patchAccountUuid, AccountUuidPatcher } from '../src/account-uuid-rewrit
 const OLD = '4c39e915-eb47-450d-9bf4-4cbbcd049a08';
 const NEW = '11111111-2222-3333-4444-555555555555';
 
+test('whole-body rewrite never mistakes nested metadata for request metadata', () => {
+  const body = Buffer.from(JSON.stringify({ tools: [{ metadata: { user_id: JSON.stringify({ account_uuid: OLD }) } }] }));
+  assert.deepEqual(patchAccountUuid(body, NEW), body);
+});
+
+test('short account IDs cannot overwrite the enclosing JSON or adjacent fields', () => {
+  const body = Buffer.from(JSON.stringify({ metadata: { user_id: JSON.stringify({ account_uuid: 'short', device_id: 'a'.repeat(80) }) } }));
+  assert.deepEqual(patchAccountUuid(body, NEW), body);
+});
+
+test('escaped metadata keys and duplicated user strings change only top-level metadata', () => {
+  const userId = JSON.stringify({ account_uuid: OLD });
+  const body = Buffer.from(JSON.stringify({ copy: userId, metadata: { user_id: userId } }).replace('"metadata"', '"meta\\u0064ata"'));
+  const out = JSON.parse(patchAccountUuid(body, NEW));
+  assert.equal(out.copy, userId);
+  assert.equal(JSON.parse(out.metadata.user_id).account_uuid, NEW);
+});
+
+test('a canonical-looking string elsewhere cannot substitute for an escaped metadata value', () => {
+  const userId = JSON.stringify({ account_uuid: OLD });
+  const raw = `{${JSON.stringify(userId)}:1,"metadata":{"user_id":${JSON.stringify(userId).replace('account_uuid', 'account_\\u0075uid')}}}`;
+  const out = JSON.parse(patchAccountUuid(Buffer.from(raw), NEW));
+  assert.equal(out[userId], 1);
+  assert.equal(JSON.parse(out.metadata.user_id).account_uuid, NEW);
+});
+
 test('patches account_uuid inside metadata.user_id (escaped) same-length', () => {
   const body = Buffer.from(JSON.stringify({
     model: 'claude',

--- a/test/admission-gate.test.js
+++ b/test/admission-gate.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AdmissionGate } from '../src/admission-gate.js';
+
+test('admission gate bounds active work, queues FIFO, and rejects overflow', async () => {
+  const gate = new AdmissionGate(2, 2);
+  assert.equal(await gate.enter(), true);
+  assert.equal(await gate.enter(), true);
+  const third = gate.enter();
+  const fourth = gate.enter();
+  assert.equal(await gate.enter(), false);
+  assert.deepEqual(gate.status(), { active: 2, queued: 2, limit: 2, maxQueue: 2 });
+
+  gate.leave();
+  assert.equal(await third, true);
+  assert.deepEqual(gate.status(), { active: 2, queued: 1, limit: 2, maxQueue: 2 });
+  gate.leave();
+  assert.equal(await fourth, true);
+  gate.leave();
+  gate.leave();
+  assert.equal(gate.active, 0);
+});

--- a/test/admission-gate.test.js
+++ b/test/admission-gate.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
 import { AdmissionGate } from '../src/admission-gate.js';
 
 test('admission gate bounds active work, queues FIFO, and rejects overflow', async () => {
@@ -19,4 +20,42 @@ test('admission gate bounds active work, queues FIFO, and rejects overflow', asy
   gate.leave();
   gate.leave();
   assert.equal(gate.active, 0);
+});
+
+test('queued cancellation removes the waiter immediately without stealing a permit', async () => {
+  const gate = new AdmissionGate(1, 1);
+  await gate.enter();
+  const ac = new AbortController();
+  const waiting = gate.enter({ signal: ac.signal });
+  ac.abort();
+  assert.equal(await Promise.race([waiting, delay(100, 'hung')]), false);
+  assert.equal(gate.status().queued, 0);
+  assert.equal(gate.status().active, 1);
+  const next = gate.enter();
+  gate.leave();
+  assert.equal(await next, true);
+  gate.leave();
+  assert.equal(gate.status().active, 0);
+});
+
+test('queue deadline removes only its own waiter and allows recovery', async () => {
+  const gate = new AdmissionGate(1, 2);
+  await gate.enter();
+  const expired = gate.enter({ timeoutMs: 20 });
+  const next = gate.enter({ timeoutMs: 1000 });
+  assert.equal(await Promise.race([expired, delay(100, 'hung')]), false);
+  assert.equal(gate.status().queued, 1);
+  gate.leave();
+  assert.equal(await next, true);
+  gate.leave();
+  assert.equal(gate.status().active, 0);
+});
+
+test('already cancelled entry never acquires a permit; zero-length queue rejects', async () => {
+  const gate = new AdmissionGate(1, 0);
+  assert.equal(await gate.enter({ signal: AbortSignal.abort() }), false);
+  assert.equal(gate.active, 0);
+  assert.equal(await gate.enter(), true);
+  assert.equal(await gate.enter(), false);
+  gate.leave();
 });

--- a/test/advisor-routing.test.js
+++ b/test/advisor-routing.test.js
@@ -23,6 +23,18 @@ test('parseAdvisorModel extracts the advisor model from tools[]', () => {
   assert.equal(parseAdvisorModel(Buffer.from(advisorBody())), 'claude-fable-5');
 });
 
+test('parseAdvisorModel uses the native whole-body path instead of the byte scanner', () => {
+  const original = AdvisorModelFinder.prototype.push;
+  AdvisorModelFinder.prototype.push = () => {
+    throw new Error('whole-body advisor parsing must not use the byte scanner');
+  };
+  try {
+    assert.equal(parseAdvisorModel(advisorBody()), 'claude-fable-5');
+  } finally {
+    AdvisorModelFinder.prototype.push = original;
+  }
+});
+
 test('parseAdvisorModel ignores requests without an advisor tool', () => {
   assert.equal(parseAdvisorModel(JSON.stringify({ model: 'claude-opus-4-8', tools: [{ name: 'Bash' }] })), null);
   assert.equal(parseAdvisorModel('{"model":"claude-opus-4-8"}'), null);

--- a/test/cli-switch.test.js
+++ b/test/cli-switch.test.js
@@ -52,9 +52,9 @@ async function writeConfig(port) {
   return path;
 }
 
-function runCli(configPath, cliArgs) {
+function runCli(configPath, cliArgs, extraEnv = {}) {
   const child = spawn(process.execPath, [cliPath, ...cliArgs], {
-    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath, ...extraEnv },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   let stdout = '';
@@ -223,5 +223,21 @@ test('a down server exits 1 with the same hint as status', async () => {
     assert.equal(res.code, 1, cliArgs.join(' '));
     assert.match(res.stderr, new RegExp(`Cannot connect to proxy at localhost:${port}`));
     assert.match(res.stderr, /Is the server running\?/);
+  }
+});
+
+test('status diagnoses an accepted connection whose server never answers', async () => {
+  const silent = http.createServer(() => { /* accept and intentionally hang */ });
+  const port = await listen(silent);
+  const configPath = await writeConfig(port);
+  try {
+    const res = await runCli(configPath, ['status'], { TEAMCLAUDE_STATUS_TIMEOUT_MS: '100' });
+    assert.equal(res.code, 1);
+    assert.match(res.stderr, /did not answer status within 100ms/);
+    assert.match(res.stderr, /event loop may be stalled/);
+    assert.doesNotMatch(res.stderr, /Is the server running/);
+  } finally {
+    silent.closeAllConnections?.();
+    silent.close();
   }
 });

--- a/test/event-loop-monitor.test.js
+++ b/test/event-loop-monitor.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startEventLoopMonitor } from '../src/event-loop-monitor.js';
+
+test('event-loop monitor records stalls and rate-limits warnings', () => {
+  let clock = 0;
+  let tick;
+  let cancelled = false;
+  const warnings = [];
+  const timer = { unrefCalled: false, unref() { this.unrefCalled = true; } };
+  const monitor = startEventLoopMonitor({
+    intervalMs: 100,
+    warnLagMs: 50,
+    warnCooldownMs: 1_000,
+    now: () => clock,
+    schedule(fn) { tick = fn; return timer; },
+    cancel(value) { assert.equal(value, timer); cancelled = true; },
+    log(message) { warnings.push(message); },
+  });
+
+  assert.equal(timer.unrefCalled, true);
+  clock = 180; tick(); // 80ms late
+  clock = 360; tick(); // another 80ms late, inside warning cooldown
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /lag=80ms/);
+  assert.deepEqual(monitor.status(), {
+    lastLagMs: 80,
+    maxLagMs: 80,
+    stallCount: 2,
+    lastStallAt: monitor.status().lastStallAt,
+    warnLagMs: 50,
+  });
+  assert.ok(monitor.status().lastStallAt);
+
+  monitor.stop();
+  assert.equal(cancelled, true);
+});

--- a/test/ingress-safety.test.js
+++ b/test/ingress-safety.test.js
@@ -1,9 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
+import http2 from 'node:http2';
+import { performance } from 'node:perf_hooks';
 import { setTimeout as delay } from 'node:timers/promises';
 import { AccountManager } from '../src/account-manager.js';
-import { createProxyServer } from '../src/server.js';
+import { createProxyServer, createProxyRequestListener } from '../src/server.js';
+import { AdmissionGate } from '../src/admission-gate.js';
 
 async function until(fn) {
   for (let i = 0; i < 200; i++) { if (fn()) return; await delay(5); }
@@ -19,16 +22,27 @@ async function fixture(t, overrides = {}) {
   const old = Object.fromEntries(Object.keys(vars).map(k => [k, process.env[k]]));
   Object.assign(process.env, vars);
   t.after(() => { for (const [k, v] of Object.entries(old)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; } });
-  let forwarded = 0;
+  let forwarded = 0, upstreamClosed = 0;
   const upstream = http.createServer(async (req, res) => {
     for await (const c of req) void c;
     forwarded++;
+    if (req.headers['x-test-response']) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write('{');
+      if (req.headers['x-test-response'] === 'large') res.end('x'.repeat(2048));
+      return;
+    }
+    if (req.headers['x-test-stall']) {
+      req.socket.once('close', () => upstreamClosed++);
+      return;
+    }
     res.end('{}');
   });
   await new Promise(r => upstream.listen(0, '127.0.0.1', r));
   const started = [], ended = [];
-  const proxy = createProxyServer(new AccountManager([{ name: 'test', type: 'apikey', apiKey: 'fake' }], .98),
-    { proxy: {}, upstream: `http://127.0.0.1:${upstream.address().port}` },
+  const am = new AccountManager([{ name: 'test', type: 'apikey', apiKey: 'fake' }], .98);
+  const proxy = createProxyServer(am,
+    { proxy: {}, holdSeconds: 120, upstream: `http://127.0.0.1:${upstream.address().port}` },
     { onRequestStart: id => started.push(id), onRequestEnd: (id, info) => ended.push({ id, ...info }) });
   await new Promise(r => proxy.listen(0, '127.0.0.1', r));
   t.after(() => { proxy.closeAllConnections(); proxy.close(); upstream.closeAllConnections(); upstream.close(); });
@@ -36,15 +50,49 @@ async function fixture(t, overrides = {}) {
   function upload(headers = {}) {
     const req = http.request(`${url}/v1/messages`, { method: 'POST', headers });
     const outcome = new Promise(resolve => {
-      req.once('response', res => { res.resume(); res.once('end', () => resolve(res.statusCode)); });
+      req.once('response', res => { res.resume(); res.once('end', () => resolve(res.statusCode)); res.once('error', () => resolve('truncated')); });
       req.once('error', () => resolve('closed'));
     });
     t.after(() => req.destroy());
     req.flushHeaders();
     return { req, outcome };
   }
-  return { url, upload, started, ended, forwarded: () => forwarded };
+  return { am, url, upload, started, ended, forwarded: () => forwarded, upstreamClosed: () => upstreamClosed };
 }
+
+test('disconnect during a quota hold clears activity without waiting for the retry timer', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  f.am.getActiveAccount = () => null;
+  const client = f.upload(); client.req.end('{}');
+  await until(() => f.started.length === 1);
+  await delay(20);
+  client.req.destroy();
+  await until(() => f.ended.length === 1);
+  assert.equal(f.ended[0].status, 499);
+  assert.equal(f.forwarded(), 0);
+});
+
+test('silent or oversized buffered upstream responses are truncated, not held or reported complete', { timeout: 4000 }, async t => {
+  const f = await fixture(t, { TEAMCLAUDE_RESPONSE_BODY_MAX_BYTES: '1024', TEAMCLAUDE_UPSTREAM_BODY_TIMEOUT_MS: '50' });
+  for (const mode of ['silent', 'large']) {
+    const client = f.upload({ 'x-test-response': mode }); client.req.end('{}');
+    const result = await Promise.race([client.outcome, delay(500, 'hung')]);
+    assert.ok(result === 'closed' || result === 'truncated', `${mode}: ${result}`);
+  }
+  await until(() => f.ended.length === 2);
+  const good = f.upload(); good.req.end('{}');
+  assert.equal(await good.outcome, 200);
+});
+
+test('disconnect before upstream headers cancels upstream and closes activity promptly', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  const client = f.upload({ 'x-test-stall': '1' }); client.req.end('{}');
+  await until(() => f.forwarded() === 1);
+  client.req.destroy();
+  await until(() => f.upstreamClosed() === 1);
+  await until(() => f.ended.length === 1);
+  assert.equal(f.ended[0].status, 499);
+});
 
 test('overload and queued disconnect close activity entries; control plane bypasses admission', { timeout: 4000 }, async t => {
   const f = await fixture(t, { TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS: '2000', TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS: '1000' });
@@ -96,4 +144,78 @@ test('declared and chunked oversized bodies get 413 without upstream traffic; bo
   assert.equal(await good.outcome, 200);
   await until(() => f.ended.length === 3);
   assert.deepEqual(f.ended.map(e => e.status), [413, 413, 200]);
+});
+
+test('disconnect mid-upload releases its permit and closes activity exactly once', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  const broken = f.upload(); broken.req.write('{');
+  await until(() => f.started.length === 1);
+  broken.req.destroy();
+  await until(() => f.ended.length === 1);
+  assert.equal(f.ended[0].status, 499);
+  const next = f.upload(); next.req.end('{}');
+  assert.equal(await next.outcome, 200);
+  await until(() => f.ended.length === 2);
+  assert.equal(f.forwarded(), 1);
+});
+
+test('h2 upload rejection closes only its stream; another stream on the session succeeds', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  const gate = new AdmissionGate(1, 1);
+  // Exercise the same compatibility request listener used by MITM, without
+  // generating certificates or contacting a real account.
+  const h2 = http2.createServer(createProxyRequestListener({ accountManager: f.am, upstream: f.url, ingressGate: gate }));
+  await new Promise(r => h2.listen(0, '127.0.0.1', r));
+  const client = http2.connect(`http://127.0.0.1:${h2.address().port}`);
+  t.after(() => { client.destroy(); h2.close(); });
+  const post = body => new Promise((resolve, reject) => {
+    const req = client.request({ ':method': 'POST', ':path': '/v1/messages' });
+    let status;
+    req.on('response', headers => { status = headers[':status']; });
+    req.on('error', reject); req.resume();
+    req.on('end', () => resolve(status));
+    req.end(body);
+  });
+  assert.equal(await post('x'.repeat(1025)), 413);
+  assert.equal(client.destroyed, false);
+  assert.equal(await post('{}'), 200);
+  assert.deepEqual(gate.status(), { active: 0, queued: 0, limit: 1, maxQueue: 1 });
+});
+
+test('repeated large-body bursts preserve status responsiveness and drain admission', { timeout: 15000 }, async t => {
+  const f = await fixture(t, { TEAMCLAUDE_INGRESS_CONCURRENCY: '2', TEAMCLAUDE_INGRESS_QUEUE: '4',
+    TEAMCLAUDE_REQUEST_BODY_MAX_BYTES: String(2 * 1024 * 1024), TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS: '5000',
+    TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS: '2000' });
+  const body = JSON.stringify({ model: 'claude-test', messages: [{ content: 'x'.repeat(1024 * 1024) }] });
+  const latencies = [];
+  let successes = 0, rejected = 0;
+  for (let round = 0; round < 5; round++) {
+    const clients = Array.from({ length: 12 }, () => {
+      const client = f.upload(); client.req.write(body.slice(0, 128)); return client;
+    });
+    const burst = Promise.all(clients.map(c => c.outcome));
+    await until(() => f.started.length === (round + 1) * 12);
+    for (let i = 0; i < 5; i++) {
+      const start = performance.now();
+      const r = await fetch(`${f.url}/teamclaude/status`, { signal: AbortSignal.timeout(1000) });
+      assert.equal(r.status, 200);
+      const { ingress } = await r.json();
+      latencies.push(performance.now() - start);
+      assert.ok(ingress.active <= 2 && ingress.queued <= 4);
+    }
+    for (const client of clients) if (!client.req.destroyed) client.req.end(body.slice(128));
+    for (const status of await burst) {
+      assert.ok(status === 200 || status === 503, `unexpected burst status ${status}`);
+      if (status === 200) successes++; else rejected++;
+    }
+    await until(() => f.ended.length === (round + 1) * 12);
+    const { ingress } = await (await fetch(`${f.url}/teamclaude/status`)).json();
+    assert.equal(ingress.active, 0); assert.equal(ingress.queued, 0);
+  }
+  assert.ok(successes > 0 && rejected > 0);
+  assert.equal(f.forwarded(), successes);
+  assert.equal(new Set(f.ended.map(e => e.id)).size, 60);
+  latencies.sort((a, b) => a - b);
+  t.diagnostic(JSON.stringify({ requests: 60, successes, rejected, statusProbes: latencies.length,
+    medianMs: latencies[12], p95Ms: latencies[23], maxMs: latencies[24] }));
 });

--- a/test/ingress-safety.test.js
+++ b/test/ingress-safety.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+async function until(fn) {
+  for (let i = 0; i < 200; i++) { if (fn()) return; await delay(5); }
+  assert.fail('condition did not settle within 1s');
+}
+
+async function fixture(t, overrides = {}) {
+  const vars = {
+    TEAMCLAUDE_INGRESS_CONCURRENCY: '1', TEAMCLAUDE_INGRESS_QUEUE: '1',
+    TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS: '150', TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS: '300',
+    TEAMCLAUDE_REQUEST_BODY_MAX_BYTES: '1024', ...overrides,
+  };
+  const old = Object.fromEntries(Object.keys(vars).map(k => [k, process.env[k]]));
+  Object.assign(process.env, vars);
+  t.after(() => { for (const [k, v] of Object.entries(old)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; } });
+  let forwarded = 0;
+  const upstream = http.createServer(async (req, res) => {
+    for await (const c of req) void c;
+    forwarded++;
+    res.end('{}');
+  });
+  await new Promise(r => upstream.listen(0, '127.0.0.1', r));
+  const started = [], ended = [];
+  const proxy = createProxyServer(new AccountManager([{ name: 'test', type: 'apikey', apiKey: 'fake' }], .98),
+    { proxy: {}, upstream: `http://127.0.0.1:${upstream.address().port}` },
+    { onRequestStart: id => started.push(id), onRequestEnd: (id, info) => ended.push({ id, ...info }) });
+  await new Promise(r => proxy.listen(0, '127.0.0.1', r));
+  t.after(() => { proxy.closeAllConnections(); proxy.close(); upstream.closeAllConnections(); upstream.close(); });
+  const url = `http://127.0.0.1:${proxy.address().port}`;
+  function upload(headers = {}) {
+    const req = http.request(`${url}/v1/messages`, { method: 'POST', headers });
+    const outcome = new Promise(resolve => {
+      req.once('response', res => { res.resume(); res.once('end', () => resolve(res.statusCode)); });
+      req.once('error', () => resolve('closed'));
+    });
+    t.after(() => req.destroy());
+    req.flushHeaders();
+    return { req, outcome };
+  }
+  return { url, upload, started, ended, forwarded: () => forwarded };
+}
+
+test('overload and queued disconnect close activity entries; control plane bypasses admission', { timeout: 4000 }, async t => {
+  const f = await fixture(t, { TEAMCLAUDE_REQUEST_BODY_TIMEOUT_MS: '2000', TEAMCLAUDE_INGRESS_QUEUE_TIMEOUT_MS: '1000' });
+  const first = f.upload(); first.req.write('{');
+  await until(() => f.started.length === 1);
+  const queued = f.upload(); queued.req.write('{');
+  await until(() => f.started.length === 2);
+  const rejected = f.upload(); rejected.req.end('{}');
+  assert.equal(await rejected.outcome, 503);
+  await until(() => f.ended.some(e => e.status === 503));
+  assert.equal((await fetch(`${f.url}/teamclaude/status`, { signal: AbortSignal.timeout(500) })).status, 200);
+  queued.req.destroy();
+  await until(() => f.ended.some(e => e.status === 499));
+  // The cancelled request must free the queue immediately, not on admission.
+  const replacement = f.upload(); replacement.req.end('{}');
+  await until(() => f.started.length === 4);
+  first.req.end('}');
+  assert.equal(await first.outcome, 200);
+  assert.equal(await replacement.outcome, 200);
+  await until(() => f.ended.length === 4);
+  assert.equal(new Set(f.ended.map(e => e.id)).size, 4);
+  assert.equal(f.forwarded(), 2);
+});
+
+test('queue and trickling-body deadlines return errors and recover permits', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  const slow = f.upload(); slow.req.write('{');
+  const trickle = setInterval(() => slow.req.write(' '), 25);
+  t.after(() => clearInterval(trickle));
+  await until(() => f.started.length === 1);
+  const queued = f.upload(); queued.req.end('{}');
+  assert.equal(await queued.outcome, 503);
+  assert.equal(await slow.outcome, 408);
+  clearInterval(trickle);
+  const good = f.upload(); good.req.end('{}');
+  assert.equal(await good.outcome, 200);
+  await until(() => f.ended.length === 3);
+  assert.equal(f.forwarded(), 1);
+});
+
+test('declared and chunked oversized bodies get 413 without upstream traffic; boundary body succeeds', { timeout: 4000 }, async t => {
+  const f = await fixture(t);
+  const declared = f.upload({ 'content-length': '1025' });
+  assert.equal(await declared.outcome, 413);
+  const chunked = f.upload(); chunked.req.write('x'.repeat(1025));
+  assert.equal(await chunked.outcome, 413);
+  assert.equal(f.forwarded(), 0);
+  const good = f.upload(); good.req.end(JSON.stringify({ x: 'a'.repeat(1016) }));
+  assert.equal(await good.outcome, 200);
+  await until(() => f.ended.length === 3);
+  assert.deepEqual(f.ended.map(e => e.status), [413, 413, 200]);
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -18,6 +18,18 @@ test('parseRequestModel reads the top-level model', () => {
   assert.equal(parseRequestModel(null), null);
 });
 
+test('parseRequestModel avoids the incremental byte scanner for whole bodies', () => {
+  const original = TopLevelFieldFinder.prototype.push;
+  TopLevelFieldFinder.prototype.push = () => {
+    throw new Error('whole-body model parsing must not use the byte scanner');
+  };
+  try {
+    assert.equal(parseRequestModel('{"model":"claude-opus-4-8"}'), 'claude-opus-4-8');
+  } finally {
+    TopLevelFieldFinder.prototype.push = original;
+  }
+});
+
 test('parseRequestModel ignores a "model" key nested in conversation content', () => {
   // A user message literally contains `"model":"DECOY"`; the real field comes
   // after it at the top level. A regex would grab DECOY — the structural finder

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -88,6 +88,9 @@ test('the LaunchAgent asks for restart-on-exit and headless mode', () => {
   assert.match(plist, /<string>server<\/string>\s*<string>--headless<\/string>/);
   assert.match(plist, /<key>KeepAlive<\/key>\s*<true\/>/);
   assert.match(plist, /<key>RunAtLoad<\/key>\s*<true\/>/);
+  // HTTP requests cannot lift launchd's Background QoS clamp through XPC.
+  // This process is on the interactive client's response path.
+  assert.match(plist, /<key>ProcessType<\/key>\s*<string>Interactive<\/string>/);
   assert.match(plist, /<key>PATH<\/key>\s*<string>\/opt\/homebrew\/bin:\/usr\/bin<\/string>/);
 });
 

--- a/test/upstream-pool.test.js
+++ b/test/upstream-pool.test.js
@@ -2,7 +2,49 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import { once } from 'node:events';
+import { setTimeout as delay } from 'node:timers/promises';
 import { upstreamFetch, DEFAULT_UPSTREAM_MAX_SOCKETS } from '../src/upstream-fetch.js';
+
+test('twelve long-lived streams receive headers without waiting for another stream to end', { timeout: 4000 }, async t => {
+  const { server, port } = await listen((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('event: ping\n\n');
+  });
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  const results = await Promise.allSettled(Array.from({ length: 12 }, () =>
+    upstreamFetch(`http://127.0.0.1:${port}/`, { headersTimeoutMs: 500 })));
+  for (const r of results) if (r.status === 'fulfilled') await r.value.body.cancel();
+  assert.equal(results.filter(r => r.status === 'fulfilled').length, 12);
+});
+
+test('upstream queue is bounded, cancellable, separately timed, and recovers on stream release', { timeout: 5000 }, async t => {
+  const keys = ['TEAMCLAUDE_UPSTREAM_MAX_SOCKETS', 'TEAMCLAUDE_UPSTREAM_MAX_QUEUE'];
+  const saved = keys.map(k => process.env[k]);
+  process.env[keys[0]] = '1'; process.env[keys[1]] = '1';
+  t.after(() => keys.forEach((k, i) => { if (saved[i] === undefined) delete process.env[k]; else process.env[k] = saved[i]; }));
+  const { upstreamFetch: limited } = await import('../src/upstream-fetch.js?queue-test');
+  const reached = [];
+  const { server, port } = await listen((req, res) => {
+    reached.push(req.url);
+    if (req.url === '/hold') { res.writeHead(200); res.write('held'); }
+    else res.end('ok');
+  });
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  const base = `http://127.0.0.1:${port}`;
+  const hold = await limited(`${base}/hold`);
+  const ac = new AbortController();
+  const cancel = limited(`${base}/cancel`, { signal: ac.signal });
+  const cancelled = assert.rejects(cancel, { name: 'AbortError' });
+  await assert.rejects(limited(`${base}/overflow`), { code: 'TEAMCLAUDE_UPSTREAM_OVERLOADED' });
+  ac.abort(); await cancelled;
+  await assert.rejects(limited(`${base}/expired`, { queueTimeoutMs: 25 }), { code: 'TEAMCLAUDE_UPSTREAM_OVERLOADED' });
+  // Waiting 75ms must not consume the 50ms upstream headers deadline.
+  const next = limited(`${base}/next`, { queueTimeoutMs: 1000, headersTimeoutMs: 50 });
+  await delay(75);
+  await hold.body.cancel();
+  assert.equal(await (await next).text(), 'ok');
+  assert.deepEqual(reached, ['/hold', '/next']);
+});
 
 async function listen(handler) {
   const server = http.createServer(handler);
@@ -39,7 +81,12 @@ test('concurrent requests each open their own connection and run in parallel', a
   server.close();
 });
 
-test('default pool bounds reconnect fan-out before it starves the event loop', async () => {
+test('configured pool bounds reconnect fan-out and drains queued work', async (t) => {
+  const old = process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS;
+  process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS = '8';
+  const { upstreamFetch: boundedFetch } = await import('../src/upstream-fetch.js?bounded-test');
+  if (old === undefined) delete process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS;
+  else process.env.TEAMCLAUDE_UPSTREAM_MAX_SOCKETS = old;
   let active = 0;
   let peak = 0;
   let release;
@@ -53,18 +100,20 @@ test('default pool bounds reconnect fan-out before it starves the event loop', a
     res.end('ok');
   });
 
-  const total = DEFAULT_UPSTREAM_MAX_SOCKETS + 4;
-  const requests = Array.from({ length: total }, () =>
-    upstreamFetch(`http://127.0.0.1:${port}/bounded`, { headersTimeoutMs: 5_000 })
-      .then(response => response.text()));
+  t.after(() => { release(); server.closeAllConnections(); server.close(); });
+  assert.equal(DEFAULT_UPSTREAM_MAX_SOCKETS, 256);
+  const total = 12;
+  const requests = Promise.all(Array.from({ length: total }, () =>
+    boundedFetch(`http://127.0.0.1:${port}/bounded`, { headersTimeoutMs: 5_000 })
+      .then(response => response.text())));
 
   // Give every request time to reach the agent. The first pool-width batch is
   // deliberately held, so any extra connection here proves the cap failed.
   await new Promise(resolve => setTimeout(resolve, 100));
-  assert.equal(peak, DEFAULT_UPSTREAM_MAX_SOCKETS);
+  assert.equal(peak, 8);
   release();
-  assert.deepEqual(await Promise.all(requests), Array(total).fill('ok'));
-  assert.equal(peak, DEFAULT_UPSTREAM_MAX_SOCKETS);
+  assert.deepEqual(await requests, Array(total).fill('ok'));
+  assert.equal(peak, 8);
 
   server.close();
 });

--- a/test/upstream-pool.test.js
+++ b/test/upstream-pool.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import { once } from 'node:events';
-import { upstreamFetch } from '../src/upstream-fetch.js';
+import { upstreamFetch, DEFAULT_UPSTREAM_MAX_SOCKETS } from '../src/upstream-fetch.js';
 
 async function listen(handler) {
   const server = http.createServer(handler);
@@ -35,6 +35,36 @@ test('concurrent requests each open their own connection and run in parallel', a
   assert.equal(conns, N, `expected ${N} parallel connections, saw ${conns}`);
   // Parallel: total ≈ one request's delay, NOT N × delay (serialization).
   assert.ok(elapsed < HEADER_DELAY * 3, `expected parallel (~${HEADER_DELAY}ms), took ${elapsed}ms`);
+
+  server.close();
+});
+
+test('default pool bounds reconnect fan-out before it starves the event loop', async () => {
+  let active = 0;
+  let peak = 0;
+  let release;
+  const gate = new Promise(resolve => { release = resolve; });
+  const { server, port } = await listen(async (req, res) => {
+    active += 1;
+    peak = Math.max(peak, active);
+    await gate;
+    active -= 1;
+    res.writeHead(200);
+    res.end('ok');
+  });
+
+  const total = DEFAULT_UPSTREAM_MAX_SOCKETS + 4;
+  const requests = Array.from({ length: total }, () =>
+    upstreamFetch(`http://127.0.0.1:${port}/bounded`, { headersTimeoutMs: 5_000 })
+      .then(response => response.text()));
+
+  // Give every request time to reach the agent. The first pool-width batch is
+  // deliberately held, so any extra connection here proves the cap failed.
+  await new Promise(resolve => setTimeout(resolve, 100));
+  assert.equal(peak, DEFAULT_UPSTREAM_MAX_SOCKETS);
+  release();
+  assert.deepEqual(await Promise.all(requests), Array(total).fill('ok'));
+  assert.equal(peak, DEFAULT_UPSTREAM_MAX_SOCKETS);
 
   server.close();
 });

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -8,6 +8,16 @@ import { TextEncoder, TextDecoder } from 'node:util';
 import { upstreamFetch, writeRequestBody } from '../src/upstream-fetch.js';
 import { readWithIdleTimeout, relayFair, streamResponse } from '../src/server.js';
 
+test('client disconnect cancels a silent upstream immediately, not at idle timeout', { timeout: 2000 }, async () => {
+  let cancelled = false;
+  const upstream = new ReadableStream({ cancel() { cancelled = true; } });
+  const client = new Writable({ write(chunk, enc, cb) { cb(); } });
+  const running = streamResponse(upstream, client, 0, { recordTokenUsage() {} });
+  client.destroy();
+  await Promise.race([running, new Promise((_, reject) => setTimeout(() => reject(new Error('disconnect did not cancel upstream')), 200))]);
+  assert.equal(cancelled, true);
+});
+
 // Bring up an HTTP server on an ephemeral port and hand back {server, port}.
 async function listen(handler) {
   const server = http.createServer(handler);

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -5,7 +5,7 @@ import { once } from 'node:events';
 import { ReadableStream } from 'node:stream/web';
 import { TextEncoder, TextDecoder } from 'node:util';
 import { upstreamFetch } from '../src/upstream-fetch.js';
-import { readWithIdleTimeout } from '../src/server.js';
+import { readWithIdleTimeout, streamResponse } from '../src/server.js';
 
 // Bring up an HTTP server on an ephemeral port and hand back {server, port}.
 async function listen(handler) {
@@ -146,4 +146,36 @@ test('body watchdog does not fire when chunks keep arriving', async () => {
   } finally {
     clearInterval(alive);
   }
+});
+
+test('a continuously buffered SSE stream yields to other server work', async () => {
+  const totalChunks = 10_000;
+  const chunk = new TextEncoder().encode('event: ping\n\n');
+  let emitted = 0;
+  let written = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (emitted === totalChunks) {
+        controller.close();
+        return;
+      }
+      emitted += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  const res = {
+    destroyed: false,
+    writableEnded: false,
+    write() { written += 1; return true; },
+    end() { this.writableEnded = true; },
+  };
+  const accountManager = { recordTokenUsage() {} };
+
+  const relay = streamResponse(stream, res, 0, accountManager);
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.ok(written > 0, 'the relay never started');
+  assert.ok(written < totalChunks,
+    `the relay consumed all ${totalChunks} ready chunks without yielding an event-loop turn`);
+  await relay;
 });

--- a/test/upstream-timeout.test.js
+++ b/test/upstream-timeout.test.js
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import { once } from 'node:events';
 import { ReadableStream } from 'node:stream/web';
+import { Readable, Writable } from 'node:stream';
 import { TextEncoder, TextDecoder } from 'node:util';
-import { upstreamFetch } from '../src/upstream-fetch.js';
-import { readWithIdleTimeout, streamResponse } from '../src/server.js';
+import { upstreamFetch, writeRequestBody } from '../src/upstream-fetch.js';
+import { readWithIdleTimeout, relayFair, streamResponse } from '../src/server.js';
 
 // Bring up an HTTP server on an ephemeral port and hand back {server, port}.
 async function listen(handler) {
@@ -178,4 +179,51 @@ test('a continuously buffered SSE stream yields to other server work', async () 
   assert.ok(written < totalChunks,
     `the relay consumed all ${totalChunks} ready chunks without yielding an event-loop turn`);
   await relay;
+});
+
+test('a buffered Remote Control relay yields to control-plane work', async () => {
+  const totalChunks = 10_000;
+  let written = 0;
+  const source = new Readable({
+    highWaterMark: 1024 * 1024,
+    read() {
+      for (let i = 0; i < totalChunks; i++) this.push(Buffer.from('x'));
+      this.push(null);
+    },
+  });
+  const destination = new Writable({
+    highWaterMark: 1024 * 1024,
+    write(_chunk, _encoding, callback) { written += 1; callback(); },
+  });
+
+  relayFair(source, destination);
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.ok(written > 0, 'the relay never started');
+  assert.ok(written < totalChunks,
+    `the relay consumed all ${totalChunks} ready chunks without yielding an event-loop turn`);
+  await once(destination, 'finish');
+});
+
+test('a large upstream upload yields to control-plane work', async () => {
+  const body = Buffer.alloc(4 * 1024 * 1024, 'x');
+  let written = 0;
+  let ended = false;
+  const req = {
+    write(chunk) { written += chunk.length; return true; },
+    end(chunk) {
+      if (chunk) written += chunk.length;
+      ended = true;
+    },
+    once() {},
+  };
+
+  writeRequestBody(req, body);
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.ok(written > 0, 'the upload never started');
+  assert.ok(written < body.length,
+    `the upload wrote all ${body.length} bytes without yielding an event-loop turn`);
+  while (!ended) await new Promise(resolve => setImmediate(resolve));
+  assert.equal(written, body.length);
 });


### PR DESCRIPTION
## Summary

Fix macOS scheduling starvation and harden proxy request lifecycles under concurrent load. Adaptive-routing PR #290 remains separate.

- Use Interactive LaunchAgent scheduling instead of Background. A controlled same-work comparison on the affected, resource-contended host took 5,141 ms versus 90 ms; this identifies a scheduling contributor, not a general throughput gain.
- Add a bounded CLI status deadline, event-loop diagnostics, and ingestion/upstream occupancy in status JSON.
- Bound uploads and buffered responses; cancel queued work, upstream reads and quota-hold timers on disconnect. Close activity entries exactly once on all tested paths.
- Add explicit bounded upstream admission, separate queue/headers deadlines, and 503 with Retry-After on local overload without account rotation. Preserve the original 256-socket default so long streams do not serialize ordinary concurrent sessions.
- Keep ingestion concurrency opt-in. Add HTTP/2 stream-isolation and overload/recovery tests, safe structural metadata rewriting, shared agent guidance and a reliability runbook.

## Validation

- Standalone PR suite: **1,363 passed**, zero failed/skipped/cancelled on Node 20.19.4, 22.22.0 and 24.13.0. Fresh post-review full-suite run also passed all 1,363 tests.
- Targeted hardening suite: 40 passed. ESLint and git whitespace checks passed.
- TDD covered queue expiry/cancellation, rejected/disconnected activity cleanup, slow/oversized uploads, silent and oversized buffered responses, upstream disconnects, quota-hold cancellation, and metadata ambiguity. A burst regression caught h1 teardown hiding the rejection response.
- Twenty repeated recovery runs: 1,200 one-MiB requests, 500 successful status probes, HTTP/2 isolation and queue drain checks.
- Continuous 60-second isolated soak: **1,608 requests accounted for**, **585/585 status probes passed**, p95 **5.92 ms**, zero event-loop stalls. After one synthetic account began returning 429s, both unaffected pinned accounts continued progressing (536 successful requests each). The throttled account had 328 successes, four 429s and 204 expected client cancellations during its existing rate-limit pause; all activity entries closed.
- Soak memory samples after explicit GC: heap approximately 11–12 MiB; sampled RSS up to 311 MiB for the combined proxy, fake upstream and load generator. RSS levelled off near the end; this is not a long-term leak guarantee or universal memory bound.

## Local deployment

The hardening is deployed locally alongside adaptive routing as commit `bfc6e9a`; that combined checkout passed **1,418 tests** before restart. Post-restart checks: 30/30 status probes succeeded, median 2.3 ms, and zero event-loop stalls. A later check after over five minutes still showed zero stalls, Interactive scheduling, and no queued upstream requests. The ingress gate remains disabled by default. This PR's final cleanup changes comments and documentation only; no additional service restart was needed.

## Scope and operational follow-ups

Privacy review: checked added content across the final diff and all PR commits, commit messages, and PR text for personal identifiers, private paths and credentials. No such data was found in the reviewed additions; fixtures use synthetic values and operational evidence is aggregated. Shared agent guidance now requires this check before publishing or marking future PRs ready. Normal Git contributor attribution is unchanged.

This is ready for review/merge as scoped; it is not a guarantee against upstream outages. Keep ingestion admission opt-in and observe multi-hour real workloads before broader tuning. Its limits do not cap total sessions, retained retry bodies or whole-process memory. OAuth/Remote Control/attachments/forward-proxy/WebSocket relays have separate paths; the legacy global-fetch escape hatch bypasses Node-transport admission.

Upstream 429 pauses can still delay first bytes while local status is healthy. The synthetic pinned-account test does not establish adaptive-routing fairness. Optimal yield batch size, sustained production memory behavior and alert thresholds remain operational tuning work, not claims made by this PR. See `docs/reliability.md` for limits, incident checks and rollout guidance.
