### PR TITLE
fix(server): refuse dot-segment paths before any prefix classification

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,33 @@ export const HOP_BY_HOP_HEADERS = new Set([
 ]);
 // Path prefix for the deprecated URL-based account pin (superseded by TC_ACCT).
 const PIN_PREFIX = '/tc-acct/';
+
+/**
+ * Does the request path carry a dot-segment (`.` or `..`, in any percent-encoded
+ * spelling, on either slash)?
+ *
+ * Every path classification in the listener — the Codex pool, the
+ * client-credential relay, the `/tc-acct/` pin — is a prefix test on the path
+ * AS SENT, while the upstream URL is normalised afterwards by `new URL()` and
+ * fetch. So `/backend-api/codex/../conversations` classifies as Codex and
+ * reaches chatgpt.com as `/backend-api/conversations`, pooled token attached;
+ * `/v1/messages/../../api/oauth/profile` does not start with `/api/oauth/`,
+ * takes the pool path, and reaches the profile endpoint with a rotated token —
+ * the exact thing the relay exists to prevent for the literal path. Backslash
+ * counts because the URL parser treats it as a slash for http(s). No client of
+ * ours ever sends one; refusing the request is the whole fix.
+ */
+export function hasDotSegment(url) {
+  const path = String(url || '').split('?')[0].split('#')[0];
+  for (const seg of path.split(/[\/\\]/)) {
+    let s = seg;
+    // An undecodable segment (`%`) is compared as sent: the URL parser leaves
+    // it alone too, so it cannot become a dot-segment upstream.
+    try { s = decodeURIComponent(seg); } catch { /* keep raw */ }
+    if (s === '.' || s === '..') return true;
+  }
+  return false;
+}
 const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
 // How long the proxy will absorb a rate-limit 429's retry-after inline (waiting
 // on the SAME account) before surfacing a 429 + retry-after to the client. A
@@ -569,6 +596,19 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
     // already closed.
     let openEntry = null;
     try {
+      // Refused before any path-prefix classification below, so each of those
+      // sees the path upstream will see (see hasDotSegment). Logged like the
+      // unknown-pin 404: an operator should see a client probing the boundary.
+      if (hasDotSegment(req.url)) {
+        const reqId = ++counter;
+        const sessionId = req.headers['x-claude-code-session-id'] || null;
+        hooks.onRequestEnd?.(reqId, { method: req.method, path: safeLine(req.url), account: '(refused: dot-segment in path)', status: 400, model: null, sessionId, pinned: false });
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'Request path must not contain dot-segments' } }));
+        recordEarlyOutcome(accountManager, sessionId, req.url, true);
+        return;
+      }
+
       // Claude Code's telemetry (`/api/event_logging/*`) is high-volume noise in
       // the activity log. `config.eventLogging` (read live so the TUI toggle takes
       // effect immediately): 'show' forwards + displays; 'hide' (default) forwards

--- a/test/path-dot-segments.test.js
+++ b/test/path-dot-segments.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { createProxyRequestListener, hasDotSegment } from '../src/server.js';
+
+// Every path classification in the listener is a prefix test on the path as
+// sent, while the upstream URL is normalised afterwards — so a dot-segment
+// passes the check as one path and reaches upstream as another (#285). The
+// listener refuses such a path before any classification runs.
+
+test('hasDotSegment catches every spelling the URL parser would resolve', () => {
+  for (const p of [
+    '/backend-api/codex/../conversations',
+    '/backend-api/codex/%2e%2e/conversations',
+    '/backend-api/codex/%2E%2E/conversations',
+    '/v1/messages/../../api/oauth/profile',
+    '/v1/messages/./count_tokens',
+    '/v1/messages/%2e/count_tokens',
+    '/backend-api/codex\\..\\conversations',      // backslash is a slash to the parser
+    '/tc-acct/a/../v1/messages',
+    '/v1/..',
+  ]) assert.equal(hasDotSegment(p), true, p);
+});
+
+test('hasDotSegment leaves ordinary paths alone', () => {
+  for (const p of [
+    '/v1/messages',
+    '/v1/messages/count_tokens',
+    '/v1/messages?x=..',                           // query, not path
+    '/api/oauth/files/a.b.c',                      // dots inside a segment
+    '/v1/code/sessions/abc/worker/events/stream',
+    '/backend-api/codex/responses',
+    '/tc-acct/%/v1/messages',                      // undecodable pin segment stays as sent
+    '/a/...',                                      // three dots is a plain segment
+    '', null, undefined,
+  ]) assert.equal(hasDotSegment(p), false, String(p));
+});
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+function rawRequest(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method: 'POST', path, headers: { 'content-type': 'application/json' } }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.end('{}');
+  });
+}
+
+// The listener must answer 400 itself: upstream is never reached and the
+// account manager is never consulted, on either boundary the issue names.
+test('a dot-segment path is refused before the Codex or relay boundary is classified', async () => {
+  let upstreamHits = 0;
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => { upstreamHits++; res.writeHead(200); res.end('{}'); });
+  const accountManager = { getActiveAccount() { throw new Error('must not select an account'); } };
+  const listener = createProxyRequestListener({ accountManager, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const { server: proxy, port } = await listen(listener);
+  try {
+    for (const path of [
+      '/backend-api/codex/../conversations',
+      '/backend-api/codex/%2e%2e/conversations',
+      '/v1/messages/../../api/oauth/profile',
+    ]) {
+      // http.request, not fetch: fetch resolves the dot-segments client-side
+      // and would send the normalised path, which is not what a probe sends.
+      const { status, body } = await rawRequest(port, path);
+      assert.equal(status, 400, path);
+      assert.equal(JSON.parse(body).error.type, 'invalid_request_error', path);
+    }
+    assert.equal(upstreamHits, 0, 'upstream never saw a dot-segment request');
+  } finally {
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.closeAllConnections?.(); upstream.close();
+  }
+});


### PR DESCRIPTION
Fixes #285.

Every path classification in the listener (Codex pool, client-credential relay, `/tc-acct/` pin) is a prefix test on the path as sent, while the upstream URL is normalised afterwards, so a dot-segment passed one check and reached upstream as another path. Verified both examples from the issue against master.

- `hasDotSegment` refuses `.`/`..` in any percent-encoded spelling and on either slash (the URL parser treats `\` as `/` for http). An undecodable segment is compared as sent, since the parser leaves it alone too.
- The guard is at the top of `createProxyRequestListener`, which the MITM tunnel feeds directly, so one check covers both listeners. Refusals are logged to the activity feed like the unknown-pin 404.

Tests: the helper on every spelling plus the ordinary paths it must leave alone, and the listener answering 400 on the three issue paths (sent raw via `http.request`, since `fetch` resolves dot-segments client-side) with an upstream that asserts it was never reached and an account manager that throws if consulted.

Not included: the side note in #285 about `GET /teamclaude/quota` running the session-reset switch. With `expiryRouting` off that is pinned as intended behaviour by `test/expiry-pressure.test.js` ("the knob-off poll spends the reset on sight", from #298), so it is a policy question for its own issue rather than a slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)