### PR TITLE
fix(routing): a 429 without rate-limit headers is about the request, not the account

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -26,6 +26,7 @@ Reacting the wrong way to either one makes things worse, so they are handled sep
 
 - A **quota rejection** (a spent 5h or weekly bucket, `unified-…-status: rejected`) switches accounts immediately.
 - A **rate-limit 429** (the per-minute throttle) does **not** switch. It pauses the account so concurrent requests wait instead of flooding, retries the same account (absorbing short `retry-after`s inline, default ≤ 60s via `TEAMCLAUDE_RATE_LIMIT_ABSORB_MAX_SECONDS`), and only surfaces a 429 to the client for longer waits.
+- A **request-scoped 429** — no `retry-after` and no `anthropic-ratelimit-*` headers at all, which is how upstream refuses a model id it will not serve — is about the request, not the account. Nothing is paused. The request gets the same one hop to an idle sibling (or, with no sibling, one retry after 2s); if the answer is the same, the 429 goes back to the client without a fabricated `retry-after`, and the client's own backoff applies.
 
 Rotating on a rate-limit 429 would just move the burst to the next account and throw away the first account's prompt cache.
 

--- a/src/server.js
+++ b/src/server.js
@@ -1781,10 +1781,27 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // and out-of-range values are bounded to [1, 300]. A negative value would
       // otherwise bypass the wait cap — setTimeout returns immediately and a
       // pause/hold would be armed in the past.
-      let retryAfter = parseInt(upstreamRes.headers.get('retry-after'), 10);
+      const retryAfterHeader = upstreamRes.headers.get('retry-after');
+      let retryAfter = parseInt(retryAfterHeader, 10);
       if (Number.isNaN(retryAfter)) retryAfter = 60;
-      // Discard the 429 response body
-      await upstreamRes.body?.cancel();
+      // A 429 that says nothing about the account — no retry-after, no
+      // anthropic-ratelimit-* — is about the REQUEST: a model id upstream
+      // refuses, a shape it will not take. Neither of the account-level
+      // responses below applies to it. Pausing the account made every other
+      // session on it wait out a fabricated 60s for one client's bad model id,
+      // and the inline wait then held that client for the same 60s per attempt;
+      // together they turned one request's problem into a fleet-wide stall
+      // (#288). A throttle, by contrast, always carries the headers.
+      const requestScoped = retryAfterHeader == null && Object.keys(rateLimitHeaders).length === 0;
+      // The body is diagnostic for a request-scoped refusal (it names the
+      // reason) and noise otherwise.
+      let refusal = '';
+      if (requestScoped) {
+        const raw = await readErrorBody(upstreamRes.body).catch(() => null);
+        try { refusal = raw ? String(JSON.parse(raw.toString('utf8'))?.error?.message || '') : ''; } catch { refusal = ''; }
+      } else {
+        await upstreamRes.body?.cancel();
+      }
 
       // Durable quota exhaustion vs. a transient rate limit. A "rejected" unified
       // status means a quota bucket is spent, so waiting and retrying the SAME
@@ -1818,7 +1835,11 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // wait (a fresh IP isn't throttled). Also arm the sticky window for MITM.
       const nextUseSx = !!(sx?.useOn429());
       const switchingToSx = nextUseSx && !route;
-      sx?.noteRateLimited(retryAfter);
+      // The sticky window routes every new MITM tunnel through sx.org for a
+      // while, which is metered. A request-scoped 429 is not an IP limit, so it
+      // does not arm it; the one-shot sx retry below still runs, in case an
+      // IP-scoped limit ever presents without headers.
+      if (!requestScoped) sx?.noteRateLimited(retryAfter);
 
       // This is a rate-limit 429 (per-minute throttle), NOT quota exhaustion —
       // quota rejection is handled above and is the only thing that rotates.
@@ -1828,7 +1849,9 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
       // (capped, then released through a fresh ramp) instead of piling on, and
       // retry the SAME account. The pause never marks the account throttled, so
       // selection keeps choosing it.
-      accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
+      // Not for a request-scoped 429: the account is fine, and the pause is
+      // exactly the fleet-wide stall #288 describes.
+      if (!requestScoped) accountManager.pauseAccount(account.index, Math.min(retryAfter, RATE_LIMIT_ABSORB_MAX_SECONDS));
 
       // ONE bounded failover hop to an idle sibling (#137, #165, #156).
       //
