### PR TITLE
Bump to 1.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Multi-account proxy for Claude Code and Codex: pools Claude Max, ChatGPT/Codex, API-key and third-party backend accounts, and rotates on quota",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Fourteen commits since 1.1.16. Three routing changes and one behaviour
revert worth reading before upgrading.

Behaviour changes
  #302 `teamclaude run` and `teamclaude env` no longer touch Claude Code's own
       auth: the 1.1.15 bootstrap key (#209/#261) put Claude Code in API-key
       mode, dropping subscription mode and leaving Remote Control and
       claude.ai file transfers unauthenticated. Routing only, as before 1.1.15
  #306 a one-hop 429/5xx failover detours one request without moving the fleet
       cursor — under a sustained 429 the cursor no longer bounces between two
       siblings on every request
  #307 a 429 with no retry-after and no rate-limit headers (a model id
       upstream refuses) is about the request, not the account: nothing is
       paused, one hop, then the 429 reaches the client with the upstream
       reason and no fabricated 60s retry-after
  #296 a Fable-cap 429 bars the account for Fable only; haiku and Opus no
       longer fail over with it

Security boundary
  #305 dot-segment paths (`..`, `%2e%2e`, either slash) are refused before the
       Codex-pool and client-credential prefix checks, so they can no longer
       reach upstream as a different path with a pooled token

Features
  #289 `starved` per session and `starvedMax` fleet-wide: consecutive client
       requests that got nothing usable back
  #287 dashboard banner for starving sessions and accounts that need a person
  #293 a third-party backend's own quota (DeepSeek balance) on the status row
  #295 `teamclaude status` lists accounts in priority order

Fixes
  #298 expiry routing: a held roll is released only by a served request, and
       the session-reset switch respects the request's provider exclusions
  #294 the quota probe never sends a third-party backend's key to Anthropic
  #308 the TUI account row is budgeted per category, so API-key rows stop
       paying for family bars they never draw

Docs
  #303 README and npm metadata describe the Claude and Codex pools
  #304 sx.org referral link for users starting with the residential egress

🤖 Generated with [Claude Code](https://claude.com/claude-code)