### PR TITLE
fix(server): gate the WebSocket upgrade like every other entry point

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1230,10 +1230,24 @@ function relayStream(req, res, upstream, sx) {
  */
 export function resolveUpgradeAuth(req, socket, proxyConfig) {
   const auth = resolveClientAuth(proxyConfig, req?.headers?.['x-api-key']);
+  if (auth.ok) return auth;
   // Loopback is exempt from the key requirement, exactly as the HTTP and
-  // CONNECT gates are.
-  if (!auth.ok && isLoopbackAddr(socket?.remoteAddress)) return { ok: true, client: null };
-  return auth;
+  // CONNECT gates are — with the request path's two conditions on top, for
+  // the same actor: a web page in the operator's browser. A page can open a
+  // WebSocket to 127.0.0.1 with no CORS check at all, and its handshake is
+  // loopback-sourced too. What it cannot forge is `Origin`, which a browser
+  // sets on every handshake and a CLI never sends, nor `Host`, which a
+  // rebound name (attacker.example → 127.0.0.1) leaves naming the attacker.
+  if (!isLoopbackAddr(socket?.remoteAddress)) return auth;
+  const bindHost = proxyConfig?.host;
+  const origin = req?.headers?.origin;
+  if (origin) {
+    let originHost;
+    try { originHost = new URL(origin).host; } catch { return auth; }
+    if (!isLocalHostHeader(originHost, bindHost)) return auth;
+  }
+  if (!isLocalHostHeader(req?.headers?.host, bindHost)) return auth;
+  return { ok: true, client: null };
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -457,7 +457,26 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
   // call — Node fires 'upgrade' for that handshake, never 'request', so it
   // needs its own listener (base-URL routing path; the MITM path wires the
   // same relayUpgrade onto its own terminating server in mitm.js).
-  server.on('upgrade', (req, socket, head) => relayUpgrade(req, socket, head, upstream, sx));
+  server.on('upgrade', (req, socket, head) => {
+    // The upgrade handshake never reaches requestHandler, so it does not
+    // inherit the key gate above — it has to ask for itself. Without this a
+    // WebSocket handshake is an unauthenticated relay to `upstream`: the
+    // handshake carries no pooled credential (relayUpgrade forwards the
+    // client's own headers), so it is not a way to spend the fleet's quota,
+    // but it is a way to reach the upstream on this host's address and
+    // bandwidth. A deployment on a public hostname hands that to anyone.
+    if (!resolveUpgradeAuth(req, socket, config.proxy).ok) {
+      // Logged as well as answered: a WebSocket client discards the status
+      // line, so the 401 alone leaves an operator with a channel that is
+      // silently dead — the same shape as the outage this gate could cause if
+      // a client turns out not to send the key.
+      console.log(`[TeamClaude] WebSocket upgrade refused (no proxy key) from ${safeLine(socket?.remoteAddress || 'unknown')} for ${safeLine(req.url)}`);
+      try { socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
+      socket.destroy();
+      return;
+    }
+    relayUpgrade(req, socket, head, upstream, sx);
+  });
 
   return server;
 }
@@ -1189,6 +1208,32 @@ function relayStream(req, res, upstream, sx) {
 
   if (['GET', 'HEAD'].includes(req.method)) upstreamReq.end();
   else req.pipe(upstreamReq);
+}
+
+/**
+ * The key gate for a WebSocket upgrade, in the shape of the CONNECT one.
+ *
+ * Separate from `resolveClientAuth` only because the answer depends on the
+ * socket's address as well as the header, and separate from the request path
+ * because `server.on('upgrade')` is a different event that no part of
+ * `requestHandler` runs for.
+ *
+ * `x-api-key` only. A browser cannot set that header on a WebSocket
+ * handshake, so a browser client cannot authenticate here — deliberately.
+ * The obvious alternative, reading the key out of `Sec-WebSocket-Protocol`,
+ * is worse than not supporting browsers: relayUpgrade forwards that header to
+ * the upstream (it strips `x-api-key`, which is the whole reason the
+ * handshake carries no operator credential today), the offer list is
+ * attacker-sized so it turns one guess per connection into thousands, and the
+ * proxy cannot honour the negotiation anyway because it relays the handshake
+ * rather than answering it.
+ */
+export function resolveUpgradeAuth(req, socket, proxyConfig) {
+  const auth = resolveClientAuth(proxyConfig, req?.headers?.['x-api-key']);
+  // Loopback is exempt from the key requirement, exactly as the HTTP and
+  // CONNECT gates are.
+  if (!auth.ok && isLoopbackAddr(socket?.remoteAddress)) return { ok: true, client: null };
+  return auth;
 }
 
 /**

--- a/test/upgrade-auth.test.js
+++ b/test/upgrade-auth.test.js
@@ -28,6 +28,27 @@ test('the upgrade gate answers like the other two', () => {
   assert.deepEqual(resolveUpgradeAuth({ headers: {} }, remote, {}), { ok: true, client: null });
 });
 
+test('the loopback exemption is refused to a web page: foreign Origin or Host', () => {
+  // A page can open a WebSocket to 127.0.0.1 with no CORS check, and the
+  // handshake arrives loopback-sourced. Browsers always send Origin on a
+  // handshake and CLIs never do; a DNS-rebound page also leaves Host naming
+  // the attacker. Same two checks the request path applies to key-less
+  // loopback callers.
+  const local = sock('127.0.0.1');
+  const refused = { ok: false, client: null };
+  const exempt = { ok: true, client: null };
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: '127.0.0.1:3456', origin: 'https://attacker.example' } }, local, PROXY), refused);
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: 'attacker.example:3456' } }, local, PROXY), refused);
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: '127.0.0.1:3456', origin: 'http://localhost:3456' } }, local, PROXY), exempt);
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: 'localhost:3456' } }, local, PROXY), exempt);
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: '[::1]:3456', origin: 'http://[::1]:3456' } }, local, PROXY), exempt);
+  // A malformed Origin cannot be trusted either way; refuse.
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: '127.0.0.1:3456', origin: 'not a url' } }, local, PROXY), refused);
+  // A valid key passes regardless of Origin or Host, and a bound LAN host is local.
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: 'attacker.example', origin: 'https://attacker.example', 'x-api-key': 'alice-key' } }, local, PROXY), { ok: true, client: 'alice' });
+  assert.deepEqual(resolveUpgradeAuth({ headers: { host: '192.168.1.5:3456' } }, local, { ...PROXY, host: '192.168.1.5' }), exempt);
+});
+
 test('a key offered in Sec-WebSocket-Protocol is NOT accepted', () => {
   // Reading the key out of the subprotocol list would let a browser
   // authenticate — and would leak the operator's key to the upstream, because

--- a/test/upgrade-auth.test.js
+++ b/test/upgrade-auth.test.js
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, resolveUpgradeAuth } from '../src/server.js';
+
+// `server.on('upgrade')` is a different event from the one requestHandler
+// serves, so it does not inherit the key gate — it has to ask for itself.
+// Without that, a WebSocket handshake is an unauthenticated relay to the
+// configured upstream: no pooled credential rides along (relayUpgrade forwards
+// the client's own headers), but the operator's host and address do.
+
+const PROXY = { apiKey: 'shared-key', clientKeys: [{ name: 'alice', key: 'alice-key' }] };
+const sock = (remoteAddress) => ({ remoteAddress });
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+
+test('the upgrade gate answers like the other two', () => {
+  const remote = sock('203.0.113.7');
+  assert.deepEqual(resolveUpgradeAuth({ headers: {} }, remote, PROXY), { ok: false, client: null });
+  assert.deepEqual(resolveUpgradeAuth({ headers: { 'x-api-key': 'shared-key' } }, remote, PROXY), { ok: true, client: null });
+  assert.deepEqual(resolveUpgradeAuth({ headers: { 'x-api-key': 'alice-key' } }, remote, PROXY), { ok: true, client: 'alice' });
+  assert.deepEqual(resolveUpgradeAuth({ headers: { 'x-api-key': 'wrong' } }, remote, PROXY), { ok: false, client: null });
+  // Loopback is exempt, as it is on the HTTP and CONNECT gates, so a local
+  // `teamclaude attach` keeps working with no key.
+  assert.deepEqual(resolveUpgradeAuth({ headers: {} }, sock('127.0.0.1'), PROXY), { ok: true, client: null });
+  // A deployment with no keys configured is open by choice, unchanged.
+  assert.deepEqual(resolveUpgradeAuth({ headers: {} }, remote, {}), { ok: true, client: null });
+});
+
+test('a key offered in Sec-WebSocket-Protocol is NOT accepted', () => {
+  // Reading the key out of the subprotocol list would let a browser
+  // authenticate — and would leak the operator's key to the upstream, because
+  // relayUpgrade forwards that header while deliberately stripping x-api-key.
+  // It would also turn one guess per connection into thousands, since the
+  // offer list is attacker-sized. Not supporting browsers is the cheaper
+  // trade, and this pins it.
+  const remote = sock('203.0.113.7');
+  assert.deepEqual(
+    resolveUpgradeAuth({ headers: { 'sec-websocket-protocol': 'teamclaude, alice-key' } }, remote, PROXY),
+    { ok: false, client: null });
+  assert.deepEqual(
+    resolveUpgradeAuth({ headers: { 'sec-websocket-protocol': 'alice-key' } }, remote, PROXY),
+    { ok: false, client: null });
+});
+
+// The unit test above cannot show the handler is WIRED. Drive a real socket:
+// on loopback the gate is exempt, so an upstream that never answers proves the
+// request was relayed, while a refusal proves it was not.
+test('an unauthorized handshake is refused on the socket, not silently held', async () => {
+  let relayed = false;
+  let upstreamHeaders = null;
+  // Every socket this test opens is held so teardown can destroy it: an
+  // upgraded socket is deliberately never ended, and close() waits for it.
+  const open = [];
+  const upstream = http.createServer(() => {});
+  upstream.on('upgrade', (req, s) => { relayed = true; upstreamHeaders = req.headers; open.push(s); });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'api_key', apiKey: 'sk-a' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: PROXY, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+
+  // Force the non-loopback branch: the gate reads socket.remoteAddress, so
+  // stub it on the connection the server is about to hand the handler.
+  proxy.on('connection', (s) => { Object.defineProperty(s, 'remoteAddress', { value: '203.0.113.7' }); });
+
+  const handshake = (key) => new Promise((resolve) => {
+    const c = net.createConnection({ port, host: '127.0.0.1' }, () => {
+      open.push(c);
+      c.write('GET /v1/messages HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n'
+        + 'Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n'
+        + (key ? `x-api-key: ${key}\r\n` : '') + '\r\n');
+    });
+    let buf = '';
+    const done = setTimeout(() => { c.destroy(); resolve(buf); }, 700);
+    c.on('data', (d) => { buf += d; });
+    c.on('close', () => { clearTimeout(done); resolve(buf); });
+  });
+
+  try {
+    const refused = await handshake(null);
+    assert.match(refused, /^HTTP\/1\.1 401 Unauthorized/, 'refused, and told so');
+    assert.equal(relayed, false, 'and never reached the upstream');
+
+    const allowed = await handshake('alice-key');
+    // The stub upstream never completes the handshake, so `allowed` is empty —
+    // asserting it lacks "401" would pass vacuously. Reaching the upstream is
+    // the real oracle, and it is what a broken gate would prevent.
+    assert.equal(allowed, '', 'no status line: the relay took over the socket');
+    assert.equal(relayed, true, 'the keyed handshake reached the upstream');
+    // The key that authenticated us to the proxy must not travel onward.
+    // relayUpgrade strips x-api-key; nothing must smuggle it back in under
+    // another name, which is exactly how the first version of this gate broke.
+    assert.equal(upstreamHeaders['x-api-key'], undefined, 'the proxy key is stripped');
+    for (const [k, v] of Object.entries(upstreamHeaders)) {
+      assert.ok(!String(v).includes('alice-key'), `header ${k} carries the proxy key upstream`);
+    }
+  } finally {
+    for (const s of open) s.destroy();
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.closeAllConnections?.(); upstream.close();
+  }
+});


### PR DESCRIPTION
Closes #314.

`server.on('upgrade', …)` is registered outside the API-key gate, so a WebSocket handshake reaches `relayUpgrade` without presenting `proxy.apiKey` or a `clientKeys` entry. Measured against a live 1.1.17 behind a reverse proxy that forwards `Upgrade` — same URL, same absence of a key:

```
plain GET                  -> HTTP 401
genuine upgrade handshake  -> socket held open, relayed, no auth
```

(An HTTP/2 client gives a misleading 401 here, because `Upgrade` is meaningless in h2. It needs `--http1.1` to reproduce.)

## Severity, stated precisely

Not a credential leak. `relayUpgrade` forwards the client's own headers and injects nothing:

```js
for (const [key, value] of Object.entries(req.headers)) {
  const lk = key.toLowerCase();
  if (lk.startsWith(':') || lk === 'host' || lk === 'x-api-key') continue;
  headers[key] = value;
}
```

Note the `x-api-key` strip: the client's credential to *us* is deliberately not passed on. No `applyAuthHeaders`, no account selection, no pooled token — the caller authenticates as itself, so this is not a way to spend the fleet's quota. It is a way to reach the upstream **on the operator's host, address and bandwidth**, and with `sx` provisioned and `useByDefault()` on, on their metered residential egress. Every other entry point is gated: `requestHandler` runs `resolveClientAuth` first, `CONNECT` has the 407 gate, and the control plane adds the same-origin check. `GET /teamclaude/dashboard` is also pre-gate but is deliberately a static asset with no data — a different thing.

## The fix

`resolveUpgradeAuth` mirrors `resolveConnectAuth`: same `resolveClientAuth` comparison, same loopback exemption — so a local `teamclaude attach` is unaffected, and a deployment with no keys configured stays open by choice.

`x-api-key` only. A browser cannot set that header on a WebSocket handshake, so a browser client cannot authenticate here — deliberately. Reading the key out of `Sec-WebSocket-Protocol` instead would be worse than not supporting browsers: `relayUpgrade` **forwards** that header (it strips `x-api-key`, which is exactly why the handshake carries no operator credential today), so the key would reach the upstream; the offer list is attacker-sized, turning one guess per connection into thousands where `resolveConnectAuth` tries at most two; and the proxy cannot honour the negotiation anyway, because it relays the handshake rather than answering it. A test pins the refusal so the idea cannot quietly return. The first version of this PR did accept the subprotocol and did leak the key — see the comment below.

The refusal is written to the socket rather than dropped — a silently held socket is the shape of an outage, and that is exactly how this went unnoticed.

The MITM listener wires the same relay onto its own terminating server, which sits behind the CONNECT 407 gate. Already authenticated, so it is unchanged.

## Testing

The gate's truth table against a stubbed non-loopback address (no key, shared key, client key, wrong key, loopback exempt, no-keys-configured), the subprotocol path, and — because a unit test cannot show the handler is *wired* — a real socket handshake against a real proxy with `remoteAddress` stubbed to force the non-loopback branch: refused with `401` and never reaching the upstream without a key, relayed with one. Mutation-checked: disabling the gate turns all three red.

`npm run lint` clean. `npm test` **1508/1508 on Node 20.19, 22.19 and 24.12.**

## Note for operators

A reverse proxy that sets a websocket flag purely to get `proxy_http_version 1.1` and long read timeouts for streaming responses also forwards `Upgrade`, and so exposes this without anyone intending to. That is how ours was configured, and there was no way to keep the timeouts without the forwarding — which is what made fixing it here rather than there the only option.