@@ -1871,6 +1894,11 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
           if (clientGone(res)) { ctx.abandoned = true; return; }
           return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, route);
         }
+      } else if (ctx.rateLimitHopped && requestScoped) {
+        // Second headerless 429, on a different account: it followed the
+        // request. Nothing here is about either account.
+        console.log(`[TeamClaude] 429 followed the request onto "${account.name}" with no rate-limit headers — it is about the request, not the accounts; returning it to the client`
+          + (refusal ? ` (${safeLine(refusal)})` : ''));
       } else if (ctx.rateLimitHopped) {
         // Second 429 this request, on a different account. Say so once: the
         // operator chasing "why is my fleet throttled" is looking for exactly
@@ -1886,6 +1914,30 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
         console.log(`[TeamClaude] 429 on "${account.name}" — retrying via sx.org (fresh egress IP)`);
         if (clientGone(res)) { ctx.abandoned = true; return; }
         return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
+      }
+
+      // A request-scoped 429 goes back to the client now. The hop above (and
+      // the sx retry, for the IP-scoped case that might present the same way)
+      // has had its chance; a second account saying the same thing about the
+      // same request is the answer, and waiting a fabricated 60s to hear it a
+      // third time is the other half of #288. With no sibling to hop to, one
+      // short retry covers a momentary blip, and then it is the client's turn.
+      if (requestScoped) {
+        if (!ctx.rateLimitHopped && !ctx.requestScopedRetried && retryCount < maxRetries) {
+          ctx.requestScopedRetried = true;
+          console.log(`[TeamClaude] 429 with no rate-limit headers on "${account.name}" — retrying once in 2s${refusal ? ` (${safeLine(refusal)})` : ''}`);
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          if (clientGone(res)) { ctx.abandoned = true; return; }
+          return forwardRequest(req, res, body, accountManager, upstream, retryCount + 1, hooks, reqId, ctx, logDir, sx, nextUseSx);
+        }
+        ctx.status = 429;
+        if (!res.headersSent && !clientGone(res)) {
+          // No retry-after: upstream gave none, and inventing one would tell the
+          // client to wait for a limit that does not exist. Its own backoff applies.
+          res.writeHead(429, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: refusal || 'Upstream refused this request (429) without rate-limit headers.' } }));
+        }
+        return;
       }
 
       // Absorb short waits inline on the same account — the client never sees the

