### PR TITLE
fix(routing): a failover hop detours one request without moving the fleet cursor

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -606,6 +606,22 @@ export class AccountManager {
   }
 
   /**
+   * The best account this request could hop to, moving NOTHING: no cursor, no
+   * observation, no route cursor. For the one-hop failovers in the server, which
+   * detour a single request around an account that just refused it. A detour
+   * is not a decision about where the fleet rests — but routing it through
+   * getActiveAccount made every hop a "Switched to account" the whole fleet
+   * then followed, and under a sustained 429 the cursor bounced between two
+   * siblings with every request (#286).
+   *
+   * Same candidate set as a real selection: the request's own exclusions, the
+   * provider partition, the expiry band. Returns the account or null.
+   */
+  pickAlternate(exclude, model = null, advisorModel = null, provider = DEFAULT_PROVIDER) {
+    return this._pickBestAvailable(this._excludeOtherProviders(exclude, provider), model, advisorModel);
+  }
+
+  /**
    * Widen a request's exclude set to every account that belongs to a different
    * provider.
    *

--- a/src/server.js
+++ b/src/server.js
@@ -1427,7 +1427,13 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   // Taken before the walk, which can move the observation, and a request cannot
   // confirm the stay its own selection began. A pinned request bypasses
   // selection, so it consults no observation and is no evidence about a rest.
-  const restingGen = ctx.pinnedIndex == null
+  // A failover hop names its destination up front (ctx.hopTo, set by the 429
+  // and 5xx hops below) and is one attempt long: consumed here so the attempt
+  // after it, if any, selects normally. Like a pin it bypasses selection, so it
+  // is no evidence about a rest either.
+  const hopTo = ctx.hopTo ?? null;
+  ctx.hopTo = null;
+  const restingGen = ctx.pinnedIndex == null && hopTo == null
     ? accountManager.observedGeneration(ctx.sessionId, ctx.model)
     : null;
 
@@ -1456,11 +1462,16 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   const pinnedWrongProvider = pinned
     && isSubscriptionAccount(pinned)
     && providerOf(pinned) !== (ctx.provider || DEFAULT_PROVIDER);
-  const account = ctx.pinnedIndex != null
-    ? (pinned && !pinnedWrongProvider && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
-    : accountManager.getActiveAccount(
-      ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider, selection,
-    );
+  // The hop's destination was picked by pickAlternate against this request's
+  // own exclusions, and is taken as-is: re-selecting here would walk the fleet
+  // cursor onto it, which is exactly the move a detour must not make (#286).
+  const account = hopTo != null
+    ? accountManager.accounts[hopTo]
+    : ctx.pinnedIndex != null
+      ? (pinned && !pinnedWrongProvider && !accountManager.capExceeded(pinned, ctx.model) ? pinned : null)
+      : accountManager.getActiveAccount(
+        ctx.tried, ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider, selection,
+      );
   // Accounts a rollover deliberately routed this request away from. Request-
   // scoped: the decision belongs to the request, not to one attempt of it.
   if (selection.rolledOff) {
@@ -1806,12 +1817,15 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
         // ctx.rolledOff as well as tried: an account a rollover moved this
         // request off was never sent a request, so it is not in `tried`, and
         // hopping back onto it would reverse that decision one step later.
-        const alt = accountManager.getActiveAccount(
+        // pickAlternate, not getActiveAccount: the hop detours THIS request and
+        // must leave the fleet cursor where it is (#286).
+        const alt = accountManager.pickAlternate(
           new Set([...ctx.tried, ...(ctx.rolledOff || []), account.index]),
-          ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider,
+          ctx.model, ctx.advisorModel, ctx.provider,
         );
         if (alt && !accountManager.isPaused(alt.index)) {
           ctx.rateLimitHopped = true;
+          ctx.hopTo = alt.index;
           ctx.tried.add(account.index);
           console.log(`[TeamClaude] Rate-limit 429 on "${account.name}" — failing over once to idle account "${alt.name}"`);
           if (clientGone(res)) { ctx.abandoned = true; return; }
@@ -1880,14 +1894,15 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // account'"'"'s cache discovering that. After the hop the response goes to the
     // client as it does today, with its own retry-after intact.
     if (upstreamRes.status >= 500 && !res.headersSent && !ctx.serverErrorHopped && retryCount < maxRetries) {
-      // Same exclusion as the 429 hop: see there.
-      const alt = accountManager.getActiveAccount(
+      // Same exclusion as the 429 hop, and the same cursor-preserving pick.
+      const alt = accountManager.pickAlternate(
         new Set([...ctx.tried, ...(ctx.rolledOff || []), account.index]),
-        ctx.model, ctx.advisorModel, ctx.sessionId, ctx.provider,
+        ctx.model, ctx.advisorModel, ctx.provider,
       );
       if (alt && !accountManager.isPaused(alt.index)) {
         await upstreamRes.body?.cancel();
         ctx.serverErrorHopped = true;
+        ctx.hopTo = alt.index;
         ctx.tried.add(account.index);
         console.log(`[TeamClaude] Upstream ${upstreamRes.status} on "${account.name}" — failing over once to "${alt.name}"`);
         if (clientGone(res)) { ctx.abandoned = true; return; }

--- a/test/hop-keeps-cursor.test.js
+++ b/test/hop-keeps-cursor.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// The one-hop failovers (#271) detour ONE request around an account that just
+// refused it. Their destination used to come from getActiveAccount, which is a
+// selection: it moved currentIndex, logged "Switched to account", and every
+// other session followed the hop. Under a sustained 429 the cursor bounced
+// between two siblings on every request (#286). The hop now picks its
+// destination without moving anything, and the next request starts from the
+// account the fleet was on.
+
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+const HOUR = 3600_000;
+const accounts = () => ([
+  { name: 'a', type: 'oauth', accessToken: 't-a', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+  { name: 'b', type: 'oauth', accessToken: 't-b', refreshToken: 'r', expiresAt: Date.now() + HOUR },
+]);
+const tokenOf = (req) => (req.headers.authorization || '').replace(/^Bearer /, '');
+
+async function post(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'claude-x', messages: [] }),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+async function withFleet(handler, fn) {
+  const seen = [];
+  const upstream = http.createServer((req, res) => { seen.push(tokenOf(req)); handler(req, res); });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(accounts(), 0.98, { refreshFn: async () => { throw new Error('no refresh'); } });
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+  try { await fn({ am, proxyPort, seen }); } finally { proxy.close(); upstream.close(); }
+}
+
+const ok = (res) => { res.writeHead(200, { 'content-type': 'application/json' }); res.end('{"ok":true}'); };
+
+// Refuse `a` for the first request only, so the second request shows where
+// the fleet actually rests afterwards.
+function refuseOnce(status, headers) {
+  let refused = false;
+  return (req, res) => {
+    if (tokenOf(req) === 't-a' && !refused) {
+      refused = true;
+      res.writeHead(status, { 'content-type': 'application/json', ...headers });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }));
+      return;
+    }
+    ok(res);
+  };
+}
+
+test('a rate-limit hop serves the request from the sibling and leaves the cursor where it was', async () => {
+  // retry-after 1: the hop happens before any wait, and the short pause on `a`
+  // keeps the second request quick.
+  await withFleet(refuseOnce(429, { 'retry-after': '1' }), async ({ am, proxyPort, seen }) => {
+    assert.equal(am.currentIndex, 0);
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200, 'the sibling served it');
+    assert.deepEqual(seen, ['t-a', 't-b']);
+    assert.equal(am.currentIndex, 0, 'the detour did not move the fleet');
+    // Once the pause is over the fleet is still on `a`: the next request
+    // starts there, not on the account the detour happened to use.
+    await new Promise(r => setTimeout(r, 1100));
+    const second = await post(proxyPort);
+    assert.equal(second.status, 200);
+    assert.equal(am.currentIndex, 0, 'still there after the pause');
+    assert.equal(seen[2], 't-a', 'the fleet still rests on the original account');
+  });
+});
+
+test('a 5xx hop leaves the cursor where it was, and the next request goes back to the original account', async () => {
+  await withFleet(refuseOnce(529, {}), async ({ am, proxyPort, seen }) => {
+    const { status } = await post(proxyPort);
+    assert.equal(status, 200);
+    assert.deepEqual(seen, ['t-a', 't-b']);
+    assert.equal(am.currentIndex, 0, 'the detour did not move the fleet');
+    // Nothing paused `a` (a 5xx is the provider's problem, not the account's),
+    // so the fleet is still on it and the next request goes there first.
+    await post(proxyPort);
+    assert.equal(seen[2], 't-a', 'the fleet still rests on the original account');
+  });
+});
+
+test('pickAlternate names the sibling without touching the cursor or the observation', () => {
+  const am = new AccountManager(accounts(), 0.98);
+  am.getActiveAccount(null, 'claude-x'); // settle the fleet on `a`
+  const before = am.currentIndex;
+  const alt = am.pickAlternate(new Set([before]), 'claude-x');
+  assert.equal(alt.name, 'b');
+  assert.equal(am.currentIndex, before);
+  assert.equal(am.pickAlternate(new Set([0, 1]), 'claude-x'), null, 'nothing left to hop to');
+});


### PR DESCRIPTION
Fixes #286.

Both one-hop failovers (429 and 5xx, from #271) picked their destination with `getActiveAccount`, which is a selection: it moves `currentIndex`, logs "Switched to account", and every other session follows the hop. The retry then re-selected from the moved cursor, so — as the reporter found — fixing either call alone is unobservable. Under a sustained 429 the cursor bounced between two siblings on every request.

- `AccountManager.pickAlternate(exclude, model, advisorModel, provider)` returns the best available account for the request's own exclusions (same candidate set, provider partition and expiry band as a real selection) and moves nothing: no cursor, no observation, no route cursor.
- Both hops use it and record the destination as `ctx.hopTo`. The next attempt takes that account as-is instead of selecting, the way a pin does. Like a pin it takes no resting-generation stamp, so a detour never confirms a held roll (#298).

Tests drive the real proxy: a 429 hop and a 5xx hop both serve from the sibling with `currentIndex` unchanged, and the next request starts on the original account; plus a unit test that `pickAlternate` names the sibling without touching the cursor. Existing failover tests assert token order only and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)