### PR TITLE
Security audit fixes: credential hygiene, forward-target policy, loopback gate, supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Keep the commit-SHA-pinned actions in .github/workflows/ up to date.
+#
+# The workflows pin every `uses:` to a full commit SHA (with the release tag as
+# a trailing comment) so a repointed tag cannot change what runs in CI or in the
+# publish job. The price of pinning is that nothing moves on its own; dependabot
+# closes that gap by opening a PR whenever an action publishes a new release,
+# bumping the SHA and the version comment together.
+#
+# No npm ecosystem entry on purpose: the package has zero runtime dependencies,
+# eslint is the only devDependency, and package-lock.json is gitignored, so
+# there is nothing for dependabot to track there. The `npm install -g npm@x.y.z`
+# pin in publish.yml is also outside its reach and is bumped by hand.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,14 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      # `--ignore-scripts`: eslint (the only devDependency) is needed for lint
+      # only, and neither it nor its transitive packages need lifecycle scripts to
+      # work. Not running them denies a compromised package arbitrary code
+      # execution at install time. Still `npm install` rather than `npm ci`:
+      # package-lock.json is deliberately gitignored for this zero-dependency
+      # package, so there is no lockfile for `npm ci` to consume.
       - name: Install dependencies
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         node: [20, 22, 24]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node }}
 
@@ -44,10 +44,10 @@ jobs:
     name: nix package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,9 +70,15 @@ jobs:
 
       # Trusted Publishing (OIDC) needs npm >= 11.5.1. Upgrade so this works
       # regardless of which npm the runner image happens to ship.
+      #
+      # Pinned to an exact version rather than `npm@latest`: this is the one tool
+      # that receives our OIDC token and builds the tarball, so it must not be
+      # whatever the registry serves at run time. Dependabot does not track this
+      # line (only the `uses:` actions), so bump it by hand occasionally
+      # (`npm view npm version`); anything >= 11.5.1 keeps publishing working.
       - name: Upgrade npm for Trusted Publishing
         if: steps.check.outputs.publish == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish to npm (Trusted Publishing via OIDC)
         if: steps.check.outputs.publish == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,10 +56,14 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install dependencies
-        if: steps.check.outputs.publish == 'true'
-        run: npm install
-
+      # Deliberately no `npm install` here. The package has zero runtime
+      # dependencies, the tests are plain `node --test` and import nothing from
+      # node_modules, and the published tarball is just `files: ["src/"]`. The
+      # only devDependency is eslint, which is linted in ci.yml, not here. This
+      # job holds `id-token: write` + `contents: write` and ends in `npm publish`,
+      # so pulling ~90 unpinned transitive packages from the registry (and
+      # running their lifecycle scripts) in the same job would hand any one of
+      # them a path to publishing under our name.
       - name: Run tests
         if: steps.check.outputs.publish == 'true'
         run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,10 @@ jobs:
       contents: write   # create the git tag + GitHub release
       id-token: write   # OIDC token for npm Trusted Publishing + provenance
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/docs/proxy-modes.md
+++ b/docs/proxy-modes.md
@@ -75,7 +75,11 @@ restart.
   ciphertext only, and certificate verification is unchanged. A proxy that
   intercepts TLS needs its CA in `NODE_EXTRA_CA_CERTS`.
 - SOCKS proxies are not supported — only HTTP `CONNECT`. A `socks5://` value is
