### PR TITLE
chore: untrack the node_modules symlink and ignore it in any form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 config.json
 *.log
 package-lock.json

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/magicaltux/projects/teamclaude/node_modules


### PR DESCRIPTION
A `node_modules` symlink was committed by accident in #297: `.gitignore` listed `node_modules/`, which matches only a directory, so a symlink of that name was tracked, and checking master out then replaced every clone's real `node_modules` directory with a dangling link. This untracks it and ignores the name in any form.

Local clones that already checked out the symlink: `rm node_modules && npm install --ignore-scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)