### PR TITLE
fix: sanitize and bound third-party quota replies; guard ensureTokenFresh on upstream accounts

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -3009,7 +3009,12 @@ export class AccountManager {
    */
   async ensureTokenFresh(accountIndex, force = false) {
     const account = this.accounts[accountIndex];
-    if (!account || account.type !== 'oauth' || !account.refreshToken) return;
+    // A third-party backend (`upstream` set) carries a DIFFERENT provider's
+    // credential; the token endpoint here is Anthropic's, so refreshing would
+    // hand that credential to a party it was never issued for. The prober and
+    // the warmer already draw this line; this is the third caller that reaches
+    // a credential, and the one the send path and the 401 retry go through.
+    if (!account || account.type !== 'oauth' || !account.refreshToken || account.upstream) return;
 
     // Dead-token guard: a refresh token upstream already rejected (invalid_grant)
     // will be rejected every time, so retrying it only floods the OAuth endpoint

--- a/src/backend-quota.js
+++ b/src/backend-quota.js
@@ -12,6 +12,13 @@
 // reports nothing simply has no entry and reads as unknown, exactly as now.
 
 import { proxyFetch } from './upstream-fetch.js';
+import { safeLine } from './safe-text.js';
+
+// A balance reply is a few hundred bytes. The host it comes from is whatever
+// `account.upstream` names, so bound the read the way server.js bounds a
+// diagnostic error body: a hostile or broken backend must not be able to make
+// the proxy buffer an arbitrary response on every probe cycle.
+const RESPONSE_LIMIT = 64 * 1024;
 
 /**
  * A normalized reading. `text` is what the operator reads; `utilization` is set
@@ -34,7 +41,10 @@ const PROVIDERS = [
       if (!info) return null;
       const amount = Number(info.total_balance);
       if (!Number.isFinite(amount)) return null;
-      const currency = String(info.currency || '').toUpperCase();
+      // `currency` is the one string in the reply that reaches the operator's
+      // terminal (via status-renderer) verbatim when it is not USD/CNY, so it
+      // is stripped and bounded like every other externally sourced string.
+      const currency = safeLine(String(info.currency || ''), 8).toUpperCase();
       const symbol = currency === 'USD' ? '$' : currency === 'CNY' ? '¥' : '';
       const text = symbol ? `${symbol}${amount.toFixed(2)}` : `${amount.toFixed(2)} ${currency}`;
       // `is_available: false` means the account cannot spend, whatever the
@@ -80,9 +90,40 @@ export async function fetchBackendQuota(account, { fetchImpl = proxyFetch, timeo
       signal,
     });
     if (!res.ok) return { error: `HTTP ${res.status}` };
-    const reading = provider.parse(await res.json());
+    const body = await readJsonBounded(res, RESPONSE_LIMIT);
+    if (body === undefined) return { error: 'response too large' };
+    const reading = provider.parse(body);
     return reading ? { ...reading, at: Date.now() } : { error: 'unrecognized response' };
   } catch (err) {
     return { error: err?.message || String(err) };
   }
+}
+
+/**
+ * Parse a JSON response body of at most `limit` bytes; `undefined` when it is
+ * larger (declared or actual). A response without a readable stream (a test
+ * double) falls back to `json()`.
+ */
+async function readJsonBounded(res, limit) {
+  const declared = Number(res.headers?.get?.('content-length'));
+  if (Number.isFinite(declared) && declared > limit) return undefined;
+  if (typeof res.body?.getReader !== 'function') return res.json();
+  const reader = res.body.getReader();
+  const chunks = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > limit) {
+        await reader.cancel().catch(() => {});
+        return undefined;
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return JSON.parse(Buffer.concat(chunks, length).toString('utf8'));
 }

--- a/test/backend-quota.test.js
+++ b/test/backend-quota.test.js
@@ -1,4 +1,6 @@
 import { test } from 'node:test';
+import { ReadableStream } from 'node:stream/web';
+import { Blob } from 'node:buffer';
 import assert from 'node:assert/strict';
 import { providerFor, hasBackendQuota, fetchBackendQuota } from '../src/backend-quota.js';
 import { AccountManager } from '../src/account-manager.js';
@@ -124,4 +126,36 @@ test('status draws whatever the reading says, knowing no provider', () => {
   assert.match(out, /Balance\s+\$25\.81/);
   assert.match(out, /Credits\s+\[█+░+\] 42% used/, 'a reported fraction gets a bar');
   assert.match(out, /Quota\s+unknown/, 'a provider that reports nothing is still honest');
+});
+
+// ── hostile backend (#310) ───────────────────────────────────
+
+// The reply comes from whatever host `account.upstream` names, and `currency`
+// is printed to the operator's terminal by `teamclaude status`.
+test('a currency carrying terminal controls is stripped and bounded before it can be rendered', async () => {
+  const hostile = { balance_infos: [{ currency: 'X\x1b]0;PWNED\x07\x1b[2J\rBALANCE  100% OK', total_balance: '12.34' }] };
+  const r = await fetchBackendQuota({ upstream: DS, credential: 'k' }, { fetchImpl: okFetch(hostile) });
+  assert.doesNotMatch(r.text, /[\x00-\x1f\x7f]/, 'no control character survives');
+  assert.ok(r.text.length < 24, `bounded: ${JSON.stringify(r.text)}`);
+
+  const am = new AccountManager([backend('ds', DS)], 0.98);
+  am.accounts[0].quota.backend = { ...r, at: Date.now() };
+  const out = renderStatus(am.getStatus(), { color: false, now: Date.now() });
+  assert.doesNotMatch(out, /[\x1b\x07\r]/, 'nothing reaches the terminal raw');
+});
+
+test('a response larger than the cap is refused, not buffered', async () => {
+  const stream = (bytes) => new ReadableStream({
+    start(c) { for (let i = 0; i < bytes; i += 4096) c.enqueue(new Uint8Array(Math.min(4096, bytes - i)).fill(0x20)); c.close(); },
+  });
+  const huge = async () => ({ ok: true, status: 200, headers: new Map(), body: stream(200 * 1024), json: async () => { throw new Error('must not be called'); } });
+  assert.deepEqual(await fetchBackendQuota({ upstream: DS, credential: 'k' }, { fetchImpl: huge }), { error: 'response too large' });
+
+  const declared = async () => ({ ok: true, status: 200, headers: new Map([['content-length', String(10 * 1024 * 1024)]]), body: stream(16), json: async () => BALANCE });
+  assert.deepEqual(await fetchBackendQuota({ upstream: DS, credential: 'k' }, { fetchImpl: declared }), { error: 'response too large' });
+
+  // A small real stream still parses.
+  const small = async () => ({ ok: true, status: 200, headers: new Map(), body: new Blob([JSON.stringify(BALANCE)]).stream() });
+  const r = await fetchBackendQuota({ upstream: DS, credential: 'k' }, { fetchImpl: small });
+  assert.equal(r.text, '$26.11');
 });

--- a/test/dead-refresh-token.test.js
+++ b/test/dead-refresh-token.test.js
@@ -168,3 +168,18 @@ test('an unchanged token is refreshed normally (the guard only fires on a swap)'
   assert.strictEqual(m.accounts[0].refreshToken, 'rt-new');
   assert.strictEqual(m.accounts[0].credential, 'at-new');
 });
+
+// #315: a third-party backend's credential must never be sent to Anthropic's
+// token endpoint. The prober and warmer already skip `upstream` accounts; the
+// send path and the 401 retry go through here and did not.
+test('an account with a third-party upstream is never refreshed against Anthropic', async () => {
+  let calls = 0;
+  const m = new AccountManager([{
+    name: 'glm', type: 'oauth', upstream: 'https://glm.example/anthropic',
+    accessToken: 'third-party-key', refreshToken: 'rt-third-party', expiresAt: Date.now() - 1000,
+  }], 0.98, { refreshFn: async () => { calls++; return { accessToken: 'x', refreshToken: 'y', expiresAt: Date.now() + 1e6 }; } });
+  await m.ensureTokenFresh(0);
+  await m.ensureTokenFresh(0, true);
+  assert.strictEqual(calls, 0, 'the refresh token was not sent anywhere');
+  assert.strictEqual(m.accounts[0].credential, 'third-party-key', 'the credential is untouched');
+});


### PR DESCRIPTION
Two follow-ups from the 1.1.17 security review.

**#310 — `src/backend-quota.js`.** The `currency` field of a third-party balance reply reached the operator's terminal verbatim via `teamclaude status`, and the body was read with no size cap. `currency` now goes through `safeLine` (bounded to 8 chars), and the body is read through a 64 KiB cap (declared `content-length` or actual bytes) before parsing, mirroring the error-body bound in `server.js`. Tests cover a hostile currency end to end through `renderStatus`, an oversized stream, an oversized declared length, and a small real stream.

**#315 — `src/account-manager.js`.** `ensureTokenFresh` now skips accounts with an `upstream`, so a third-party backend's refresh token can never be sent to Anthropic's token endpoint. This aligns the third credential-reaching call site with the prober and warmer. Test asserts the refresh function is never called for such an account, even under `force`.

Closes #310. Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)