-  rejected at startup rather than failing later at connect time.
+  rejected at startup rather than failing later at connect time. So is an
+  `https://` proxy URL: TeamClaude does not speak TLS *to* the proxy, and
+  accepting the scheme would send the `CONNECT` (credentials included) in
+  plaintext to port 443. Write `http://host:port` — the tunnel through it is
+  end-to-end TLS regardless.
 
 This is a property of the **network**, not a routing policy: when set, it is
 simply how this machine reaches Anthropic. That is what separates it from sx.org

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -3004,14 +3004,25 @@ export class AccountManager {
 
     account._refreshPromise = (async () => {
       console.log(`[TeamClaude] Refreshing token for account "${account.name}"...`);
+      // The token we SEND, captured before the await. A config reload or
+      // `teamclaude import` (updateAccountTokens) can install newer tokens while
+      // the grant is in flight; reading `account.refreshToken` afterwards would
+      // attribute this call's outcome to the wrong token — marking the freshly
+      // imported one dead on invalid_grant (locking the account out until a
+      // re-login), or overwriting it with a result minted from the old family.
+      const sent = account.refreshToken;
       try {
         // Each provider mints tokens at its own endpoint with its own client
         // id, so the grant is dispatched by provider. Both return the same
         // { accessToken, refreshToken, expiresAt } shape, which is what lets
         // everything downstream stay provider-agnostic.
         const newTokens = await (providerOf(account) === 'codex'
-          ? this._codexRefreshFn(account.refreshToken)
-          : this._refreshFn(account.refreshToken));
+          ? this._codexRefreshFn(sent)
+          : this._refreshFn(sent));
+        if (account.refreshToken !== sent) {
+          console.log(`[TeamClaude] Discarding refresh result for account "${account.name}" — its tokens were replaced while the refresh was in flight`);
+          return;
+        }
         account.credential = newTokens.accessToken;
         account.refreshToken = newTokens.refreshToken;
         account.expiresAt = newTokens.expiresAt;
@@ -3029,11 +3040,17 @@ export class AccountManager {
         // what kept accounts wrongly "errored" after a momentary refresh blip.
         const isAuthRejection = err.status === 400 || err.status === 401 || err.status === 403;
         if (isAuthRejection) {
-          account.status = 'error';
           // Remember WHICH token was rejected so we stop re-sending it (see the
           // dead-token guard above). A transient failure deliberately does not
-          // arm this — that token may still be good.
-          account._deadRefreshToken = account.refreshToken;
+          // arm this — that token may still be good. The token that was SENT,
+          // not whatever the account holds now: the guard compares by value, so
+          // a token imported mid-refresh stays untouched and gets its own try.
+          account._deadRefreshToken = sent;
+          if (account.refreshToken !== sent) {
+            console.log(`[TeamClaude] Account "${account.name}" received new tokens while its old refresh token was being rejected — keeping the new ones`);
+            return;
+          }
+          account.status = 'error';
           console.error(`[TeamClaude] Account "${account.name}" needs re-login (refresh token rejected) — run: teamclaude login`);
         }
       } finally {

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -530,7 +530,11 @@ export class AccountManager {
   pauseAccount(index, seconds) {
     const account = this.accounts[index];
     if (!account) return;
-    const until = Date.now() + Math.max(0, seconds) * 1000;
+    // A Retry-After that did not parse arrives as NaN, and Math.max(NaN, x) is
+    // NaN: pausedUntil and rampStartedAt would both go NaN, _rampCap would
+    // return NaN, and admit() would spin on `inFlight < NaN`. No number, no pause.
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    const until = Date.now() + seconds * 1000;
     account.pausedUntil = Math.max(account.pausedUntil || 0, until);
     // Arm the ramp to begin when the pause ends: while paused, admit() holds on
     // the pause branch; once it lifts, _rampCap counts from here and releases the
@@ -2972,6 +2976,9 @@ export class AccountManager {
   markRateLimited(accountIndex, retryAfterSeconds) {
     const account = this.accounts[accountIndex];
     if (!account) return;
+    // Same guard as pauseAccount: a NaN hold would throttle the account with a
+    // rateLimitedUntil that never compares as expired.
+    if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) return;
     account.status = 'throttled';
     account.rateLimitedUntil = Date.now() + (retryAfterSeconds * 1000);
     // Marks when the hold was (re-)armed: a revalidation probe is allowed only

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -8,6 +8,7 @@ import { SessionTracker } from './session-tracker.js';
 import { buildQuotaSummary } from './quota-summary.js';
 import { ROLLOVER_MIN_JUMP_MS, remapHeld } from './rollover.js';
 import { decideBand, pressureOf, pressureRank, assertNever } from './band-decision.js';
+import { safeLine } from './safe-text.js';
 
 // Re-exported for callers that import these model helpers from here.
 export { isFableModel, parseRequestModel, parseAdvisorModel } from './model.js';
@@ -22,6 +23,26 @@ const FORCED_REFRESH_FLOOR_MS = 10_000;
 // members to serve, then re-admit it so an administrator's policy change is
 // discovered without a restart.
 const ENTITLEMENT_DENIAL_COOLDOWN_SECONDS = 5 * 60;
+
+// Codex model-scoped weekly buckets are keyed by slugs taken from response
+// header NAMES, so the table needs a ceiling an upstream cannot talk past.
+const MAX_CODEX_MODEL_BUCKETS = 32;
+
+// An `anthropic-ratelimit-*-reset` header (epoch seconds) as ms, or null when
+// it is not a positive finite number. Never NaN: see updateQuota.
+function resetHeaderMs(value) {
+  if (value == null || value === '') return null;
+  const seconds = parseInt(value, 10);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : null;
+}
+
+// An RFC 3339 reset header, stripped and bounded, or null when it does not
+// name a moment in time.
+function resetTimestamp(value) {
+  if (value == null || value === '') return null;
+  const text = safeLine(value, 64);
+  return Number.isFinite(new Date(text).getTime()) ? text : null;
+}
 
 // Fallback when a per-bucket threshold table names neither the bucket nor a
 // `default` — the same value the single-number form has always used.
@@ -692,7 +713,9 @@ export class AccountManager {
       // Throttled so a busy advisor session doesn't flood the activity log.
       if (Date.now() >= (this._advisorDegradeLogAt || 0)) {
         this._advisorDegradeLogAt = Date.now() + 60_000;
-        console.log(`[TeamClaude] No account eligible for advisor model "${advisorModel}" — routing by request model only`);
+        // The model names come out of the client's request body, so they are
+        // stripped before reaching the log (see safe-text.js).
+        console.log(`[TeamClaude] No account eligible for advisor model "${safeLine(advisorModel, 64)}" — routing by request model only`);
       }
     }
     return this._select(exclude, model, null, true);
@@ -2550,7 +2573,7 @@ export class AccountManager {
       if (switched) {
         this._beginRamp(best);
         console.log(scoped
-          ? `[TeamClaude] Diverting "${model}" to "${best.name}" — "${current.name}" cannot serve it`
+          ? `[TeamClaude] Diverting "${safeLine(model, 64)}" to "${best.name}" — "${current.name}" cannot serve it`
           : `[TeamClaude] Switched to account "${best.name}"`);
       }
       return best;
@@ -2606,8 +2629,10 @@ export class AccountManager {
    */
   _updateCodexQuota(account, headers) {
     const parsed = parseCodexQuota(headers);
+    // Header-derived strings are rendered into status and logs, so they are
+    // stripped and bounded here rather than trusted from a third-party upstream.
     const plan = parseCodexPlanType(headers);
-    if (plan) account.quota.planType = plan;
+    if (plan) account.quota.planType = safeLine(plan, 64);
 
     if (parsed.unified5h != null) account.quota.unified5h = parsed.unified5h;
     if (parsed.unified7d != null) account.quota.unified7d = parsed.unified7d;
@@ -2618,9 +2643,22 @@ export class AccountManager {
     // Fable bucket: it rides only on responses for that model, so stamp when
     // the reading was taken. That timestamp is what lets a spent bucket be
     // revalidated instead of sealing the account out of the family forever.
+    //
+    // The slugs are header NAMES, so an upstream can mint as many as it likes;
+    // a response never legitimately names more than a handful of families, so
+    // the table is capped and the reading not refreshed longest ago makes room.
+    const buckets = (account.quota.codexModelBuckets ??= {});
     for (const bucket of parsed.modelBuckets || []) {
-      (account.quota.codexModelBuckets ??= {})[bucket.slug] = {
-        name: bucket.name,
+      const slug = safeLine(bucket.slug, 64);
+      if (!slug) continue;
+      if (!(slug in buckets)) {
+        while (Object.keys(buckets).length >= MAX_CODEX_MODEL_BUCKETS) {
+          const stalest = Object.entries(buckets).sort((a, b) => a[1].seenAt - b[1].seenAt)[0][0];
+          delete buckets[stalest];
+        }
+      }
+      buckets[slug] = {
+        name: safeLine(bucket.name, 64),
         utilization: bucket.utilization,
         resetAt: bucket.resetAt,
         seenAt: Date.now(),
@@ -2663,10 +2701,14 @@ export class AccountManager {
     if (!isNaN(u5h)) account.quota.unified5h = u5h;
     if (!isNaN(u7d)) account.quota.unified7d = u7d;
 
-    const r5h = headers['anthropic-ratelimit-unified-5h-reset'];
-    const r7d = headers['anthropic-ratelimit-unified-7d-reset'];
-    if (r5h) account.quota.unified5hReset = parseInt(r5h, 10) * 1000;
-    if (r7d) account.quota.unified7dReset = parseInt(r7d, 10) * 1000;
+    // A reset that does not parse is treated as absent, never stored: parseInt
+    // of a non-numeric value is NaN, and `now >= NaN` is false forever, so a
+    // NaN reset would leave the bucket unclearable and park the account until
+    // the next valid response (a third-party upstream can send anything here).
+    const r5h = resetHeaderMs(headers['anthropic-ratelimit-unified-5h-reset']);
+    const r7d = resetHeaderMs(headers['anthropic-ratelimit-unified-7d-reset']);
+    if (r5h != null) account.quota.unified5hReset = r5h;
+    if (r7d != null) account.quota.unified7dReset = r7d;
 
     // Model-scoped weekly bucket — surfaced in headers as `7d_oi` ("7-day,
     // overage included"). On current subscription plans this is the Fable weekly
@@ -2680,8 +2722,8 @@ export class AccountManager {
       account.quota.unified7dFable = u7dOi;
       account.quota.unified7dFableSeenAt = Date.now();
     }
-    const r7dOi = headers['anthropic-ratelimit-unified-7d_oi-reset'];
-    if (r7dOi) account.quota.unified7dFableReset = parseInt(r7dOi, 10) * 1000;
+    const r7dOi = resetHeaderMs(headers['anthropic-ratelimit-unified-7d_oi-reset']);
+    if (r7dOi != null) account.quota.unified7dFableReset = r7dOi;
 
     // We switched to this account to discover its weekly quota; now that we
     // know it, flag for re-evaluation so selection can pick the best account.
@@ -2706,7 +2748,9 @@ export class AccountManager {
       const s5h = headers['anthropic-ratelimit-unified-5h-status'];
       const s7d = headers['anthropic-ratelimit-unified-7d-status'];
       const sharedSaidAllowed = (s5h || s7d) && s5h !== 'rejected' && s7d !== 'rejected';
-      account.quota.unifiedStatus = uStatus === 'rejected' && sharedSaidAllowed ? 'allowed' : uStatus;
+      // Rendered into status output, so stripped and bounded like every other
+      // header-derived string.
+      account.quota.unifiedStatus = uStatus === 'rejected' && sharedSaidAllowed ? 'allowed' : safeLine(uStatus, 32);
       account.quota.unifiedStatusSeenAt = Date.now();
     }
 
@@ -2723,8 +2767,11 @@ export class AccountManager {
     if (!isNaN(requestsLimit)) account.quota.requestsLimit = requestsLimit;
     if (!isNaN(requestsRemaining)) account.quota.requestsRemaining = requestsRemaining;
 
-    if (tokensReset) account.quota.resetsAt = tokensReset;
-    else if (requestsReset) account.quota.resetsAt = requestsReset;
+    // Kept as the RFC 3339 string upstream sent (status renders it), but only
+    // one that parses: _clearExpiredQuotas compares `new Date(resetsAt)`, and an
+    // unparseable value would never compare true and never clear.
+    const resetsAt = resetTimestamp(tokensReset) ?? resetTimestamp(requestsReset);
+    if (resetsAt != null) account.quota.resetsAt = resetsAt;
 
     account.usage.totalRequests++;
     account.usage.lastUsed = new Date().toISOString();

--- a/src/alias.js
+++ b/src/alias.js
@@ -9,11 +9,32 @@
 // that exec `claude` themselves). It's intentionally lighter than a PATH shim:
 // no binary shadowing, one line per rc, trivially reversible.
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, realpathSync, renameSync, statSync, chmodSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 
 const MARKER = '# teamclaude alias';
+
+/**
+ * Replace `path` with `text` atomically: write a sibling temp file, then rename
+ * it over. Writing the rc file in place left a truncated .bashrc behind a crash
+ * or a full disk, and a truncated .bashrc breaks every new shell. The existing
+ * mode is carried over, so a 0600 rc file stays 0600.
+ */
+function writeFileAtomic(path, text) {
+  let mode = null;
+  try { mode = statSync(path).mode & 0o777; } catch { /* new file: default mode */ }
+  const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`);
+  try {
+    writeFileSync(tmp, text);
+    if (mode !== null) chmodSync(tmp, mode);
+    renameSync(tmp, path);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+}
 
 /** Basename of the user's login shell, e.g. "zsh". Defaults to bash. */
 export function detectShell() {
@@ -39,12 +60,22 @@ export function teamclaudeRef() {
   if (!entry) return 'teamclaude';
   let abs;
   try { abs = realpathSync(entry); } catch { abs = entry; }
-  return `"${abs}"`;
+  // The double quotes are read by the shell each time the alias runs, so the
+  // characters special inside them — `\`, `"`, `$` in both bash and fish — are
+  // escaped. A path with a `'` is handled by aliasLine, which wraps this.
+  return `"${abs.replace(/[\\"$]/g, (c) => `\\${c}`)}"`;
 }
 
-/** The alias definition for a given shell family. */
+/**
+ * The alias definition for a given shell family.
+ *
+ * The body is single-quoted, and a `'` in the embedded path used to terminate
+ * that quote (verified: /home/o'brien produced a broken alias). It is spliced
+ * the POSIX way — close the quote, add a double-quoted `'`, reopen — which
+ * fish accepts too, since it also concatenates adjacent quoted strings.
+ */
 export function aliasLine(shell = detectShell(), ref = teamclaudeRef()) {
-  const body = `${ref} run --`;
+  const body = `${ref} run --`.replaceAll("'", "'\"'\"'");
   if (shell === 'fish') return `alias claude '${body}'`;
   return `alias claude='${body}'`;
 }
@@ -87,7 +118,7 @@ export function installAlias({ shell = detectShell(), rcPath = rcPathForShell(sh
   }
   if (text && !text.endsWith('\n')) text += '\n';
   text += `${MARKER}\n${line}\n`;
-  writeFileSync(rcPath, text);
+  writeFileAtomic(rcPath, text);
   console.log(`Installed alias in ${rcPath}`);
   console.log('Reload your shell (or open a new terminal) to use it.');
 }
@@ -116,7 +147,7 @@ export function uninstallAlias({ shell = detectShell(), rcPath = rcPathForShell(
     console.log(`Removed ${rcPath}`);
     return;
   }
-  writeFileSync(rcPath, cleaned);
+  writeFileAtomic(rcPath, cleaned);
   console.log(`Removed alias from ${rcPath}`);
 }
 

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -8,6 +8,24 @@ export function encodePinComponent(s) {
   return encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+}
+
+/**
+ * `port` as a number in 1..65535, or a throw. Strict on purpose: parseInt alone
+ * would turn "3456; touch /tmp/x" into 3456 and hide the bad config value that
+ * would otherwise have been eval'd.
+ */
+export function validPort(port) {
+  const text = String(port ?? '').trim();
+  const n = /^\d{1,5}$/.test(text) ? Number.parseInt(text, 10) : NaN;
+  if (!(n >= 1 && n <= 65535)) {
+    throw new Error(`proxy.port must be an integer between 1 and 65535, got ${JSON.stringify(port)}`);
+  }
+  return n;
+}
+
 // Build the shell `export` lines that point Claude Code — or any tool that
 // spawns it, e.g. an agent multiplexer — at the proxy. This is the same
 // environment `teamclaude run` sets up, but emitted for `eval "$(teamclaude
@@ -33,6 +51,9 @@ export function encodePinComponent(s) {
 export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '' }) {
   const lines = [];
   const pin = (account || '').trim();
+  // The port is interpolated unquoted into URLs the shell evals, so it has to
+  // BE a port: a config value of "3456; rm -rf ~" was emitted verbatim.
+  port = validPort(port);
 
   if (useMitm) {
     const userinfo = pin ? `${encodePinComponent(pin)}:${encodePinComponent(proxyApiKey || '')}@` : '';
@@ -45,7 +66,9 @@ export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdS
       'export NO_PROXY=localhost,127.0.0.1,::1',
       'export no_proxy=localhost,127.0.0.1,::1',
     );
-    if (caPath) lines.push(`export NODE_EXTRA_CA_CERTS=${caPath}`);
+    // Quoted: the path is under $HOME (or XDG_CONFIG_HOME), which can carry a
+    // space or a quote, and this line is eval'd.
+    if (caPath) lines.push(`export NODE_EXTRA_CA_CERTS=${shellQuote(caPath)}`);
     // Clear any stale base-URL so the two modes don't stack in one shell.
     lines.push('unset ANTHROPIC_BASE_URL');
   } else {

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -177,8 +177,10 @@ export function credentialsFromTokenResponse(data) {
 }
 
 function openBrowser(url) {
+  // `start` takes its first quoted argument as the window title, so the URL
+  // needs an empty title in front of it or the browser never opens.
   const cmd = process.platform === 'darwin' ? 'open'
-    : process.platform === 'win32' ? 'start'
+    : process.platform === 'win32' ? 'start ""'
       : 'xdg-open';
   exec(`${cmd} ${JSON.stringify(url)}`, () => {});
 }

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -191,6 +191,45 @@ function openBrowser(url) {
  * port, which is why the bind failure is reported as such rather than as a
  * generic error.
  */
+/**
+ * The request handler for the login callback, settling `resolve`/`reject` with
+ * the authorization code or the failure.
+ *
+ * The state is checked FIRST, and a request without the expected state gets a
+ * 400 and settles nothing: port 1455 is open while the user is in the browser,
+ * and a stray GET — a drive-by page probing localhost, a scanner, a stale tab —
+ * used to abort the whole login by arriving with `?error=` or with no state.
+ * Exported for tests, which run it on an ephemeral port instead of 1455.
+ */
+export function codexCallbackHandler(expectedState, { resolve, reject }) {
+  return (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    if (url.pathname !== '/auth/callback') { res.writeHead(404); res.end('Not found'); return; }
+
+    const returnedState = url.searchParams.get('state');
+    if (!returnedState || returnedState !== expectedState) {
+      res.writeHead(400, { 'Content-Type': 'text/html' });
+      res.end('<html><body><h2>Invalid request</h2><p>State mismatch. You can close this tab.</p></body></html>');
+      return;
+    }
+
+    const err = url.searchParams.get('error');
+    const returnedCode = url.searchParams.get('code');
+    const fail = (message) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body><h2>Authentication failed</h2><p>You can close this tab.</p></body></html>');
+      reject(new Error(message));
+    };
+
+    if (err) return fail(`OAuth error: ${err} ${url.searchParams.get('error_description') || ''}`.trim());
+    if (!returnedCode) return fail('OAuth callback carried no code');
+
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<html><body><h2>Signed in</h2><p>You can close this tab and return to the terminal.</p></body></html>');
+    resolve(returnedCode);
+  };
+}
+
 export async function loginCodex({ noBrowser = false, timeoutMs = 120_000 } = {}) {
   const codeVerifier = randomBytes(32).toString('base64url');
   const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
@@ -199,27 +238,7 @@ export async function loginCodex({ noBrowser = false, timeoutMs = 120_000 } = {}
 
   let server;
   const code = await new Promise((resolve, reject) => {
-    server = http.createServer((req, res) => {
-      const url = new URL(req.url, 'http://localhost');
-      if (url.pathname !== '/auth/callback') { res.writeHead(404); res.end('Not found'); return; }
-
-      const err = url.searchParams.get('error');
-      const returnedState = url.searchParams.get('state');
-      const returnedCode = url.searchParams.get('code');
-      const fail = (message) => {
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end('<html><body><h2>Authentication failed</h2><p>You can close this tab.</p></body></html>');
-        reject(new Error(message));
-      };
-
-      if (err) return fail(`OAuth error: ${err} ${url.searchParams.get('error_description') || ''}`.trim());
-      if (returnedState !== state) return fail('OAuth state mismatch');
-      if (!returnedCode) return fail('OAuth callback carried no code');
-
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end('<html><body><h2>Signed in</h2><p>You can close this tab and return to the terminal.</p></body></html>');
-      resolve(returnedCode);
-    });
+    server = http.createServer(codexCallbackHandler(state, { resolve, reject }));
 
     server.on('error', (e) => reject(e.code === 'EADDRINUSE'
       ? new Error(`Port ${CALLBACK_PORT} is in use. OpenAI only accepts ${REDIRECT_URI} for this client, so close whatever holds it (a running \`codex login\`) and retry.`)

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -16,6 +16,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { exec } from 'node:child_process';
 import http from 'node:http';
 import { proxyFetch } from './upstream-fetch.js';
+import { tokenPairFromResponse } from './oauth.js';
 
 export const DEFAULT_CODEX_CREDENTIALS_PATH = '~/.codex/auth.json';
 
@@ -104,12 +105,9 @@ export async function refreshCodexToken(refreshToken, endpoint = TOKEN_ENDPOINT)
     throw err;
   }
 
-  const data = await res.json();
-  return {
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token || refreshToken,
-    expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
-  };
+  // Same checks as the Anthropic path: a 200 without an access token is an
+  // error, not a `Bearer undefined` waiting to happen.
+  return tokenPairFromResponse(await res.json(), { previousRefreshToken: refreshToken });
 }
 
 // ── Browser login ───────────────────────────────────────────────────────────
@@ -167,12 +165,10 @@ export function credentialsFromTokenResponse(data) {
   const claims = decodeJwtClaims(data.id_token) || {};
   const auth = claims['https://api.openai.com/auth'] || {};
   return {
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token,
+    ...tokenPairFromResponse(data),
     accountId: auth.chatgpt_account_id,
     email: claims.email,
     planType: auth.chatgpt_plan_type,
-    expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
   };
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { readFile, open, mkdir, chmod, rename, unlink } from 'node:fs/promises';
+import { readFile, open, mkdir, chmod, rename, unlink, realpath } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -62,6 +62,11 @@ export async function saveState(state) {
  * never on disk under a looser mode even for an instant.
  */
 async function writeJsonAtomic(path, value) {
+  // A rename replaces the NAME, so a config that is a symlink (a dotfiles
+  // checkout, say) would silently become a regular file where the old in-place
+  // write followed the link. Resolve it first; a dangling or absent path is
+  // written where it is.
+  path = await realpath(path).catch(() => path);
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`;
   try {

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { readFile, open, mkdir, chmod, rename, unlink } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -41,12 +41,45 @@ export async function loadState() {
 }
 
 export async function saveState(state) {
-  const path = getStatePath();
+  await writeJsonAtomic(getStatePath(), state);
+}
+
+/**
+ * Write a JSON document so that the file at `path` is, at every instant, either
+ * the previous complete document or the new one.
+ *
+ * A plain writeFile truncates first and fills in afterwards. The config holds
+ * every account's OAuth tokens and the proxy key; a crash or power loss in that
+ * gap left an empty or half-written file, and the next start threw on
+ * JSON.parse with the credentials gone. So the document goes to a sibling
+ * temp file, is fsynced so it is on disk before it is named, and is renamed
+ * over the target — rename replaces atomically on POSIX and, in Node, on
+ * Windows too (same scheme mitm.js uses for the leaf key).
+ *
+ * The temp file is created 0600 and chmod'ed before the rename, so the
+ * "enforce 0600 on every save" behaviour of the old code holds: a config that
+ * was once world-readable becomes 0600 on the next save, and the tokens are
+ * never on disk under a looser mode even for an instant.
+ */
+async function writeJsonAtomic(path, value) {
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
-  // `mode` only applies when the file is CREATED; enforce 0600 on every save so
-  // a pre-existing state file (holding quota + tokens) can't linger world-readable.
-  await chmod(path, 0o600).catch(() => {});
+  const tmp = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`;
+  try {
+    const fh = await open(tmp, 'w', 0o600);
+    try {
+      await fh.writeFile(JSON.stringify(value, null, 2) + '\n');
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
+    // `open`'s mode is masked by the umask; make the mode exact regardless.
+    await chmod(tmp, 0o600).catch(() => {});
+    await rename(tmp, path);
+  } catch (err) {
+    // Never leave a half-written copy of the credentials lying beside the config.
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
 }
 
 export function createDefaultConfig() {
@@ -124,12 +157,9 @@ export async function loadOrCreateConfig() {
 }
 
 export async function saveConfig(config) {
-  const path = getConfigPath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
-  // Enforce 0600 even if the file already existed (the proxy apiKey + account
-  // tokens live here); `mode` above is honored only on creation.
-  await chmod(path, 0o600).catch(() => {});
+  // The proxy apiKey and every account's tokens live here: see writeJsonAtomic
+  // for why this is not a plain writeFile.
+  await writeJsonAtomic(getConfigPath(), config);
 }
 
 // Serialize config updates. atomicConfigUpdate is a read-modify-write, so two

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -13,10 +13,38 @@
 // rendering uses textContent — status fields (account names, client names) are
 // operator/OAuth-derived, but they still never reach innerHTML.
 
+import { createHash } from 'node:crypto';
 import { UNAVAILABLE_TEXT } from './status-renderer.js';
 
 export function renderDashboardHtml() {
   return PAGE;
+}
+
+/**
+ * Content-Security-Policy for the dashboard, sent by the server with the page.
+ *
+ * The page holds the proxy key in localStorage, so the policy is the backstop
+ * for a script that should never run there: nothing loads from anywhere
+ * (`default-src 'none'`), the one inline script is admitted by its hash rather
+ * than by `'unsafe-inline'` — the page is static, so the hash is stable — and
+ * the only network the script may touch is this origin, for status and switch.
+ * Styles need `'unsafe-inline'` because the layout uses `style=` attributes,
+ * which hashes do not cover; CSSOM writes (`el.style.width = …`) are not
+ * governed by CSP at all. `frame-ancestors 'none'` keeps the page out of
+ * another site's iframe, where a click on "switch" could be overlaid.
+ */
+export function dashboardCsp(html = PAGE) {
+  const script = html.slice(html.indexOf('<script>') + 8, html.indexOf('</script>'));
+  const hash = createHash('sha256').update(script, 'utf8').digest('base64');
+  return [
+    "default-src 'none'",
+    `script-src 'sha256-${hash}'`,
+    "style-src 'unsafe-inline'",
+    "connect-src 'self'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+  ].join('; ');
 }
 
 // The page's pure logic lives here, not in the script string: these functions

--- a/src/forward-target.js
+++ b/src/forward-target.js
@@ -1,0 +1,183 @@
+// Destination policy for the two transparent forward paths: the blind CONNECT
+// tunnel (mitm.js) and the absolute-form plain-HTTP relay (server.js).
+//
+// Both forward to whatever host the client names, with no account logic — that
+// is the point, third-party traffic must pass untouched. But "whatever host"
+// used to include this machine. The HTTP gate exempts loopback callers from the
+// proxy API key (a local process is trusted), so a remote holder of a low-trust
+// clientKeys entry could `CONNECT 127.0.0.1:<our port>`, speak plain HTTP inside
+// the tunnel, and arrive at our own listener AS a loopback client: unauthenticated,
+// unattributed access to /teamclaude/switch, /reload, /status and /v1/messages,
+// plus any other loopback-only service on the box and the link-local cloud
+// metadata endpoint (169.254.169.254). The plain-HTTP relay had the same hole.
+//
+// So a forward may not target loopback, the unspecified address (connecting to
+// 0.0.0.0 lands on loopback), or link-local. RFC1918 ranges stay open: a LAN
+// target is a legitimate thing to proxy to. Nothing legitimate is lost on the
+// loopback side either — `teamclaude run`/`env` hand the launched client
+// NO_PROXY=localhost,127.0.0.1,::1, so its own loopback traffic never comes here.
+//
+// The check runs on the RESOLVED address, not the name, because a name is what
+// an attacker controls (localtest.me and friends resolve to 127.0.0.1). It also
+// runs on the literal name before any dial, so the obvious case never opens a
+// connection at all.
+
+import dns from 'node:dns';
+import net from 'node:net';
+
+/** Error code carried by a lookup refused by this policy. */
+export const FORBIDDEN_FORWARD = 'EFORBIDDENFORWARD';
+
+/** Parse dotted-quad text to four octets, or null. */
+function v4Octets(ip) {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip);
+  if (!m) return null;
+  const o = m.slice(1).map(Number);
+  return o.every((n) => n <= 255) ? o : null;
+}
+
+/**
+ * Expand an IPv6 address to its eight 16-bit groups, or null. Handles `::`
+ * compression and a trailing dotted-quad (`::ffff:127.0.0.1`), which is how
+ * Node reports a mapped IPv4 peer on a dual-stack socket.
+ */
+function v6Groups(ip) {
+  let s = ip.toLowerCase().replace(/%.*$/, ''); // drop a zone id (fe80::1%eth0)
+  const tail = /:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(s);
+  let v4tail = [];
+  if (tail) {
+    const o = v4Octets(tail[1]);
+    if (!o) return null;
+    v4tail = [(o[0] << 8) | o[1], (o[2] << 8) | o[3]];
+    // Drop the quad and its colon — unless that colon was half of a `::`, as
+    // in "::1.2.3.4", where it must survive as the compression marker.
+    s = s.slice(0, tail.index);
+    if (s.endsWith(':')) s += ':';
+  }
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const parse = (part) => (part === '' ? [] : part.split(':').map((g) => {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return NaN;
+    return parseInt(g, 16);
+  }));
+  const head = parse(halves[0]);
+  const rest = halves.length === 2 ? parse(halves[1]) : [];
+  if ([...head, ...rest].some(Number.isNaN)) return null;
+  const known = head.length + rest.length + v4tail.length;
+  if (halves.length === 2 ? known > 7 : known !== 8) return null;
+  return [...head, ...new Array(8 - known).fill(0), ...rest, ...v4tail];
+}
+
+/** Why `ip` (a literal address) may not be a forward target, or null when it may. */
+export function forbiddenAddressReason(ip) {
+  const kind = net.isIP(ip);
+  if (kind === 4) {
+    const o = v4Octets(ip);
+    if (!o) return null;
+    if (o[0] === 127) return 'loopback';
+    if (o[0] === 0) return 'unspecified';           // 0.0.0.0/8 — connects to loopback
+    if (o[0] === 169 && o[1] === 254) return 'link-local';
+    return null;
+  }
+  if (kind === 6) {
+    const g = v6Groups(ip);
+    if (!g) return null;
+    const zeroTo = (n) => g.slice(0, n).every((x) => x === 0);
+    if (zeroTo(8)) return 'unspecified';                                   // ::
+    if (zeroTo(7) && g[7] === 1) return 'loopback';                        // ::1
+    if ((g[0] & 0xffc0) === 0xfe80) return 'link-local';                  // fe80::/10
+    // ::ffff:a.b.c.d (mapped) and the deprecated ::a.b.c.d (compatible) both
+    // carry an IPv4 address in the low 32 bits; judge that address.
+    if (zeroTo(5) && (g[5] === 0xffff || g[5] === 0)) {
+      return forbiddenAddressReason(`${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`);
+    }
+    return null;
+  }
+  return null;
+}
+
+/** True when a forward to the literal address `ip` must be refused. */
+export function isForbiddenForwardAddress(ip) {
+  return forbiddenAddressReason(ip) != null;
+}
+
+/**
+ * Why a forward to `host` — as named by the client, optionally with the address
+ * it resolved to — must be refused, or null when it may proceed. `localhost`
+ * and `*.localhost` are refused by name (RFC 6761 reserves them for loopback),
+ * so no dial is attempted for the obvious spelling.
+ */
+export function forbiddenForwardReason(host, resolvedAddress = null) {
+  const name = String(host || '').toLowerCase().replace(/\.$/, '');
+  if (name === 'localhost' || name.endsWith('.localhost')) return `${host} is a loopback name`;
+  const byName = forbiddenAddressReason(name);
+  if (byName) return `${host} is ${article(byName)} ${byName} address`;
+  if (resolvedAddress) {
+    const byAddr = forbiddenAddressReason(resolvedAddress);
+    if (byAddr) return `${host} resolves to ${resolvedAddress}, ${article(byAddr)} ${byAddr} address`;
+  }
+  return null;
+}
+const article = (word) => (/^[aeiou]/.test(word) ? 'an' : 'a');
+
+// ── Test hook ────────────────────────────────────────────────
+//
+// The test suite has no host but this one, so its tunnel and relay tests target
+// 127.0.0.1 — exactly what the policy forbids. A server registered here may
+// forward to loopback (and only loopback; unspecified and link-local stay
+// refused). Keyed on the server object rather than a config or env knob so
+// nothing an operator or client can set reaches it: the only way in is a
+// process that already holds the server instance.
+const loopbackAllowed = new WeakSet();
+
+/** Tests only: permit loopback forward targets on connections `server` accepts. */
+export function allowLoopbackForward(server) {
+  loopbackAllowed.add(server);
+}
+
+/** Whether the server that accepted `socket` is registered by allowLoopbackForward. */
+export function loopbackForwardAllowed(socket) {
+  const server = socket?.server;
+  return !!server && loopbackAllowed.has(server);
+}
+
+/**
+ * Policy decision for a target the client named and the address it resolved to.
+ * `socket` is the inbound client socket (for the test hook).
+ */
+export function forwardRefusal(host, resolvedAddress, socket) {
+  const why = forbiddenForwardReason(host, resolvedAddress);
+  if (why && loopbackForwardAllowed(socket) && /loopback/.test(why)) return null;
+  return why;
+}
+
+/**
+ * A `lookup` function for net.connect / http.request that resolves every
+ * address of the target and refuses the whole dial if ANY of them is a
+ * forbidden destination — before a single SYN is sent. Refusals arrive on the
+ * socket as an error with code FORBIDDEN_FORWARD so the caller can turn it into
+ * a 403 rather than the 502 a connect failure gets.
+ *
+ * Resolving all addresses (not just the one Node would pick) closes the
+ * dual-stack gap: a name with one public A record and a loopback AAAA record
+ * must not become reachable by luck of address selection.
+ */
+export function guardedLookup(socket, { lookup = dns.lookup } = {}) {
+  return (hostname, options, callback) => {
+    if (typeof options === 'function') { callback = options; options = {}; }
+    lookup(hostname, { ...options, all: true }, (err, addrs) => {
+      if (err) return callback(err);
+      const list = Array.isArray(addrs) ? addrs : [{ address: addrs, family: net.isIP(addrs) }];
+      for (const { address } of list) {
+        const why = forwardRefusal(hostname, address, socket);
+        if (why) {
+          const e = new Error(`forward to ${hostname} refused: ${why}`);
+          e.code = FORBIDDEN_FORWARD;
+          return callback(e);
+        }
+      }
+      if (options.all) return callback(null, list);
+      return callback(null, list[0]?.address, list[0]?.family);
+    });
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { createWriteStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import net from 'node:net';
 import { loadOrCreateConfig, loadConfig, saveConfig, atomicConfigUpdate, getConfigPath, getCrashLogPath, loadState, saveState } from './config.js';
 import { installCrashHandlers } from './crash-log.js';
@@ -200,6 +201,9 @@ async function serverCommand() {
   installCrashHandlers(crashLog);
 
   const config = await loadOrCreateConfig();
+  // Token writes below pair rows by entry id against a re-read of the file, so
+  // the ids have to be on disk before the first refresh, not just in memory.
+  await persistMintedAccountIds(config);
 
   // --log-to <dir>
   const logTo = argValue('--log-to');
@@ -293,7 +297,8 @@ async function serverCommand() {
           accountManager.addAccount(diskAcct);
         }
       }
-      // Match by UUID first, then by name — index may have shifted
+      // By entry id only — the index may have shifted, and identity is not
+      // one-to-one (see findConfigAccount). No row: nothing is written.
       const cfgIdx = findConfigAccount(diskConfig, account);
       if (cfgIdx >= 0) {
         diskConfig.accounts[cfgIdx].accessToken = newTokens.accessToken;
@@ -2047,26 +2052,49 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
 // ── config sync helpers ─────────────────────────────────────
 
 /**
- * Find the config entry a running account came from.
+ * Find the config entry a running account came from, by entry id only; -1 when
+ * no row carries its id.
  *
- * By entry id first. Identity is the fallback, and it is not one-to-one:
- * sameIdentity compares organization only when BOTH records carry one and falls
- * back to the name otherwise, so for one person holding accounts in two
- * organizations — the case the identity module exists for — both rows match and
- * the first one wins. Resolving a token write that way records one account's
- * refresh-token family against another account's row (#203).
+ * There is deliberately no identity fallback (mirroring syncRefreshedTokens).
+ * sameIdentity is not one-to-one: it compares organization only when BOTH
+ * records carry one and falls back to the name otherwise, so for one person
+ * holding accounts in two organizations — the case the identity module exists
+ * for — both rows match and the first one wins. Resolving a token write that way
+ * records one account's refresh-token family against another account's row
+ * (#203), and on a fleet holding other people's accounts that is a credential
+ * crossing. A -1 means the write is skipped: an account the file no longer
+ * describes has no row of its own, and any row picked for it would be another
+ * account's.
  *
- * The id is exact and survives the refresh that rewrites the credential, which
- * is the one field that might otherwise have separated two records of one
- * person. loadConfig gives every entry an id, so the fallback is only for a disk
- * row written before the field existed and not yet saved back.
+ * The id is exact and survives the refresh that rewrites the credential. A file
+ * written before the field existed gets its ids persisted at startup
+ * (persistMintedAccountIds), so the in-memory ids are the on-disk ids.
  */
 function findConfigAccount(diskConfig, account) {
-  if (account?.id) {
-    const byId = diskConfig.accounts.findIndex(a => a?.id === account.id);
-    if (byId >= 0) return byId;
+  if (!account?.id) return -1;
+  return diskConfig.accounts.findIndex(a => a?.id === account.id);
+}
+
+/**
+ * Persist the entry ids loadConfig just minted, if the file did not carry them.
+ *
+ * Every later token write pairs its row by id and re-reads the file to do it. A
+ * config written before the field existed has ids in memory only, and the
+ * re-read would mint a second, different set — nothing would pair until the
+ * next start, and refreshed tokens would never reach disk. One save up front
+ * makes the in-memory ids the on-disk ids. A file that already carries a
+ * complete, unique set is left alone.
+ */
+async function persistMintedAccountIds(config) {
+  let raw;
+  try {
+    raw = JSON.parse(await readFile(getConfigPath(), 'utf-8'));
+  } catch {
+    return; // nothing on disk to reconcile with (or unreadable — the next save will tell)
   }
-  return diskConfig.accounts.findIndex(a => sameIdentity(a, account));
+  const ids = (Array.isArray(raw?.accounts) ? raw.accounts : []).map(a => a?.id);
+  const complete = ids.every(id => typeof id === 'string' && id !== '') && new Set(ids).size === ids.length;
+  if (!complete) await saveConfig(config);
 }
 
 // ── helpers ─────────────────────────────────────────────────

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,9 @@ import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-p
 // reaches through a top-level `await`. The await suspends module evaluation at
 // the switch, so a const declared under the switch is still in the temporal
 // dead zone when the command body runs — keep them above the dispatch.
+// Ceiling for `teamclaude probe <seconds>`: setInterval takes a 32-bit signed
+// millisecond delay, so anything past ~2,147,483 s overflows to 1 ms.
+const MAX_PROBE_SECONDS = 7 * 24 * 3600;
 const ROUTE_USAGE = [
   'Usage: teamclaude route [list]',
   '       teamclaude route add <name> --match "<glob>[,<glob>]" [--accounts "<name-or-index>[,...]"] [--bucket <quota-bucket>] [--color <name>]',
@@ -1409,6 +1412,11 @@ async function probeCommand() {
     }
     if (seconds > 0 && seconds < 30) {
       console.error('Minimum probe interval is 30s (to avoid hammering the usage endpoint).');
+      process.exit(1);
+    }
+    // Past the ceiling the interval would overflow into a 1 ms probe storm.
+    if (seconds > MAX_PROBE_SECONDS) {
+      console.error(`Maximum probe interval is ${MAX_PROBE_SECONDS}s (7 days).`);
       process.exit(1);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -878,10 +878,17 @@ async function envCommand() {
 
   // Same pin as `teamclaude run`, so `eval "$(teamclaude env)"` and `run` agree.
   const account = (process.env.TC_ACCT || '').trim();
-  const lines = buildClaudeEnvLines({
-    port, useMitm, caPath, holdSeconds: config.holdSeconds,
-    account, proxyApiKey: config.proxy?.apiKey || '',
-  });
+  let lines;
+  try {
+    lines = buildClaudeEnvLines({
+      port, useMitm, caPath, holdSeconds: config.holdSeconds,
+      account, proxyApiKey: config.proxy?.apiKey || '',
+    });
+  } catch (err) {
+    // A bad proxy.port. Nothing reaches stdout: the shell is eval'ing it.
+    process.stderr.write(`teamclaude env: ${err.message} (in ${getConfigPath()})\n`);
+    process.exit(1);
+  }
   process.stdout.write(`${lines.join('\n')}\n`);
 
   const mode = useMitm ? 'MITM forward-proxy' : 'base-URL';

--- a/src/index.js
+++ b/src/index.js
@@ -656,7 +656,10 @@ async function serverCommand() {
 // ── import ──────────────────────────────────────────────────
 
 async function importCommand() {
-  const config = await loadOrCreateConfig();
+  // First-run entry point: the file has to exist (and the egress proxy be
+  // applied) before anything reaches the network. The list is not written back
+  // from this copy — upsertOAuthAccount re-reads the file when it saves.
+  await loadOrCreateConfig();
 
   let name = argValue('--name');
   const jsonStr = argValue('--json');
@@ -691,7 +694,7 @@ async function importCommand() {
     }
   }
 
-  await upsertOAuthAccount(config, name, creds, 'import');
+  await upsertOAuthAccount(name, creds, 'import');
 }
 
 // ── login ───────────────────────────────────────────────────
@@ -706,8 +709,9 @@ async function importCommand() {
  */
 async function loginCodexCommand() {
   // loadOrCreateConfig, not loadConfig: `login` is a first-run entry point and
-  // must work before any config file exists.
-  const config = await loadOrCreateConfig();
+  // must work before any config file exists. This copy is not what gets
+  // written — see the atomicConfigUpdate below.
+  await loadOrCreateConfig();
   let creds;
   try {
     creds = await loginCodex({ noBrowser: args.includes('--no-browser') });
@@ -720,37 +724,42 @@ async function loginCodexCommand() {
     process.exit(1);
   }
 
-  const name = argValue('--name') || creds.email
-    || `codex-${config.accounts.filter(a => a.provider === 'codex').length + 1}`;
+  // The browser flow above can take minutes, and a running server may have
+  // rotated another account's refresh token on disk in the meantime. Writing
+  // the copy loaded before the flow would put the dead token back, and that
+  // account would fail on its next restart. So the upsert runs against a fresh
+  // read of the file, and only this account's row is touched.
+  await atomicConfigUpdate(config => {
+    const name = argValue('--name') || creds.email
+      || `codex-${config.accounts.filter(a => a.provider === 'codex').length + 1}`;
 
-  const account = {
-    name,
-    type: 'oauth',
-    provider: 'codex',
-    source: 'login',
-    accountId: creds.accountId,
-    accessToken: creds.accessToken,
-    refreshToken: creds.refreshToken,
-    expiresAt: creds.expiresAt,
-  };
+    const account = {
+      name,
+      type: 'oauth',
+      provider: 'codex',
+      source: 'login',
+      accountId: creds.accountId,
+      accessToken: creds.accessToken,
+      refreshToken: creds.refreshToken,
+      expiresAt: creds.expiresAt,
+    };
 
-  // Identity for a Codex account is its ChatGPT account id; fall back to the
-  // display name when upstream did not supply one.
-  const idx = config.accounts.findIndex(a => (
-    a.provider === 'codex' && (
-      (account.accountId && a.accountId === account.accountId) || a.name === account.name
-    )
-  ));
-  if (idx >= 0) {
-    const prev = config.accounts[idx];
-    config.accounts[idx] = { ...prev, ...account, name: prev.name };
-    console.log(`Updated account "${prev.name}"`);
-  } else {
-    config.accounts.push(account);
-    console.log(`Added account "${account.name}"${creds.planType ? ` (${creds.planType})` : ''}`);
-  }
-
-  await saveConfig(config);
+    // Identity for a Codex account is its ChatGPT account id; fall back to the
+    // display name when upstream did not supply one.
+    const idx = config.accounts.findIndex(a => (
+      a.provider === 'codex' && (
+        (account.accountId && a.accountId === account.accountId) || a.name === account.name
+      )
+    ));
+    if (idx >= 0) {
+      const prev = config.accounts[idx];
+      config.accounts[idx] = { ...prev, ...account, name: prev.name };
+      console.log(`Updated account "${prev.name}"`);
+    } else {
+      config.accounts.push(account);
+      console.log(`Added account "${account.name}"${creds.planType ? ` (${creds.planType})` : ''}`);
+    }
+  });
   console.log(`Saved to ${getConfigPath()}`);
 }
 
@@ -823,7 +832,7 @@ async function loginApiCommand() {
 }
 
 async function loginOAuthCommand({ pasteOnly = false } = {}) {
-  const config = await loadOrCreateConfig();
+  await loadOrCreateConfig(); // first run: create the file; the save re-reads it
   let name = argValue('--name');
 
   console.log('Starting OAuth login...');
@@ -839,7 +848,7 @@ async function loginOAuthCommand({ pasteOnly = false } = {}) {
     process.exit(1);
   }
 
-  await upsertOAuthAccount(config, name, creds, 'login');
+  await upsertOAuthAccount(name, creds, 'login');
 }
 
 // ── env ─────────────────────────────────────────────────────
@@ -1167,8 +1176,12 @@ async function accountsCommand() {
     return;
   }
 
+  // Both writes below pair rows by entry id against a fresh read of the file,
+  // so a file written before ids existed needs its ids on disk first.
+  await persistMintedAccountIds(config);
+
   // Refresh expired tokens before fetching profiles
-  let configDirty = false;
+  const refreshed = [];
   await Promise.all(config.accounts.map(async (a) => {
     if (a.type !== 'oauth' || !a.refreshToken) return;
     if (!isTokenExpiringSoon(a.expiresAt)) return;
@@ -1177,12 +1190,26 @@ async function accountsCommand() {
       a.accessToken = newTokens.accessToken;
       a.refreshToken = newTokens.refreshToken;
       a.expiresAt = newTokens.expiresAt;
-      configDirty = true;
+      refreshed.push(a);
     } catch {
       // refresh failed — fetchProfile will report the specific error
     }
   }));
-  if (configDirty) await saveConfig(config);
+  // Only the refreshed rows are written, each onto the on-disk row with its id.
+  // Saving the whole in-memory list here would put back whatever a running
+  // server rotated on disk since the load — a refresh token that is now dead,
+  // and an account lost on its next restart.
+  if (refreshed.length > 0) {
+    await atomicConfigUpdate(disk => {
+      for (const a of refreshed) {
+        const i = findConfigAccount(disk, a);
+        if (i < 0) continue; // no row of its own; any other row would be another account's
+        disk.accounts[i].accessToken = a.accessToken;
+        disk.accounts[i].refreshToken = a.refreshToken;
+        disk.accounts[i].expiresAt = a.expiresAt;
+      }
+    });
+  }
 
   // Fetch profiles in parallel for all OAuth accounts
   const profiles = await Promise.all(
@@ -1196,16 +1223,18 @@ async function accountsCommand() {
   // account, not a duplicate. Keep the last (most recently added) entry.
   const seen = new Map();
   let removed = 0;
-  let touched = false;
+  // Which entries changed, by id, so the write below touches only those rows.
+  const touchedIds = new Set();
+  const removedIds = new Set();
   for (let i = config.accounts.length - 1; i >= 0; i--) {
     const a = config.accounts[i];
     const p = profiles[i];
     if (p && !p.error) {
-      if (p.accountUuid && a.accountUuid !== p.accountUuid) { a.accountUuid = p.accountUuid; touched = true; }
-      if (p.orgUuid && a.orgUuid !== p.orgUuid) { a.orgUuid = p.orgUuid; touched = true; }
-      if (p.orgName && a.orgName !== p.orgName) { a.orgName = p.orgName; touched = true; }
+      if (p.accountUuid && a.accountUuid !== p.accountUuid) { a.accountUuid = p.accountUuid; touchedIds.add(a.id); }
+      if (p.orgUuid && a.orgUuid !== p.orgUuid) { a.orgUuid = p.orgUuid; touchedIds.add(a.id); }
+      if (p.orgName && a.orgName !== p.orgName) { a.orgName = p.orgName; touchedIds.add(a.id); }
       for (const field of ['organizationType', 'rateLimitTier', 'seatTier', 'hasClaudeMax', 'hasClaudePro']) {
-        if (p[field] != null && a[field] !== p[field]) { a[field] = p[field]; touched = true; }
+        if (p[field] != null && a[field] !== p[field]) { a[field] = p[field]; touchedIds.add(a.id); }
       }
     }
     const uuid = a.accountUuid;
@@ -1215,7 +1244,7 @@ async function accountsCommand() {
       config.accounts.splice(i, 1);
       profiles.splice(i, 1);
       removed++;
-      touched = true;
+      removedIds.add(a.id);
     } else {
       seen.set(key, i);
     }
@@ -1233,10 +1262,24 @@ async function accountsCommand() {
     const email = (p && !p.error && p.email) ? p.email : null;
     if (!email) continue;
     const newName = orgCount.get(a.accountUuid) > 1 ? `${email} (${orgLabel(a)})` : email;
-    if (a.name !== newName) { a.name = newName; touched = true; }
+    if (a.name !== newName) { a.name = newName; touchedIds.add(a.id); }
   }
 
-  if (touched) await saveConfig(config);
+  // Same discipline as the token write: drop the duplicates by id and copy the
+  // profile fields onto the touched rows only, leaving every other row — and
+  // every other field of these rows — as it is on disk.
+  if (touchedIds.size > 0 || removedIds.size > 0) {
+    const fields = ['name', 'accountUuid', 'orgUuid', 'orgName', 'organizationType', 'rateLimitTier', 'seatTier', 'hasClaudeMax', 'hasClaudePro'];
+    await atomicConfigUpdate(disk => {
+      disk.accounts = disk.accounts.filter(d => !removedIds.has(d?.id));
+      for (const a of config.accounts) {
+        if (!touchedIds.has(a.id)) continue;
+        const i = findConfigAccount(disk, a);
+        if (i < 0) continue;
+        for (const f of fields) if (a[f] !== undefined) disk.accounts[i][f] = a[f];
+      }
+    });
+  }
   if (removed > 0) console.log(`Removed ${removed} duplicate account(s)\n`);
 
   for (const [i, a] of config.accounts.entries()) {
@@ -1983,7 +2026,7 @@ function orgLabel(a) {
   return a.orgName || (a.orgUuid ? a.orgUuid.slice(0, 8) : 'org');
 }
 
-async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
+async function upsertOAuthAccount(name, creds, source = 'unknown') {
   // Fetch profile to auto-name and deduplicate by account+org identity.
   const userNamed = !!name;
   const profile = await fetchProfile(creds.accessToken);
@@ -2003,56 +2046,64 @@ async function upsertOAuthAccount(config, name, creds, source = 'unknown') {
     const tier = profile.hasClaudeMax ? 'Max' : profile.hasClaudePro ? 'Pro' : null;
     if (tier) console.log(`Detected Claude ${tier} account: ${profile.email}`);
   }
-  if (!name) {
-    const n = config.accounts.filter(a => a.name.startsWith('account-')).length + 1;
-    name = `account-${n}`;
-  }
-
-  const account = {
-    name,
-    type: 'oauth',
-    source,
-    ...oauthIdentityFields(profile),
-    organizationType: profile?.organizationType || null,
-    rateLimitTier: profile?.rateLimitTier || creds.rateLimitTier || null,
-    seatTier: profile?.seatTier || null,
-    hasClaudeMax: profile?.hasClaudeMax ?? null,
-    hasClaudePro: profile?.hasClaudePro ?? null,
-    accessToken: creds.accessToken,
-    refreshToken: creds.refreshToken,
-    expiresAt: creds.expiresAt,
-  };
-
-  // Deduplicate by account+org identity (same email in a different org is a
-  // distinct account), then by name — but only where the name is not standing in
-  // for a different account+org, which is exactly the multi-org case below.
-  const idx = findUpsertTarget(config.accounts, account);
-
-  if (idx >= 0) {
-    // Same account+org: refresh credentials and org info, but keep the existing
-    // display name, entry id, and any disk-only fields (e.g. importFrom).
-    const prev = config.accounts[idx];
-    config.accounts[idx] = updateAccountEntry(prev, account);
-    console.log(`Updated account "${prev.name}"`);
-  } else {
-    // New org for this person: if another entry shares the accountUuid, the bare
-    // email name would collide — disambiguate both with " (org)".
-    if (!userNamed && account.accountUuid) {
-      const collisions = config.accounts.filter(
-        a => a.accountUuid === account.accountUuid && !sameIdentity(a, account)
-      );
-      if (collisions.length > 0) {
-        for (const c of collisions) {
-          if (!c.name.includes(' (')) c.name = `${c.name} (${orgLabel(c)})`;
-        }
-        account.name = `${name} (${orgLabel(account)})`;
-      }
+  // The login or import that produced `creds` ran between the caller's config
+  // load and this save — a browser flow can take minutes — and a running server
+  // may have rotated another account's refresh token on disk meanwhile. Saving
+  // a copy loaded before that would put the dead token back, and the account
+  // would fail on its next restart. So the whole upsert runs against a fresh
+  // read of the file: only this account's row (and, in the multi-org case, the
+  // display name of its namesakes) changes; every other row stays as it is on
+  // disk.
+  const config = await atomicConfigUpdate(config => {
+    if (!name) {
+      const n = config.accounts.filter(a => a.name.startsWith('account-')).length + 1;
+      name = `account-${n}`;
     }
-    config.accounts.push(account);
-    console.log(`Added account "${account.name}"`);
-  }
 
-  await saveConfig(config);
+    const account = {
+      name,
+      type: 'oauth',
+      source,
+      ...oauthIdentityFields(profile),
+      organizationType: profile?.organizationType || null,
+      rateLimitTier: profile?.rateLimitTier || creds.rateLimitTier || null,
+      seatTier: profile?.seatTier || null,
+      hasClaudeMax: profile?.hasClaudeMax ?? null,
+      hasClaudePro: profile?.hasClaudePro ?? null,
+      accessToken: creds.accessToken,
+      refreshToken: creds.refreshToken,
+      expiresAt: creds.expiresAt,
+    };
+
+    // Deduplicate by account+org identity (same email in a different org is a
+    // distinct account), then by name — but only where the name is not standing in
+    // for a different account+org, which is exactly the multi-org case below.
+    const idx = findUpsertTarget(config.accounts, account);
+
+    if (idx >= 0) {
+      // Same account+org: refresh credentials and org info, but keep the existing
+      // display name, entry id, and any disk-only fields (e.g. importFrom).
+      const prev = config.accounts[idx];
+      config.accounts[idx] = updateAccountEntry(prev, account);
+      console.log(`Updated account "${prev.name}"`);
+    } else {
+      // New org for this person: if another entry shares the accountUuid, the bare
+      // email name would collide — disambiguate both with " (org)".
+      if (!userNamed && account.accountUuid) {
+        const collisions = config.accounts.filter(
+          a => a.accountUuid === account.accountUuid && !sameIdentity(a, account)
+        );
+        if (collisions.length > 0) {
+          for (const c of collisions) {
+            if (!c.name.includes(' (')) c.name = `${c.name} (${orgLabel(c)})`;
+          }
+          account.name = `${name} (${orgLabel(account)})`;
+        }
+      }
+      config.accounts.push(account);
+      console.log(`Added account "${account.name}"`);
+    }
+  });
   console.log(`Saved to ${getConfigPath()}`);
   await notifyRunningServer(config);
 }

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -465,15 +465,28 @@ function refuseRaw(sock, statusLine) {
   sock.destroy();
 }
 
+// How long a client has to complete the TLS handshake on a locally-terminated
+// tunnel, and how long the test host waits for a request. A raw TLSSocket has no
+// handshakeTimeout of its own, so a client that CONNECTs and then sends nothing
+// held a socket (and the tunnel behind it) open for ever.
+const HANDSHAKE_TIMEOUT_MS = 30_000;
+
 function termClaude(clientSocket, head, key, cert, alpn) {
   if (head && head.length) clientSocket.unshift(head);
   const t = new tls.TLSSocket(clientSocket, { isServer: true, key, cert, ALPNProtocols: alpn });
   t.on('error', () => t.destroy());
+  // Scoped to the handshake only: an idle timer on a live session would cut a
+  // long-lived connection that is legitimately quiet. Cleared on 'secure'.
+  const timer = setTimeout(() => t.destroy(), HANDSHAKE_TIMEOUT_MS);
+  t.once('secure', () => clearTimeout(timer));
+  t.once('close', () => clearTimeout(timer));
   return t;
 }
 
 // Answer the built-in test host locally over h1 with a canned JSON response.
 function serveTest(tlsSock) {
+  // One request, one response: a peer that never sends the request is done.
+  tlsSock.setTimeout(HANDSHAKE_TIMEOUT_MS, () => tlsSock.destroy());
   let buf = Buffer.alloc(0);
   const onData = (chunk) => {
     buf = Buffer.concat([buf, chunk]);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -52,12 +52,26 @@ async function atomicWrite(path, data, mode) {
   await rename(tmp, path);
 }
 
-// Is the stored leaf signed by the stored CA and valid for every host in `hosts`?
-function leafCovers(caCertPem, leafCertPem, hosts) {
+// A stored chain is reused only while it has this much life left. Without a
+// date check an expired leaf or CA was reused forever: every handshake failed
+// and nothing regenerated it, so the only cure was deleting the files by hand.
+// Renewing early keeps a long-running server from crossing the line mid-flight.
+const MIN_CERT_REMAINING_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Is the stored leaf signed by the stored CA, valid for every host in `hosts`,
+ * and (both certs) good for at least MIN_CERT_REMAINING_MS past `now`?
+ * Exported for tests.
+ */
+export function leafCovers(caCertPem, leafCertPem, hosts, now = Date.now()) {
   try {
     const ca = new X509Certificate(caCertPem);
     const leaf = new X509Certificate(leafCertPem);
     if (!leaf.verify(ca.publicKey)) return false;
+    for (const cert of [ca, leaf]) {
+      const validTo = new Date(cert.validTo).getTime();
+      if (!Number.isFinite(validTo) || validTo - now < MIN_CERT_REMAINING_MS) return false;
+    }
     const names = (leaf.subjectAltName || '').split(',').map((s) => s.trim());
     return hosts.every((h) => names.includes(`DNS:${h}`));
   } catch {

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -10,7 +10,7 @@
 // different account when one returns a quota 429, instead of surfacing it. A host
 // routing table decides per-CONNECT behavior:
 //   api.anthropic.com → terminate + forward,  www.example.org → local test server,
-//   anything else      → blind tunnel.
+//   anything else      → blind tunnel (never to this machine — see forward-target.js).
 
 import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { X509Certificate } from 'node:crypto';
@@ -22,6 +22,7 @@ import { getConfigPath } from './config.js';
 import { generateCertChain } from './x509.js';
 import { createProxyRequestListener, resolveClientAuth, isLoopbackAddr, relayUpgrade, resolveAccountPin, describeConnectError } from './server.js';
 import { interceptHostsFor, isNeverIntercepted } from './provider.js';
+import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-target.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -225,6 +226,18 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     const mode = hostMode(host, config);
 
     if (mode === 'tunnel') {
+      // Destination policy (see forward-target.js): a tunnel may not reach
+      // this machine's loopback, the unspecified address, or link-local — that
+      // is how a remote client with only a low-trust key would reach our own
+      // listener as a "local" caller, or a cloud metadata endpoint. Refused by
+      // name here so the obvious case never dials; refused by resolved address
+      // in the lookup below so a DNS alias for 127.0.0.1 does not get past.
+      const refused = forwardRefusal(host, null, clientSocket);
+      if (refused) {
+        log(`[TeamClaude] CONNECT ${host}:${port} refused: ${refused}`);
+        refuseRaw(clientSocket, '403 Forbidden');
+        return;
+      }
       // Until the upstream connects we still owe the client a CONNECT status
       // line. If we tore the socket down on an upstream failure without one,
       // the client reports "Proxy connection ended before receiving CONNECT
@@ -243,13 +256,31 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
         }
         up.destroy(); clientSocket.destroy();
       };
-      const up = net.connect(port, host, () => {
+      const up = net.connect({ port, host, lookup: guardedLookup(clientSocket) }, () => {
+        // The lookup already vetted every resolved address; this re-checks the
+        // one actually connected (cheap, and independent of how the dial got
+        // there). A tunnel back to our own listener — any local address, our
+        // port — is a request loop with nothing legitimate behind it, whether
+        // or not the address class would otherwise pass.
+        const ownPort = clientSocket.server?.address?.()?.port;
+        const refusedAfter = forwardRefusal(host, up.remoteAddress, clientSocket)
+          || (up.remotePort === ownPort && up.localAddress === up.remoteAddress ? 'that is this proxy\'s own listener' : null);
+        if (refusedAfter) {
+          log(`[TeamClaude] CONNECT ${host}:${port} refused: ${refusedAfter}`);
+          teardown('403 Forbidden');
+          return;
+        }
         established = true;
         reply200Raw(clientSocket);
         if (head && head.length) up.write(head);
         up.pipe(clientSocket); clientSocket.pipe(up);
       });
       up.on('error', (err) => {
+        if (err.code === FORBIDDEN_FORWARD) {
+          log(`[TeamClaude] CONNECT ${host}:${port} refused: ${err.message}`);
+          teardown('403 Forbidden');
+          return;
+        }
         if (!established) log(`[TeamClaude] tunnel ${host}:${port} failed: ${describeConnectError(err)}`);
         teardown('502 Bad Gateway');
       });
@@ -382,7 +413,12 @@ export function connectAuthorized(req, socket, proxyApiKey) {
 }
 
 function reply200Raw(sock) { sock.write('HTTP/1.1 200 Connection Established\r\n\r\n'); }
-function reply502Raw(sock) { try { sock.write('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n'); } catch { /* client already gone */ } }
+function reply502Raw(sock) { refuseRaw(sock, '502 Bad Gateway'); }
+// Answer a CONNECT with a final status line and close — the client never gets a tunnel.
+function refuseRaw(sock, statusLine) {
+  try { sock.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`); } catch { /* client already gone */ }
+  sock.destroy();
+}
 
 function termClaude(clientSocket, head, key, cert, alpn) {
   if (head && head.length) clientSocket.unshift(head);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -123,6 +123,33 @@ export function hostMode(host, config) {
 }
 
 /**
+ * Parse a CONNECT request-target (authority-form, `host:port`) into
+ * { host, port }, or null when it is not one we will dial.
+ *
+ * A naive `split(':')` got every awkward spelling wrong, and each one landed
+ * on the blind tunnel: `[::1]:443` became host `[`; `:443` an empty host,
+ * which Node dials as localhost; `API.ANTHROPIC.COM:443` and
+ * `api.anthropic.com.:443` missed hostMode's exact match and were tunnelled
+ * instead of intercepted. So the host goes through the URL parser (lowercase,
+ * IDNA, character validation), a root dot is dropped, IPv6 brackets are
+ * removed, and an empty host or an out-of-range port is refused. The port
+ * defaults to 443 as before; authority-form nominally requires one, but
+ * refusing its absence would break nothing and help nobody.
+ */
+export function parseConnectAuthority(target) {
+  const m = /^(\[[^\]]*\]|[^:[\]/?#@\s]+)(?::(\d{1,5}))?$/.exec(String(target || ''));
+  if (!m) return null;
+  let host;
+  try { host = new URL(`http://${m[1]}`).hostname; } catch { return null; }
+  host = host.toLowerCase().replace(/\.$/, '');
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+  if (!host) return null;
+  const port = m[2] == null ? 443 : Number(m[2]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { host, port };
+}
+
+/**
  * Build a `connect` event handler implementing the terminating MITM described at
  * the top of this file.
  * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
@@ -221,8 +248,12 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
       return;
     }
 
-    const [host, portStr] = (req.url || '').split(':');
-    const port = parseInt(portStr, 10) || 443;
+    const authority = parseConnectAuthority(req.url);
+    if (!authority) {
+      refuseRaw(clientSocket, '400 Bad Request');
+      return;
+    }
+    const { host, port } = authority;
     const mode = hostMode(host, config);
 
     if (mode === 'tunnel') {

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -23,6 +23,7 @@ import { generateCertChain } from './x509.js';
 import { createProxyRequestListener, resolveClientAuth, isLoopbackAddr, relayUpgrade, resolveAccountPin, describeConnectError } from './server.js';
 import { interceptHostsFor, isNeverIntercepted } from './provider.js';
 import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-target.js';
+import { safeLine } from './safe-text.js';
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -412,9 +413,20 @@ export function resolveConnectPin(req, accountManager, proxyConfig) {
     return { pin: null, error: null };
   }
   if (resolveAccountPin(accountManager, token) == null) {
-    return { pin: null, error: `Unknown account pin "${token}"` };
+    return { pin: null, error: `Unknown account pin ${redactToken(token)}` };
   }
   return { pin: token, error: null };
+}
+
+// An unrecognized CONNECT username reaches the log, and it is not necessarily a
+// typo'd account name: HTTPS_PROXY=http://<secret>@host:port is the documented
+// remote form, so a wrong key — or some other tool's credential inherited from
+// the environment — would be written out verbatim. Enough to spot the typo
+// (first two characters, length), stripped of anything that could forge a log
+// line, and never the whole value.
+function redactToken(token) {
+  const s = String(token);
+  return `"${safeLine(s.slice(0, 2), 2)}…" (${s.length} chars)`;
 }
 
 /**

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -706,7 +706,17 @@ function raceWithStdinCode(callbackPromise, expectedState) {
   });
 }
 
-function startCallbackServer(expectedState) {
+/**
+ * The loopback listener the browser is redirected back to.
+ *
+ * Only a request carrying the expected `state` may settle the login. The state
+ * is checked FIRST, and a mismatch is answered 400 without touching the
+ * promise: this port is briefly open while the user is in the browser, and a
+ * stray GET — a drive-by page hitting localhost ports, a scanner, a stale tab —
+ * used to abort the whole login by arriving with `?error=` or with no state at
+ * all. Exported for tests.
+ */
+export function startCallbackServer(expectedState) {
   return new Promise((resolve, reject) => {
     let resolveCode, rejectCode;
     const codePromise = new Promise((res, rej) => { resolveCode = res; rejectCode = rej; });
@@ -715,10 +725,14 @@ function startCallbackServer(expectedState) {
       const url = new URL(req.url, `http://localhost`);
 
       if (url.pathname === '/callback') {
-        const code = url.searchParams.get('code');
-        const error = url.searchParams.get('error');
         const state = url.searchParams.get('state');
+        if (!state || state !== expectedState) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end('<html><body><h2>Invalid request</h2><p>State mismatch. You can close this tab.</p></body></html>');
+          return;
+        }
 
+        const error = url.searchParams.get('error');
         if (error) {
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.end('<html><body><h2>Authentication failed</h2><p>You can close this tab.</p></body></html>');
@@ -726,13 +740,7 @@ function startCallbackServer(expectedState) {
           return;
         }
 
-        if (expectedState && state !== expectedState) {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end('<html><body><h2>Authentication failed</h2><p>State mismatch. You can close this tab.</p></body></html>');
-          rejectCode(new Error('OAuth state mismatch'));
-          return;
-        }
-
+        const code = url.searchParams.get('code');
         if (code) {
           res.writeHead(302, { 'Location': 'https://platform.claude.com/oauth/code/success?app=claude-code' });
           res.end();
@@ -745,7 +753,9 @@ function startCallbackServer(expectedState) {
       res.end('Not found');
     });
 
-    server.listen(0, () => {
+    // Loopback only: the redirect URI is http://localhost:<port>/callback, so
+    // nothing off this machine ever has a reason to reach the listener.
+    server.listen(0, '127.0.0.1', () => {
       resolve({ port: server.address().port, codePromise, server });
     });
     server.on('error', reject);

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -771,8 +771,10 @@ export function startCallbackServer(expectedState) {
 
 function openBrowser(url) {
   const platform = process.platform;
+  // `start` takes its first quoted argument as the window title, so the URL
+  // needs an empty title in front of it or the browser never opens.
   const cmd = platform === 'darwin' ? 'open'
-    : platform === 'win32' ? 'start'
+    : platform === 'win32' ? 'start ""'
     : 'xdg-open';
   exec(`${cmd} ${JSON.stringify(url)}`, () => {});
 }

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -182,12 +182,7 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
         throw err;
       }
 
-      const data = await res.json();
-      return {
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token || refreshToken,
-        expiresAt: normalizeExpiresAt(data.expires_at) || (Date.now() + (data.expires_in || 3600) * 1000),
-      };
+      return tokenPairFromResponse(await res.json(), { previousRefreshToken: refreshToken });
     } catch (err) {
       const isNetworkError = err instanceof Error &&
         (err.name === 'TimeoutError' || err.name === 'AbortError' ||
@@ -204,22 +199,58 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
 }
 
 /**
- * Normalize an expires_at value to milliseconds.
+ * The credential fields of a token-endpoint response, checked.
+ *
+ * A 200 is not proof the body is usable. One without `access_token` used to be
+ * stored as `accessToken: undefined` and sent upstream as `Bearer undefined`,
+ * and a non-numeric expiry was stored as-is, where isTokenExpired never fired
+ * on it. So a missing or empty access token is an error here, the refresh token
+ * is taken only when it is a non-empty string (else the previous one is kept),
+ * and the expiry is `expires_at` (seconds or milliseconds) or `expires_in`
+ * seconds when either is a finite number — or one hour from now when neither
+ * is, which just makes the next refresh happen early.
+ */
+export function tokenPairFromResponse(data, { previousRefreshToken = undefined, now = Date.now() } = {}) {
+  const accessToken = data?.access_token;
+  if (typeof accessToken !== 'string' || accessToken === '') {
+    throw new Error('Token response carried no access_token');
+  }
+  const rotated = data.refresh_token;
+  const refreshToken = typeof rotated === 'string' && rotated !== '' ? rotated : previousRefreshToken;
+  const expiresIn = Number(data.expires_in);
+  const expiresAt = normalizeExpiresAt(data.expires_at)
+    ?? (Number.isFinite(expiresIn) && expiresIn > 0 ? now + expiresIn * 1000 : now + 3600 * 1000);
+  return { accessToken, refreshToken, expiresAt };
+}
+
+/**
+ * Normalize an expires_at value to milliseconds, or null when it is absent or
+ * not a positive finite number — a value that cannot be compared with the clock
+ * must not pass for one that can.
  * OAuth endpoints may return seconds; Claude Code credentials use milliseconds.
  */
 export function normalizeExpiresAt(expiresAt) {
-  if (!expiresAt) return expiresAt;
+  if (!expiresAt) return null;
+  const n = Number(expiresAt);
+  if (!Number.isFinite(n) || n <= 0) return null;
   // If the value is plausibly in seconds (< 10^12 ≈ year 2001 in ms, year 33658 in s),
   // convert to milliseconds
-  return expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+  return n < 1e12 ? n * 1000 : n;
 }
 
 /**
  * Check if an OAuth token is expiring within the given threshold.
+ *
+ * No expiry at all means unknown, and the token is used until upstream says
+ * otherwise. An expiry that is present but not a number is treated as already
+ * reached: it cannot be trusted to lie in the future, and refreshing replaces
+ * it with one that can be compared.
  */
 export function isTokenExpiringSoon(expiresAt, thresholdMs = 5 * 60 * 1000) {
   if (!expiresAt) return false;
-  return Date.now() + thresholdMs >= normalizeExpiresAt(expiresAt);
+  const at = normalizeExpiresAt(expiresAt);
+  if (at == null) return true;
+  return Date.now() + thresholdMs >= at;
 }
 
 /**
@@ -230,7 +261,9 @@ export function isTokenExpiringSoon(expiresAt, thresholdMs = 5 * 60 * 1000) {
  */
 export function isTokenExpired(expiresAt) {
   if (!expiresAt) return false;
-  return Date.now() >= normalizeExpiresAt(expiresAt);
+  const at = normalizeExpiresAt(expiresAt);
+  if (at == null) return true; // present but unusable — see isTokenExpiringSoon
+  return Date.now() >= at;
 }
 
 /** Normalize the OAuth profile fields TeamClaude persists and exposes. */
@@ -518,12 +551,7 @@ async function exchangeCodeForTokens(code, state, codeVerifier, redirectUri, tok
     throw new Error(`Token exchange failed (${tokenRes.status}): ${text}`);
   }
 
-  const tokens = await tokenRes.json();
-  return {
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    expiresAt: normalizeExpiresAt(tokens.expires_at) || (Date.now() + (tokens.expires_in || 3600) * 1000),
-  };
+  return tokenPairFromResponse(await tokenRes.json());
 }
 
 /**

--- a/src/prober.js
+++ b/src/prober.js
@@ -10,10 +10,20 @@
 import { fetchUsage } from './oauth.js';
 import { fetchBackendQuota, hasBackendQuota } from './backend-quota.js';
 
+// Node's timers take a 32-bit signed delay: anything above 2^31-1 ms is
+// coerced to 1 ms, so an interval large enough to mean "practically never"
+// would instead probe in a tight loop. The TUI and CLI accept any number of
+// seconds, so the ceiling lives here where the timer is armed.
+export const MAX_PROBE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function clampInterval(ms) {
+  return ms > 0 ? Math.min(ms, MAX_PROBE_INTERVAL_MS) : 0;
+}
+
 export class Prober {
   constructor(accountManager, { intervalMs = 0, probeFn = fetchUsage, profileFn = null, backendFn = fetchBackendQuota, timeoutMs = 10_000, log = console.log } = {}) {
     this.am = accountManager;
-    this.intervalMs = intervalMs;
+    this.intervalMs = clampInterval(intervalMs);
     this.probeFn = probeFn;
     this.profileFn = profileFn;
     this.backendFn = backendFn;
@@ -23,7 +33,7 @@ export class Prober {
     this._running = false;
     this.lastRunStartedAt = null;
     this.lastRunFinishedAt = null;
-    this.nextRunAt = intervalMs > 0 ? Date.now() + intervalMs : null;
+    this.nextRunAt = this.intervalMs > 0 ? Date.now() + this.intervalMs : null;
     this.accountStatus = new Map();
   }
 
@@ -34,6 +44,7 @@ export class Prober {
   /** Change interval at runtime (0 = off). Probes once immediately when on. */
   reschedule(intervalMs) {
     const wasOn = this.intervalMs > 0 && this.timer;
+    intervalMs = clampInterval(intervalMs);
     this.intervalMs = intervalMs;
     if (this.timer) { clearInterval(this.timer); this.timer = null; }
 
@@ -64,7 +75,7 @@ export class Prober {
     this.nextRunAt = this.intervalMs > 0 ? this.lastRunStartedAt + this.intervalMs : null;
     try {
       const accounts = this.am.accounts.filter(account =>
-        this._isProbeTarget(account) || this._isBackendTarget(account));
+        this._probeable(account) && (this._isProbeTarget(account) || this._isBackendTarget(account)));
       await Promise.all(accounts.map(account => this.probeAccount(account)));
     } finally {
       this.lastRunFinishedAt = Date.now();
@@ -91,6 +102,20 @@ export class Prober {
    * module decides which; nothing in this file knows one by name. */
   _isBackendTarget(account) {
     return !!account?.credential && hasBackendQuota(account);
+  }
+
+  // Only accounts in rotation are probed. A probe forces a token refresh and
+  // sends the access token upstream, and neither belongs to an account the
+  // operator took out of service (`disabled`) or one whose refresh token upstream
+  // has already rejected — refreshing it again only rotates the token family
+  // once more, and its access token cannot be trusted either. The manager's
+  // dead-token guard is keyed on the token value, so a re-login lifts this skip
+  // on its own.
+  _probeable(account) {
+    if (!account?.credential) return false;
+    if (account.disabled) return false;
+    if (account._deadRefreshToken && account._deadRefreshToken === account.refreshToken) return false;
+    return true;
   }
 
   async probeAccount(account) {

--- a/src/server.js
+++ b/src/server.js
@@ -2536,7 +2536,11 @@ export function stripBodyFields(body, fields) {
 export function rewriteModel(body, modelMap) {
   try {
     const obj = JSON.parse(body.toString('utf8'));
-    if (obj.model && modelMap[obj.model]) {
+    // Own keys only: the map is a plain object, so a model named
+    // "constructor" or "toString" would otherwise look up a prototype
+    // function, which JSON.stringify then drops — the request goes upstream
+    // with no model at all.
+    if (typeof obj.model === 'string' && Object.hasOwn(modelMap, obj.model) && typeof modelMap[obj.model] === 'string') {
       obj.model = modelMap[obj.model];
       return Buffer.from(JSON.stringify(obj), 'utf8');
     }

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,7 @@ import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath, providerO
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
+import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-target.js';
 import { renderDashboardHtml, dashboardCsp } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
 
@@ -632,6 +633,24 @@ export function relayHttpForward(req, res) {
     res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'Malformed forward-proxy URL' } }));
     return;
   }
+  // Destination policy, same as the CONNECT tunnel's (forward-target.js): a
+  // relay may not target this machine's loopback, the unspecified address, or
+  // link-local. `GET http://127.0.0.1:<our port>/teamclaude/status` would
+  // otherwise arrive at our own listener from a loopback socket and pass the
+  // API-key gate as a local caller. Refused by literal name here; the guarded
+  // lookup below refuses by resolved address, so a DNS alias for 127.0.0.1 does
+  // not get past either. Launched clients carry NO_PROXY for loopback, so no
+  // legitimate request is lost.
+  const hostname = target.hostname.replace(/^\[|\]$/g, '');
+  const refuse = (why) => {
+    console.error(`[TeamClaude] HTTP forward to ${target.host} refused: ${why}`);
+    if (res.headersSent) { res.destroy(); return; }
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'permission_error', message: `Forward to ${target.host} refused: ${why}` } }));
+  };
+  const refused = forwardRefusal(hostname, null, req.socket);
+  if (refused) { refuse(refused); return; }
+
   const transport = target.protocol === 'http:' ? http : https;
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
@@ -641,7 +660,7 @@ export function relayHttpForward(req, res) {
     headers[key] = value;
   }
 
-  const upstreamReq = transport.request(target, { method: req.method, headers }, (upstreamRes) => {
+  const upstreamReq = transport.request(target, { method: req.method, headers, lookup: guardedLookup(req.socket) }, (upstreamRes) => {
     const responseHeaders = {};
     for (const [key, value] of Object.entries(upstreamRes.headers)) {
       if (CONNECTION_SPECIFIC_HEADERS.has(key)) continue;
@@ -651,6 +670,7 @@ export function relayHttpForward(req, res) {
     upstreamRes.pipe(res);
   });
   upstreamReq.on('error', (err) => {
+    if (err.code === FORBIDDEN_FORWARD) { refuse(err.message); return; }
     console.error(`[TeamClaude] HTTP forward to ${target.host} failed:`, describeConnectError(err));
     if (!res.headersSent) {
       res.writeHead(502, { 'Content-Type': 'application/json' });

--- a/src/server.js
+++ b/src/server.js
@@ -1000,6 +1000,10 @@ function relayStream(req, res, upstream, sx) {
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
     if (lk.startsWith(':') || HOP_BY_HOP_HEADERS.has(lk) || lk === 'accept-encoding') continue;
+    // The client's identity on this path is its bearer; x-api-key is how it
+    // authenticated to THIS proxy, so relaying it would hand the operator's
+    // proxy key to upstream.
+    if (lk === 'x-api-key') continue;
     headers[key] = value;
   }
 
@@ -1063,8 +1067,9 @@ export function relayUpgrade(req, socket, head, upstream, sx) {
     const lk = key.toLowerCase();
     // Unlike relayStream, do NOT strip 'upgrade'/'connection' here — they ARE
     // the handshake. Only 'host' (the client transport reconstructs it from
-    // `target`) and h2 pseudo-headers are dropped.
-    if (lk.startsWith(':') || lk === 'host') continue;
+    // `target`), h2 pseudo-headers and the proxy's own x-api-key (the client's
+    // credential to us, not to upstream) are dropped.
+    if (lk.startsWith(':') || lk === 'host' || lk === 'x-api-key') continue;
     headers[key] = value;
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -666,6 +666,21 @@ export function relayHttpForward(req, res) {
 // fleet; the whole prefix is the fix, not a growing allowlist of sub-paths.
 const CLIENT_CREDENTIAL_PATHS = ['/v1/code/', '/api/oauth/'];
 
+// Claude Code's session id is a UUID, but other clients tag sessions too, so
+// the shape is a conservative charset rather than the UUID grammar: wide enough
+// that a non-UUID client keeps its session tracking, tight enough that nothing
+// odd gets in. The value becomes a Map key in the session tracker (the length
+// cap is what bounds that map per client) and a column in the TUI, where Node's
+// header parser would otherwise let C1 control bytes through untouched.
+const SESSION_ID_SHAPE = /^[A-Za-z0-9._-]{1,128}$/;
+
+/** The session id a request carries, or null when the header is absent or
+ *  malformed — a malformed one is treated as no session, not rejected. */
+export function clientSessionId(headers) {
+  const raw = headers['x-claude-code-session-id'];
+  return typeof raw === 'string' && SESSION_ID_SHAPE.test(raw) ? raw : null;
+}
+
 /**
  * Build the core proxy request listener — buffer the body, then forward with
  * account selection + retry (forwardRequest). Shared by the base HTTP server and
@@ -773,7 +788,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
           // value on the path that can carry raw control bytes.
           const shown = safeLine(token ?? raw);
           const reqId = ++counter;
-          const sessionId = req.headers['x-claude-code-session-id'] || null;
+          const sessionId = clientSessionId(req.headers);
           if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${shown}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${shown}"` } }));
@@ -793,7 +808,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         pinnedIndex = resolveAccountPin(accountManager, forcedPin);
         if (pinnedIndex == null) {
           const reqId = ++counter;
-          const sessionId = req.headers['x-claude-code-session-id'] || null;
+          const sessionId = clientSessionId(req.headers);
           if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: `(unknown pin: "${safeLine(forcedPin)}")`, status: 404, model: null, sessionId, pinned: false });
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `Unknown account pin "${forcedPin}" (from TC_ACCT)` } }));
@@ -806,7 +821,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // Claude Code tags each session's requests with this header (present on
       // /v1/messages and count_tokens). Read from headers up front so it drives
       // session-aware routing (issue #109) and colors the TUI activity stream.
-      const sessionId = req.headers['x-claude-code-session-id'] || null;
+      const sessionId = clientSessionId(req.headers);
       if (!hideActivity) {
         // Marked open BEFORE the hook runs. The shipped TUI hook registers its
         // row and then renders, and the render can rethrow, so a hook that

--- a/src/server.js
+++ b/src/server.js
@@ -1653,7 +1653,12 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     // req.headers on the h2 server path; fetch rejects `:`-prefixed names.
     if (lk.startsWith(':')) continue;
     if (HOP_BY_HOP_HEADERS.has(lk)) continue;
-    if (lk === 'x-api-key') continue;
+    // Both credential headers are dropped, not just the one the account will
+    // set: applyAuthHeaders overwrites `authorization` only for bearer-token
+    // accounts, so on an API-key account the CLIENT's own
+    // `Authorization: Bearer <its Anthropic OAuth token>` would otherwise ride
+    // along untouched — to whatever host that account's `upstream` names.
+    if (lk === 'x-api-key' || lk === 'authorization') continue;
     // Strip accept-encoding: Node fetch auto-decompresses, which would
     // mismatch the Content-Encoding header we forward to the client
     if (lk === 'accept-encoding') continue;

--- a/src/server.js
+++ b/src/server.js
@@ -729,7 +729,7 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       }
       // Client token refresh: pass through untouched (the proxy manages its own
       // tokens via ensureTokenFresh; rewriting client refreshes would conflict).
-      if (req.method === 'POST' && req.url === '/v1/oauth/token') { await relayRaw(req, res, upstream, sx); return; }
+      if (req.method === 'POST' && req.url === '/v1/oauth/token') { await relayRaw(req, res, upstream, sx, resolveMaxBodyBytes(config)); return; }
       // Remote Control (/v1/code/*) is bound to the session's paired claude.ai
       // identity — forward with the client's OWN credential (streamed), never a
       // rotated account token, which would 403 the worker event stream.
@@ -819,7 +819,19 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // frame — rather than waiting for the whole body and the request to finish.
       const bodyChunks = [];
       const modelFinder = new TopLevelFieldFinder('model');
+      const maxBodyBytes = resolveMaxBodyBytes(config);
+      let bodyBytes = 0;
       for await (const chunk of req) {
+        bodyBytes += chunk.length;
+        // Buffering is what makes retry possible, and also what lets one client
+        // hold as much memory as it cares to send. Past the cap, stop reading
+        // and say so; the request is torn down once the answer is out.
+        if (bodyBytes > maxBodyBytes) {
+          await refuseOversizedBody(req, res);
+          openEntry = null;   // this path owns the close below; the outer catch must not repeat it
+          if (!hideActivity) hooks.onRequestEnd?.(reqId, { method: req.method, path: req.url, account: '(too large)', status: 413, model: modelFinder.done ? modelFinder.value : null, sessionId, pinned: pinnedIndex != null });
+          return;
+        }
         bodyChunks.push(chunk);
         if (!modelFinder.done) {
           const found = modelFinder.push(chunk);
@@ -1197,11 +1209,43 @@ export function relayUpgrade(req, socket, head, upstream, sx) {
 }
 
 /**
+ * Refuse a request whose body ran past the buffering cap.
+ *
+ * The 413 goes out first and the request is torn down only once it has been
+ * flushed. The order matters: destroying first races the answer off the
+ * socket, while merely ending the response makes Node drain (read and discard)
+ * the rest of the body, which is exactly the traffic the cap exists to stop.
+ * 'close' is raced against the flush so a client that has already gone away
+ * cannot hold the handler open waiting for a 'finish' that never comes.
+ * Mid-stream (headers already out) there is no status left to send.
+ */
+async function refuseOversizedBody(req, res) {
+  if (!res.headersSent) {
+    res.writeHead(413, { 'Content-Type': 'application/json' });
+    await new Promise((resolve) => {
+      res.once('close', resolve);
+      res.end(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Request body too large' },
+      }), resolve);
+    });
+  }
+  req.destroy();
+}
+
+/**
  * Relay a request to upstream with no header rewriting — pure passthrough.
  */
-async function relayRaw(req, res, upstream, sx) {
+async function relayRaw(req, res, upstream, sx, maxBodyBytes = DEFAULT_MAX_BODY_BYTES) {
   const bodyChunks = [];
-  for await (const chunk of req) bodyChunks.push(chunk);
+  let bodyBytes = 0;
+  for await (const chunk of req) {
+    bodyBytes += chunk.length;
+    // Same cap as the forward path: this buffers too, and a token exchange is
+    // a few hundred bytes.
+    if (bodyBytes > maxBodyBytes) { await refuseOversizedBody(req, res); return; }
+    bodyChunks.push(chunk);
+  }
   const body = Buffer.concat(bodyChunks);
 
   try {
@@ -1269,6 +1313,23 @@ export function resolveLogMaxBodyBytes(config) {
   const max = typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : raw;
   if (max === 0) return 0;
   return Number.isFinite(max) && max > 0 ? max : DEFAULT_LOG_MAX_BODY_BYTES;
+}
+
+// Cap on a buffered request body. The forward path buffers the whole body so
+// it can be resent on another account after a 429; without a cap, one client
+// holds as much of the proxy's memory as it cares to send. 64 MiB sits
+// comfortably above the largest legitimate request — a 1M-token context is a
+// few MiB of text, and the API bounds inline images and PDFs well below this —
+// so nothing real is refused. `proxy.maxBodyBytes` overrides it; 0 opts out.
+export const DEFAULT_MAX_BODY_BYTES = 64 * 1024 * 1024;
+
+export function resolveMaxBodyBytes(config) {
+  const raw = config?.proxy?.maxBodyBytes;
+  // Same reading rules as resolveLogMaxBodyBytes: a quoted number counts, a
+  // blank string means unset, and 0 is the explicit opt-out.
+  const max = typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : raw;
+  if (max === 0) return Infinity;
+  return Number.isFinite(max) && max > 0 ? max : DEFAULT_MAX_BODY_BYTES;
 }
 
 // The names openRequestLog writes, and nothing else. Deletion keys off this

--- a/src/server.js
+++ b/src/server.js
@@ -240,8 +240,8 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
       // this costs legitimate callers nothing. Deliberately not a content-type
       // requirement, which would also close the hole but would break the
       // documented `curl -X POST .../teamclaude/reload` that sends no body.
-      if (req.method === 'POST' && (req.url || '').startsWith('/teamclaude/')
-          && !isSameOriginControlRequest(req)) {
+      const crossOrigin = !isSameOriginControlRequest(req);
+      if (crossOrigin && req.method === 'POST' && (req.url || '').startsWith('/teamclaude/')) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           ok: false,
@@ -254,7 +254,45 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
       // proxying plain HTTP to some host. Account logic is only for hosts we
       // manage (the Anthropic upstream, which is HTTPS-only and never arrives
       // this way); forward anything else transparently instead of hijacking it.
+      // Dispatched BEFORE the loopback-only checks below: a page cannot make a
+      // browser emit an absolute-form request line, the relay injects no fleet
+      // credential, and its Host header names the TARGET, not this proxy.
       if (/^https?:\/\//i.test(req.url || '')) { relayHttpForward(req, res); return; }
+
+      // A request admitted ONLY by the loopback exemption — no valid key — is
+      // held to two more conditions. Both target the same actor: a web page in
+      // the operator's browser, whose requests are loopback-sourced too. A
+      // caller that presented a valid key has proven itself and skips both.
+      if (!auth.ok) {
+        // Cross-origin, for every method and path this time. The control-plane
+        // gate above covers its mutations, but the same no-cors trick reaches
+        // POST /v1/messages, where the proxy injects a fleet credential (a quota
+        // drain, with prompt content booked to the operator), and a GET of
+        // /teamclaude/status is unreadable to the page only for as long as no
+        // CORS header ever leaks. Same browser-set headers, same zero cost to
+        // curl, the CLI and Node clients, which send neither.
+        if (crossOrigin) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            type: 'error',
+            error: { type: 'permission_error', message: 'cross-origin request refused: a web page cannot use the proxy without a key' },
+          }));
+          return;
+        }
+        // DNS rebinding. A page at attacker.example whose name flips to
+        // 127.0.0.1 sends requests that are loopback-sourced AND same-origin as
+        // far as the browser can tell, and it can read the answers. What it
+        // cannot forge is the Host header, which the browser derives from its
+        // own URL bar — so a key-less loopback request must name this machine.
+        if (!isLocalHostHeader(req.headers.host ?? req.headers[':authority'], config.proxy?.host)) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            type: 'error',
+            error: { type: 'permission_error', message: 'request refused: the Host header does not name this proxy' },
+          }));
+          return;
+        }
+      }
 
       // Status endpoint
       if (req.method === 'GET' && req.url === '/teamclaude/status') {
@@ -437,6 +475,51 @@ export function isSameOriginControlRequest(req) {
   const site = req.headers['sec-fetch-site'];
   if (site) return site === 'same-origin' || site === 'none';
   return !req.headers.origin;
+}
+
+// Names a browser can reach this machine by. `::ffff:127.0.0.1` is how a
+// dual-stack listener reports loopback and is accepted for symmetry with
+// isLoopbackAddr, though no browser writes it in a URL.
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1']);
+// Binding to a wildcard says nothing about what name reaches us, so it does
+// not widen the set.
+const WILDCARD_BINDS = new Set(['0.0.0.0', '::', '']);
+
+// The hostname part of a Host header (or a bind address): port stripped, IPv6
+// brackets removed, lowercased. null when the value cannot be one.
+function hostnameOf(host) {
+  const h = String(host).trim().toLowerCase();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return end < 0 ? null : h.slice(1, end);
+  }
+  // A bare IPv6 address (how config.proxy.host spells one) has several colons
+  // and no port to strip; a `name:port` has exactly one.
+  const colon = h.indexOf(':');
+  if (colon >= 0 && h.indexOf(':', colon + 1) >= 0) return h;
+  return colon >= 0 ? h.slice(0, colon) : h;
+}
+
+/**
+ * Whether a request's Host header names this proxy, for the DNS-rebinding
+ * check on key-less loopback requests.
+ *
+ * Accepted: localhost, 127.0.0.1, ::1 (bracketed or not), and the address the
+ * proxy is bound to (`config.proxy.host`) unless that is a wildcard. Port and
+ * case are ignored.
+ *
+ * A MISSING Host header is accepted. Only an HTTP/1.0 client can omit it (Node
+ * rejects an HTTP/1.1 request without one before this code runs), and no
+ * browser speaks HTTP/1.0 — while a hand-rolled local tool might. Refusing it
+ * would break that tool without closing anything.
+ */
+export function isLocalHostHeader(host, bindHost = null) {
+  if (host == null || host === '') return true;
+  const name = hostnameOf(host);
+  if (name == null) return false;
+  if (LOCAL_HOSTNAMES.has(name)) return true;
+  const bound = typeof bindHost === 'string' ? hostnameOf(bindHost) : null;
+  return bound != null && !WILDCARD_BINDS.has(bound) && bound === name;
 }
 
 // Read a control-endpoint body as text. Capped, unlike the proxied request path:

--- a/src/server.js
+++ b/src/server.js
@@ -15,7 +15,7 @@ import { applyAuthHeaders, upstreamFor, rewritesBody, providerForPath, providerO
 import { tunnelTls } from './sx.js';
 import { createEgressGuard } from './egress-guard.js';
 import { safeLine } from './safe-text.js';
-import { renderDashboardHtml } from './dashboard.js';
+import { renderDashboardHtml, dashboardCsp } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
 
 
@@ -201,7 +201,14 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
       // x-api-key, so gating the asset would just 401 every remote browser
       // without protecting anything.
       if (req.method === 'GET' && req.url === '/teamclaude/dashboard') {
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+        // The page keeps the proxy key in localStorage; the policy is what
+        // stops any script but its own from ever running next to it.
+        res.writeHead(200, {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'no-store',
+          'Content-Security-Policy': dashboardCsp(),
+          'X-Content-Type-Options': 'nosniff',
+        });
         res.end(renderDashboardHtml());
         return;
       }

--- a/src/server.js
+++ b/src/server.js
@@ -327,8 +327,12 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true, added: added || 0 }));
         } catch (err) {
+          // The reason belongs in the log, not the reply: a reload failure
+          // names config paths and account details, and this endpoint is
+          // reachable by anyone holding a client key.
+          console.error('[TeamClaude] Reload failed:', err.message);
           res.writeHead(500, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: false, error: err.message }));
+          res.end(JSON.stringify({ ok: false, error: 'reload failed; see the proxy log' }));
         }
         return;
       }
@@ -2322,10 +2326,14 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     ctx.status = 502;
 
     if (!res.headersSent) {
+      // Generic on purpose, as relayStream's 502 already is: the described
+      // error names the resolved upstream hosts and ports (per-account
+      // upstreams included), which is the operator's business — it went to
+      // the log above — and not the client's.
       res.writeHead(502, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         type: 'error',
-        error: { type: 'proxy_error', message: `Upstream error: ${describeConnectError(err)}` },
+        error: { type: 'proxy_error', message: 'Upstream error; see the proxy log' },
       }));
     } else if (!res.writableEnded) {
       // Error after headers were already sent (mid-stream) and it wasn't

--- a/src/service.js
+++ b/src/service.js
@@ -118,16 +118,35 @@ ${env.join('\n')}
 `;
 }
 
+/**
+ * One word of a systemd unit value, double-quoted the way systemd.syntax(7)
+ * reads it: `\` and `"` escaped inside the quotes. Unquoted, a path with a
+ * space split into two words (ExecStart would run the wrong program), and a
+ * newline anywhere started a new line of the unit — so a TEAMCLAUDE_CONFIG
+ * carrying "\n" injected directives of its own into [Service]. Control
+ * characters are refused outright: systemd has no escape that makes them safe
+ * in a path, and no real path holds one.
+ */
+export function systemdQuote(value) {
+  const s = String(value);
+  if (/[\x00-\x1f\x7f]/.test(s)) {
+    throw new Error(`Cannot write a systemd unit with a control character in ${JSON.stringify(s)}`);
+  }
+  return `"${s.replace(/[\\"]/g, (c) => `\\${c}`)}"`;
+}
+
 export function renderSystemdUnit({ node, entry, path, configPath = null }) {
-  const environment = [`Environment=PATH=${path}`];
-  if (configPath) environment.push(`Environment=TEAMCLAUDE_CONFIG=${configPath}`);
+  // Environment= takes whole VAR=VALUE assignments as its words, so the quotes
+  // wrap the assignment, not just the value.
+  const environment = [`Environment=${systemdQuote(`PATH=${path}`)}`];
+  if (configPath) environment.push(`Environment=${systemdQuote(`TEAMCLAUDE_CONFIG=${configPath}`)}`);
   return `[Unit]
 Description=TeamClaude multi-account Claude proxy
 Documentation=https://github.com/KarpelesLab/teamclaude
 After=network-online.target
 
 [Service]
-ExecStart=${node} ${entry} server --headless
+ExecStart=${systemdQuote(node)} ${systemdQuote(entry)} server --headless
 Restart=always
 RestartSec=5
 ${environment.join('\n')}

--- a/src/session-tracker.js
+++ b/src/session-tracker.js
@@ -26,6 +26,22 @@ export const SESSION_ACTIVE_TTL_MS = 2 * 60 * 1000; // 2min idle → no longer "
 
 const SWEEP_INTERVAL_MS = 60 * 1000; // bound growth without an external timer
 
+// The session id is a client-supplied header, and every distinct value becomes
+// a Map key that lives for the known window. A client minting a fresh id per
+// request would otherwise grow this map for an hour with nothing to stop it, so
+// the tracker bounds itself: at most this many sessions (the idle ones go first
+// when the cap is hit — one still in flight is never dropped), and no key longer
+// than this. server.js validates the header too; this is the tracker's own guard.
+export const MAX_SESSIONS = 10_000;
+export const MAX_SESSION_ID_LENGTH = 128;
+
+// The Map key for a client-supplied id. Bounded here so every entry point keys
+// the same way and a long id cannot hold more memory than a short one.
+function keyOf(sessionId) {
+  if (typeof sessionId !== 'string' || sessionId.length <= MAX_SESSION_ID_LENGTH) return sessionId;
+  return sessionId.slice(0, MAX_SESSION_ID_LENGTH);
+}
+
 // Per-session token totals, kept per weekly bucket rather than once per session.
 // Fable meters into its own weekly bucket, so how much capacity a point there
 // costs is a per-family quantity by construction; totals summed across families
@@ -123,6 +139,10 @@ export class SessionTracker {
     s.inFlight += 1;
     s.lastSeen = now;
     applyMetadata(s, metadata);
+    // Same throttled sweep as touch(): this is the one call every client request
+    // makes, so a server that never routes (all requests failing early) or never
+    // renders status must still shed idle sessions from here.
+    if (now - this._lastSweep > SWEEP_INTERVAL_MS) this.sweep(now);
     return s;
   }
 
@@ -142,6 +162,7 @@ export class SessionTracker {
   // requests on different families can still refresh the wrong one, which is the
   // same limit the in-flight arm has.
   endRequest(sessionId, now = this._now()) {
+    sessionId = keyOf(sessionId);
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return;
     s.inFlight = Math.max(0, s.inFlight - 1);
@@ -223,6 +244,7 @@ export class SessionTracker {
   // A known, non-expired session's record, or null. Never creates one, and
   // drops an expired one on read like pinnedAccount does.
   _live(sessionId, now) {
+    sessionId = keyOf(sessionId);
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return null;
     if (this._isExpired(s, now)) {
@@ -233,8 +255,10 @@ export class SessionTracker {
   }
 
   _ensure(sessionId, now) {
+    sessionId = keyOf(sessionId);
     let s = this.sessions.get(sessionId);
     if (!s) {
+      this._makeRoom(now);
       s = {
         pins: new Map(), refs: new Map(), firstSeen: now, lastSeen: now, count: 0, inFlight: 0,
         // bucket -> emptyTokens(). On the session's own record rather than in a
@@ -260,6 +284,27 @@ export class SessionTracker {
     return s;
   }
 
+  // Keep the map under MAX_SESSIONS before a new session is added. Expired
+  // entries go first (the ordinary sweep); if the cap still binds, the idle
+  // session seen longest ago is dropped — its pin is an hour of cache affinity
+  // at most, and losing one is the price of a flood of unique ids not being
+  // able to grow the map without bound. A session with a request in flight is
+  // never evicted, so under a genuine 10k-concurrent load the cap yields rather
+  // than the accounting breaking.
+  _makeRoom(now) {
+    if (this.sessions.size < MAX_SESSIONS) return;
+    this.sweep(now);
+    while (this.sessions.size >= MAX_SESSIONS) {
+      let oldestId = null;
+      let oldestSeen = Infinity;
+      for (const [id, s] of this.sessions) {
+        if (s.inFlight === 0 && s.lastSeen < oldestSeen) { oldestSeen = s.lastSeen; oldestId = id; }
+      }
+      if (oldestId === null) return;
+      this.sessions.delete(oldestId);
+    }
+  }
+
   // Active = a request in flight now, or one seen within the active window.
   _isActive(s, now) {
     return s.inFlight > 0 || now - s.lastSeen <= this.activeTtlMs;
@@ -278,6 +323,7 @@ export class SessionTracker {
   // this session on" is precisely the question with no single answer, and
   // answering it anyway is what used to move a session wholesale.
   pinnedAccount(sessionId, bucket, now = this._now()) {
+    sessionId = keyOf(sessionId);
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return null;
     if (this._isExpired(s, now)) {
@@ -294,6 +340,7 @@ export class SessionTracker {
     // observation has to still be there when the traffic comes back. It dies
     // with the session.
   refsFor(sessionId, bucket, create = false, now = this._now()) {
+    sessionId = keyOf(sessionId);
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return null;
     if (this._isExpired(s, now)) {
@@ -331,6 +378,7 @@ export class SessionTracker {
   // pin yet, so the session stays where it already is. Empty for an unknown or
   // expired session (expired-on-read entries are dropped).
   pinnedAccounts(sessionId, now = this._now()) {
+    sessionId = keyOf(sessionId);
     const s = sessionId && this.sessions.get(sessionId);
     if (!s) return [];
     if (this._isExpired(s, now)) {

--- a/src/status-renderer.js
+++ b/src/status-renderer.js
@@ -15,11 +15,16 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   // at the bottom. The payload arrives in config-file order, so an account moved
   // to the back of the ladder still read as second in the list. Ties keep their
   // configured order (the sort is stable), which is also the rotation cursor's.
-  const accounts = [...(status.accounts || [])].sort((a, b) => (a.priority || 0) - (b.priority || 0));
-  const blocked = (status.blockedModels || []).filter(p => typeof p === 'string' && p.length);
+    const accounts = [...(status.accounts || [])].sort((a, b) => (a.priority || 0) - (b.priority || 0));
+  const blocked = (status.blockedModels || []).filter(p => typeof p === 'string' && p.length).map(p => safeLine(p, 64));
+  // This payload can come off the wire (`teamclaude status` against a running
+  // server), and account/route strings in it started life in an OAuth reply or
+  // a config file. Names are cut down once here and compared in that form, so a
+  // stripped account still matches a stripped current-account marker.
+  const currentAccount = status.currentAccount == null ? null : nameText(status.currentAccount);
 
   lines.push(paint.bold('TeamClaude status'));
-  lines.push(`${paint.dim('Active'.padEnd(12))} ${paint.cyan(status.currentAccount || 'none')}`);
+  lines.push(`${paint.dim('Active'.padEnd(12))} ${paint.cyan(currentAccount || 'none')}`);
   lines.push(`${paint.dim('Switch at'.padEnd(12))} ${formatPercent(status.switchThreshold)}`);
   // Only when something is blocked: a always-visible "Blocked" row would be
   // noise for the common case, but its ABSENCE is what made a blocked model
@@ -43,7 +48,7 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
   for (const line of routingLines(status.routes, blocked, paint)) lines.push(line);
 
   for (const account of accounts) {
-    lines.push(renderAccountHeader(account, status.currentAccount, paint, now));
+    lines.push(renderAccountHeader(account, currentAccount, paint, now));
     for (const quotaLine of quotaLines(account, now, paint)) {
       lines.push(`  ${quotaLine}`);
     }
@@ -54,7 +59,7 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
     const spend = spendLine(account, paint);
     if (spend) lines.push(`  ${spend}`);
     lines.push(`  ${paint.dim('Usage'.padEnd(8))} ${formatUsage(account.usage, now)}`);
-    lines.push(`  ${paint.dim('Probe'.padEnd(8))} ${formatAccountProbe(account.name, probe, now, paint)}`);
+    lines.push(`  ${paint.dim('Probe'.padEnd(8))} ${formatAccountProbe(nameText(account.name), probe, now, paint)}`);
     lines.push('');
   }
 
@@ -80,6 +85,9 @@ export function renderStatus(status, { color = process.stdout.isTTY, now = Date.
 
   return lines.join('\n').trimEnd();
 }
+
+// A name-sized field, fit to print: an account or route name, a glob, a pin.
+const nameText = value => safeLine(value, 64);
 
 function renderUsageEntries(lines, entries, paint, now) {
   entries.sort(([, a], [, b]) => ((b.inputTokens || 0) + (b.outputTokens || 0)) - ((a.inputTokens || 0) + (a.outputTokens || 0)));
@@ -144,7 +152,7 @@ export function spendLine(account, paint) {
   // Not enabled, but money was spent this month. Say why it is off now, since
   // "out_of_credits" and "the member turned it off" have different futures.
   const why = spend.userDisabled ? 'now disabled by the account holder'
-    : spend.disabledReason ? `now off (${spend.disabledReason})`
+    : spend.disabledReason ? `now off (${safeLine(spend.disabledReason, 64)})`
     : 'now off';
   return `${paint.dim('Spend'.padEnd(8))} ${paint.yellow(`${amount} spent this month, ${why}`)}`;
 }
@@ -152,7 +160,7 @@ export function spendLine(account, paint) {
 export function unavailableLine(account, paint) {
   const reason = account?.unavailable;
   if (!reason) return null;
-  const text = UNAVAILABLE_TEXT[reason] || reason;
+  const text = UNAVAILABLE_TEXT[reason] || safeLine(reason, 64);
   return `${paint.dim('Blocked'.padEnd(8))} ${paint.yellow(text)}`;
 }
 
@@ -187,7 +195,7 @@ function routingLines(routes, blocked, paint) {
   if (!Array.isArray(routes) || routes.length === 0) return [];
   const lines = [paint.bold('Routing')];
   for (const route of routes) {
-    const globs = route.match || [];
+    const globs = (route.match || []).map(nameText);
     const match = globs.join(', ');
     // A route every one of whose globs is blocked can carry no traffic at all —
     // say so, rather than listing eligible accounts it will never reach.
@@ -196,9 +204,9 @@ function routingLines(routes, blocked, paint) {
     const accounts = routeBlocked
       ? paint.red('blocked')
       : (route.accounts || [])
-        .map(a => (a.eligible ? paint.green(a.name) : paint.red(a.name))).join(' ') || paint.gray('(none)');
-    const tag = route.autocreated ? paint.dim(' (auto)') : route.bucket ? paint.dim(` [${route.bucket}]`) : '';
-    const pin = route.pinned ? paint.dim(` [pinned: ${route.pinned}]`) : '';
+        .map(a => (a.eligible ? paint.green(nameText(a.name)) : paint.red(nameText(a.name)))).join(' ') || paint.gray('(none)');
+    const tag = route.autocreated ? paint.dim(' (auto)') : route.bucket ? paint.dim(` [${nameText(route.bucket)}]`) : '';
+    const pin = route.pinned ? paint.dim(` [pinned: ${nameText(route.pinned)}]`) : '';
     // padEnd on the raw text, color after, so ANSI codes don't throw off alignment.
     const label = paintRoute(paint, route.color, match.padEnd(16));
     lines.push(`  ${label} ${paint.dim('→')} ${accounts}${tag}${pin}`);
@@ -208,13 +216,14 @@ function routingLines(routes, blocked, paint) {
 }
 
 function renderAccountHeader(account, currentAccount, paint, now) {
-  const current = account.name === currentAccount;
+  const acctName = nameText(account.name);
+  const current = acctName === currentAccount;
   const marker = current ? paint.cyan('>') : ' ';
-  const name = current ? paint.bold(account.name) : account.name;
+  const shown = current ? paint.bold(acctName) : acctName;
   const status = formatAccountStatus(account, now, paint);
-  const org = account.orgName ? ` ${paint.dim(account.orgName)}` : '';
+  const org = account.orgName ? ` ${paint.dim(nameText(account.orgName))}` : '';
   const sess = account.sessions ? ` ${paint.dim(`${account.sessions} sess`)}` : '';
-  return `${marker} ${name} ${paint.dim(`(${account.type}, prio ${account.priority || 0})`)} ${status}${org}${sess}`;
+  return `${marker} ${shown} ${paint.dim(`(${safeLine(account.type, 16)}, prio ${account.priority || 0})`)} ${status}${org}${sess}`;
 }
 
 // "2 active / 3 known · distributing" — the running-sessions readout. While a
@@ -235,7 +244,7 @@ function formatAccountStatus(account, now, paint) {
   const parts = [];
   if (account.disabled) parts.push(paint.gray('disabled'));
 
-  const status = account.status || 'unknown';
+  const status = safeLine(account.status || 'unknown', 32) || 'unknown';
   const colored = status === 'active'
     ? paint.green(status)
     : status === 'throttled'
@@ -457,7 +466,7 @@ function formatAccountProbe(accountName, probe, now, paint) {
       ? paint.yellow('running')
       : row.status === 'never'
         ? paint.gray('never')
-        : paint.red(row.status || 'error');
+        : paint.red(safeLine(row.status, 32) || 'error');
   const last = parseTs(row.lastProbedAt || row.startedAt);
   const when = last ? ` ${formatAgo(last, now)}` : '';
   const duration = typeof row.durationMs === 'number' ? `, ${Math.round(row.durationMs)}ms` : '';

--- a/src/sx.js
+++ b/src/sx.js
@@ -101,10 +101,32 @@ export function connectThroughProxy({ proxyHost, proxyPort, auth, targetHost, ta
 }
 
 /**
+ * Complete a TLS handshake over an already-open tunnel socket. Resolves with the
+ * TLSSocket after secureConnect; rejects (and destroys the tunnel) on error or
+ * when the handshake takes longer than `timeout`. The CONNECT had its own timer;
+ * without one here a proxy that answers 200 and then goes quiet — or a target
+ * that never sends a ServerHello — held the caller for ever, with every request
+ * behind it. Cert verification stays at its secure default; tests inject a CA
+ * via tlsOptions.ca.
+ */
+export function handshakeOverTunnel(sock, { servername, tlsOptions = {}, timeout = CONNECT_TIMEOUT_MS }) {
+  return new Promise((resolve, reject) => {
+    const tlsSock = tls.connect({ socket: sock, servername, ...tlsOptions });
+    const settle = () => { clearTimeout(timer); tlsSock.removeListener('secureConnect', onOk); tlsSock.removeListener('error', onErr); };
+    // On failure nothing will listen to the dying TLSSocket any more, so give it
+    // a sink: a late error from the teardown must not become an uncaught one.
+    const onErr = (err) => { settle(); tlsSock.on('error', () => {}); tlsSock.destroy(); sock.destroy(); reject(err); };
+    const onOk = () => { settle(); resolve(tlsSock); };
+    const timer = setTimeout(() => onErr(new Error(`TLS handshake with ${servername} through the tunnel timed out after ${timeout}ms`)), timeout);
+    tlsSock.once('secureConnect', onOk);
+    tlsSock.once('error', onErr);
+  });
+}
+
+/**
  * CONNECT through `proxy`, then complete a TLS handshake to targetHost so TLS is
  * end-to-end (the proxy sees ciphertext only). Resolves with the TLSSocket after
- * secureConnect. Cert verification stays at its secure default; tests inject a CA
- * via tlsOptions.ca.
+ * secureConnect.
  */
 export async function tunnelTls({ proxy, targetHost, targetPort = 443, tlsOptions = {} }) {
   const sock = await connectThroughProxy({
@@ -114,13 +136,7 @@ export async function tunnelTls({ proxy, targetHost, targetPort = 443, tlsOption
     targetHost,
     targetPort,
   });
-  return new Promise((resolve, reject) => {
-    const tlsSock = tls.connect({ socket: sock, servername: targetHost, ...tlsOptions });
-    const onErr = (err) => { tlsSock.removeListener('secureConnect', onOk); sock.destroy(); reject(err); };
-    const onOk = () => { tlsSock.removeListener('error', onErr); resolve(tlsSock); };
-    tlsSock.once('secureConnect', onOk);
-    tlsSock.once('error', onErr);
-  });
+  return handshakeOverTunnel(sock, { servername: targetHost, tlsOptions });
 }
 
 /**

--- a/src/sx.js
+++ b/src/sx.js
@@ -18,7 +18,27 @@ import tls from 'node:tls';
 const CONNECT_TIMEOUT_MS = 30000; // residential exits can be slow to establish
 
 // Resolved per call (not at import) so tests can point it at a local mock.
-const sxBase = () => process.env.SX_API_BASE || 'https://api.sx.org';
+//
+// The API key travels as a query parameter (the provider's design), so the base
+// URL decides whether it crosses the network in the clear. An override must be
+// https:, or plain http: to this machine only (a test mock): anything else is
+// reported once and the default is used, rather than sending the key to whatever
+// an inherited environment variable happens to name.
+const DEFAULT_SX_BASE = 'https://api.sx.org';
+let warnedBase = null;
+export function sxBase(env = process.env, warn = (m) => console.error(m)) {
+  const raw = env.SX_API_BASE;
+  if (!raw) return DEFAULT_SX_BASE;
+  let u = null;
+  try { u = new URL(raw); } catch { /* reported below */ }
+  const loopback = u && /^(localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[::1\])$/.test(u.hostname);
+  if (u && (u.protocol === 'https:' || (u.protocol === 'http:' && loopback))) return raw.replace(/\/$/, '');
+  if (warnedBase !== raw) {
+    warnedBase = raw;
+    warn(`[TeamClaude] ignoring SX_API_BASE=${JSON.stringify(raw)}: the sx.org API key rides in the URL, so the base must be https:// (plain http:// is allowed for loopback only); using ${DEFAULT_SX_BASE}`);
+  }
+  return DEFAULT_SX_BASE;
+}
 
 // ── sx.org REST (apiKey is a query param; these hit api.sx.org directly, never
 // the proxy, and are unrelated to Anthropic traffic) ──

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -1,6 +1,7 @@
 import { TUI } from './tui.js';
 import { SessionTitles } from './session-titles.js';
 import { modelGlobMatches } from './model.js';
+import { safeLine } from './safe-text.js';
 
 // Attach mode — the dashboard against a server running somewhere else (a
 // background service, another terminal). The renderer is the same one the
@@ -9,6 +10,20 @@ import { modelGlobMatches } from './model.js';
 
 const DEFAULT_POLL_MS = 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
+
+// Ceiling on a control-plane reply. A status payload is a few KiB; the poll
+// runs every second against whatever answers on the configured port, and
+// buffering an unbounded body from it once a second is not a dashboard.
+const MAX_REPLY_BYTES = 1024 * 1024;
+
+// A string off the wire, fit to be drawn: coerced (a number where a name was
+// expected used to throw inside strip() and kill the poll loop), stripped of
+// controls, and capped. `fallback` when nothing is left.
+const text = (value, max, fallback = '') => {
+  if (value == null || typeof value === 'object') return fallback;
+  return safeLine(value, max) || fallback;
+};
+const NAME_MAX = 64;
 
 // Addresses that reach this machine. A server bound to one of these exempts
 // loopback clients from the proxy-key gate, which changes what a 401 can mean.
@@ -101,9 +116,9 @@ export class RemoteControl {
       }
       throw err;
     }
-    const text = await res.text();
+    const raw = await res.text();
     let payload = null;
-    try { payload = text ? JSON.parse(text) : null; } catch { /* not JSON — the status carries the meaning */ }
+    try { payload = raw ? JSON.parse(raw) : null; } catch { /* not JSON — the status carries the meaning */ }
 
     if (!res.ok) {
       // `ok: false` + a string reason is this control plane's own error shape;
@@ -119,13 +134,13 @@ export class RemoteControl {
         ? (LOOPBACK_HOSTS.has(this.host)
           ? `something other than teamclaude is answering on port ${this.port} (HTTP ${res.status})`
           : `the server rejected the proxy API key (HTTP ${res.status})`)
-        : answered ? payload.error : `HTTP ${res.status}`);
+        : answered ? text(payload.error, 200, `HTTP ${res.status}`) : `HTTP ${res.status}`);
       err.status = res.status;
       err.answered = answered;
       throw err;
     }
     // A 200 body can still report failure (the reload endpoint does this).
-    if (payload && payload.ok === false) throw new Error(payload.error || 'request rejected');
+    if (payload && payload.ok === false) throw new Error(text(payload.error, 200, 'request rejected'));
     return payload;
   }
 }
@@ -172,17 +187,22 @@ export class RemoteAccountManager {
     const accounts = Array.isArray(status?.accounts) ? status.accounts : [];
     // The payload crosses a process boundary, and the renderer calls string
     // methods on name/type unguarded: a malformed reply (wrong port, older or
-    // newer server) should read as unknown, not take the dashboard down.
+    // newer server) should read as unknown, not take the dashboard down. The
+    // same strings are drawn straight into the frame, so whatever answered on
+    // that port must not be able to put an escape sequence there either.
     this.accounts = accounts.map((a, index) => ({
       ...a,
       index,
-      name: a.name || '(unnamed)',
-      type: a.type || '?',
-      quota: { ...(a.quota || {}) },
+      name: text(a?.name, NAME_MAX, '(unnamed)'),
+      type: text(a?.type, 16, '?'),
+      status: text(a?.status, 16, a?.status == null ? undefined : '?'),
+      orgName: a?.orgName == null ? a?.orgName : text(a.orgName, NAME_MAX),
+      unavailable: a?.unavailable == null ? a?.unavailable : text(a.unavailable, 64),
+      quota: { ...(a?.quota || {}) },
     }));
     // -1 when the payload names an account that is no longer listed: nothing is
     // marked current, which is the truth, rather than defaulting to the first row.
-    this.currentIndex = this.accounts.findIndex(a => a.name === status?.currentAccount);
+    this.currentIndex = this.accounts.findIndex(a => a.name === text(status?.currentAccount, NAME_MAX));
     if (status?.switchThreshold != null) this.switchThreshold = status.switchThreshold;
     this.switchThresholds = status?.switchThresholds || null;
 
@@ -198,8 +218,14 @@ export class RemoteAccountManager {
     // leaves half-specified would take the whole dashboard down mid-frame.
     this.routes = (Array.isArray(status?.routes) ? status.routes : []).map(r => ({
       ...r,
-      match: Array.isArray(r?.match) ? r.match : [],
-      accounts: Array.isArray(r?.accounts) ? r.accounts : [],
+      name: text(r?.name, NAME_MAX, '(unnamed)'),
+      color: r?.color == null ? r?.color : text(r.color, 16),
+      bucket: r?.bucket == null ? r?.bucket : text(r.bucket, 32),
+      pinned: r?.pinned == null ? r?.pinned : text(r.pinned, NAME_MAX),
+      target: r?.target == null ? r?.target : text(r.target, NAME_MAX),
+      match: (Array.isArray(r?.match) ? r.match : []).map(g => text(g, 64)).filter(Boolean),
+      accounts: (Array.isArray(r?.accounts) ? r.accounts : [])
+        .map(a => ({ ...a, name: text(a?.name, NAME_MAX, '?'), eligible: !!a?.eligible })),
     }));
     this.status = status;
     this.connected = true;

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -116,7 +116,7 @@ export class RemoteControl {
       }
       throw err;
     }
-    const raw = await res.text();
+    const raw = await readReply(res);
     let payload = null;
     try { payload = raw ? JSON.parse(raw) : null; } catch { /* not JSON — the status carries the meaning */ }
 
@@ -143,6 +143,35 @@ export class RemoteControl {
     if (payload && payload.ok === false) throw new Error(text(payload.error, 200, 'request rejected'));
     return payload;
   }
+}
+
+/**
+ * The reply body as text, refused past MAX_REPLY_BYTES. A declared length over
+ * the cap is refused before a byte is read; an undeclared (chunked) body is
+ * read off the stream and abandoned the moment it passes the cap, so a wedged
+ * or hostile listener on the port cannot make the poller buffer it whole.
+ * A reply without a stream (a test double, a bodiless response) reads as text.
+ */
+async function readReply(res) {
+  const declared = Number(res.headers?.get?.('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_REPLY_BYTES) {
+    throw new Error(`reply too large (${declared} bytes)`);
+  }
+  if (typeof res.body?.getReader !== 'function') return res.text();
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_REPLY_BYTES) {
+      reader.cancel().catch(() => {});
+      throw new Error(`reply too large (over ${MAX_REPLY_BYTES} bytes)`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
 }
 
 /**

--- a/src/tui.js
+++ b/src/tui.js
@@ -386,6 +386,15 @@ function cleanRequestInfo(info) {
   return out;
 }
 
+// A stored key, shown enough to recognise and no more. First-4/last-4 on a key
+// of eight characters or fewer is the whole key; a short one shows its tail only.
+export function maskKey(key) {
+  const k = String(key);
+  if (k.length <= 4) return '****';
+  if (k.length < 12) return `…${k.slice(-4)}`;
+  return `${k.slice(0, 4)}…${k.slice(-4)}`;
+}
+
 function timestamp() {
   return new Date().toLocaleTimeString('en-US', { hour12: false });
 }
@@ -434,6 +443,7 @@ export class TUI {
     this.inputPrompt = '';
     this.inputBuf = '';
     this.inputCb = null;
+    this.inputSecret = false;    // a key is being typed: the footer echoes * for each char
     this.inputReturn = 'normal'; // mode to fall back to when an input is cancelled
     this.frame = 0;
     this.running = false;
@@ -790,10 +800,9 @@ export class TUI {
         label: 'sx.org API key',
         hint: 'Enter to set',
         value: () => {
-          const key = this.config.sx?.apiKey;
-          return key ? key.slice(0, 4) + '…' + key.slice(-4) : dim('(not set)');
+          return this.config.sx?.apiKey ? maskKey(this.config.sx.apiKey) : dim('(not set)');
         },
-        enter: () => this._promptInput('sx.org API key', v => this._doSetSxKey(v.trim())),
+        enter: () => this._promptInput('sx.org API key', v => this._doSetSxKey(v.trim()), { secret: true }),
       });
 
       if (this.config.sx?.apiKey) {
@@ -825,11 +834,14 @@ export class TUI {
   }
 
   // Open the text-input prompt and return to the settings screen afterward.
-  _promptInput(prompt, cb) {
+  // `secret` masks the echo — the footer is on screen for as long as a key is
+  // being typed, and a terminal is the one thing a screen-share always shows.
+  _promptInput(prompt, cb, { secret = false } = {}) {
     this.mode = 'input';
     this.inputReturn = 'settings';
     this.inputPrompt = prompt;
     this.inputBuf = '';
+    this.inputSecret = secret;
     this.inputCb = v => { if (v) cb(v); };
   }
 
@@ -1003,6 +1015,7 @@ export class TUI {
       this.inputReturn = 'settings';
       this.inputPrompt = 'API key';
       this.inputBuf = '';
+      this.inputSecret = true;
       this.inputCb = v => { if (v) this._doAddKey(v); };
     }
     else if (k === 'esc' || k === 'q') { this.mode = 'settings'; }
@@ -1012,10 +1025,10 @@ export class TUI {
     if (k === 'enter') {
       const cb = this.inputCb;
       const v = this.inputBuf;
-      this.mode = this.inputReturn; this.inputCb = null; this.inputBuf = '';
+      this.mode = this.inputReturn; this.inputCb = null; this.inputBuf = ''; this.inputSecret = false;
       cb?.(v);
     }
-    else if (k === 'esc') { this.mode = this.inputReturn; this.inputCb = null; this.inputBuf = ''; }
+    else if (k === 'esc') { this.mode = this.inputReturn; this.inputCb = null; this.inputBuf = ''; this.inputSecret = false; }
     else if (k === 'bs') { this.inputBuf = this.inputBuf.slice(0, -1); }
     else if (k.length === 1) { this.inputBuf += k; }
   }
@@ -2072,7 +2085,7 @@ export class TUI {
       case 'add':
         return ` ${bold('i')}mport Claude Code  ${bold('k')} API key  ${bold('Esc')} cancel`;
       case 'input':
-        return ` ${this.inputPrompt}: ${this.inputBuf}█`;
+        return ` ${this.inputPrompt}: ${this.inputSecret ? '*'.repeat(this.inputBuf.length) : this.inputBuf}█`;
       default:
         return '';
     }

--- a/src/tui.js
+++ b/src/tui.js
@@ -13,7 +13,7 @@ import { mintAccountId } from './account-id.js';
 import { formatPercent } from './status-renderer.js';
 import { resolveMaxUsage } from './model.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, describeSelfProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
-import { sanitizeText } from './safe-text.js';
+import { sanitizeText, safeLine } from './safe-text.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -79,8 +79,13 @@ function sessionColorCode(sid) {
 // no session (e.g. a telemetry request). One width for every row, named or not,
 // keeps the columns after it aligned. Measured in display columns, not UTF-16
 // units, so a CJK title takes the same room as an ASCII one.
+// The id is a client header. Node's parser lets C1 bytes (U+009B is a CSI on
+// its own) through, so only an id of the shape Claude Code actually sends is
+// shown as-is; anything else is stripped down before it reaches the frame.
+const SAFE_SID = /^[A-Za-z0-9._-]+$/;
+const shortSid = sid => (SAFE_SID.test(sid) ? sid : safeLine(sid, 64) || '?').slice(0, SESSION_ID_LEN);
 const sessionTag = (sid, title = null, width = SESSION_ID_LEN) =>
-  sid ? fg(sessionColorCode(sid), rpad(truncate(title || sid.slice(0, SESSION_ID_LEN), width), width)) : ' '.repeat(width);
+  sid ? fg(sessionColorCode(sid), rpad(truncate(title || shortSid(sid), width), width)) : ' '.repeat(width);
 
 // Which quota-family bar (F7/S7) a route binds to, or null for a general route.
 // Auto routes are named 'fable'/'sonnet'; a configured route is classified by its
@@ -100,6 +105,17 @@ const routeGlyph = (paint, eligible, pinned) =>
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const strip = s => s.replace(ANSI_RE, '');
+
+// What a composed line may still carry when it reaches the frame: the SGR
+// colour this file adds, and nothing else that a terminal would act on. Every
+// other escape form (an OSC 52 clipboard write, a CSI erase, a bare C0/C1
+// control) came from a value that was not ours, and unlike sanitizeText this
+// keeps the colour, so it can run on a line after it has been painted.
+// Alternatives, in order: SGR (kept), OSC through its BEL/ST terminator, any
+// other CSI, any remaining control or format character.
+const NON_SGR_CONTROL = /(\x1b\[[0-9;]*m)|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b\[[0-?]*[ -/]*[@-~]|\p{C}/gu;
+export const scrubLine = s => String(s).replace(NON_SGR_CONTROL, (m, sgr) => sgr || '');
+const SGR_AT = /\x1b\[[0-9;]*m/y;   // sticky: "an SGR starting exactly here"
 
 // Terminal display width of one code point: 0 for combining and zero-width
 // marks, 2 for East Asian wide/fullwidth characters and emoji, 1 otherwise.
@@ -157,10 +173,16 @@ export function truncate(s, w) {
   let i = 0;
   while (i < s.length) {
     if (s[i] === '\x1b') {
-      const end = s.indexOf('m', i);
-      if (end >= 0) { out += s.slice(i, end + 1); i = end + 1; continue; }
+      // Only a well-formed SGR is copied through. Copying "ESC up to the next
+      // m" carried an erase or a clipboard write into the frame whole.
+      SGR_AT.lastIndex = i;
+      const m = SGR_AT.exec(s);
+      if (m) { out += m[0]; i += m[0].length; continue; }
+      i++; continue;
     }
     const cp = s.codePointAt(i);
+    // A stray control (BEL, a C1 byte) is dropped, not drawn.
+    if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) { i++; continue; }
     const cw = charWidth(cp);
     // A wide glyph that would cross the limit is dropped whole rather than split;
     // the one leftover column is filled by the caller's padding.
@@ -346,6 +368,19 @@ export function bar(ratio, w = 10, resetTs, windowMs, threshold) {
   return out;
 }
 
+// The request fields the hooks hand us come from the client — the path and
+// method off the request line, the model peeked from the body, the session id
+// from a header — so they are cut down once here, before they are stored to be
+// drawn every frame and logged.
+const REQ_FIELD_MAX = { method: 16, path: 256, model: 64, account: 64, sessionId: 64 };
+function cleanRequestInfo(info) {
+  const out = { ...info };
+  for (const [k, max] of Object.entries(REQ_FIELD_MAX)) {
+    if (out[k] != null) out[k] = safeLine(out[k], max);
+  }
+  return out;
+}
+
 function timestamp() {
   return new Date().toLocaleTimeString('en-US', { hour12: false });
 }
@@ -505,6 +540,7 @@ export class TUI {
   // ── server hooks ───────────────────────────────────
 
   onRequestStart(id, info) {
+    info = cleanRequestInfo(info);
     // Start the lookup now, so the title is cached by the time the request ends
     // and its log line is composed.
     this._sessionTag(info.sessionId);
@@ -515,15 +551,17 @@ export class TUI {
 
   onRequestModel(id, info) {
     const r = this.active.get(id);
-    if (r && info.model) { r.model = info.model; this.render(); }
+    const model = info.model ? safeLine(info.model, 64) : '';
+    if (r && model) { r.model = model; this.render(); }
   }
 
   onRequestRouted(id, info) {
     const r = this.active.get(id);
-    if (r) r.account = info.account;
+    if (r) r.account = info.account == null ? info.account : safeLine(info.account, 64);
   }
 
   onRequestEnd(id, info) {
+    info = cleanRequestInfo(info);
     const r = this.active.get(id);
     this.active.delete(id);
     const dur = r ? ((Date.now() - r.started) / 1000).toFixed(1) : '?';
@@ -536,7 +574,10 @@ export class TUI {
   }
 
   _addLog(msg) {
-    msg = msg.replace(/^\[TeamClaude\]\s*/, '');
+    // The screen copy keeps the colour callers painted on, and only that: a
+    // request's model string is repainted from this list every frame for as
+    // long as the entry lives, so an escape stored here would fire 200 times.
+    msg = scrubLine(msg).replace(/^\[TeamClaude\]\s*/, '');
     const t = timestamp();
     this.log.unshift({ t, msg });
     if (this.log.length > 200) this.log.length = 200;

--- a/src/tui.js
+++ b/src/tui.js
@@ -33,6 +33,11 @@ const IDLE_TICK_MS = 5_000;
 // is shared state, and anything that writes over it (a stray warning, a resumed
 // job) would otherwise leave the screen corrupted until the next real change.
 const FORCE_REPAINT_MS = 60_000;
+// Longest quota-probe interval the settings screen accepts. Node's timers take
+// a 32-bit millisecond delay: past 2,147,483 s setInterval overflows and fires
+// every millisecond, which is a probe storm rather than a slow probe. A week
+// is far under that and already longer than any quota window.
+const PROBE_MAX_SECONDS = 7 * 24 * 3600;
 const ESC = '\x1b[';
 const RESET = `${ESC}0m`;
 const BOLD = `${ESC}1m`;
@@ -875,6 +880,9 @@ export class TUI {
     let secs = parseInt(input, 10);
     if (Number.isNaN(secs) || secs < 0) {
       this._addLog('Invalid interval — enter 0 (off) or seconds'); this.mode = 'settings'; if (this.running) this.render(); return;
+    }
+    if (secs > PROBE_MAX_SECONDS) {
+      this._addLog(`Invalid interval — at most ${PROBE_MAX_SECONDS}s (7 days)`); this.mode = 'settings'; if (this.running) this.render(); return;
     }
     if (secs > 0 && secs < 30) secs = 30; // match the CLI minimum (don't hammer the usage endpoint)
     this.config.quotaProbeSeconds = secs;

--- a/src/tui.js
+++ b/src/tui.js
@@ -967,7 +967,7 @@ export class TUI {
       // prefer that over what was highlighted here. `eligible: false` means the
       // switch applied to an account that cannot currently serve requests, which
       // the row already shows but is worth stating at the moment it is chosen.
-      const name = res?.account || acct.name;
+      const name = res?.account ? safeLine(res.account, 64) || acct.name : acct.name;
       if (res?.eligible === false) {
         // The server knows WHY — disabled, out of quota, outranked by a
         // higher-priority account — so quote it rather than restating the

--- a/src/updater.js
+++ b/src/updater.js
@@ -121,8 +121,25 @@ export async function checkForUpdate({
   return { current, latest, updateAvailable: compareVersions(latest, current) > 0 };
 }
 
-/** Install a specific version globally. Returns true on success. */
+/**
+ * Whether `v` is a plain release version, the only shape we ever pass to npm.
+ *
+ * The registry's `dist-tags.latest` is a string from the network, and
+ * compareVersions is lenient by design (it parses what it can), so a value like
+ * "99.0.0 || npm:evil" reads as newer and would go straight into
+ * `npm install -g <name>@<value>`. Only x.y.z is installed; anything else is
+ * reported and skipped.
+ */
+export function isReleaseVersion(v) {
+  return /^\d+\.\d+\.\d+$/.test(String(v));
+}
+
+/**
+ * Install a specific version globally. Returns true on success. `version` must
+ * be a release version (or the literal `latest`), or nothing is spawned.
+ */
 export function runUpdate(version = 'latest', { spawnImpl = spawnSync } = {}) {
+  if (version !== 'latest' && !isReleaseVersion(version)) return false;
   const r = spawnImpl('npm', ['install', '-g', `${PKG_NAME}@${version}`], {
     stdio: 'inherit',
     timeout: 180000,
@@ -130,29 +147,53 @@ export function runUpdate(version = 'latest', { spawnImpl = spawnSync } = {}) {
   return !!r && !r.error && r.status === 0;
 }
 
+// The root warning is printed once per process: autoUpdate runs at startup and
+// again at session end, and a daemon would otherwise say it every day.
+let rootWarned = false;
+
 /**
  * The automatic path used at startup / session-end. Skips dev checkouts and
  * respects the opt-out; when an update exists it silently installs it for a
  * global install, or just prints a one-line notice otherwise. Cheap in the
  * common case: the expensive `npm root -g` probe only runs when an update is
  * actually available.
+ *
+ * Never runs as root. `sudo teamclaude server` would otherwise run
+ * `npm install -g` as root on a daily schedule, off a version string fetched
+ * from the network — the operator can run `teamclaude update` deliberately.
+ *
+ * `root`, `uid`, `check`, `kind` and `install` are injectable for tests.
  */
-export async function autoUpdate({ config = {}, force = false, log = console.error } = {}) {
-  const root = packageRoot();
+export async function autoUpdate({
+  config = {}, force = false, log = console.error,
+  root = packageRoot(), uid = process.getuid?.(),
+  check = checkForUpdate, kind = installKind, install = runUpdate,
+} = {}) {
   if (existsSync(join(root, '.git'))) return { skipped: 'git' }; // dev checkout — never touch
   if (process.env.TEAMCLAUDE_DISABLE_AUTOUPDATE || config.autoUpdate === false) {
     return { skipped: 'disabled' };
   }
-  const info = await checkForUpdate({ force });
+  if (uid === 0) {
+    if (!rootWarned) {
+      rootWarned = true;
+      log('[TeamClaude] Auto-update is disabled when running as root. Update deliberately with: teamclaude update');
+    }
+    return { skipped: 'root' };
+  }
+  const info = await check({ force });
   if (!info) return { skipped: 'check-failed' };
   if (!info.updateAvailable) return { ...info, upToDate: true };
+  if (!isReleaseVersion(info.latest)) {
+    log(`[TeamClaude] Ignoring registry "latest" that is not a release version: ${JSON.stringify(String(info.latest)).slice(0, 80)}`);
+    return { ...info, skipped: 'bad-version' };
+  }
 
-  if (installKind({ root }) !== 'global') {
+  if (kind({ root }) !== 'global') {
     log(`[TeamClaude] Update available: ${info.current} → ${info.latest}. Run: teamclaude update`);
     return { ...info, notified: true };
   }
   log(`[TeamClaude] Updating ${info.current} → ${info.latest}…`);
-  const ok = runUpdate(info.latest);
+  const ok = install(info.latest);
   log(ok
     ? `[TeamClaude] Updated to ${info.latest}. Restart teamclaude to use the new version.`
     : `[TeamClaude] Auto-update failed. Run manually: npm install -g ${PKG_NAME}@latest`);

--- a/src/upstream-proxy.js
+++ b/src/upstream-proxy.js
@@ -28,8 +28,9 @@ import { connectThroughProxy, handshakeOverTunnel } from './sx.js';
  * Accepts `http://host:port`, `http://user:pass@host:port`, and a bare
  * `host:port` (people write proxies that way constantly, and rejecting it would
  * be pedantry). Returns null for empty input; throws on input that looks like a
- * URL but isn't usable, so a typo in the config surfaces at startup rather than
- * as a mystery connection failure on the first request.
+ * URL but isn't usable — including `https://`, which we cannot honour — so a
+ * typo in the config surfaces at startup rather than as a mystery connection
+ * failure on the first request.
  */
 export function parseProxyUrl(value) {
   if (!value || typeof value !== 'string') return null;
@@ -44,14 +45,21 @@ export function parseProxyUrl(value) {
   } catch {
     throw new Error(`invalid proxy URL: ${value}`);
   }
-  if (!/^https?:$/.test(u.protocol)) {
+  if (u.protocol === 'https:') {
+    // Accepting this used to be a silent lie: nothing here speaks TLS TO the
+    // proxy, so the CONNECT — Basic credentials included — went out in
+    // plaintext to port 443 and the connection never worked. Refuse it and
+    // name the fix; the tunnel's own TLS is end-to-end regardless of scheme.
+    throw new Error(`unsupported proxy protocol "https" (TLS to the proxy itself is not supported; use http://host:port — the tunnel through it is still end-to-end TLS): ${value}`);
+  }
+  if (u.protocol !== 'http:') {
     // socks5:// is a different wire protocol, not a CONNECT proxy — say so
     // plainly instead of failing later inside the tunnel.
-    throw new Error(`unsupported proxy protocol "${u.protocol.replace(/:$/, '')}" (only http/https): ${value}`);
+    throw new Error(`unsupported proxy protocol "${u.protocol.replace(/:$/, '')}" (only http): ${value}`);
   }
   if (!u.hostname) throw new Error(`proxy URL has no host: ${value}`);
 
-  const port = u.port ? Number(u.port) : (u.protocol === 'https:' ? 443 : 8080);
+  const port = u.port ? Number(u.port) : 8080;
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`proxy URL has an invalid port: ${value}`);
   }

--- a/src/upstream-proxy.js
+++ b/src/upstream-proxy.js
@@ -20,8 +20,7 @@
 
 import http from 'node:http';
 import https from 'node:https';
-import tls from 'node:tls';
-import { connectThroughProxy } from './sx.js';
+import { connectThroughProxy, handshakeOverTunnel } from './sx.js';
 
 /**
  * Parse a proxy URL into the shape connectThroughProxy wants.
@@ -276,11 +275,8 @@ export function proxyAgent(proxy, { targetHost, targetPort, tls: useTls = true, 
         }
         // TLS is established end-to-end over the tunnel, so the proxy sees only
         // ciphertext and cert verification stays at its secure default.
-        const tlsSock = tls.connect({ socket: sock, servername: targetHost, ...tlsOptions });
-        const onErr = (err) => { tlsSock.removeListener('secureConnect', onOk); sock.destroy(); cb(err); };
-        const onOk = () => { tlsSock.removeListener('error', onErr); cb(null, tlsSock); };
-        tlsSock.once('secureConnect', onOk);
-        tlsSock.once('error', onErr);
+        handshakeOverTunnel(sock, { servername: targetHost, tlsOptions })
+          .then((tlsSock) => cb(null, tlsSock), (err) => cb(err));
       })
       .catch((err) => cb(err));
     return undefined; // socket is delivered asynchronously through cb

--- a/src/x509.js
+++ b/src/x509.js
@@ -134,29 +134,36 @@ function newRsaKey() {
   };
 }
 
-export function createCA(cn = 'TeamClaude Local CA') {
+// Default lifetimes. Callers (tests) may shorten them to exercise renewal.
+export const CA_DAYS = 3650;
+export const LEAF_DAYS = 825;
+
+export function createCA(cn = 'TeamClaude Local CA', { days = CA_DAYS } = {}) {
   const key = newRsaKey();
   const certPem = buildCert({
     subjectCN: cn, issuerCN: cn, spkiDer: key.spkiDer, signKey: key.privateKey,
-    isCA: true, days: 3650,
+    isCA: true, days,
   });
   return { cn, certPem, keyPem: key.keyPem, privateKey: key.privateKey };
 }
 
-export function createLeaf(hosts, ca) {
+export function createLeaf(hosts, ca, { days = LEAF_DAYS } = {}) {
   const list = Array.isArray(hosts) ? hosts : [hosts];
   const key = newRsaKey();
   const certPem = buildCert({
     subjectCN: list[0], issuerCN: ca.cn, spkiDer: key.spkiDer, signKey: ca.privateKey,
-    isCA: false, altDnsNames: list, days: 825,
+    isCA: false, altDnsNames: list, days,
   });
   return { certPem, keyPem: key.keyPem };
 }
 
-/** Generate a fresh CA + a leaf covering `hosts` (string or array). Returns PEM strings. */
-export function generateCertChain(hosts) {
-  const ca = createCA();
-  const leaf = createLeaf(hosts, ca);
+/**
+ * Generate a fresh CA + a leaf covering `hosts` (string or array). Returns PEM
+ * strings. `caDays` / `leafDays` override the default lifetimes (tests).
+ */
+export function generateCertChain(hosts, { caDays = CA_DAYS, leafDays = LEAF_DAYS } = {}) {
+  const ca = createCA(undefined, { days: caDays });
+  const leaf = createLeaf(hosts, ca, { days: leafDays });
   return {
     caCertPem: ca.certPem,
     caKeyPem: ca.keyPem,

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
-import { existsSync, writeFileSync, chmodSync } from 'node:fs';
+import { existsSync, writeFileSync, chmodSync, statSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { aliasLine, rcPathForShell, teamclaudeRef, installAlias, uninstallAlias } from '../src/alias.js';
@@ -15,6 +16,69 @@ test('aliasLine uses the right syntax per shell (explicit ref)', () => {
 test('aliasLine embeds a quoted absolute path when teamclaude is not on PATH', () => {
   assert.equal(aliasLine('bash', '"/opt/tc/index.js"'), `alias claude='"/opt/tc/index.js" run --'`);
   assert.equal(aliasLine('fish', '"/opt/tc/index.js"'), `alias claude '"/opt/tc/index.js" run --'`);
+});
+
+// A `'` in the embedded path used to terminate the single-quoted alias body:
+// alias claude='"/home/o'brien/tc/src/index.js" run --' is a broken alias.
+test("aliasLine survives a ' in the embedded path, in bash and in fish", () => {
+  const ref = `"/home/o'brien/tc/index.js"`;
+  assert.equal(aliasLine('bash', ref), `alias claude='"/home/o'"'"'brien/tc/index.js" run --'`);
+  assert.equal(aliasLine('fish', ref), `alias claude '"/home/o'"'"'brien/tc/index.js" run --'`);
+});
+
+// The proof is the shell: define the alias, run it, and see the script at the
+// awkward path receive the arguments.
+test('an alias with a quote and a space in the path runs the script under bash', async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tc-o'brien has space-"));
+  try {
+    const script = join(dir, 'index.js');
+    writeFileSync(script, '#!/bin/sh\nprintf "%s|" "$@"\n', { mode: 0o755 });
+    chmodSync(script, 0o755);
+    const ref = `"${script.replace(/[\\"$]/g, (c) => `\\${c}`)}"`;
+    const line = aliasLine('bash', ref);
+    const result = spawnSync('bash', ['-O', 'expand_aliases', '-c', `${line}\nclaude one "two words"`], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, 'run|--|one|two words|');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('teamclaudeRef escapes what the shell reads inside double quotes', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-path-'));
+  const prev = { PATH: process.env.PATH, argv1: process.argv[1] };
+  try {
+    process.env.PATH = dir; // no teamclaude on PATH → embed argv[1]
+    process.argv[1] = '/opt/we$ird"dir\\x/index.js';
+    assert.equal(teamclaudeRef(), '"/opt/we\\$ird\\"dir\\\\x/index.js"');
+  } finally {
+    process.env.PATH = prev.PATH;
+    process.argv[1] = prev.argv1;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// The rc file is replaced by rename, so a crash mid-write cannot leave a
+// truncated .bashrc — and the file keeps its mode.
+test('install and uninstall replace the rc file whole, keeping its mode', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-alias-'));
+  const rcPath = join(dir, '.bashrc');
+  await writeFile(rcPath, 'export FOO=1\n');
+  chmodSync(rcPath, 0o600);
+  try {
+    const before = statSync(rcPath).ino;
+    installAlias({ shell: 'bash', rcPath });
+    assert.notEqual(statSync(rcPath).ino, before, 'a new inode: written beside and renamed over');
+    assert.equal(statSync(rcPath).mode & 0o777, 0o600);
+    assert.match(await readFile(rcPath, 'utf8'), /alias claude=/);
+    uninstallAlias({ shell: 'bash', rcPath });
+    assert.equal(statSync(rcPath).mode & 0o777, 0o600);
+    assert.equal(await readFile(rcPath, 'utf8'), 'export FOO=1\n');
+    // No temp file left behind either way.
+    assert.deepEqual(readdirSync(dir), ['.bashrc']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('teamclaudeRef returns the bare command when it is on PATH', async () => {

--- a/test/claude-env.test.js
+++ b/test/claude-env.test.js
@@ -1,4 +1,5 @@
 import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
 import assert from 'node:assert/strict';
 import { buildClaudeEnvLines } from '../src/claude-env.js';
 
@@ -11,9 +12,34 @@ test('MITM mode (default) emits proxy vars + CA cert, and clears ANTHROPIC_BASE_
     'export http_proxy=http://127.0.0.1:3456',
     'export NO_PROXY=localhost,127.0.0.1,::1',
     'export no_proxy=localhost,127.0.0.1,::1',
-    'export NODE_EXTRA_CA_CERTS=/home/u/.config/teamclaude-ca.pem',
+    "export NODE_EXTRA_CA_CERTS='/home/u/.config/teamclaude-ca.pem'",
     'unset ANTHROPIC_BASE_URL',
   ]);
+});
+
+// NODE_EXTRA_CA_CERTS is a path under $HOME, and $HOME can carry a space or a
+// quote. The line is eval'd, so it has to survive the shell intact.
+test('the CA path is shell-quoted: a space and a quote survive eval', () => {
+  for (const caPath of ['/home/first last/.config/teamclaude-ca.pem', "/home/o'brien/.config/tc-ca.pem", '/h/a b\'c"d$e/ca.pem']) {
+    const lines = buildClaudeEnvLines({ port: 3456, caPath });
+    const result = spawnSync('/bin/sh', ['-c', `${lines.join('\n')}\nprintf %s "$NODE_EXTRA_CA_CERTS"`], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, caPath);
+  }
+});
+
+// The port is interpolated unquoted into URLs. A config value that is not a
+// port used to be emitted verbatim — "3456; touch /tmp/x" included.
+test('a port that is not an integer in 1..65535 is refused, not emitted', () => {
+  for (const port of ['3456; touch /tmp/x', 'abc', '', null, undefined, 0, 65536, -1, 3456.5, '0x1000', ' 3456 ; x']) {
+    assert.throws(() => buildClaudeEnvLines({ port, caPath: '/x' }), /proxy\.port must be an integer between 1 and 65535/, String(port));
+    assert.throws(() => buildClaudeEnvLines({ port, useMitm: false }), /proxy\.port/, String(port));
+  }
+});
+
+test('a numeric string port is accepted as the number it spells', () => {
+  assert.deepEqual(buildClaudeEnvLines({ port: '8080', useMitm: false }), ['export ANTHROPIC_BASE_URL=http://localhost:8080']);
+  assert.deepEqual(buildClaudeEnvLines({ port: 65535, useMitm: false }), ['export ANTHROPIC_BASE_URL=http://localhost:65535']);
 });
 
 test('MITM mode without a caPath omits NODE_EXTRA_CA_CERTS (never emits an empty value)', () => {
@@ -87,7 +113,10 @@ test('a pinned line is shell-safe: no unquoted metacharacters survive', () => {
   for (const name of ["work (Acme)", "o'brien", "a!b", "x*y"]) {
     for (const useMitm of [true, false]) {
       const lines = buildClaudeEnvLines({ port: 3456, useMitm, account: name, caPath: '/x' });
-      for (const l of lines) assert.ok(!/[()'!*]/.test(l), `${l} (from ${name})`);
+      // The pin rides unquoted in the URL lines; the CA path line is quoted separately.
+      for (const l of lines.filter(l => !l.startsWith('export NODE_EXTRA_CA_CERTS='))) {
+        assert.ok(!/[()'!*]/.test(l), `${l} (from ${name})`);
+      }
     }
   }
 });

--- a/test/cli-import-atomic.test.js
+++ b/test/cli-import-atomic.test.js
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `teamclaude import` (and `login`) load the config, spend a while on the
+// network — a browser flow can take minutes — and then save. A running server
+// may rotate another account's refresh token on disk in between; saving the
+// copy loaded before that put the OLD refresh token back, which is dead by then,
+// and that account was lost on its next restart. The save has to re-read the
+// file and touch only the account being added.
+//
+// The window is made deterministic here: the CLI's profile fetch is routed
+// through a fake CONNECT proxy (config.upstreamProxy), and that proxy plays the
+// running server — it rewrites the config while the CLI is between its load and
+// its save, then fails the fetch. `--name` keeps the import going without a
+// profile, exactly as it does for a real machine that cannot reach Anthropic.
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+const baseConfig = (proxyPort) => ({
+  proxy: { port: 3, apiKey: 'tc-test' }, // nothing listens on 3: the reload notify is a no-op
+  upstream: 'https://api.anthropic.com',
+  upstreamProxy: `http://127.0.0.1:${proxyPort}`,
+  accounts: [{
+    id: 'y-id', name: 'y@example.com', type: 'oauth', accountUuid: 'uy', orgUuid: 'oy',
+    accessToken: 'y-at-old', refreshToken: 'y-rt-old', expiresAt: Date.now() + 3_600_000,
+  }],
+});
+
+function runCli(configPath, cliArgs) {
+  const env = { ...process.env, TEAMCLAUDE_CONFIG: configPath };
+  // A NO_PROXY naming api.anthropic.com would send the fetch around the fake
+  // proxy — and around the synchronisation point this test is built on.
+  delete env.NO_PROXY; delete env.no_proxy;
+  const child = spawn(process.execPath, [cliPath, ...cliArgs], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', c => { stdout += c; });
+  child.stderr.on('data', c => { stderr += c; });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`CLI did not exit\n${stdout}\n${stderr}`)); }, 20_000);
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('exit', code => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+  });
+}
+
+test('import saves onto a fresh read of the config, not the copy it loaded', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-import-'));
+  const configPath = join(dir, 'config.json');
+
+  let connects = 0;
+  const proxy = http.createServer((_req, res) => { res.writeHead(400); res.end(); });
+  proxy.on('connect', (req, socket) => {
+    connects++;
+    // The CLI has loaded its config by now and is about to save. Rotate the
+    // other account's refresh token the way a running server would...
+    const rotated = baseConfig(proxy.address().port);
+    rotated.accounts[0].refreshToken = 'y-rt-rotated';
+    rotated.accounts[0].accessToken = 'y-at-rotated';
+    writeFile(configPath, JSON.stringify(rotated)).then(() => {
+      // ...then fail the profile fetch; the named import carries on without it.
+      socket.end('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n');
+    });
+  });
+  await new Promise(r => proxy.listen(0, '127.0.0.1', r));
+
+  try {
+    await writeFile(configPath, JSON.stringify(baseConfig(proxy.address().port)));
+    const creds = JSON.stringify({ accessToken: 'z-at', refreshToken: 'z-rt', expiresAt: Date.now() + 3_600_000 });
+    const res = await runCli(configPath, ['import', '--json', creds, '--name', 'z']);
+    assert.equal(res.code, 0, res.stderr);
+    assert.ok(connects >= 1, 'the profile fetch went through the fake proxy');
+    assert.match(res.stdout, /Added account "z"/);
+
+    const saved = JSON.parse(await readFile(configPath, 'utf8'));
+    const y = saved.accounts.find(a => a.id === 'y-id');
+    // The row the CLI never touched keeps what the "server" wrote — before,
+    // y-rt-old came back and killed the account on its next restart.
+    assert.equal(y.refreshToken, 'y-rt-rotated');
+    assert.equal(y.accessToken, 'y-at-rotated');
+    const z = saved.accounts.find(a => a.name === 'z');
+    assert.equal(z.type, 'oauth');
+    assert.equal(z.accessToken, 'z-at');
+    assert.equal(z.refreshToken, 'z-rt');
+    assert.equal(z.source, 'import');
+    assert.equal(saved.accounts.length, 2);
+  } finally {
+    proxy.close();
+  }
+});

--- a/test/cli-probe.test.js
+++ b/test/cli-probe.test.js
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `teamclaude probe <seconds>` drives the real CLI as a subprocess against a
+// throwaway TEAMCLAUDE_CONFIG. The interval it stores becomes a setInterval
+// delay, which is a 32-bit signed millisecond count: past ~2,147,483 s it
+// overflows to 1 ms and the probe fires in a tight loop against the usage
+// endpoint. The command has a floor already; this pins the ceiling.
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+async function writeConfig() {
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-probe-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify({
+    proxy: { port: 3, apiKey: 'tc-test' },
+    upstream: 'https://api.anthropic.com',
+    upstreamProxy: false,
+    quotaProbeSeconds: 300,
+    accounts: [{ name: 'a@example.com', type: 'apikey', apiKey: 'k1' }],
+  }));
+  return path;
+}
+
+function runCli(configPath, cliArgs) {
+  const child = spawn(process.execPath, [cliPath, ...cliArgs], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', c => { stdout += c; });
+  child.stderr.on('data', c => { stderr += c; });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('CLI did not exit')); }, 10_000);
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('exit', code => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+  });
+}
+
+const readSeconds = async (p) => JSON.parse(await readFile(p, 'utf8')).quotaProbeSeconds;
+
+test('probe refuses an interval past seven days and leaves the config alone', async () => {
+  const configPath = await writeConfig();
+  for (const arg of ['604801', '2147484', '99999999999']) {
+    const res = await runCli(configPath, ['probe', arg]);
+    assert.equal(res.code, 1, arg);
+    assert.match(res.stderr, /Maximum probe interval is 604800s/);
+    assert.equal(await readSeconds(configPath), 300);
+  }
+});
+
+test('probe accepts the seven-day ceiling itself', async () => {
+  const configPath = await writeConfig();
+  const res = await runCli(configPath, ['probe', '604800']);
+  assert.equal(res.code, 0, res.stderr);
+  assert.equal(await readSeconds(configPath), 604800);
+});

--- a/test/config-atomic-save.test.js
+++ b/test/config-atomic-save.test.js
@@ -76,3 +76,16 @@ test('the round trip through loadConfig reads back what saveConfig wrote', async
     assert.equal(loaded.accounts[0].refreshToken, 'rt');
   });
 });
+
+test('saveConfig follows a symlinked config to its target instead of replacing the link', { skip: !onPosix }, async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    const { symlink, lstat } = await import('node:fs/promises');
+    const real = join(dir, 'real.json');
+    await writeFile(real, '{"old":true}\n');
+    await symlink(real, path);
+    await cfg.saveConfig({ proxy: { port: 2, apiKey: 'k' }, accounts: [] });
+    assert.ok((await lstat(path)).isSymbolicLink(), 'the config path is still a symlink');
+    assert.deepEqual(JSON.parse(await readFile(real, 'utf-8')).proxy.port, 2, 'the link target received the write');
+    assert.deepEqual((await readdir(dir)).sort(), ['real.json', 'teamclaude.json']);
+  });
+});

--- a/test/config-atomic-save.test.js
+++ b/test/config-atomic-save.test.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, writeFile, stat, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// The config holds every account's OAuth tokens and the proxy key. A save that
+// truncates in place leaves nothing behind if the process dies mid-write; a
+// save must therefore replace the file whole or not at all, and must not leave
+// a half-written copy of the credentials beside it.
+
+async function withConfigDir(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-atomic-'));
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = join(dir, 'teamclaude.json');
+  try {
+    const cfg = await import('../src/config.js');
+    await fn({ dir, cfg, path: process.env.TEAMCLAUDE_CONFIG });
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+  }
+}
+
+const onPosix = process.platform !== 'win32';
+
+test('saveConfig writes the whole document and leaves no temp file behind', async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    const config = { proxy: { port: 1, apiKey: 'tc-secret' }, accounts: [{ name: 'a', refreshToken: 'rt' }] };
+    await cfg.saveConfig(config);
+    assert.deepEqual(JSON.parse(await readFile(path, 'utf-8')), config);
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'only the config itself is on disk');
+    if (onPosix) assert.equal((await stat(path)).mode & 0o777, 0o600);
+  });
+});
+
+test('saveConfig replaces a pre-existing file and tightens its mode', async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    await writeFile(path, '{"old":true}\n');
+    if (onPosix) await chmod(path, 0o644);
+    await cfg.saveConfig({ fresh: true });
+    assert.deepEqual(JSON.parse(await readFile(path, 'utf-8')), { fresh: true });
+    assert.deepEqual(await readdir(dir), ['teamclaude.json']);
+    if (onPosix) assert.equal((await stat(path)).mode & 0o777, 0o600, 'a world-readable config becomes 0600 on save');
+  });
+});
+
+test('saveState is atomic the same way', async () => {
+  await withConfigDir(async ({ dir, cfg }) => {
+    const statePath = cfg.getStatePath();
+    await cfg.saveState({ quota: { a: 1 } });
+    assert.deepEqual(JSON.parse(await readFile(statePath, 'utf-8')), { quota: { a: 1 } });
+    assert.deepEqual(await readdir(dir), ['teamclaude.state.json']);
+    if (onPosix) assert.equal((await stat(statePath)).mode & 0o777, 0o600);
+  });
+});
+
+test('a save that cannot complete leaves the previous config intact and no temp file', async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    await cfg.saveConfig({ good: true });
+    // A BigInt cannot be serialized: the failure happens before anything is
+    // written, and the file on disk must still be the last complete document.
+    await assert.rejects(cfg.saveConfig({ bad: 1n }), TypeError);
+    assert.deepEqual(JSON.parse(await readFile(path, 'utf-8')), { good: true });
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'no temp file is left beside the config');
+  });
+});
+
+test('the round trip through loadConfig reads back what saveConfig wrote', async () => {
+  await withConfigDir(async ({ cfg }) => {
+    const config = cfg.createDefaultConfig();
+    config.accounts.push({ name: 'a', type: 'oauth', accessToken: 'at', refreshToken: 'rt' });
+    await cfg.saveConfig(config);
+    const loaded = await cfg.loadConfig();
+    assert.equal(loaded.proxy.apiKey, config.proxy.apiKey);
+    assert.equal(loaded.accounts[0].refreshToken, 'rt');
+  });
+});

--- a/test/connect-error-message.test.js
+++ b/test/connect-error-message.test.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer, describeConnectError } from '../src/server.js';
 import { createConnectHandler } from '../src/mitm.js';
+import { allowLoopbackForward } from '../src/forward-target.js';
 import { setUpstreamProxy, resolveUpstreamProxy, resetUpstreamProxy } from '../src/upstream-proxy.js';
 
 // A test that expects a CONNECTION-LEVEL failure must not be able to reach a
@@ -137,6 +138,7 @@ test('a forward-proxy target whose every address refuses is logged with its reas
   const realErr = console.error;
   console.error = (...a) => logged.push(a.map(String).join(' '));
   const proxy = createProxyServer(am, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  allowLoopbackForward(proxy); // localhost:1 is a loopback target, refused by default
   const port = await listen(proxy);
   try {
     await new Promise((resolve) => {
@@ -170,6 +172,7 @@ test('a tunnel whose every address refuses is logged with its reasons', { skip: 
   const logged = [];
   const am = new AccountManager([{ name: 'alice', type: 'apikey', apiKey: 'k1' }], 0.98);
   const server = http.createServer();
+  allowLoopbackForward(server); // localhost:1 is a loopback target, refused by default
   server.on('connect', createConnectHandler({
     config: { proxy: {}, upstream: 'https://api.anthropic.com' },
     accountManager: am,

--- a/test/control-csrf.test.js
+++ b/test/control-csrf.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer, isSameOriginControlRequest } from '../src/server.js';
 
@@ -100,15 +101,73 @@ test('a same-origin browser request is allowed through', async () => {
   });
 });
 
-// Reading status cross-origin is already prevented by the same-origin policy —
-// the page issues the request but cannot see the answer — so the guard is
-// deliberately scoped to mutations and does not break anyone polling status.
-test('the guard applies to mutations, not to reads', async () => {
-  await withServer(async (_am, port) => {
-    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/status`, {
-      headers: { Origin: 'https://evil.example' },
+// The control plane is not the only thing the loopback exemption exposes to a
+// page. The same no-cors POST reaches /v1/messages, where the proxy injects a
+// fleet credential — a quota drain, with the page's prompt content booked to
+// the operator — so a key-less loopback request is refused cross-origin on
+// EVERY path, not only under /teamclaude/.
+test('a page cannot spend fleet quota through /v1/messages cross-origin', async () => {
+  let reached = 0;
+  const upstream = http.createServer((_req, res) => {
+    reached++;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(ACCTS, 0.98);
+  const proxy = createProxyServer(am, { ...CONFIG, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+  try {
+    for (const headers of [{ Origin: 'https://evil.example' }, { 'Sec-Fetch-Site': 'cross-site' }]) {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain', ...headers },
+        body: JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }),
+      });
+      assert.equal(res.status, 403);
+      assert.match((await res.json()).error.message, /cross-origin/);
+    }
+    assert.equal(reached, 0, 'a refused request must not have been forwarded');
+    // The same request from a non-browser client is forwarded as before.
+    const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }),
     });
     assert.equal(res.status, 200);
+    assert.equal(reached, 1);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+});
+
+// Reads too: the same-origin policy keeps the answer from the page only for as
+// long as no CORS header ever leaks, so a key-less cross-origin GET is refused
+// rather than relied upon to be unreadable.
+test('a key-less cross-origin read of status is refused; a keyed one is served', async () => {
+  await withServer(async (_am, port) => {
+    const refused = await fetch(`http://127.0.0.1:${port}/teamclaude/status`, {
+      headers: { Origin: 'https://evil.example' },
+    });
+    assert.equal(refused.status, 403);
+    // A caller that presented a valid key has proven itself; the browser
+    // headers no longer matter. (The dashboard polls status this way.)
+    const keyed = await fetch(`http://127.0.0.1:${port}/teamclaude/status`, {
+      headers: { Origin: 'https://evil.example', 'x-api-key': 'tc-test' },
+    });
+    assert.equal(keyed.status, 200);
+  });
+});
+
+// The control-plane gate still applies to mutations even WITH a key: the
+// browser would preflight a request carrying x-api-key and never send it
+// cross-origin, so nothing legitimate is lost by keeping the stricter rule.
+test('a keyed cross-origin control-plane POST is still refused', async () => {
+  await withServer(async (am, port) => {
+    const res = await switchTo(port, 'bob@example.com', { Origin: 'https://evil.example', 'x-api-key': 'tc-test' });
+    assert.equal(res.status, 403);
+    assert.equal(am.currentIndex, 0);
   });
 });
 

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,10 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
+import { createHash } from 'node:crypto';
 import { AccountManager } from '../src/account-manager.js';
 import { createProxyServer } from '../src/server.js';
 import {
-  renderDashboardHtml, scopedWeeklyRows, accountTokens,
+  renderDashboardHtml, dashboardCsp, scopedWeeklyRows, accountTokens,
   sessionRows, filterSessionRows, sortRows, uniqSorted,
   switchRequest, switchOutcome, routeRows, problems, STARVED_MIN, STARVED_LIST_MAX,
 } from '../src/dashboard.js';
@@ -426,7 +427,23 @@ test('GET /teamclaude/dashboard serves HTML without a key; other methods take th
     const page = await fetch(`http://127.0.0.1:${port}/teamclaude/dashboard`);
     assert.equal(page.status, 200);
     assert.match(page.headers.get('content-type'), /text\/html/);
-    assert.match(await page.text(), /TeamClaude/);
+    const html = await page.text();
+    assert.match(html, /TeamClaude/);
+
+    // The page keeps the proxy key in localStorage, so it ships with a policy
+    // that lets nothing load from anywhere and admits only its own script —
+    // by hash, so a script that is not byte-for-byte this one does not run.
+    const csp = page.headers.get('content-security-policy');
+    assert.ok(csp, 'the dashboard must carry a Content-Security-Policy');
+    assert.equal(csp, dashboardCsp(html));
+    assert.match(csp, /(^|; )default-src 'none'(;|$)/);
+    assert.match(csp, /(^|; )connect-src 'self'(;|$)/);
+    assert.match(csp, /(^|; )frame-ancestors 'none'(;|$)/);
+    assert.doesNotMatch(csp, /script-src[^;]*'unsafe-inline'/);
+    const script = html.slice(html.indexOf('<script>') + 8, html.indexOf('</script>'));
+    const hash = createHash('sha256').update(script, 'utf8').digest('base64');
+    assert.match(csp, new RegExp(`script-src 'sha256-${hash.replace(/[+/=]/g, '\\$&')}'`));
+    assert.equal(page.headers.get('x-content-type-options'), 'nosniff');
 
     // The asset route is GET + exact path only — a POST to the same path must
     // NOT hit the dashboard handler but flow down the normal (gated, then

--- a/test/dead-refresh-token.test.js
+++ b/test/dead-refresh-token.test.js
@@ -115,3 +115,56 @@ test('the dead-token field is part of the account record from construction', () 
   assert.ok('_deadRefreshToken' in m.accounts[0]);
   assert.strictEqual(m.accounts[0]._deadRefreshToken, null);
 });
+
+// A config reload or `teamclaude import` can install new tokens WHILE a refresh
+// of the old ones is awaiting upstream. The outcome of that call belongs to the
+// token that was sent, not to whatever the account holds when it lands.
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+test('an invalid_grant for the OLD token does not mark a token imported mid-refresh dead', async () => {
+  const d = deferred();
+  const m = mgr(async () => d.promise);
+  const inflight = m.ensureTokenFresh(0);
+
+  // Import lands while the refresh is in flight and hands over a valid token.
+  m.updateAccountTokens(0, { accessToken: 'at-imported', refreshToken: 'rt-imported', expiresAt: Date.now() + 3600_000 });
+  d.reject(authError(400));
+  await inflight;
+
+  const a = m.accounts[0];
+  assert.strictEqual(a._deadRefreshToken, 'rt-dead', 'the token that was SENT is the dead one');
+  assert.strictEqual(a.refreshToken, 'rt-imported');
+  assert.strictEqual(a.status, 'active', 'the account must not be locked out — its live token was never rejected');
+  assert.strictEqual(a.credential, 'at-imported');
+});
+
+test('a successful refresh of the OLD token does not overwrite tokens imported mid-refresh', async () => {
+  const d = deferred();
+  let persisted = 0;
+  const m = mgr(async () => d.promise);
+  m.onTokenRefresh(() => { persisted++; });
+  const inflight = m.ensureTokenFresh(0);
+
+  m.updateAccountTokens(0, { accessToken: 'at-imported', refreshToken: 'rt-imported', expiresAt: 4_000_000_000_000 });
+  const persistedByImport = persisted;
+  d.resolve({ accessToken: 'at-stale', refreshToken: 'rt-stale', expiresAt: Date.now() + 3600_000 });
+  await inflight;
+
+  const a = m.accounts[0];
+  assert.strictEqual(a.refreshToken, 'rt-imported', 'the stale result is discarded');
+  assert.strictEqual(a.credential, 'at-imported');
+  assert.strictEqual(a.expiresAt, 4_000_000_000_000);
+  assert.strictEqual(persisted, persistedByImport, 'nothing stale is persisted to config');
+  assert.strictEqual(a._refreshPromise, null, 'the coalescing slot is released');
+});
+
+test('an unchanged token is refreshed normally (the guard only fires on a swap)', async () => {
+  const m = mgr(async () => ({ accessToken: 'at-new', refreshToken: 'rt-new', expiresAt: Date.now() + 3600_000 }));
+  await m.ensureTokenFresh(0);
+  assert.strictEqual(m.accounts[0].refreshToken, 'rt-new');
+  assert.strictEqual(m.accounts[0].credential, 'at-new');
+});

--- a/test/dns-rebinding.test.js
+++ b/test/dns-rebinding.test.js
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { once } from 'node:events';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, isLocalHostHeader } from '../src/server.js';
+
+// DNS rebinding against the loopback exemption. A page at attacker.example
+// whose DNS answer flips to 127.0.0.1 has the browser send loopback-sourced,
+// same-origin requests to the proxy — and, unlike the cross-origin case, the
+// page can READ the answers. The one header the page cannot forge is Host,
+// which the browser derives from its own URL bar, so a key-less loopback
+// request must carry a Host that names this machine.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const ACCTS = [{ name: 'alice@example.com', type: 'apikey', apiKey: 'k1' }];
+
+async function withServer(config, fn) {
+  const am = new AccountManager(ACCTS, 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'tc-test' }, upstream: 'https://api.anthropic.com', ...config });
+  const port = await listen(proxy);
+  try {
+    await fn(port);
+  } finally {
+    proxy.close();
+  }
+}
+
+// fetch() refuses to set Host, so drive http.request, which lets the test say
+// exactly what the browser would have sent.
+function get(port, headers) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path: '/teamclaude/status', headers }, (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test('a rebound name is refused even though the request is loopback and same-origin', async () => {
+  await withServer({}, async (port) => {
+    const res = await get(port, { host: 'attacker.example', 'sec-fetch-site': 'same-origin' });
+    assert.equal(res.status, 403);
+    assert.match(JSON.parse(res.body).error.message, /Host header/);
+  });
+});
+
+test('the names a local browser actually uses are all accepted', async () => {
+  await withServer({}, async (port) => {
+    for (const host of [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`, 'LocalHost']) {
+      const res = await get(port, { host, 'sec-fetch-site': 'same-origin' });
+      assert.equal(res.status, 200, `Host: ${host}`);
+    }
+  });
+});
+
+test('a valid key makes the Host header irrelevant', async () => {
+  await withServer({}, async (port) => {
+    const res = await get(port, { host: 'attacker.example', 'x-api-key': 'tc-test' });
+    assert.equal(res.status, 200);
+  });
+});
+
+test('the configured bind address is accepted, a wildcard bind widens nothing', async () => {
+  await withServer({ proxy: { apiKey: 'tc-test', host: '192.0.2.10' } }, async (port) => {
+    assert.equal((await get(port, { host: '192.0.2.10:3456' })).status, 200);
+    assert.equal((await get(port, { host: '192.0.2.11:3456' })).status, 403);
+  });
+  await withServer({ proxy: { apiKey: 'tc-test', host: '0.0.0.0' } }, async (port) => {
+    assert.equal((await get(port, { host: '0.0.0.0:3456' })).status, 403);
+    assert.equal((await get(port, { host: `localhost:${port}` })).status, 200);
+  });
+});
+
+// Node rejects an HTTP/1.1 request without Host before the handler runs, so
+// the only client that can arrive without one speaks HTTP/1.0 — a hand-rolled
+// local tool, never a browser. It stays served.
+test('an HTTP/1.0 request with no Host header is still served', async () => {
+  await withServer({}, async (port) => {
+    const sock = net.connect(port, '127.0.0.1');
+    await once(sock, 'connect');
+    sock.write('GET /teamclaude/status HTTP/1.0\r\n\r\n');
+    let raw = '';
+    sock.on('data', (c) => { raw += c; });
+    await once(sock, 'close');
+    assert.match(raw, /^HTTP\/1\.[01] 200/);
+  });
+});
+
+test('isLocalHostHeader: hostname extraction and the accepted set', () => {
+  assert.equal(isLocalHostHeader('localhost'), true);
+  assert.equal(isLocalHostHeader('localhost:3456'), true);
+  assert.equal(isLocalHostHeader('127.0.0.1:3456'), true);
+  assert.equal(isLocalHostHeader('[::1]:3456'), true);
+  assert.equal(isLocalHostHeader('::1'), true);
+  assert.equal(isLocalHostHeader(undefined), true);            // HTTP/1.0
+  assert.equal(isLocalHostHeader('attacker.example'), false);
+  assert.equal(isLocalHostHeader('127.0.0.1.attacker.example'), false);
+  assert.equal(isLocalHostHeader('localhost.attacker.example'), false);
+  assert.equal(isLocalHostHeader('[::1'), false);              // malformed
+  // The bind address counts, unless it is a wildcard.
+  assert.equal(isLocalHostHeader('192.0.2.10:1', '192.0.2.10'), true);
+  assert.equal(isLocalHostHeader('[fe80::1]:1', 'fe80::1'), true);
+  assert.equal(isLocalHostHeader('0.0.0.0', '0.0.0.0'), false);
+  assert.equal(isLocalHostHeader('::', '::'), false);
+});

--- a/test/forward-target.test.js
+++ b/test/forward-target.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  forbiddenAddressReason, isForbiddenForwardAddress, forbiddenForwardReason,
+  guardedLookup, allowLoopbackForward, FORBIDDEN_FORWARD,
+} from '../src/forward-target.js';
+
+// The policy behind both transparent forward paths (CONNECT tunnel, plain-HTTP
+// relay): never to this machine's loopback, the unspecified address, or
+// link-local — the three that turn a low-trust remote key into a local caller
+// at our own listener, or into a reader of cloud metadata. Everything else,
+// RFC1918 included, is a legitimate place to proxy to.
+
+test('loopback, unspecified and link-local addresses are forbidden in every spelling', () => {
+  const forbidden = {
+    '127.0.0.1': 'loopback', '127.255.0.9': 'loopback', '::1': 'loopback',
+    '::ffff:127.0.0.1': 'loopback',   // how Node reports a mapped IPv4 peer
+    '::ffff:7f00:1': 'loopback',      // the same address in hex
+    '::127.0.0.1': 'loopback',        // deprecated IPv4-compatible form
+    '0.0.0.0': 'unspecified', '0.1.2.3': 'unspecified', '::': 'unspecified',
+    '169.254.169.254': 'link-local', 'fe80::1': 'link-local', 'FE80::1%eth0': 'link-local', 'febf::1': 'link-local',
+  };
+  for (const [ip, why] of Object.entries(forbidden)) {
+    assert.equal(forbiddenAddressReason(ip), why, ip);
+    assert.equal(isForbiddenForwardAddress(ip), true, ip);
+  }
+});
+
+test('public and private (LAN) addresses are allowed', () => {
+  for (const ip of ['8.8.8.8', '10.0.0.5', '172.16.4.4', '192.168.1.20', '2001:db8::1', '::ffff:10.0.0.5', 'fec0::1', 'fd00::1']) {
+    assert.equal(forbiddenAddressReason(ip), null, ip);
+  }
+  assert.equal(forbiddenAddressReason('not-an-ip'), null);
+  assert.equal(forbiddenAddressReason(undefined), null);
+});
+
+test('forbiddenForwardReason refuses by name for the obvious spellings, and by resolved address otherwise', () => {
+  assert.match(forbiddenForwardReason('localhost'), /loopback name/);
+  assert.match(forbiddenForwardReason('LOCALHOST.'), /loopback name/);
+  assert.match(forbiddenForwardReason('foo.localhost'), /loopback name/);
+  assert.match(forbiddenForwardReason('127.0.0.1'), /loopback address/);
+  assert.match(forbiddenForwardReason('::1'), /loopback address/);
+  // A DNS alias for loopback gets past the name and is caught by the address.
+  assert.equal(forbiddenForwardReason('localtest.me'), null);
+  assert.match(forbiddenForwardReason('localtest.me', '127.0.0.1'), /resolves to 127\.0\.0\.1, a loopback/);
+  assert.match(forbiddenForwardReason('metadata.internal', '169.254.169.254'), /link-local/);
+  assert.equal(forbiddenForwardReason('example.com', '93.184.216.34'), null);
+  assert.equal(forbiddenForwardReason('nas.lan', '192.168.1.20'), null);
+});
+
+// The lookup wrapper is what makes the policy hold against DNS: it sees every
+// address the name has and refuses the dial before any SYN is sent.
+function fakeLookup(table) {
+  return (host, _opts, cb) => {
+    const rows = table[host];
+    if (!rows) { const e = new Error(`getaddrinfo ENOTFOUND ${host}`); e.code = 'ENOTFOUND'; return cb(e); }
+    cb(null, rows);
+  };
+}
+const lookupAsync = (fn, host, opts = { all: true }) => new Promise((resolve, reject) => {
+  fn(host, opts, (err, ...rest) => (err ? reject(err) : resolve(rest)));
+});
+
+test('guardedLookup refuses when ANY resolved address is forbidden, in either callback shape', async () => {
+  const table = {
+    'good.example': [{ address: '93.184.216.34', family: 4 }, { address: '2606:2800::1', family: 6 }],
+    'sneaky.example': [{ address: '93.184.216.34', family: 4 }, { address: '::1', family: 6 }],
+    'metadata.example': [{ address: '169.254.169.254', family: 4 }],
+  };
+  const lookup = guardedLookup(null, { lookup: fakeLookup(table) });
+
+  const [all] = await lookupAsync(lookup, 'good.example');
+  assert.deepEqual(all, table['good.example']);
+  const [addr, family] = await lookupAsync(lookup, 'good.example', {});
+  assert.equal(addr, '93.184.216.34'); assert.equal(family, 4);
+
+  for (const host of ['sneaky.example', 'metadata.example']) {
+    await assert.rejects(lookupAsync(lookup, host), (err) => {
+      assert.equal(err.code, FORBIDDEN_FORWARD, host);
+      assert.match(err.message, /refused/);
+      return true;
+    });
+  }
+  // A resolver failure is passed through untouched — a 502, not a 403.
+  await assert.rejects(lookupAsync(lookup, 'missing.example'), { code: 'ENOTFOUND' });
+});
+
+test('the test hook admits loopback only, and only for its registered server', async () => {
+  const table = { 'me.example': [{ address: '127.0.0.1', family: 4 }], 'link.example': [{ address: '169.254.1.1', family: 4 }] };
+  const server = {};
+  allowLoopbackForward(server);
+  const registered = guardedLookup({ server }, { lookup: fakeLookup(table) });
+  const other = guardedLookup({ server: {} }, { lookup: fakeLookup(table) });
+
+  const [rows] = await lookupAsync(registered, 'me.example');
+  assert.equal(rows[0].address, '127.0.0.1');
+  await assert.rejects(lookupAsync(registered, 'link.example'), { code: FORBIDDEN_FORWARD });
+  await assert.rejects(lookupAsync(other, 'me.example'), { code: FORBIDDEN_FORWARD });
+});

--- a/test/http-forward-proxy.test.js
+++ b/test/http-forward-proxy.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import { once } from 'node:events';
 import { createProxyServer } from '../src/server.js';
+import { allowLoopbackForward } from '../src/forward-target.js';
 
 async function listen(server) {
   server.listen(0, '127.0.0.1');
@@ -40,6 +41,7 @@ test('forwards an absolute-form HTTP request to its target host, not to Anthropi
   const targetPort = await listen(target);
 
   const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  allowLoopbackForward(proxy); // the target stands in for a remote host but lives on 127.0.0.1
   const proxyPort = await listen(proxy);
 
   const r = await proxyRequest({ proxyPort, absoluteUrl: `http://127.0.0.1:${targetPort}/hello` });
@@ -62,6 +64,7 @@ test('forwards a POST body and method to the target', async () => {
   const targetPort = await listen(target);
 
   const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  allowLoopbackForward(proxy); // the target stands in for a remote host but lives on 127.0.0.1
   const proxyPort = await listen(proxy);
 
   const r = await proxyRequest({ proxyPort, method: 'POST', absoluteUrl: `http://127.0.0.1:${targetPort}/`, body: 'payload-123' });
@@ -73,6 +76,7 @@ test('forwards a POST body and method to the target', async () => {
 
 test('returns 502 (not a hang) when the target host is unreachable', async () => {
   const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  allowLoopbackForward(proxy); // the target stands in for a remote host but lives on 127.0.0.1
   const proxyPort = await listen(proxy);
 
   // Port 1 is not listening → connection refused.
@@ -81,4 +85,60 @@ test('returns 502 (not a hang) when the target host is unreachable', async () =>
   assert.match(r.body, /proxy_error/);
 
   proxy.close();
+});
+
+// ── Destination policy ───────────────────────────────────────
+//
+// The relay is transparent, and "transparent to anywhere" included this machine:
+// `GET http://127.0.0.1:<our port>/teamclaude/status` arrived at our own listener
+// from a loopback socket and passed the API-key gate as a local caller — so a
+// remote client holding only a low-trust key had the whole control plane, plus
+// any loopback-only service and the cloud metadata address.
+
+test('a forward to a loopback address is refused with 403 and never dialled', async () => {
+  const trap = http.createServer(() => { throw new Error('the proxy must not connect to a loopback target'); });
+  const trapPort = await listen(trap);
+  let connections = 0;
+  trap.on('connection', () => { connections++; });
+
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+  try {
+    for (const target of [`http://127.0.0.1:${trapPort}/x`, `http://localhost:${trapPort}/x`, `http://[::1]:${trapPort}/x`, `http://0.0.0.0:${trapPort}/x`]) {
+      const r = await proxyRequest({ proxyPort, absoluteUrl: target });
+      assert.equal(r.status, 403, target);
+      assert.match(r.body, /refused/, target);
+    }
+    assert.equal(connections, 0, 'no connection may reach a loopback target');
+  } finally {
+    proxy.close(); trap.close();
+  }
+});
+
+test("a forward to the proxy's own listener is refused, not answered as a local caller", async () => {
+  // A key is configured, so a remote caller without it must be turned away —
+  // including one trying to arrive at the control plane through the relay.
+  const proxy = createProxyServer(noRouteManager, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+  try {
+    // The test client is itself loopback and so passes the gate for the relay
+    // request; what matters is that the relayed hop is refused rather than
+    // served — the answer must be the 403, never the status document.
+    const r = await proxyRequest({ proxyPort, absoluteUrl: `http://127.0.0.1:${proxyPort}/teamclaude/status` });
+    assert.equal(r.status, 403);
+    assert.doesNotMatch(r.body, /accounts/);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('the link-local range is refused by literal address', async () => {
+  const proxy = createProxyServer(noRouteManager, { proxy: {}, upstream: 'https://api.anthropic.com' });
+  const proxyPort = await listen(proxy);
+  try {
+    const r = await proxyRequest({ proxyPort, absoluteUrl: 'http://169.254.169.254/latest/meta-data/' });
+    assert.equal(r.status, 403);
+  } finally {
+    proxy.close();
+  }
 });

--- a/test/mitm-integration.test.js
+++ b/test/mitm-integration.test.js
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { generateCertChain } from '../src/x509.js';
 import { createConnectHandler } from '../src/mitm.js';
+import { allowLoopbackForward } from '../src/forward-target.js';
 import { AccountManager } from '../src/account-manager.js';
 
 // The MITM now TERMINATES the tunnel (real h2/h1 server) and forwards each
@@ -69,6 +70,7 @@ function makeUpstream(handler) {
 // Build the teamclaude proxy (CONNECT → terminate + forward) against `upPort`.
 function makeProxy(am, upPort, { leafCertPem, leafKeyPem }, { logDir = null, hooks = {}, sx = null } = {}) {
   const proxy = http.createServer();
+  allowLoopbackForward(proxy); // tunnel-mode targets in these tests are on this machine
   proxy.on('connect', createConnectHandler({
     // upstream host is 127.0.0.1 so a `CONNECT 127.0.0.1:<port>` is 'rewrite' mode.
     config: { upstream: `http://127.0.0.1:${upPort}` },

--- a/test/mitm-pin.test.js
+++ b/test/mitm-pin.test.js
@@ -7,6 +7,7 @@ import tls from 'node:tls';
 import { once } from 'node:events';
 import { generateCertChain } from '../src/x509.js';
 import { createConnectHandler, resolveConnectPin, connectPinToken } from '../src/mitm.js';
+import { allowLoopbackForward } from '../src/forward-target.js';
 import { AccountManager } from '../src/account-manager.js';
 
 // MITM-mode account pinning (TC_ACCT). Inside a CONNECT tunnel the request path
@@ -64,6 +65,7 @@ function makeUpstream(handler) {
 
 function makeProxy(am, upPort, { leafCertPem, leafKeyPem }, config = {}) {
   const proxy = http.createServer();
+  allowLoopbackForward(proxy); // the tunnel targets below are on this machine
   proxy.on('connect', createConnectHandler({
     config: { upstream: `http://127.0.0.1:${upPort}`, ...config },
     accountManager: am,

--- a/test/mitm-pin.test.js
+++ b/test/mitm-pin.test.js
@@ -98,7 +98,7 @@ test('the Basic username selects the account', () => {
   // No key configured — username alone still pins.
   assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('personal:') } }, am, null), { pin: 'personal', error: null });
   // A rotation index is not a pin form — array position moves under deletion.
-  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('1:') } }, am, null), { pin: null, error: 'Unknown account pin "1"' });
+  assert.deepEqual(resolveConnectPin({ headers: { 'proxy-authorization': basic('1:') } }, am, null), { pin: null, error: 'Unknown account pin "1…" (1 chars)' });
 });
 
 // The documented remote form is `--proxy http://<key>@host:port`, which puts the
@@ -117,7 +117,10 @@ test('an unknown username is an error rather than an ignored pin', () => {
   const am = { accounts: [{ name: 'work' }] };
   const { pin, error } = resolveConnectPin({ headers: { 'proxy-authorization': basic('typo:') } }, am, 'secret');
   assert.equal(pin, null);
-  assert.match(error, /Unknown account pin "typo"/);
+  // The username slot can carry a secret (`http://<key>@proxy`), so the log gets
+  // enough to spot a typo — a prefix and the length — and never the whole value.
+  assert.match(error, /Unknown account pin "ty…" \(4 chars\)/);
+  assert.doesNotMatch(error, /typo/);
 });
 
 test('no header, or a Bearer key, yields no pin', () => {

--- a/test/mitm.test.js
+++ b/test/mitm.test.js
@@ -12,10 +12,11 @@ import { X509Certificate } from 'node:crypto';
 const TMP = mkdtempSync(join(tmpdir(), 'tc-mitm-'));
 process.env.TEAMCLAUDE_CONFIG = join(TMP, 'config.json');
 
-const { ensureCerts, caCertPath, TEST_HOST, parseConnectAuthority } = await import('../src/mitm.js');
+const { ensureCerts, caCertPath, TEST_HOST, leafCovers, parseConnectAuthority } = await import('../src/mitm.js');
 const { AccountManager } = await import('../src/account-manager.js');
 const { createProxyServer } = await import('../src/server.js');
 const { allowLoopbackForward } = await import('../src/forward-target.js');
+const { generateCertChain } = await import('../src/x509.js');
 
 function listen(server) {
   return new Promise((r) => server.listen(0, '127.0.0.1', () => r(server.address().port)));
@@ -196,4 +197,39 @@ test('an unparseable CONNECT target gets a 400, and a differently-cased test hos
   } finally {
     proxy.close();
   }
+});
+
+// ── Stored chain validity ────────────────────────────────────
+//
+// leafCovers used to check signature and SANs only, so an expired leaf or CA
+// was reused for ever — every handshake failed and nothing regenerated it.
+
+test('leafCovers rejects a chain with under 30 days left, on either certificate', () => {
+  const hosts = ['api.anthropic.com', TEST_HOST];
+  const fresh = generateCertChain(hosts);
+  assert.equal(leafCovers(fresh.caCertPem, fresh.leafCertPem, hosts), true);
+  const DAY = 24 * 3600 * 1000;
+  // Judged from a clock 20 days before the leaf's expiry: too close to renew.
+  assert.equal(leafCovers(fresh.caCertPem, fresh.leafCertPem, hosts, Date.now() + (825 - 20) * DAY), false);
+  const shortLeaf = generateCertChain(hosts, { leafDays: 10 });
+  assert.equal(leafCovers(shortLeaf.caCertPem, shortLeaf.leafCertPem, hosts), false);
+  const shortCa = generateCertChain(hosts, { caDays: 10 });
+  assert.equal(leafCovers(shortCa.caCertPem, shortCa.leafCertPem, hosts), false);
+});
+
+test('ensureCerts regenerates a stored chain that is about to expire', async () => {
+  const { writeFile } = await import('node:fs/promises');
+  const dir = join(caCertPath(), '..');
+  const hosts = ['api.anthropic.com', TEST_HOST];
+  const short = generateCertChain(hosts, { leafDays: 5 });
+  await writeFile(join(dir, 'teamclaude-ca.pem'), short.caCertPem);
+  await writeFile(join(dir, 'teamclaude-leaf.pem'), short.leafCertPem);
+  await writeFile(join(dir, 'teamclaude-leaf.key'), short.leafKeyPem);
+
+  const renewed = await ensureCerts('api.anthropic.com');
+  assert.notEqual(renewed.leafCertPem, short.leafCertPem);
+  assert.ok(new Date(new X509Certificate(renewed.leafCertPem).validTo) - Date.now() > 300 * 24 * 3600 * 1000);
+  // And the renewed chain is then kept.
+  const again = await ensureCerts('api.anthropic.com');
+  assert.equal(again.leafCertPem, renewed.leafCertPem);
 });

--- a/test/mitm.test.js
+++ b/test/mitm.test.js
@@ -12,7 +12,7 @@ import { X509Certificate } from 'node:crypto';
 const TMP = mkdtempSync(join(tmpdir(), 'tc-mitm-'));
 process.env.TEAMCLAUDE_CONFIG = join(TMP, 'config.json');
 
-const { ensureCerts, caCertPath, TEST_HOST } = await import('../src/mitm.js');
+const { ensureCerts, caCertPath, TEST_HOST, parseConnectAuthority } = await import('../src/mitm.js');
 const { AccountManager } = await import('../src/account-manager.js');
 const { createProxyServer } = await import('../src/server.js');
 const { allowLoopbackForward } = await import('../src/forward-target.js');
@@ -143,7 +143,7 @@ test('CONNECT to a loopback target is refused with 403 and never dialled', async
   const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' }, {});
   const port = await listen(proxy);
   try {
-    for (const target of [`127.0.0.1:${trapPort}`, `127.1.2.3:${trapPort}`, `localhost:${trapPort}`, `0.0.0.0:${trapPort}`, '169.254.169.254:80']) {
+    for (const target of [`127.0.0.1:${trapPort}`, `127.1.2.3:${trapPort}`, `localhost:${trapPort}`, `[::1]:${trapPort}`, `0.0.0.0:${trapPort}`, `[::ffff:127.0.0.1]:${trapPort}`, '169.254.169.254:80', '[fe80::1]:80']) {
       assert.match(await connectStatus(port, target), /^HTTP\/1\.1 403 /, target);
     }
     assert.equal(connections, 0, 'no connection may reach a loopback target');
@@ -162,6 +162,37 @@ test("CONNECT to the proxy's own port is refused even where loopback is admitted
     // (our port, connected to ourselves) still refuses the request loop.
     allowLoopbackForward(proxy);
     assert.match(await connectStatus(port, `127.0.0.1:${port}`), /^HTTP\/1\.1 403 /);
+  } finally {
+    proxy.close();
+  }
+});
+
+// ── CONNECT authority parsing ────────────────────────────────
+
+test('parseConnectAuthority normalizes the host and refuses what cannot be dialled', () => {
+  assert.deepEqual(parseConnectAuthority('api.anthropic.com:443'), { host: 'api.anthropic.com', port: 443 });
+  // Case and a root dot must not dodge hostMode's exact match into the blind tunnel.
+  assert.deepEqual(parseConnectAuthority('API.ANTHROPIC.COM:443'), { host: 'api.anthropic.com', port: 443 });
+  assert.deepEqual(parseConnectAuthority('api.anthropic.com.:443'), { host: 'api.anthropic.com', port: 443 });
+  assert.deepEqual(parseConnectAuthority('[::1]:8443'), { host: '::1', port: 8443 });
+  assert.deepEqual(parseConnectAuthority('example.org'), { host: 'example.org', port: 443 });
+  // An empty host used to be dialled as localhost.
+  for (const bad of [':443', '', undefined, 'host:0', 'host:65536', 'host:abc', '[::1', 'a:b:c', 'host/path:443', 'ho st:443', '[]:443']) {
+    assert.equal(parseConnectAuthority(bad), null, String(bad));
+  }
+});
+
+test('an unparseable CONNECT target gets a 400, and a differently-cased test host is still intercepted', async () => {
+  const { caCertPem } = await ensureCerts('api.anthropic.com');
+  const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' }, {});
+  const port = await listen(proxy);
+  try {
+    assert.match(await connectStatus(port, ':443'), /^HTTP\/1\.1 400 /);
+    assert.match(await connectStatus(port, 'example.org:0'), /^HTTP\/1\.1 400 /);
+    const sock = await connectTls(port, `${TEST_HOST.toUpperCase()}.:443`, caCertPem, TEST_HOST);
+    const resp = await httpOver(sock, TEST_HOST, '/upper');
+    assert.match(resp, /"teamclaude":"mitm-proxy-ok"/);
   } finally {
     proxy.close();
   }

--- a/test/mitm.test.js
+++ b/test/mitm.test.js
@@ -15,6 +15,7 @@ process.env.TEAMCLAUDE_CONFIG = join(TMP, 'config.json');
 const { ensureCerts, caCertPath, TEST_HOST } = await import('../src/mitm.js');
 const { AccountManager } = await import('../src/account-manager.js');
 const { createProxyServer } = await import('../src/server.js');
+const { allowLoopbackForward } = await import('../src/forward-target.js');
 
 function listen(server) {
   return new Promise((r) => server.listen(0, '127.0.0.1', () => r(server.address().port)));
@@ -79,12 +80,26 @@ test('CONNECT to the test host is intercepted and answered locally (proxy + CA p
   }
 });
 
+// Send a CONNECT and resolve with the status line the proxy answers.
+function connectStatus(proxyPort, target) {
+  return new Promise((resolve, reject) => {
+    const raw = net.connect(proxyPort, '127.0.0.1');
+    raw.once('error', reject);
+    raw.once('connect', () => raw.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`));
+    let buf = '';
+    raw.on('data', (d) => { buf += d.toString('latin1'); if (buf.includes('\r\n\r\n')) { raw.destroy(); resolve(buf.split('\r\n')[0]); } });
+    raw.on('close', () => { if (!buf.includes('\r\n\r\n')) reject(new Error(`closed with no CONNECT response: ${JSON.stringify(buf)}`)); });
+  });
+}
+
 test('CONNECT to a non-intercepted host is blind-tunneled', async () => {
-  // Echo server stands in for "some other host".
+  // Echo server stands in for "some other host". It is on loopback, which the
+  // tunnel refuses by default, so the test hook admits it for this server.
   const echo = net.createServer((s) => s.pipe(s));
   const echoPort = await listen(echo);
   const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
   const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' }, {});
+  allowLoopbackForward(proxy);
   const port = await listen(proxy);
   try {
     const raw = net.connect(port, '127.0.0.1');
@@ -110,5 +125,44 @@ test('CONNECT to a non-intercepted host is blind-tunneled', async () => {
   } finally {
     proxy.close();
     echo.close();
+  }
+});
+
+// ── Tunnel destination policy ────────────────────────────────
+//
+// A blind tunnel to this machine is how a remote client with only a low-trust
+// key reaches our own listener as a loopback caller (no API-key gate: /switch,
+// /reload, /status, /v1/messages), any loopback-only service, or cloud metadata.
+
+test('CONNECT to a loopback target is refused with 403 and never dialled', async () => {
+  const trap = net.createServer(() => { throw new Error('the proxy must not connect to a loopback target'); });
+  let connections = 0;
+  trap.on('connection', () => { connections++; });
+  const trapPort = await listen(trap);
+  const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' }, {});
+  const port = await listen(proxy);
+  try {
+    for (const target of [`127.0.0.1:${trapPort}`, `127.1.2.3:${trapPort}`, `localhost:${trapPort}`, `0.0.0.0:${trapPort}`, '169.254.169.254:80']) {
+      assert.match(await connectStatus(port, target), /^HTTP\/1\.1 403 /, target);
+    }
+    assert.equal(connections, 0, 'no connection may reach a loopback target');
+  } finally {
+    proxy.close(); trap.close();
+  }
+});
+
+test("CONNECT to the proxy's own port is refused even where loopback is admitted", async () => {
+  const am = new AccountManager([{ name: 'k', type: 'apikey', apiKey: 'sk' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: 'https://api.anthropic.com' }, {});
+  const port = await listen(proxy);
+  try {
+    assert.match(await connectStatus(port, `127.0.0.1:${port}`), /^HTTP\/1\.1 403 /);
+    // With the test hook the address class passes; the own-listener rule
+    // (our port, connected to ourselves) still refuses the request loop.
+    allowLoopbackForward(proxy);
+    assert.match(await connectStatus(port, `127.0.0.1:${port}`), /^HTTP\/1\.1 403 /);
+  } finally {
+    proxy.close();
   }
 });

--- a/test/oauth-callback.test.js
+++ b/test/oauth-callback.test.js
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { startCallbackServer } from '../src/oauth.js';
+import { codexCallbackHandler } from '../src/codex-auth.js';
+
+// The loopback callback listener is open for as long as the user is in the
+// browser. A request that does not carry the expected state must be answered
+// and otherwise ignored: it used to abort the whole login, so any drive-by GET
+// (a page probing localhost ports, a scanner, a stale tab) could deny the login
+// by arriving first with `?error=` or with no state at all.
+
+/** Whether `p` settles within `ms`. */
+async function settles(p, ms = 50) {
+  const pending = Symbol('pending');
+  const r = await Promise.race([p.then(() => 'ok', () => 'err'), new Promise(r => setTimeout(() => r(pending), ms))]);
+  return r !== pending;
+}
+
+test('the Anthropic callback server binds loopback only', async () => {
+  const { server } = await startCallbackServer('st');
+  try {
+    assert.equal(server.address().address, '127.0.0.1');
+  } finally {
+    server.close();
+  }
+});
+
+test('an Anthropic callback without the expected state is refused and does not settle the login', async () => {
+  const { port, codePromise, server } = await startCallbackServer('st');
+  try {
+    const base = `http://127.0.0.1:${port}/callback`;
+    // `?error=` used to reject the login before the state was even looked at.
+    let res = await fetch(`${base}?error=access_denied`);
+    assert.equal(res.status, 400);
+    res = await fetch(`${base}?error=access_denied&state=other`);
+    assert.equal(res.status, 400);
+    // A code under the wrong state used to reject too; now it is just ignored.
+    res = await fetch(`${base}?code=abc&state=other`);
+    assert.equal(res.status, 400);
+    res = await fetch(`${base}?code=abc`);
+    assert.equal(res.status, 400);
+    assert.equal(await settles(codePromise), false, 'the login must still be waiting');
+
+    // The real redirect still completes it.
+    res = await fetch(`${base}?code=abc&state=st`, { redirect: 'manual' });
+    assert.equal(res.status, 302);
+    assert.equal(await codePromise, 'abc');
+  } finally {
+    server.close();
+  }
+});
+
+test('an Anthropic callback with the right state still reports an upstream error', async () => {
+  const { port, codePromise, server } = await startCallbackServer('st');
+  try {
+    // Attached before the request: the rejection lands as soon as the handler runs.
+    const rejected = assert.rejects(codePromise, /OAuth error: access_denied - nope/);
+    const res = await fetch(`http://127.0.0.1:${port}/callback?error=access_denied&error_description=nope&state=st`);
+    assert.equal(res.status, 200);
+    await rejected;
+  } finally {
+    server.close();
+  }
+});
+
+// The Codex handler is exercised on an ephemeral port: the real flow has to
+// bind 1455 (OpenAI's one registered redirect), which a test must not claim.
+async function codexServer(state) {
+  let resolve, reject;
+  const codePromise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  const server = http.createServer(codexCallbackHandler(state, { resolve, reject }));
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { server, codePromise, base: `http://127.0.0.1:${server.address().port}/auth/callback` };
+}
+
+test('a Codex callback without the expected state is refused and does not settle the login', async () => {
+  const { server, codePromise, base } = await codexServer('st');
+  try {
+    for (const q of ['?error=access_denied', '?error=access_denied&state=other', '?code=abc&state=other', '?code=abc']) {
+      const res = await fetch(`${base}${q}`);
+      assert.equal(res.status, 400, q);
+    }
+    assert.equal(await settles(codePromise), false, 'the login must still be waiting');
+
+    const res = await fetch(`${base}?code=abc&state=st`);
+    assert.equal(res.status, 200);
+    assert.equal(await codePromise, 'abc');
+  } finally {
+    server.close();
+  }
+});
+
+test('a Codex callback with the right state still reports an upstream error or a missing code', async () => {
+  let s = await codexServer('st');
+  try {
+    const rejected = assert.rejects(s.codePromise, /OAuth error: access_denied/);
+    await fetch(`${s.base}?error=access_denied&state=st`);
+    await rejected;
+  } finally {
+    s.server.close();
+  }
+  s = await codexServer('st');
+  try {
+    const rejected = assert.rejects(s.codePromise, /carried no code/);
+    await fetch(`${s.base}?state=st`);
+    await rejected;
+  } finally {
+    s.server.close();
+  }
+});

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeUsageBucket, findScopedWeeklyLimit, normalizeUsagePayload } from '../src/oauth.js';
 import { AccountManager, isFableModel, parseRequestModel } from '../src/account-manager.js';
-import { Prober } from '../src/prober.js';
+import { Prober, MAX_PROBE_INTERVAL_MS } from '../src/prober.js';
 
 function oauth(name, extra = {}) {
   return { name, type: 'oauth', accessToken: 't-' + name, expiresAt: Date.now() + 3600_000, ...extra };
@@ -393,4 +393,61 @@ test('prober refreshes expired token before probing', async () => {
 
   await prober.probeAll();
   assert.equal(token, 'fresh');
+});
+
+// A probe forces a refresh and sends the token upstream. Neither belongs to an
+// account the operator disabled, nor to one whose refresh token upstream has
+// already rejected: re-sending it just rotates the family once more.
+test('prober skips disabled accounts', async () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  am.setDisabled(0, true);
+  const probed = [];
+  const prober = new Prober(am, { intervalMs: 0, probeFn: async cred => { probed.push(cred); return {}; }, log: () => {} });
+  await prober.probeAll();
+  assert.deepEqual(probed, ['t-b']);
+});
+
+test('prober skips an account holding a rejected refresh token, until a new one arrives', async () => {
+  let refreshes = 0;
+  const am = new AccountManager(
+    [oauth('a', { refreshToken: 'rt-dead', expiresAt: Date.now() - 1000 })],
+    0.98,
+    { refreshFn: async () => { refreshes++; const e = new Error('invalid_grant'); e.status = 400; throw e; } },
+  );
+  let probes = 0;
+  const prober = new Prober(am, { intervalMs: 0, probeFn: async () => { probes++; return {}; }, log: () => {} });
+
+  await prober.probeAll();                 // first cycle: the refresh is tried once and rejected
+  assert.equal(refreshes, 1);
+  assert.equal(am.accounts[0]._deadRefreshToken, 'rt-dead');
+  const probesAfterRejection = probes;
+
+  await prober.probeAll();
+  await prober.probeAll();
+  assert.equal(probes, probesAfterRejection, 'no token is sent for an account that needs a re-login');
+  assert.equal(refreshes, 1);
+
+  // A re-login lifts the skip: the manager's guard is keyed on the token value.
+  am.updateAccountTokens(0, { accessToken: 'at-new', refreshToken: 'rt-new', expiresAt: Date.now() + 3600_000 });
+  await prober.probeAll();
+  assert.equal(probes, probesAfterRejection + 1);
+});
+
+// setInterval coerces a delay above 2^31-1 ms to 1 ms, which would turn an
+// interval meant as "practically never" into a tight probing loop.
+test('prober clamps its interval so the timer cannot overflow', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const prober = new Prober(am, { intervalMs: 0, probeFn: async () => ({}), log: () => {} });
+  try {
+    prober.reschedule(365 * 24 * 3600 * 1000);
+    assert.equal(prober.intervalMs, MAX_PROBE_INTERVAL_MS);
+    assert.ok(prober.intervalMs <= 2 ** 31 - 1);
+    assert.equal(prober.getStatus().intervalSeconds, MAX_PROBE_INTERVAL_MS / 1000);
+    assert.ok(prober.nextRunAt - Date.now() <= MAX_PROBE_INTERVAL_MS);
+  } finally {
+    prober.stop();
+  }
+  const huge = new Prober(am, { intervalMs: Number.MAX_SAFE_INTEGER, probeFn: async () => ({}), log: () => {} });
+  assert.equal(huge.intervalMs, MAX_PROBE_INTERVAL_MS, 'the constructor clamps too');
+  assert.equal(new Prober(am, { intervalMs: NaN, log: () => {} }).intervalMs, 0, 'a non-number is off');
 });

--- a/test/request-body-cap.test.js
+++ b/test/request-body-cap.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, resolveMaxBodyBytes, DEFAULT_MAX_BODY_BYTES } from '../src/server.js';
+
+// The forward path buffers the whole request body (to resend it on another
+// account after a 429), and so does the token-refresh passthrough. Neither had
+// a ceiling, so one client could hold as much of the proxy's memory as it cared
+// to send. The cap is driven down here so the tests stay small.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const CAP = 1024;
+
+async function withProxy(fn) {
+  let reached = 0;
+  const upstream = http.createServer((req, res) => {
+    reached++;
+    req.resume();
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k1' }], 0.98);
+  const ended = [];
+  const proxy = createProxyServer(am, {
+    proxy: { apiKey: 'k', maxBodyBytes: CAP },
+    upstream: `http://127.0.0.1:${upstreamPort}`,
+  }, { onRequestEnd: (_id, info) => ended.push(info) });
+  const port = await listen(proxy);
+  try {
+    await fn({ port, reached: () => reached, ended });
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+// http.request rather than fetch: the server tears the connection down after
+// the 413, and this client reports the response it received before that
+// rather than folding the teardown into one opaque "fetch failed".
+function post(port, path, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method: 'POST', path, headers: { 'content-type': 'application/json', 'x-api-key': 'k' } }, (res) => {
+      let text = '';
+      res.on('data', (c) => { text += c; });
+      res.on('end', () => resolve({ status: res.statusCode, text }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+const oversized = () => JSON.stringify({ model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'x'.repeat(4 * CAP) }] });
+
+test('a body past the cap is refused with a 413 and never forwarded', async () => {
+  await withProxy(async ({ port, reached, ended }) => {
+    const res = await post(port, '/v1/messages', oversized());
+    assert.equal(res.status, 413);
+    assert.match(res.text, /too large/);
+    assert.equal(reached(), 0);
+    // The activity row this request opened is closed, with the refusal on it.
+    assert.equal(ended.length, 1);
+    assert.equal(ended[0].status, 413);
+    assert.equal(ended[0].account, '(too large)');
+  });
+});
+
+test('a body under the cap is forwarded as before', async () => {
+  await withProxy(async ({ port, reached }) => {
+    const res = await post(port, '/v1/messages', JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }));
+    assert.equal(res.status, 200);
+    assert.equal(reached(), 1);
+  });
+});
+
+test('the token-refresh passthrough is capped too', async () => {
+  await withProxy(async ({ port, reached }) => {
+    const res = await post(port, '/v1/oauth/token', oversized());
+    assert.equal(res.status, 413);
+    assert.equal(reached(), 0);
+  });
+});
+
+test('resolveMaxBodyBytes: default, override, quoted number, opt-out', () => {
+  assert.equal(resolveMaxBodyBytes({}), DEFAULT_MAX_BODY_BYTES);
+  assert.equal(resolveMaxBodyBytes(undefined), DEFAULT_MAX_BODY_BYTES);
+  assert.equal(resolveMaxBodyBytes({ proxy: { maxBodyBytes: 4096 } }), 4096);
+  assert.equal(resolveMaxBodyBytes({ proxy: { maxBodyBytes: '4096' } }), 4096);
+  assert.equal(resolveMaxBodyBytes({ proxy: { maxBodyBytes: '' } }), DEFAULT_MAX_BODY_BYTES);
+  assert.equal(resolveMaxBodyBytes({ proxy: { maxBodyBytes: -1 } }), DEFAULT_MAX_BODY_BYTES);
+  assert.equal(resolveMaxBodyBytes({ proxy: { maxBodyBytes: 0 } }), Infinity);
+  assert.ok(DEFAULT_MAX_BODY_BYTES >= 64 * 1024 * 1024);
+});

--- a/test/server-persists-account-ids.test.js
+++ b/test/server-persists-account-ids.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The server persists refreshed tokens by re-reading the config and finding the
+// account's row by entry id — and by id only, since identity is not one-to-one
+// (#203). A config written before ids existed has them in memory only, and the
+// re-read would mint a different set, so nothing would pair until a restart and
+// refreshed tokens would never reach disk. Startup therefore writes the ids it
+// minted, once, so the in-memory ids are the on-disk ids.
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+
+function closedPort() {
+  return new Promise(resolve => {
+    const probe = net.createServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function startServer(configPath) {
+  const child = spawn(process.execPath, [cliPath, 'server', '--headless'], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath, TEAMCLAUDE_DISABLE_AUTOUPDATE: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', c => { output += c; });
+  child.stderr.on('data', c => { output += c; });
+  const stop = async () => {
+    child.kill('SIGTERM');
+    const killer = setTimeout(() => child.kill('SIGKILL'), 5000);
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise(resolve => child.on('exit', resolve));
+    }
+    clearTimeout(killer);
+  };
+  return { stop, output: () => output };
+}
+
+async function waitForServer(port, childOutput) {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/teamclaude/status`);
+      if (res.ok) return;
+    } catch { /* not up yet */ }
+    if (Date.now() > deadline) throw new Error(`server did not start:\n${childOutput()}`);
+    await new Promise(r => setTimeout(r, 100));
+  }
+}
+
+async function runServerOnce(configPath, port) {
+  const srv = startServer(configPath);
+  try {
+    await waitForServer(port, srv.output);
+  } finally {
+    await srv.stop();
+  }
+  return JSON.parse(await readFile(configPath, 'utf8'));
+}
+
+test('a server started on a config without entry ids writes them to disk, once', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-ids-'));
+  const configPath = join(dir, 'config.json');
+  const port = await closedPort();
+  await writeFile(configPath, JSON.stringify({
+    proxy: { port, apiKey: 'tc-test' },
+    upstream: 'https://api.anthropic.com',
+    upstreamProxy: false,
+    accounts: [
+      { name: 'a', type: 'apikey', apiKey: 'k1' },
+      { name: 'b', type: 'apikey', apiKey: 'k2', id: 'dup' },
+      { name: 'c', type: 'apikey', apiKey: 'k3', id: 'dup' }, // a hand-copied section: re-minted
+    ],
+  }));
+
+  const first = await runServerOnce(configPath, port);
+  const ids = first.accounts.map(a => a.id);
+  assert.ok(ids.every(id => typeof id === 'string' && id.length > 0), `every row carries an id: ${JSON.stringify(ids)}`);
+  assert.equal(new Set(ids).size, ids.length, 'and no two rows share one');
+  assert.deepEqual(first.accounts.map(a => a.name), ['a', 'b', 'c'], 'nothing else about the rows changed');
+
+  // A file that already carries a complete set is left exactly as it is: the
+  // ids must be stable, or the next start would break every pairing again.
+  const before = (await stat(configPath)).mtimeMs;
+  const second = await runServerOnce(configPath, port);
+  assert.deepEqual(second.accounts.map(a => a.id), ids);
+  assert.equal((await stat(configPath)).mtimeMs, before, 'no rewrite when the ids are already on disk');
+});

--- a/test/server-reload.test.js
+++ b/test/server-reload.test.js
@@ -41,17 +41,25 @@ test('reload returns 501 when no reload handler is wired', async () => {
   }
 });
 
-test('reload reports handler errors as 500', async () => {
+// The reason a reload failed names config paths and account details, so it
+// goes to the operator's log, not to a caller who merely holds a client key.
+test('reload reports handler errors as 500, with the detail logged rather than echoed', async () => {
   const am = new AccountManager(ACCT, 0.98);
-  const proxy = createProxyServer(am, CONFIG, { reload: async () => { throw new Error('boom'); } });
+  const proxy = createProxyServer(am, CONFIG, { reload: async () => { throw new Error('boom at /home/op/.teamclaude/config.json'); } });
   const port = await listen(proxy);
+  const logged = [];
+  const realErr = console.error;
+  console.error = (...a) => logged.push(a.map(String).join(' '));
   try {
     const res = await fetch(`http://127.0.0.1:${port}/teamclaude/reload`, { method: 'POST' });
     const body = await res.json();
     assert.equal(res.status, 500);
     assert.equal(body.ok, false);
-    assert.match(body.error, /boom/);
+    assert.doesNotMatch(body.error, /boom|config\.json/);
+    assert.match(body.error, /reload failed/);
+    assert.ok(logged.some(l => l.includes('boom at /home/op/.teamclaude/config.json')), 'the reason must reach the log');
   } finally {
+    console.error = realErr;
     proxy.close();
   }
 });

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   serviceKind, launchAgentPath, systemdUnitPath, logPath, resolveExec, servicePath,
-  renderLaunchAgent, renderSystemdUnit, installService, uninstallService, serviceStatus, LABEL,
+  renderLaunchAgent, renderSystemdUnit, systemdQuote, installService, uninstallService, serviceStatus, LABEL,
 } from '../src/service.js';
 
 // Records every command a call would run, and answers each with a canned result.
@@ -103,16 +103,43 @@ test('the systemd unit restarts and starts at login', () => {
   const unit = renderSystemdUnit({
     node: '/usr/bin/node', entry: '/usr/bin/teamclaude', path: '/usr/bin',
   });
-  assert.match(unit, /ExecStart=\/usr\/bin\/node \/usr\/bin\/teamclaude server --headless/);
+  assert.match(unit, /ExecStart="\/usr\/bin\/node" "\/usr\/bin\/teamclaude" server --headless/);
   assert.match(unit, /Restart=always/);
   assert.match(unit, /WantedBy=default\.target/);
-  assert.match(unit, /Environment=PATH=\/usr\/bin/);
+  assert.match(unit, /Environment="PATH=\/usr\/bin"/);
 });
 
 test('an optional config path is carried into both unit formats', () => {
   const opts = { node: '/n', entry: '/e', log: '/l', path: '/p', configPath: '/cfg/teamclaude.json' };
   assert.match(renderLaunchAgent(opts), /TEAMCLAUDE_CONFIG<\/key>\s*<string>\/cfg\/teamclaude\.json/);
-  assert.match(renderSystemdUnit(opts), /Environment=TEAMCLAUDE_CONFIG=\/cfg\/teamclaude\.json/);
+  assert.match(renderSystemdUnit(opts), /Environment="TEAMCLAUDE_CONFIG=\/cfg\/teamclaude\.json"/);
+});
+
+// Unquoted, a path with a space is two words to systemd — ExecStart would run
+// the wrong program — and a newline anywhere starts a new line of the unit, so
+// a TEAMCLAUDE_CONFIG carrying "\n" injected [Service] directives of its own.
+test('systemd unit values are quoted systemd-style: spaces kept, backslash and quote escaped', () => {
+  assert.equal(systemdQuote('/opt/my tools/node'), '"/opt/my tools/node"');
+  assert.equal(systemdQuote('/o"p\\t'), '"/o\\"p\\\\t"');
+  const unit = renderSystemdUnit({
+    node: '/opt/my tools/node', entry: '/home/o"brien/tc', path: '/opt/my tools:/usr/bin',
+    configPath: '/home/o"brien/cfg.json',
+  });
+  assert.match(unit, /^ExecStart="\/opt\/my tools\/node" "\/home\/o\\"brien\/tc" server --headless$/m);
+  assert.match(unit, /^Environment="PATH=\/opt\/my tools:\/usr\/bin"$/m);
+  assert.match(unit, /^Environment="TEAMCLAUDE_CONFIG=\/home\/o\\"brien\/cfg.json"$/m);
+});
+
+test('a control character in any unit path is refused, not written', () => {
+  const base = { node: '/n', entry: '/e', path: '/p' };
+  assert.throws(() => renderSystemdUnit({ ...base, configPath: '/cfg.json\nExecStartPre=/bin/evil' }), /control character/);
+  assert.throws(() => renderSystemdUnit({ ...base, entry: '/e\r' }), /control character/);
+  assert.throws(() => renderSystemdUnit({ ...base, node: '/n\tx' }), /control character/);
+  assert.throws(() => renderSystemdUnit({ ...base, path: '/p\n[Service]\nUser=root' }), /control character/);
+  // ...and the injected directive never appears in a rendered unit.
+  let unit = null;
+  try { unit = renderSystemdUnit({ ...base, configPath: '/cfg.json\nExecStartPre=/bin/evil' }); } catch { /* refused */ }
+  assert.equal(unit, null);
 });
 
 test('installing on launchd writes the plist and loads it', async () => {

--- a/test/session-id-ingress.test.js
+++ b/test/session-id-ingress.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, clientSessionId } from '../src/server.js';
+
+// x-claude-code-session-id is client-supplied and, unvalidated, became a Map
+// key in the session tracker (unbounded per client) and a column in the TUI
+// (Node's header parser lets C1 control bytes through). It is accepted only in
+// a conservative shape now; anything else is treated as no session at all,
+// which is what an untagged request already means.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+const UUID = '0f6b7f2a-1c3d-4e5f-8a9b-0c1d2e3f4a5b';
+
+async function withProxy(fn) {
+  const upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'k1' }], 0.98);
+  const started = [];
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'k' }, upstream: `http://127.0.0.1:${upstreamPort}` }, {
+    onRequestStart: (_id, info) => started.push(info.sessionId),
+  });
+  const port = await listen(proxy);
+  try {
+    await fn(port, started, am);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+// http.request: fetch validates header values against a narrower grammar than
+// Node's server accepts, and the point is what the server does with the rest.
+function post(port, sessionId) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1', port, method: 'POST', path: '/v1/messages',
+      headers: { 'content-type': 'application/json', 'x-api-key': 'k', 'x-claude-code-session-id': sessionId },
+    }, (res) => { res.resume(); res.on('end', () => resolve(res.statusCode)); });
+    req.on('error', reject);
+    req.end(JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }));
+  });
+}
+
+test('a UUID and a plain non-UUID tag are both tracked; malformed ones are not', async () => {
+  await withProxy(async (port, started) => {
+    assert.equal(await post(port, UUID), 200);
+    assert.equal(await post(port, 'sess-1'), 200);
+    assert.equal(await post(port, 'a b'), 200);                 // whitespace
+    assert.equal(await post(port, 'x'.repeat(129)), 200);       // over the length cap
+    assert.equal(await post(port, 'id '), 200);      // C1 bytes survive the header parser
+    assert.deepEqual(started, [UUID, 'sess-1', null, null, null]);
+  });
+});
+
+test('a malformed id leaves no trace in the session tracker', async () => {
+  await withProxy(async (port, _started, am) => {
+    assert.equal(await post(port, 'x'.repeat(2000)), 200);
+    const sessions = am.getStatus({ sessionDetail: true }).sessions;
+    const ids = (sessions?.items || []).map(s => s.id);
+    assert.ok(!ids.some(id => id && id.length > 128), `an oversized id was tracked: ${JSON.stringify(ids)}`);
+  });
+});
+
+test('clientSessionId: shape', () => {
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': UUID }), UUID);
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': 'sess_1.a-b' }), 'sess_1.a-b');
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': 'x'.repeat(128) }), 'x'.repeat(128));
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': 'x'.repeat(129) }), null);
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': '' }), null);
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': 'a/b' }), null);
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': 'ab' }), null);
+  assert.equal(clientSessionId({ 'x-claude-code-session-id': ['a', 'b'] }), null);
+  assert.equal(clientSessionId({}), null);
+});

--- a/test/session-tracker.test.js
+++ b/test/session-tracker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { SessionTracker, SESSION_KNOWN_TTL_MS, SESSION_ACTIVE_TTL_MS } from '../src/session-tracker.js';
+import { SessionTracker, SESSION_KNOWN_TTL_MS, SESSION_ACTIVE_TTL_MS, MAX_SESSIONS, MAX_SESSION_ID_LENGTH } from '../src/session-tracker.js';
 
 // The weekly buckets a pin is keyed by (see model.js weeklyBucketForModel).
 const SHARED = 'unified7d';
@@ -371,4 +371,64 @@ test('a request without labels does not erase the ones the session already has',
   const [row] = st.stats(clock.t, { detail: true }).items;
   assert.equal(row.client, 'alice');
   assert.deepEqual(row.dimensions, { project: 'p1' });
+});
+
+// The id is a client-supplied header. A client minting a new one per request
+// must not be able to grow the map for the whole known window.
+test('the session map is capped: a flood of unique ids evicts the idlest sessions', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  for (let i = 0; i < MAX_SESSIONS; i++) {
+    st.beginRequest(`flood-${i}`, clock.t);
+    st.endRequest(`flood-${i}`, clock.t);
+    clock.t += 1;
+  }
+  assert.equal(st.sessions.size, MAX_SESSIONS);
+  st.beginRequest('one-more', clock.t);
+  assert.equal(st.sessions.size, MAX_SESSIONS, 'the cap holds');
+  assert.equal(st.sessions.has('flood-0'), false, 'the session seen longest ago went first');
+  assert.equal(st.sessions.has('flood-1'), true);
+  assert.equal(st.sessions.has('one-more'), true);
+});
+
+test('the cap never evicts a session with a request in flight', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('streaming', clock.t); // oldest, but still running
+  clock.t += 1;
+  for (let i = 0; i < MAX_SESSIONS; i++) {
+    st.touch(`flood-${i}`, 0, SHARED, clock.t);
+    clock.t += 1;
+  }
+  assert.equal(st.sessions.has('streaming'), true, 'in-flight sessions are load, not garbage');
+  assert.equal(st.sessions.size, MAX_SESSIONS);
+});
+
+test('an over-long session id is keyed by its first MAX_SESSION_ID_LENGTH characters', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  const base = 'x'.repeat(MAX_SESSION_ID_LENGTH);
+  st.touch(base + '-tail-one', 3, SHARED, clock.t);
+  assert.equal(st.sessions.has(base), true);
+  assert.equal([...st.sessions.keys()][0].length, MAX_SESSION_ID_LENGTH);
+  // Every entry point keys the same way, so a long id round-trips through them.
+  assert.equal(st.pinnedAccount(base + '-tail-two', SHARED, clock.t), 3, 'the same prefix is the same session');
+  st.beginRequest(base + '-tail-three', clock.t);
+  assert.equal(st.sessions.get(base).inFlight, 1);
+  st.endRequest(base + '-tail-three', clock.t);
+  assert.equal(st.sessions.get(base).inFlight, 0);
+  assert.deepEqual(st.pinnedAccounts(base + '-tail-four', clock.t), [3]);
+  assert.equal(st.sessions.size, 1);
+});
+
+test('beginRequest sweeps expired sessions on the same throttle as touch', () => {
+  const { clock, now } = fixedClock();
+  const st = new SessionTracker({ now });
+  st.beginRequest('s1', clock.t);
+  st.endRequest('s1', clock.t);
+  clock.t += SESSION_KNOWN_TTL_MS + 1;
+  // A server whose requests all fail before routing only ever calls beginRequest.
+  st.beginRequest('s2', clock.t);
+  assert.equal(st.sessions.has('s1'), false, 'the idle session was shed without touch() or stats()');
+  assert.equal(st.sessions.size, 1);
 });

--- a/test/status-renderer.test.js
+++ b/test/status-renderer.test.js
@@ -368,3 +368,30 @@ test('accounts are listed in priority order, not config order', () => {
     .map(l => l.trim().replace(/^>\s*/, '').split(' ')[0]);
   assert.deepEqual(order, ['first', 'fallback', 'last-resort']);
 });
+
+// Every account and route string in the payload can have come off the wire
+// (`teamclaude status` against a running server) or out of an OAuth reply, and
+// the output is printed straight to the operator's terminal.
+test('renderStatus strips control characters out of account and route strings', () => {
+  const CLIP = '\x1b]52;c;aGVsbG8=\x07';
+  const status = sampleStatus();
+  status.currentAccount = `a${CLIP}`;
+  status.accounts[0].name = `a${CLIP}`;
+  status.accounts[0].orgName = `Org\x1b[2J\r\nforged`;
+  status.accounts[0].type = `oauth\x9b2J`;
+  status.accounts[0].status = `weird${CLIP}`;
+  status.accounts[0].unavailable = `custom\x1b[2Jreason`;
+  status.accounts[0].quota.spend = { enabled: false, usedMinor: 500, currency: 'USD', disabledReason: `out\x1b[2J` };
+  status.probe.accounts[0].status = `boom${CLIP}`;
+  status.routes = [{
+    name: 'r', match: [`*fable*${CLIP}`], bucket: `b\x1b[2J`, pinned: `a${CLIP}`,
+    accounts: [{ name: `a${CLIP}`, eligible: true }, { name: `b\x1b[2J`, eligible: false }],
+  }];
+
+  const output = renderStatus(status, { color: false, now });
+  assert.doesNotMatch(output, /[\x1b\x07\x9b\r]/);
+  assert.match(output, /^> a /m);           // still marked current after stripping
+  assert.match(output, /Blocked\s+custom/);
+  assert.match(output, /pinned: a/);
+  assert.equal(output.split('\n').filter(l => /forged/.test(l)).length, 1);   // no forged line
+});

--- a/test/storm-control.test.js
+++ b/test/storm-control.test.js
@@ -102,6 +102,28 @@ test('pauseAccount extends an existing pause, never shortens it', () => {
   assert.equal(am.accounts[0].pausedUntil, long);
 });
 
+// A Retry-After that did not parse reaches here as NaN (Math.max(NaN, 1) is
+// NaN). A NaN pause would arm a NaN ramp, _rampCap would return NaN, and admit()
+// would spin on `inFlight < NaN` forever.
+test('pauseAccount and markRateLimited ignore a non-finite or non-positive duration', async () => {
+  const am = new AccountManager([oauth('a')], 0.98, { ramp: { startConc: 1, stepConc: 1, stepMs: 10, windowMs: 100, pollMs: 5 } });
+  const acct = am.accounts[0];
+  for (const bad of [NaN, Infinity, -Infinity, 0, -5, undefined, 'soon']) {
+    am.pauseAccount(0, bad);
+    am.markRateLimited(0, bad);
+  }
+  assert.equal(acct.pausedUntil, null);
+  assert.equal(acct.rampStartedAt, null);
+  assert.equal(acct.rateLimitedUntil, null);
+  assert.equal(acct.status, 'active');
+  assert.equal(am._rampCap(acct), Infinity);
+  assert.equal(await am.admit(0), true, 'admit is not stuck');
+  am.release(0);
+
+  am.markRateLimited(0, 30);
+  assert.equal(acct.status, 'throttled', 'a real duration still holds');
+});
+
 test('admit holds a request during a pause, then admits once it lifts', async () => {
   const am = new AccountManager([oauth('a')], 0.98, {
     ramp: { startConc: 10, stepConc: 1, stepMs: 10, windowMs: 60_000, pollMs: 5 },

--- a/test/sx.test.js
+++ b/test/sx.test.js
@@ -5,7 +5,7 @@ import tls from 'node:tls';
 import http from 'node:http';
 import { once } from 'node:events';
 import { generateCertChain } from '../src/x509.js';
-import { connectThroughProxy, tunnelTls, SxManager } from '../src/sx.js';
+import { connectThroughProxy, tunnelTls, handshakeOverTunnel, SxManager } from '../src/sx.js';
 import { upstreamFetch } from '../src/upstream-fetch.js';
 
 const T = { timeout: 30000 };
@@ -270,4 +270,23 @@ test('SxManager.configure reports an error when provisioning fails', T, async ()
     assert.match(r.error, /create-port failed/);
     assert.equal(sx.isProvisioned(), false, 'not enabled when provisioning fails');
   } finally { delete process.env.SX_API_BASE; closeHard(api); }
+});
+
+// ── Handshake bound ──────────────────────────────────────────
+//
+// The CONNECT had a timer; the TLS handshake after it did not. A proxy that
+// answers 200 and then goes silent (or a target that never sends a ServerHello)
+// held the caller for ever, with every request queued behind it.
+test('the TLS handshake over a tunnel is bounded', T, async () => {
+  const silent = net.createServer(() => { /* accept, never speak */ });
+  const port = await listen(silent);
+  try {
+    const sock = net.connect(port, '127.0.0.1');
+    await once(sock, 'connect');
+    await assert.rejects(
+      handshakeOverTunnel(sock, { servername: 'localhost', timeout: 200 }),
+      /TLS handshake with localhost through the tunnel timed out after 200ms/,
+    );
+    assert.equal(sock.destroyed, true);
+  } finally { closeHard(silent); }
 });

--- a/test/sx.test.js
+++ b/test/sx.test.js
@@ -5,7 +5,7 @@ import tls from 'node:tls';
 import http from 'node:http';
 import { once } from 'node:events';
 import { generateCertChain } from '../src/x509.js';
-import { connectThroughProxy, tunnelTls, handshakeOverTunnel, SxManager } from '../src/sx.js';
+import { connectThroughProxy, tunnelTls, handshakeOverTunnel, sxBase, SxManager } from '../src/sx.js';
 import { upstreamFetch } from '../src/upstream-fetch.js';
 
 const T = { timeout: 30000 };
@@ -289,4 +289,27 @@ test('the TLS handshake over a tunnel is bounded', T, async () => {
     );
     assert.equal(sock.destroyed, true);
   } finally { closeHard(silent); }
+});
+
+// ── SX_API_BASE ──────────────────────────────────────────────
+//
+// The sx.org key rides in the query string, so the base URL decides whether it
+// crosses the network in the clear. An override is honoured only over https, or
+// over plain http to this machine (a test mock).
+test('SX_API_BASE must be https, or http to loopback', () => {
+  const warnings = [];
+  const warn = (m) => warnings.push(m);
+  assert.equal(sxBase({}, warn), 'https://api.sx.org');
+  assert.equal(sxBase({ SX_API_BASE: 'https://mock.example/' }, warn), 'https://mock.example');
+  assert.equal(sxBase({ SX_API_BASE: 'http://127.0.0.1:4321' }, warn), 'http://127.0.0.1:4321');
+  assert.equal(sxBase({ SX_API_BASE: 'http://localhost:4321' }, warn), 'http://localhost:4321');
+  assert.equal(warnings.length, 0);
+  for (const bad of ['http://api.sx.org', 'http://10.0.0.5:80', 'ftp://x', 'not a url']) {
+    assert.equal(sxBase({ SX_API_BASE: bad }, warn), 'https://api.sx.org', bad);
+  }
+  assert.equal(warnings.length, 4);
+  assert.match(warnings[0], /ignoring SX_API_BASE.*https/);
+  // Reported once per value, not once per request.
+  sxBase({ SX_API_BASE: 'not a url' }, warn);
+  assert.equal(warnings.length, 4);
 });

--- a/test/third-party-backend.test.js
+++ b/test/third-party-backend.test.js
@@ -135,3 +135,14 @@ test('rewriteModel passes through a JSON body that has no model field', () => {
   const out = rewriteModel(body, modelMap);
   assert.equal(out, body);
 });
+
+// The map is a plain object, so a client-chosen model name that is also a
+// prototype property ("constructor") used to look up a function, which
+// JSON.stringify drops — the request went upstream with no model at all.
+test('rewriteModel ignores prototype properties as model names', () => {
+  for (const name of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+    const body = Buffer.from(JSON.stringify({ model: name, max_tokens: 1 }));
+    const out = rewriteModel(body, modelMap);
+    assert.equal(out, body, `${name} must pass through unchanged`);
+  }
+});

--- a/test/token-response.test.js
+++ b/test/token-response.test.js
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import {
+  tokenPairFromResponse, normalizeExpiresAt, isTokenExpired, isTokenExpiringSoon, refreshAccessToken,
+} from '../src/oauth.js';
+import { credentialsFromTokenResponse, refreshCodexToken } from '../src/codex-auth.js';
+
+// A 200 from the token endpoint is not proof its body is usable. One without
+// an access_token used to be stored as `accessToken: undefined` (sent upstream
+// as `Bearer undefined`), and a non-numeric expiry was stored as-is, where the
+// expiry checks never fired on it.
+
+const NOW = 1_700_000_000_000;
+
+test('a token response without a usable access_token is an error, not undefined', () => {
+  for (const body of [{}, { access_token: '' }, { access_token: 42 }, { access_token: null }, null]) {
+    assert.throws(() => tokenPairFromResponse(body, { now: NOW }), /no access_token/, JSON.stringify(body));
+  }
+});
+
+test('the refresh token is taken only as a non-empty string, else the previous one is kept', () => {
+  const prev = 'old-rt';
+  assert.equal(tokenPairFromResponse({ access_token: 'at', refresh_token: 'new-rt' }, { previousRefreshToken: prev }).refreshToken, 'new-rt');
+  for (const rt of [undefined, '', 7, null]) {
+    assert.equal(tokenPairFromResponse({ access_token: 'at', refresh_token: rt }, { previousRefreshToken: prev }).refreshToken, prev);
+  }
+  // The code-exchange path has no previous token to fall back to.
+  assert.equal(tokenPairFromResponse({ access_token: 'at' }).refreshToken, undefined);
+});
+
+test('the expiry is a number: expires_at in seconds or ms, else expires_in, else an hour', () => {
+  const at = (body) => tokenPairFromResponse({ access_token: 'at', ...body }, { now: NOW }).expiresAt;
+  assert.equal(at({ expires_at: 1_700_003_600 }), 1_700_003_600_000);        // seconds → ms
+  assert.equal(at({ expires_at: 1_700_003_600_000 }), 1_700_003_600_000);    // already ms
+  assert.equal(at({ expires_at: '1700003600' }), 1_700_003_600_000);         // numeric string coerced
+  assert.equal(at({ expires_in: 600 }), NOW + 600_000);
+  assert.equal(at({ expires_in: '600' }), NOW + 600_000);
+  // Absent or garbage: one hour, so the next refresh merely happens early.
+  assert.equal(at({}), NOW + 3_600_000);
+  assert.equal(at({ expires_at: 'soon' }), NOW + 3_600_000);
+  assert.equal(at({ expires_at: 'soon', expires_in: 'later' }), NOW + 3_600_000);
+  assert.equal(at({ expires_in: -5 }), NOW + 3_600_000);
+  assert.equal(at({ expires_at: {}, expires_in: NaN }), NOW + 3_600_000);
+  for (const body of [{}, { expires_at: 'x' }, { expires_in: 'y' }]) {
+    assert.equal(typeof at(body), 'number', JSON.stringify(body));
+  }
+});
+
+test('normalizeExpiresAt yields null, not the input, for a value that is not a number', () => {
+  assert.equal(normalizeExpiresAt('soon'), null);
+  assert.equal(normalizeExpiresAt(undefined), null);
+  assert.equal(normalizeExpiresAt(null), null);
+  assert.equal(normalizeExpiresAt(-1), null);
+  assert.equal(normalizeExpiresAt(1_700_000_000), 1_700_000_000_000);
+  assert.equal(normalizeExpiresAt('1700000000000'), 1_700_000_000_000);
+});
+
+test('an expiry that is present but unusable counts as reached; a missing one as unknown', () => {
+  // Before, `Date.now() >= 'soon'` was false forever, so the token was never refreshed.
+  assert.equal(isTokenExpired('soon'), true);
+  assert.equal(isTokenExpiringSoon('soon'), true);
+  assert.equal(isTokenExpired(undefined), false);
+  assert.equal(isTokenExpiringSoon(null), false);
+  assert.equal(isTokenExpired(Date.now() + 60_000), false);
+  assert.equal(isTokenExpired(Date.now() - 60_000), true);
+});
+
+test('a Codex token response is checked the same way', () => {
+  assert.throws(() => credentialsFromTokenResponse({ refresh_token: 'rt' }), /no access_token/);
+  const creds = credentialsFromTokenResponse({ access_token: 'at', refresh_token: 'rt', expires_in: 'bogus' });
+  assert.equal(creds.accessToken, 'at');
+  assert.equal(typeof creds.expiresAt, 'number');
+  assert.ok(creds.expiresAt > Date.now());
+});
+
+// The live refresh paths: a 200 with an empty body rejects instead of handing
+// back a credential with no token in it.
+async function tokenServer(body) {
+  const srv = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  await new Promise(r => srv.listen(0, '127.0.0.1', r));
+  return { srv, endpoint: `http://127.0.0.1:${srv.address().port}/token` };
+}
+
+test('refreshAccessToken rejects a 200 that carries no access_token', async () => {
+  const { srv, endpoint } = await tokenServer({ token_type: 'Bearer' });
+  try {
+    await assert.rejects(refreshAccessToken('r', endpoint), /no access_token/);
+  } finally {
+    srv.close();
+  }
+});
+
+test('refreshAccessToken keeps the previous refresh token and numbers the expiry', async () => {
+  const { srv, endpoint } = await tokenServer({ access_token: 'AT', expires_in: '120' });
+  try {
+    const t = await refreshAccessToken('r', endpoint);
+    assert.equal(t.accessToken, 'AT');
+    assert.equal(t.refreshToken, 'r');
+    assert.ok(Number.isFinite(t.expiresAt) && t.expiresAt > Date.now());
+  } finally {
+    srv.close();
+  }
+});
+
+test('refreshCodexToken rejects a 200 that carries no access_token', async () => {
+  const { srv, endpoint } = await tokenServer({});
+  try {
+    await assert.rejects(refreshCodexToken('r', endpoint), /no access_token/);
+  } finally {
+    srv.close();
+  }
+});

--- a/test/tui-accounts.test.js
+++ b/test/tui-accounts.test.js
@@ -314,3 +314,20 @@ test('a probe interval over seven days is refused, not scheduled', async () => {
   assert.equal(config.quotaProbeSeconds, 604800);
 });
 
+
+// The footer echoes the prompt buffer while it is typed. For a key, that echo
+// is the key in clear on a screen that is often shared.
+test('an API key being typed is masked in the footer', () => {
+  const { tui } = makeTUI();
+  openSettingsRow(tui, 'addAccount');
+  tui._key('k');
+  type(tui, 'sk-secret');
+  const footer = tui._renderFooter().replace(/\x1b\[[0-9;]*m/g, '');
+  assert.doesNotMatch(footer, /sk-secret/);
+  assert.match(footer, /API key: \*{9}█/);
+  tui._key('esc');
+  // The next, ordinary prompt echoes again.
+  tui._promptInput('Switch threshold (%)', () => {});
+  type(tui, '95');
+  assert.match(tui._renderFooter(), /95█/);
+});

--- a/test/tui-accounts.test.js
+++ b/test/tui-accounts.test.js
@@ -299,3 +299,18 @@ test('import stores quota tier metadata returned by the OAuth profile', async ()
     accessToken: 'fresh', refreshToken: 'r', expiresAt,
   });
 });
+
+// Node's setInterval takes a 32-bit millisecond delay; an interval past
+// 2,147,483 s overflows it and the probe fires every millisecond instead.
+test('a probe interval over seven days is refused, not scheduled', async () => {
+  const { tui, config } = makeTUI();
+  config.quotaProbeSeconds = 300;
+  await tui._doSetProbe('2147484');
+  assert.equal(config.quotaProbeSeconds, 300);
+  assert.ok(tui.log.some(l => /at most 604800s/.test(l.msg)), 'the refusal is logged');
+  assert.equal(tui.mode, 'settings');
+  // The ceiling itself is accepted.
+  await tui._doSetProbe('604800');
+  assert.equal(config.quotaProbeSeconds, 604800);
+});
+

--- a/test/tui-hostile-input.test.js
+++ b/test/tui-hostile-input.test.js
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TUI, truncate, scrubLine } from '../src/tui.js';
+
+// Values the dashboard draws that did not come from the operator: the model
+// string a client put in its request body, the request path, the session-id
+// header. Each is repainted from the activity list every frame for as long as
+// the entry lives, so an escape sequence that survives ingress fires again on
+// every tick — an OSC 52 clipboard write or a screen clear, two hundred times.
+
+const CLIP = '\x1b]52;c;aGVsbG8=\x07';   // OSC 52: write the clipboard
+const CLEAR = '\x1b[2J';                 // CSI: erase the screen
+const HOSTILE_MODEL = `claude-${CLIP}${CLEAR}\x9b2J\x07evil`;
+
+export function makeTUI() {
+  const am = {
+    accounts: [{ name: 'a', index: 0, type: 'oauth', quota: {}, status: 'active' }],
+    currentIndex: 0, switchThreshold: 0.98,
+    getRoutes() { return []; },
+    sessionStats() { return { active: 0, known: 0 }; },
+    refreshExpiredQuotas() {},
+    thresholdFor() { return 0.98; },
+  };
+  const tui = new TUI({
+    accountManager: am, config: { proxy: { port: 1 }, accounts: [], routes: [] }, sx: null,
+    saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {}, probeQuota: () => {},
+  });
+  return tui;
+}
+
+/** One full frame, ANSI colour left in place so the assertions can look for
+ * the escapes that must NOT be there. */
+export function renderRaw(tui) {
+  const cols = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+  const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+  Object.defineProperty(process.stdout, 'columns', { value: 120, configurable: true });
+  Object.defineProperty(process.stdout, 'rows', { value: 30, configurable: true });
+  let frame = '';
+  try {
+    tui._paint = buf => { frame = buf; };
+    tui.running = true;
+    tui._render(true);
+  } finally {
+    if (cols) Object.defineProperty(process.stdout, 'columns', cols);
+    if (rows) Object.defineProperty(process.stdout, 'rows', rows);
+  }
+  return frame;
+}
+
+const stripSgr = s => s.replace(/\x1b\[[0-9;]*m/g, '');
+// Everything the frame is allowed to contain by way of escapes: the cursor-home
+// prefix, the SGR colour, and the show/hide-cursor toggle. Anything else is a
+// value that leaked through.
+const allowedEscapes = frame => stripSgr(frame).replace(/\x1b\[H|\x1b\[\?25[hl]/g, '');
+
+test('a hostile model string is drawn without its escapes, in flight and in the log', () => {
+  const tui = makeTUI();
+  tui.onRequestStart('r1', { method: 'POST', path: '/v1/messages', sessionId: 'abc123def', pinned: false });
+  tui.onRequestModel('r1', { model: HOSTILE_MODEL });
+
+  const live = renderRaw(tui);
+  assert.doesNotMatch(allowedEscapes(live), /[\x1b\x07\x9b]/);
+  assert.match(live, /claude-/);
+
+  tui.onRequestEnd('r1', { method: 'POST', path: '/v1/messages', account: 'a', status: 200, model: HOSTILE_MODEL, sessionId: 'abc123def' });
+  assert.equal(tui.active.size, 0);
+  assert.doesNotMatch(stripSgr(tui.log[0].msg), /[\x1b\x07\x9b]/);
+  assert.match(tui.log[0].msg, /claude-/);
+
+  const done = renderRaw(tui);
+  assert.doesNotMatch(allowedEscapes(done), /[\x1b\x07\x9b]/);
+});
+
+test('the request path and method are cut down on ingress too', () => {
+  const tui = makeTUI();
+  tui.onRequestStart('r1', { method: `POST${CLEAR}`, path: `/v1/${CLIP}messages\r\nforged`, sessionId: null });
+  const r = tui.active.get('r1');
+  assert.equal(r.method, 'POST');
+  assert.doesNotMatch(r.path, /[\x1b\x07\r\n]/);
+  assert.match(r.path, /forged/);
+  // Long paths are clamped so one request cannot claim the whole row.
+  tui.onRequestStart('r2', { method: 'GET', path: '/' + 'x'.repeat(5000), sessionId: null });
+  assert.ok(tui.active.get('r2').path.length <= 256);
+});
+
+// _addLog is also fed lines the TUI composed itself, colour included. The
+// colour has to stay; only the foreign escapes go.
+test('_addLog keeps its own colour and drops every other escape', () => {
+  const tui = makeTUI();
+  tui._addLog(`\x1b[36mtag\x1b[0m ${CLIP}${CLEAR}done`);
+  assert.equal(tui.log[0].msg, '\x1b[36mtag\x1b[0m done');
+});
+
+test('scrubLine and truncate refuse non-SGR escapes', () => {
+  assert.equal(scrubLine(`a${CLIP}b${CLEAR}c\x9bd\x07e`), 'abcde');
+  assert.equal(scrubLine('\x1b]0;title\x1b\\x'), 'x');   // OSC with an ST terminator
+  const cut = truncate(`\x1b[31m${CLIP}red${CLEAR}\x07`, 20);
+  assert.doesNotMatch(stripSgr(cut), /[\x1b\x07]/);
+  assert.match(cut, /^\x1b\[31m/);
+});
+
+// The session id is a client header. Node's parser passes C1 bytes through, and
+// U+009B alone is a CSI introducer, so only an id of the shape Claude Code sends
+// is shown as-is.
+test('a session id outside the safe shape is not drawn raw', () => {
+  const tui = makeTUI();
+  tui.onRequestEnd('r1', { method: 'POST', path: '/v1/messages', account: 'a', status: 200, model: null, sessionId: '\x9b2Jab\x1b[2Jcdef' });
+  const plain = stripSgr(tui.log[0].msg);
+  assert.doesNotMatch(plain, /[\x1b\x9b]/);
+  assert.match(plain, /2Jab/);   // what is left of it, shortened, still identifies the row
+  // The normal shape is untouched.
+  tui.onRequestEnd('r2', { method: 'POST', path: '/v1/messages', account: 'a', status: 200, model: null, sessionId: 'f00dbeef-1234' });
+  assert.match(stripSgr(tui.log[0].msg), /f00dbe /);
+});

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -621,3 +621,106 @@ test('attach mode does not present an activity stream it cannot see', async (t) 
   const out = renderToString(tui);
   assert.doesNotMatch(out, /Activity/);
 });
+
+// ── hostile payloads ─────────────────────────────────────────
+
+// Whatever answers on the configured port writes these strings, and the
+// dashboard draws them into the frame every second. A number where a name was
+// expected used to throw inside the renderer and end the poll loop; an escape
+// sequence in any of them reached the terminal as-is.
+const CLIP = '\x1b]52;c;aGVsbG8=\x07';
+const hostileStatus = () => statusFixture({
+  currentAccount: `alpha${CLIP}`,
+  routes: [{
+    name: 5, match: [`*fable*${CLIP}`, 7], bucket: `\x1b[2Jbkt`, color: ['red'],
+    pinned: `alpha${CLIP}`, target: { x: 1 },
+    accounts: [{ name: 9, eligible: 'yes' }, { name: `bravo\x1b[2J`, eligible: true }],
+  }],
+  accounts: [
+    { name: 5, type: { evil: true }, status: `active${CLIP}\r\nforged`, orgName: `org\x1b[2J`, quota: {} },
+    { name: `alpha${CLIP}`, type: `oauth\x9b2J`, status: 'active', unavailable: `disabled${CLIP}`, quota: {} },
+    { name: 'x'.repeat(500), type: 'oauth', status: 'active', quota: {} },
+  ],
+});
+
+test('a hostile status payload is coerced and stripped before it is drawn', async (t) => {
+  const { tui, am } = await makeSession(t);
+  am.applyStatus(hostileStatus());
+
+  // sanitizeText drops the control bytes and keeps the printable remainder, so
+  // an OSC payload survives as harmless text; what matters is that no ESC/BEL/C1
+  // does, and that a non-string became a string rather than an exception.
+  const noControls = v => assert.doesNotMatch(v, /[\x1b\x07\x9b\r\n]/);
+  assert.equal(am.accounts[0].name, '5');
+  assert.match(am.accounts[1].name, /^alpha/);
+  assert.equal(am.accounts[2].name, 'x'.repeat(64));
+  assert.equal(am.accounts[0].type, '?');           // an object is not a type
+  assert.match(am.accounts[0].status, /^active /);   // stripped, then capped at 16
+  assert.match(am.accounts[1].type, /^oauth/);
+  assert.equal(am.currentIndex, 1);                 // the stripped current name still matches
+  assert.equal(am.routes[0].name, '5');
+  assert.equal(am.routes[0].match[1], '7');
+  assert.deepEqual(am.routes[0].accounts.map(a => a.eligible), [true, true]);
+  assert.equal(am.routes[0].accounts[0].name, '9');
+  for (const a of am.accounts) for (const k of ['name', 'type', 'status', 'orgName', 'unavailable']) if (a[k]) noControls(a[k]);
+  for (const r of am.routes) {
+    for (const k of ['name', 'bucket', 'color', 'pinned', 'target']) if (r[k]) noControls(r[k]);
+    r.match.forEach(noControls);
+    r.accounts.forEach(a => noControls(a.name));
+  }
+
+  const chunks = [];
+  const orig = process.stdout.write;
+  process.stdout.write = chunk => { chunks.push(chunk); return true; };
+  try { tui.running = true; tui._render(true); } finally { process.stdout.write = orig; }
+  // Only the frame's own escapes may remain: cursor home, SGR colour, cursor toggle.
+  const foreign = chunks.join('').replace(/\x1b\[[0-9;]*m/g, '').replace(/\x1b\[H|\x1b\[\?25[hl]/g, '');
+  assert.doesNotMatch(foreign, /[\x1b\x07\x9b]/);
+});
+
+test('a poll that delivers a hostile payload keeps polling', async (t) => {
+  const { session, am, tui } = await makeSession(t, {
+    routes: { 'GET /teamclaude/status': json(hostileStatus()) },
+  });
+  await session.poll();
+  assert.equal(am.connected, true);
+  assert.equal(tui.log.length, 0);   // no "lost contact": the payload was rendered, not thrown on
+});
+
+test('the name a switch reply echoes is stripped before it is logged', async (t) => {
+  const { tui, am } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/switch': json({ ok: true, account: `alpha${CLIP}\x1b[2J` }),
+    },
+  });
+  am.applyStatus(statusFixture());
+  tui._key('s');
+  tui._key('enter');
+  await logged(tui);
+  assert.doesNotMatch(tui.log[0].msg, /[\x1b\x07]/);
+  assert.match(tui.log[0].msg, /Switched to "alpha/);
+});
+
+test('an error reason off the wire is stripped and clamped', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': json(statusFixture()),
+      'POST /teamclaude/reload': json({ ok: false, error: `nope${CLIP}\x1b[2J${'y'.repeat(500)}` }),
+      'POST /teamclaude/switch': (req, res) => {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: `no such account${CLIP}` }));
+      },
+    },
+  });
+  await assert.rejects(() => control.reload(), err => {
+    assert.doesNotMatch(err.message, /[\x1b\x07]/);
+    assert.ok(err.message.length <= 200);
+    return /^nope/.test(err.message);
+  });
+  await assert.rejects(() => control.switchAccount('ghost'), err => {
+    assert.equal(err.answered, true);
+    assert.doesNotMatch(err.message, /[\x1b\x07]/);
+    return /^no such account/.test(err.message);
+  });
+});

--- a/test/tui-remote.test.js
+++ b/test/tui-remote.test.js
@@ -724,3 +724,41 @@ test('an error reason off the wire is stripped and clamped', async (t) => {
     return /^no such account/.test(err.message);
   });
 });
+
+// ── reply size ───────────────────────────────────────────────
+
+// The poller runs every second against whatever listens on the configured
+// port. A status payload is a few KiB; a body that is not must not be buffered
+// whole, whether it announces its size or streams it.
+test('a reply that declares itself oversized is refused before it is read', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': String(2 * 1024 * 1024) });
+        res.write('{"accounts":[');   // never finishes; the client must not wait for it
+      },
+    },
+  });
+  await assert.rejects(() => control.status(), /too large/);
+});
+
+test('a chunked reply is abandoned once it passes the cap', async (t) => {
+  const { control } = await makeSession(t, {
+    routes: {
+      'GET /teamclaude/status': (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });   // chunked: no length
+        const chunk = 'x'.repeat(64 * 1024);
+        for (let i = 0; i < 24; i++) res.write(chunk);   // 1.5 MiB
+        res.end(']');
+      },
+    },
+  });
+  await assert.rejects(() => control.status(), /too large/);
+});
+
+test('a reply under the cap is read whole', async (t) => {
+  const big = statusFixture({ note: 'y'.repeat(200 * 1024) });
+  const { control } = await makeSession(t, { routes: { 'GET /teamclaude/status': json(big) } });
+  const status = await control.status();
+  assert.equal(status.note.length, 200 * 1024);
+});

--- a/test/tui-settings.test.js
+++ b/test/tui-settings.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { TUI } from '../src/tui.js';
+import { TUI, maskKey } from '../src/tui.js';
 
 // The settings screen keeps two lists in step: _settingsFields() drives the
 // cursor (↑↓ walk it, ←→/Enter act on the current entry) and _renderSettings()
@@ -62,4 +62,21 @@ test('settings: sx.org rows are drawn once an sx client exists', () => {
     assert.ok(text.includes(fields[i].label),
       `"${fields[i].label}" is reachable with the cursor but never drawn`);
   }
+});
+
+// first-4 + last-4 of a key eight characters long is the whole key.
+test('a short sx.org key is not shown whole by its mask', () => {
+  assert.equal(maskKey('sk-ant-api03-abcdefgh'), 'sk-a…efgh');
+  assert.equal(maskKey('12345678'), '…5678');
+  assert.equal(maskKey('abcd'), '****');
+  const sx = { getMode: () => 'always', getBalance: () => null, configure: async () => ({ ok: true }) };
+  const tui = makeTUI({ sx });
+  tui.config.sx = { apiKey: 'short-key', mode: 'always' };
+  const row = tui._settingsFields().find(f => f.id === 'sxkey');
+  const shown = stripAnsi(row.value());
+  assert.doesNotMatch(shown, /short-key/);
+  assert.equal(shown, '…-key');
+  // The prompt it opens is a masked one.
+  row.enter();
+  assert.equal(tui.inputSecret, true);
 });

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  compareVersions, installKind, fetchLatestVersion, checkForUpdate, runUpdate, PKG_NAME,
+  compareVersions, installKind, fetchLatestVersion, checkForUpdate, runUpdate, autoUpdate, isReleaseVersion, PKG_NAME,
 } from '../src/updater.js';
 
 // ── compareVersions ─────────────────────────────────────────
@@ -110,4 +110,85 @@ test('runUpdate invokes the global npm install for the requested version', () =>
 test('runUpdate returns false when npm fails', () => {
   assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ status: 1 }) }), false);
   assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ error: new Error('ENOENT') }) }), false);
+});
+
+// ── the registry's "latest" is a string from the network ─────
+
+// compareVersions parses what it can, so "99.0.0 || npm:evil" reads as newer
+// than anything installed and used to go straight into `npm install -g`.
+test('isReleaseVersion accepts only x.y.z', () => {
+  for (const v of ['1.2.3', '0.0.1', '10.20.30']) assert.equal(isReleaseVersion(v), true, v);
+  for (const v of ['99.0.0 || npm:evil', '1.2', '1.2.3-beta.1', 'latest', ' 1.2.3', '1.2.3\n', '', null, undefined, 'v1.2.3']) {
+    assert.equal(isReleaseVersion(v), false, String(v));
+  }
+});
+
+test('runUpdate spawns nothing for a version that is not a release version', () => {
+  const calls = [];
+  const spawnImpl = (cmd, argv) => { calls.push([cmd, argv]); return { status: 0 }; };
+  assert.equal(runUpdate('99.0.0 || npm:evil', { spawnImpl }), false);
+  assert.equal(runUpdate('1.2.3-beta.1', { spawnImpl }), false);
+  assert.equal(calls.length, 0);
+  // The literal tag the manual fallback uses is still fine.
+  assert.equal(runUpdate('latest', { spawnImpl }), true);
+});
+
+// ── autoUpdate guards ────────────────────────────────────────
+
+/** A package root that is not a git checkout, so autoUpdate gets past its first check. */
+function nonGitRoot() {
+  return mkdtempSync(join(tmpdir(), 'tc-root-'));
+}
+
+test('autoUpdate skips a malformed registry version with a log line and installs nothing', async () => {
+  const root = nonGitRoot();
+  const logs = [];
+  let installed = 0;
+  try {
+    const res = await autoUpdate({
+      root, uid: 1000, log: (m) => logs.push(m),
+      check: async () => ({ current: '1.0.0', latest: '99.0.0 || npm:evil', updateAvailable: true }),
+      kind: () => 'global',
+      install: () => { installed++; return true; },
+    });
+    assert.equal(res.skipped, 'bad-version');
+    assert.equal(installed, 0);
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /not a release version/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('autoUpdate still installs a well-formed newer version for a global install', async () => {
+  const root = nonGitRoot();
+  const installs = [];
+  try {
+    const res = await autoUpdate({
+      root, uid: 1000, log: () => {},
+      check: async () => ({ current: '1.0.0', latest: '2.0.0', updateAvailable: true }),
+      kind: () => 'global',
+      install: (v) => { installs.push(v); return true; },
+    });
+    assert.equal(res.updated, true);
+    assert.deepEqual(installs, ['2.0.0']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// `sudo teamclaude server` would otherwise run `npm install -g` as root every
+// day, off a version string fetched from the network.
+test('autoUpdate never runs as root, and says so once', async () => {
+  const root = nonGitRoot();
+  const logs = [];
+  let checked = 0;
+  try {
+    const opts = {
+      root, uid: 0, log: (m) => logs.push(m),
+      check: async () => { checked++; return { current: '1.0.0', latest: '2.0.0', updateAvailable: true }; },
+      kind: () => 'global',
+      install: () => { throw new Error('must not install as root'); },
+    };
+    assert.equal((await autoUpdate(opts)).skipped, 'root');
+    assert.equal((await autoUpdate(opts)).skipped, 'root');
+    assert.equal(checked, 0, 'the registry is not even consulted');
+    assert.equal(logs.filter(l => /root/.test(l)).length, 1, 'warned exactly once across calls');
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/upstream-credential-hygiene.test.js
+++ b/test/upstream-credential-hygiene.test.js
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer } from '../src/server.js';
+
+// What travels upstream on each path, credential-wise. The proxy replaces the
+// client's credential with a fleet account's on the inference path, and relays
+// the client's OWN bearer on the identity-bound paths; on neither must a
+// credential that belongs to someone else leak through. A per-account
+// `upstream` can be a third-party host, so "someone else" includes the client's
+// Anthropic OAuth token and the operator's proxy key.
+
+function listen(server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// An upstream that records the request headers it received.
+function recordingUpstream() {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    seen.push({ url: req.url, headers: req.headers });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  return { server, seen };
+}
+
+async function withProxy(accounts, fn) {
+  const { server: upstream, seen } = recordingUpstream();
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager(accounts, 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'tc-proxy-key' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+  try {
+    await fn(port, seen);
+  } finally {
+    proxy.close();
+    upstream.close();
+  }
+}
+
+test('an API-key account replaces the client credential; the client bearer does not reach upstream', async () => {
+  await withProxy([{ name: 'a', type: 'apikey', apiKey: 'sk-account-key' }], async (port, seen) => {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'tc-proxy-key',
+        // Claude Code sends its own OAuth bearer alongside; the proxy must
+        // swap it for the account's credential, not forward both.
+        authorization: 'Bearer client-anthropic-oauth-token',
+      },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(seen.length, 1);
+    const { headers } = seen[0];
+    assert.equal(headers['x-api-key'], 'sk-account-key');
+    assert.equal(headers.authorization, undefined, 'the client bearer must not be forwarded');
+  });
+});
+
+test('an OAuth account replaces the client bearer and sends no x-api-key', async () => {
+  await withProxy([{ name: 'a', type: 'oauth', accessToken: 'acct-token', refreshToken: 'r', expiresAt: Date.now() + 3600_000 }], async (port, seen) => {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'tc-proxy-key',
+        authorization: 'Bearer client-anthropic-oauth-token',
+      },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', messages: [] }),
+    });
+    assert.equal(res.status, 200);
+    const { headers } = seen[0];
+    assert.equal(headers.authorization, 'Bearer acct-token');
+    assert.equal(headers['x-api-key'], undefined, 'the proxy key must not be forwarded');
+  });
+});

--- a/test/upstream-credential-hygiene.test.js
+++ b/test/upstream-credential-hygiene.test.js
@@ -78,3 +78,54 @@ test('an OAuth account replaces the client bearer and sends no x-api-key', async
     assert.equal(headers['x-api-key'], undefined, 'the proxy key must not be forwarded');
   });
 });
+
+// The identity-bound paths relay the client's own bearer untouched — and must
+// still not relay the key the client used to authenticate to THIS proxy.
+test('relayStream (/v1/code/*) keeps the client bearer and drops the proxy key', async () => {
+  await withProxy([{ name: 'a', type: 'apikey', apiKey: 'sk-account-key' }], async (port, seen) => {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/code/sessions/abc/worker/events`, {
+      headers: { 'x-api-key': 'tc-proxy-key', authorization: 'Bearer client-own-token' },
+    });
+    assert.equal(res.status, 200);
+    const { headers } = seen[0];
+    assert.equal(headers.authorization, 'Bearer client-own-token');
+    assert.equal(headers['x-api-key'], undefined, 'the proxy key must not be relayed');
+  });
+});
+
+test('relayUpgrade keeps the client bearer and drops the proxy key on the handshake', async () => {
+  const upstream = http.createServer(() => {});
+  const handshakes = [];
+  upstream.on('upgrade', (req, socket) => {
+    handshakes.push(req.headers);
+    socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n');
+    socket.end();
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'sk-account-key' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'tc-proxy-key' }, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+  try {
+    const status = await new Promise((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1', port, path: '/v1/session_ingress/ws/abc',
+        headers: {
+          connection: 'Upgrade', upgrade: 'websocket',
+          'x-api-key': 'tc-proxy-key', authorization: 'Bearer client-own-token',
+        },
+      });
+      req.on('upgrade', (res, socket) => { socket.destroy(); resolve(res.statusCode); });
+      req.on('response', (res) => resolve(res.statusCode));
+      req.on('error', reject);
+      req.end();
+    });
+    assert.equal(status, 101);
+    assert.equal(handshakes.length, 1);
+    assert.equal(handshakes[0].authorization, 'Bearer client-own-token');
+    assert.equal(handshakes[0]['x-api-key'], undefined, 'the proxy key must not be relayed');
+  } finally {
+    proxy.close();
+    upstream.close();
+    upstream.closeAllConnections();
+  }
+});

--- a/test/upstream-header-hardening.test.js
+++ b/test/upstream-header-hardening.test.js
@@ -1,0 +1,152 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+
+// Rate-limit headers come from whatever `upstream` points at, and the model name
+// comes from the client's request body. Neither is ours: a value that does not
+// parse must not wedge a bucket, and a string must not reach a log or a status
+// line carrying a terminal escape.
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+const codex = (name) => oauth(name, { provider: 'codex', accountId: 'acct-' + name });
+
+// Capture console.log for one call.
+function captureLog(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try { fn(); } finally { console.log = orig; }
+  return lines;
+}
+
+// ── reset headers that do not parse ─────────────────────────
+
+test('an unparseable 5h reset is ignored, so the bucket still clears on the reset we knew', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  const past = Math.floor((Date.now() + 1000) / 1000); // a reset just ahead of us
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-5h-utilization': '1',
+    'anthropic-ratelimit-unified-5h-reset': String(past),
+  });
+  assert.equal(am.accounts[0].quota.unified5hReset, past * 1000);
+
+  // A later response from a lying upstream: `never` used to become NaN here,
+  // and `now >= NaN` is never true, so the bucket could not be cleared again.
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-5h-utilization': '1',
+    'anthropic-ratelimit-unified-5h-reset': 'never',
+  });
+  assert.equal(am.accounts[0].quota.unified5hReset, past * 1000, 'the valid reset survives');
+  assert.equal(am._isNearQuota(am.accounts[0]), true, 'still spent before the reset');
+
+  am.accounts[0].quota.unified5hReset = Date.now() - 1; // the window rolls over
+  assert.equal(am._isNearQuota(am.accounts[0]), false, 'and the bucket clears');
+  assert.equal(am.accounts[0].quota.unified5h, null);
+});
+
+test('reset headers are stored only as positive finite numbers, never NaN', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-5h-reset': 'never',
+    'anthropic-ratelimit-unified-7d-reset': '-5',
+    'anthropic-ratelimit-unified-7d_oi-reset': 'NaN',
+    'anthropic-ratelimit-tokens-reset': 'tomorrow-ish',
+  });
+  const q = am.accounts[0].quota;
+  assert.equal(q.unified5hReset, null);
+  assert.equal(q.unified7dReset, null);
+  assert.equal(q.unified7dFableReset, null);
+  assert.equal(q.resetsAt, null);
+
+  am.updateQuota(0, {
+    'anthropic-ratelimit-unified-5h-reset': '1900000000',
+    'anthropic-ratelimit-tokens-reset': '2030-01-01T00:00:00Z',
+  });
+  assert.equal(q.unified5hReset, 1900000000 * 1000);
+  assert.equal(q.resetsAt, '2030-01-01T00:00:00Z');
+});
+
+// ── header-derived strings ───────────────────────────────────
+
+test('unified-status is stripped of escapes and bounded before it is stored', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.updateQuota(0, { 'anthropic-ratelimit-unified-status': 'rejected\x1b[2J\n' + 'x'.repeat(100) });
+  const status = am.accounts[0].quota.unifiedStatus;
+  assert.equal(/[\x00-\x1f\x7f]/.test(status), false, 'no control characters');
+  assert.ok(status.startsWith('rejected'));
+  assert.ok(status.length <= 32);
+});
+
+test('a plain unified-status is stored as-is and still acted on', () => {
+  const am = new AccountManager([oauth('a')], 0.98);
+  am.updateQuota(0, { 'anthropic-ratelimit-unified-status': 'rejected' });
+  assert.equal(am.accounts[0].quota.unifiedStatus, 'rejected');
+  assert.equal(am.unavailableReason(am.accounts[0]), 'upstream-rejected');
+});
+
+test('codex plan type and bucket names are stripped of escapes', () => {
+  const am = new AccountManager([codex('c')], 0.98);
+  am.updateQuota(0, {
+    'x-codex-plan-type': 'pro\x1b[31m',
+    'x-codex-fox-primary-used-percent': '10',
+    'x-codex-fox-primary-window-minutes': '10080',
+    'x-codex-fox-limit-name': 'GPT\x1b[1;1H-Spark',
+  });
+  const q = am.accounts[0].quota;
+  assert.equal(q.planType, 'pro');
+  assert.equal(q.codexModelBuckets.fox.name, 'GPT -Spark');
+});
+
+test('codex model buckets are capped: the reading refreshed longest ago makes room', () => {
+  const am = new AccountManager([codex('c')], 0.98);
+  const headersFor = (slug) => ({
+    [`x-codex-${slug}-primary-used-percent`]: '10',
+    [`x-codex-${slug}-primary-window-minutes`]: '10080',
+  });
+  for (let i = 0; i < 40; i++) {
+    am.updateQuota(0, headersFor(`fam${i}`));
+    // Distinct seenAt stamps so "longest ago" is well defined.
+    for (const b of Object.values(am.accounts[0].quota.codexModelBuckets)) b.seenAt -= 1;
+  }
+  const slugs = Object.keys(am.accounts[0].quota.codexModelBuckets);
+  assert.equal(slugs.length, 32);
+  assert.equal(slugs.includes('fam0'), false, 'the oldest went first');
+  assert.equal(slugs.includes('fam39'), true);
+
+  // Refreshing a slug that is already known never evicts anything.
+  am.updateQuota(0, headersFor('fam39'));
+  assert.equal(Object.keys(am.accounts[0].quota.codexModelBuckets).length, 32);
+});
+
+// ── the model name in log lines ──────────────────────────────
+
+test('a request-body model name is stripped before it reaches the advisor log line', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  for (const acc of am.accounts) {
+    acc.quota.unified7dFable = 0.999;
+    acc.quota.unified7dFableReset = Date.now() + 3600_000;
+  }
+  const hostile = 'claude-fable-5\x1b[2J\nforged line';
+  const lines = captureLog(() => am.getActiveAccount(null, 'claude-opus-4-8', hostile));
+  const line = lines.find(l => l.includes('advisor model'));
+  assert.ok(line, 'the degrade line is logged');
+  assert.equal(line.includes('\x1b'), false);
+  assert.equal(line.includes('\n'), false);
+  assert.ok(line.includes('claude-fable-5 forged line'));
+});
+
+test('the model name in the divert log line is stripped and bounded', () => {
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  assert.equal(am.getActiveAccount(null, 'claude-opus-4-8').name, 'a');
+  // a's Fable weekly is spent: it serves Opus but a Fable request is diverted.
+  am.accounts[0].quota.unified7dFable = 0.999;
+  am.accounts[0].quota.unified7dFableReset = Date.now() + 3600_000;
+  const hostile = 'claude-fable-5\x1b[2J' + 'z'.repeat(200);
+  const lines = captureLog(() => am.getActiveAccount(null, hostile));
+  const line = lines.find(l => l.includes('Diverting'));
+  assert.ok(line, 'the divert line is logged');
+  assert.equal(line.includes('\x1b'), false);
+  assert.ok(line.length < 200, 'the model name is bounded, not echoed whole');
+});

--- a/test/upstream-proxy.test.js
+++ b/test/upstream-proxy.test.js
@@ -19,7 +19,6 @@ test('parses the forms people actually write', () => {
   assert.deepEqual(parseProxyUrl('host:3128'), { host: 'host', port: 3128, username: null, password: null });
   assert.deepEqual(parseProxyUrl('http://u:p@host:8080'), { host: 'host', port: 8080, username: 'u', password: 'p' });
   assert.equal(parseProxyUrl('http://host').port, 8080);       // default when unstated
-  assert.equal(parseProxyUrl('https://host').port, 443);
   assert.equal(parseProxyUrl(''), null);
   assert.equal(parseProxyUrl(null), null);
 });
@@ -35,6 +34,10 @@ test('credentials survive a round trip through percent-encoding', () => {
 
 test('a wrong protocol is named rather than failing later inside the tunnel', () => {
   assert.throws(() => parseProxyUrl('socks5://host:1080'), /unsupported proxy protocol "socks5"/);
+  // https:// used to be accepted, but nothing here speaks TLS to the proxy: the
+  // CONNECT and its Basic credentials went out in plaintext to port 443 and the
+  // connection never worked. Refuse it and say what to write instead.
+  assert.throws(() => parseProxyUrl('https://u:p@host'), /unsupported proxy protocol "https".*use http:\/\//);
   // Node's URL rejects an out-of-range port itself; either message is fine as
   // long as it names the offending value rather than failing at connect time.
   assert.throws(() => parseProxyUrl('http://host:99999'), /invalid proxy URL|invalid port/);


### PR DESCRIPTION
Parallel security audit of the whole tree (inbound server, MITM/egress, credentials/OAuth/config, CLI/shell/packaging, account manager/routing, TUI), followed by fixes. 42 commits, one per finding, each with tests, rebased onto master after #305–#309. Test count 1424 → 1505; eslint clean; suite verified under Node 20, 22 and 26.

## Highest-impact fixes

- **Client `Authorization` header forwarded to third-party upstreams (High).** For API-key accounts the forward loop kept the client's own `Authorization: Bearer <OAuth token>` and sent it to `account.upstream` (GLM, DeepSeek, …). Now stripped; `applyAuthHeaders` re-adds the account credential where needed.
- **CONNECT tunnel / HTTP relay could reach the proxy's own loopback listener (High).** `CONNECT 127.0.0.1:<port>` (or `GET http://127.0.0.1:<port>/…`) from a low-trust client-key holder landed on the listener as a loopback caller, bypassing the key gate and per-client attribution, and reached other loopback-only services and link-local metadata. New `src/forward-target.js` refuses loopback, unspecified and link-local targets (checked by name before dialing and on every resolved address), plus the proxy's own port. RFC1918 stays open. `teamclaude run`/`env` already set `NO_PROXY=localhost,127.0.0.1,::1`, so nothing legitimate is lost.
- **Loopback auth exemption vs. web pages (Medium).** Key-less loopback requests now require a Host naming this machine (DNS rebinding) and pass the same-origin check on every path, not only `POST /teamclaude/*` (no-cors quota drain via `/v1/messages`). Non-browser clients send neither header and are unaffected.
- **Publish workflow supply chain (Medium).** The publish job no longer runs `npm install` (tests need no deps) while holding OIDC publish rights; all actions pinned to commit SHAs (verified against the tags); npm pinned; dependabot for actions added. CI installs with `--ignore-scripts`.
- **Refresh race marked a freshly imported refresh token dead (Medium).** `ensureTokenFresh` now attributes the outcome to the token it actually sent.
- **Client-controlled strings reached the operator terminal raw (Medium).** Request `model`, session ids, attach-mode status payloads and status-report fields are sanitized at ingress; the TUI log path keeps its own colour SGR and drops every other escape.
- **`https://` upstream-proxy URLs spoke plaintext (Medium).** Basic credentials were written unencrypted to port 443 and the connection never worked; now rejected with a clear error.

## Other fixes

Proxy key no longer relayed upstream on client-credential paths · 64 MiB body cap (`proxy.maxBodyBytes`) · generic client-facing error text · `Object.hasOwn` in `rewriteModel` · session-id header validated and the tracker bounded · dashboard CSP · CONNECT authority parsing via URL · stored cert chain renewed 30 days before expiry · TLS handshake timeouts · unknown CONNECT username redacted in logs · `SX_API_BASE` must be https · upstream rate-limit headers validated (a non-numeric reset can no longer park an account) · prober skips disabled/dead accounts and clamps its interval · non-finite hold guards · atomic config/state writes (tmp + fsync + rename, follows symlinks) · OAuth callback binds 127.0.0.1 and only a state-bearing request settles it · token-endpoint fields type-checked · CLI saves merge onto a fresh read of the config by entry id (no stale refresh-token write-back) · `teamclaude env` quotes the CA path and validates the port · updater validates the registry version and never auto-updates as root · systemd unit values quoted, control chars refused · shell alias quoting and atomic rc-file write · probe interval capped at 7 days everywhere · API keys masked while typed.

## Behaviour changes to be aware of

- `upstreamProxy: "https://…"` is now a startup error (it never worked; use `http://`).
- Forward-proxy targets on loopback/link-local are refused with 403.
- Key-less requests from a browser (any Origin / Sec-Fetch-Site other than same-origin/none) get 403 on every path; a Host that does not name this machine gets 403.
- Request bodies over 64 MiB get 413 (`proxy.maxBodyBytes` to change, 0 to disable).
- A pre-id config gets its account ids persisted once at server start.

## Deferred (flagged for human review, not changed)

- Local port squatting: `teamclaude run`/`status` trust whatever listens on the configured port (a bare TCP probe). Fix needs an authenticated liveness check or a Unix socket; design decision.
- `HTTPS_PROXY=http://<acct>:<proxy.apiKey>@127.0.0.1:<port>` exposes the long-lived proxy key to every subprocess Claude spawns; a per-session ephemeral token would fix it.
- `import --json` / `api --data` put secrets on argv (shell history, `ps`); a stdin form is a small feature.
- Egress guard fails open when the IP probe is unreachable and probes via global fetch rather than the configured egress path (documented design choice).
- MITM WebSocket upgrades are routed to the Anthropic upstream regardless of the tunnelled host (low practical impact in the documented flow).
- systemd unit sandboxing directives (`NoNewPrivileges`, `ProtectSystem`, …) not added.
- Loopback exemption still trusts every local user on a shared host (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