--- a/test/request-scoped-429.test.js
+++ b/test/request-scoped-429.test.js
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// A 429 with no retry-after and no anthropic-ratelimit-* headers is upstream
+// refusing the REQUEST (a model id it will not serve), not throttling the
+// account. It used to be treated as a throttle: the account was paused for a
+// fabricated 60s, so every other session on it waited, and the client was held
+// for the same 60s per attempt (#288). Now nothing is paused, the request gets
+// its one hop, and then the 429 goes back to the client without a made-up
+// retry-after.
+
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+const HOUR = 3600_000;
+const account = (name) => ({ name, type: 'oauth', accessToken: `t-${name}`, refreshToken: 'r', expiresAt: Date.now() + HOUR });
+const tokenOf = (req) => (req.headers.authorization || '').replace(/^Bearer /, '');
+
+async function post(port, model = 'claude-retired') {
+  const t0 = Date.now();
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model, messages: [] }),
+  });
+  return { status: res.status, body: await res.json(), retryAfter: res.headers.get('retry-after'), ms: Date.now() - t0 };
+}
+
+// Refuses `claude-retired` with a headerless 429 (the shape observed upstream)
+// and serves everything else.
+function upstreamHandler(req, res) {
+  let raw = '';
+  req.on('data', (c) => { raw += c; });
+  req.on('end', () => {
+    const { model } = JSON.parse(raw || '{}');
+    if (model === 'claude-retired') {
+      res.writeHead(429, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'This model is not available.' } }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{"ok":true}');
+  });
+}
+
+async function withFleet(names, fn) {
+  const seen = [];
+  const upstream = http.createServer((req, res) => { seen.push(tokenOf(req)); upstreamHandler(req, res); });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(names.map(account), 0.98, { refreshFn: async () => { throw new Error('no refresh'); } });
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+  try { await fn({ am, proxyPort, seen }); } finally { proxy.close(); upstream.close(); }
+}
+
+const paused = (am, i) => am.accounts[i].pausedUntil != null && am.accounts[i].pausedUntil > Date.now();
+
+test('a headerless 429 that follows the request onto a sibling goes back to the client, pausing nothing', async () => {
+  await withFleet(['a', 'b'], async ({ am, proxyPort, seen }) => {
+    const r = await post(proxyPort);
+    assert.equal(r.status, 429, 'the refusal belongs to the client');
+    assert.deepEqual(seen, ['t-a', 't-b'], 'one hop, then the answer is in');
+    assert.equal(r.retryAfter, null, 'no fabricated retry-after');
+    assert.match(r.body.error.message, /not available/, 'the upstream reason reaches the client');
+    assert.ok(r.ms < 5000, `answered in ${r.ms}ms, not a fabricated 60s`);
+    assert.equal(paused(am, 0), false, 'the refused account is not paused');
+    assert.equal(paused(am, 1), false, 'nor the sibling');
+    // Other traffic on the same account is unaffected: the next request, for a
+    // model upstream serves, goes to `a` and is answered at once.
+    const ok = await post(proxyPort, 'claude-fine');
+    assert.equal(ok.status, 200);
+    assert.equal(seen[2], 't-a', 'the fleet still rests on a, unpaused');
+    assert.ok(ok.ms < 2000, `served in ${ok.ms}ms`);
+  });
+});
+
+test('with no sibling, a headerless 429 gets one short retry and then reaches the client', async () => {
+  await withFleet(['a'], async ({ am, proxyPort, seen }) => {
+    const r = await post(proxyPort);
+    assert.equal(r.status, 429);
+    assert.equal(seen.length, 2, 'one retry, not a walk');
+    assert.ok(r.ms >= 1900 && r.ms < 10_000, `one 2s retry, got ${r.ms}ms`);
+    assert.equal(paused(am, 0), false);
+  });
+});
+
+// The control: a 429 that carries rate-limit headers is still a throttle and
+// still pauses the account (the existing server-429 tests pin the rest).
+test('a 429 with a retry-after header is still treated as a throttle', async () => {
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(429, { 'retry-after': '1', 'content-type': 'application/json' });
+    res.end('{"type":"error","error":{"type":"rate_limit_error"}}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([account('a')], 0.98, { refreshFn: async () => { throw new Error('no refresh'); } });
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const proxyPort = await listen(proxy);
+  try {
+    const p = post(proxyPort);
+    await new Promise(r => setTimeout(r, 150));
+    assert.equal(paused(am, 0), true, 'a throttle pauses the account');
+    await p;
+  } finally { proxy.close(); upstream.close(); }
+});


### PR DESCRIPTION
Fixes #288.

A 429 with no `retry-after` and no `anthropic-ratelimit-*` header is upstream refusing the request (the reporter's retired model id) and says nothing about the account. It was handled as a per-minute throttle: `retry-after` defaulted to 60s, the account was paused for it so every other session on it waited in `admit()`, and the client was held for the same 60s per attempt. The reporter's 103 absorbs at exactly 60s are that default.

- `requestScoped` = no `retry-after` **and** no rate-limit headers. Such a 429 pauses nothing and does not arm the sx.org sticky window (metered).
- It still gets the one hop to an idle sibling, and the one-shot sx retry when configured, in case an IP-scoped limit ever presents without headers. When the sibling answers the same, the 429 goes back to the client with the upstream `error.message` and **without** a fabricated `retry-after`, so the client's own backoff applies. With no sibling it is retried once after 2s.
- A 429 that carries the headers is a throttle and is handled exactly as before (pause, inline absorb, IP-scoped message).
- `docs/routing.md` "The two kinds of 429" gains the third kind.

Tests drive the real proxy: two accounts refusing a model id → 429 to the client after one hop, in well under 5s, no `retry-after`, neither account paused, and the next request for a served model goes straight to the original account; single account → one 2s retry then 429; and a control that a `retry-after` 429 still pauses.

Built on #306 (merged), which keeps the hop from moving the cursor; together they answer the reporter's follow-up that neither fix alone is observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)