### PR TITLE
feat(diagnostics): event-loop lag monitor in status, and a deadline for `teamclaude status`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,12 +85,33 @@ Volatile runtime state (observed quota) is written separately to `teamclaude.sta
 | `TEAMCLAUDE_CONFIG` | Path to the config file (default `~/.config/teamclaude.json`) |
 | `TEAMCLAUDE_HOST` | Override `proxy.host` |
 | `TEAMCLAUDE_DISABLE_AUTOUPDATE` | Set to `1` to skip the background self-update check |
+| `TEAMCLAUDE_STATUS_TIMEOUT_MS` | How long `teamclaude status` waits for the server's answer before giving up (default `5000`). A connection that is accepted but never answered is reported as a stalled or overloaded server, distinct from a refused one ("Is the server running?") |
 | `HTTPS_PROXY` / `ALL_PROXY` | Outbound proxy used when the config sets no `upstreamProxy` (lowercase forms honoured too) |
 | `NO_PROXY` | Hosts that bypass the outbound proxy, when the config sets no `noProxy` |
 
 ```bash
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server
 ```
+
+### Event-loop diagnostics
+
+A wedged event loop is the one failure the status endpoint cannot report, because the endpoint itself cannot run. The server therefore keeps a small watchdog: a 1 s timer measures how late each tick fires, and a tick more than 500 ms late counts as a stall and writes one line to the service log (at most one every 30 s):
+
+```
+[TeamClaude] Event loop stalled: lag=1840ms (threshold=500ms, stalls=3)
+```
+
+The figures are reported under `server.eventLoop` in `GET /teamclaude/status` and `teamclaude status --json` — numbers only, never request content:
+
+| Field | Meaning |
+| --- | --- |
+| `lastLagMs` | How late the most recent tick fired |
+| `maxLagMs` | The worst lag seen since the server started |
+| `stallCount` | Ticks that exceeded the threshold since start |
+| `lastStallAt` | ISO timestamp of the most recent stall, or `null` |
+| `warnLagMs` | The threshold in effect (`500`) |
+
+A `teamclaude status` that times out (see `TEAMCLAUDE_STATUS_TIMEOUT_MS`) while the log shows stalls is the signature of a starved or blocked process — on macOS, check that the LaunchAgent is not running under a `Background` QoS clamp — rather than of an upstream problem.
 
 ## Usage Dimensions
 

--- a/src/event-loop-monitor.js
+++ b/src/event-loop-monitor.js
@@ -1,0 +1,47 @@
+import { performance } from 'node:perf_hooks';
+
+const DEFAULT_INTERVAL_MS = 1_000;
+const DEFAULT_WARN_LAG_MS = 500;
+const DEFAULT_WARN_COOLDOWN_MS = 30_000;
+
+// A deliberately small watchdog for a failure an HTTP health endpoint cannot
+// report: if the event loop is wedged, the endpoint itself cannot run. The
+// delayed timer writes one bounded warning after JavaScript becomes schedulable
+// again, leaving evidence in the service log without emitting request content.
+export function startEventLoopMonitor({
+  intervalMs = DEFAULT_INTERVAL_MS,
+  warnLagMs = DEFAULT_WARN_LAG_MS,
+  warnCooldownMs = DEFAULT_WARN_COOLDOWN_MS,
+  now = () => performance.now(),
+  schedule = setInterval,
+  cancel = clearInterval,
+  log = (message) => console.error(message),
+} = {}) {
+  let expectedAt = now() + intervalMs;
+  let lastLagMs = 0;
+  let maxLagMs = 0;
+  let stallCount = 0;
+  let lastStallAt = null;
+  let lastWarningClock = -Infinity;
+
+  const timer = schedule(() => {
+    const current = now();
+    const lag = Math.max(0, current - expectedAt);
+    expectedAt = current + intervalMs;
+    lastLagMs = Math.round(lag);
+    maxLagMs = Math.max(maxLagMs, lastLagMs);
+    if (lag < warnLagMs) return;
+
+    stallCount += 1;
+    lastStallAt = new Date().toISOString();
+    if (current - lastWarningClock < warnCooldownMs) return;
+    lastWarningClock = current;
+    log(`[TeamClaude] Event loop stalled: lag=${Math.round(lag)}ms (threshold=${warnLagMs}ms, stalls=${stallCount})`);
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    status: () => ({ lastLagMs, maxLagMs, stallCount, lastStallAt, warnLagMs }),
+    stop: () => cancel(timer),
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
+import { startEventLoopMonitor } from './event-loop-monitor.js';
 
 // These constants are referenced by routeCommand, which the dispatch below
 // reaches through a top-level `await`. The await suspends module evaluation at
@@ -221,6 +222,10 @@ async function serverCommand() {
   // overnight leaves nothing behind to explain why.
   const crashLog = getCrashLogPath();
   installCrashHandlers(crashLog);
+  // Same motive as the crash log: when the process is wedged, the status
+  // endpoint cannot say so. The monitor leaves the evidence (one bounded warning
+  // per stall in the service log, lag figures under `server.eventLoop`).
+  const eventLoopMonitor = startEventLoopMonitor();
 
   const config = await loadOrCreateConfig();
   // Token writes below pair rows by entry id against a re-read of the file, so
@@ -547,6 +552,7 @@ async function serverCommand() {
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),
       port,
       upstream: config.upstream || 'https://api.anthropic.com',
+      eventLoop: eventLoopMonitor.status(),
     },
     probe: prober?.getStatus() || {
       enabled: false,
@@ -673,6 +679,7 @@ async function serverCommand() {
     if (!tui) console.log('\n[TeamClaude] Shutting down...');
     prober?.stop();
     warmer?.stop();
+    eventLoopMonitor.stop();
     if (quotaSaveInterval) clearInterval(quotaSaveInterval);
     await persistQuotaState();
     // Don't linger waiting on keep-alive / streaming connections: actively

--- a/src/index.js
+++ b/src/index.js
@@ -1079,8 +1079,17 @@ async function statusCommand() {
   const color = colorArg === 'always'
     || (colorArg !== 'never' && process.stdout.isTTY);
 
+  // A connection that is accepted and then never answered is a different
+  // failure from a refused one — a stalled or overloaded server rather than a
+  // stopped one — and without a deadline this command would just hang on it.
+  const configuredTimeout = Number(process.env.TEAMCLAUDE_STATUS_TIMEOUT_MS);
+  const timeoutMs = configuredTimeout > 0 ? configuredTimeout : 5_000;
+
   try {
-    const res = await fetch(url, { headers: { 'x-api-key': config.proxy.apiKey } });
+    const res = await fetch(url, {
+      headers: { 'x-api-key': config.proxy.apiKey },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
     const data = await res.json();
     if (json) {
       console.log(JSON.stringify(data, null, 2));
@@ -1088,6 +1097,12 @@ async function statusCommand() {
     }
     console.log(renderStatus(data, { color }));
   } catch (err) {
+    if (err?.name === 'TimeoutError') {
+      console.error(`Proxy at localhost:${config.proxy.port} did not answer status within ${timeoutMs}ms.`);
+      console.error('The process may be overloaded or its event loop may be stalled.');
+      console.error(`Check the service log: ${logPath()}`);
+      process.exit(1);
+    }
     console.error('Cannot connect to proxy at localhost:' + config.proxy.port);
     console.error('Is the server running? Start with: teamclaude server');
     if (err?.message) console.error(`Details: ${err.message}`);

--- a/test/cli-switch.test.js
+++ b/test/cli-switch.test.js
@@ -52,9 +52,9 @@ async function writeConfig(port) {
   return path;
 }
 
-function runCli(configPath, cliArgs) {
+function runCli(configPath, cliArgs, extraEnv = {}) {
   const child = spawn(process.execPath, [cliPath, ...cliArgs], {
-    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath },
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath, ...extraEnv },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   let stdout = '';
@@ -223,5 +223,24 @@ test('a down server exits 1 with the same hint as status', async () => {
     assert.equal(res.code, 1, cliArgs.join(' '));
     assert.match(res.stderr, new RegExp(`Cannot connect to proxy at localhost:${port}`));
     assert.match(res.stderr, /Is the server running\?/);
+  }
+});
+
+// Accepted-but-never-answered is not "down": it is the shape of a stalled or
+// overloaded server, and the command must say so within its deadline rather
+// than hang.
+test('status diagnoses an accepted connection whose server never answers', async () => {
+  const silent = http.createServer(() => { /* accept and intentionally hang */ });
+  const port = await listen(silent);
+  const configPath = await writeConfig(port);
+  try {
+    const res = await runCli(configPath, ['status'], { TEAMCLAUDE_STATUS_TIMEOUT_MS: '100' });
+    assert.equal(res.code, 1);
+    assert.match(res.stderr, /did not answer status within 100ms/);
+    assert.match(res.stderr, /event loop may be stalled/);
+    assert.doesNotMatch(res.stderr, /Is the server running/);
+  } finally {
+    silent.closeAllConnections?.();
+    silent.close();
   }
 });

--- a/test/event-loop-monitor.test.js
+++ b/test/event-loop-monitor.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startEventLoopMonitor } from '../src/event-loop-monitor.js';
+
+test('event-loop monitor records stalls and rate-limits warnings', () => {
+  let clock = 0;
+  let tick;
+  let cancelled = false;
+  const warnings = [];
+  const timer = { unrefCalled: false, unref() { this.unrefCalled = true; } };
+  const monitor = startEventLoopMonitor({
+    intervalMs: 100,
+    warnLagMs: 50,
+    warnCooldownMs: 1_000,
+    now: () => clock,
+    schedule(fn) { tick = fn; return timer; },
+    cancel(value) { assert.equal(value, timer); cancelled = true; },
+    log(message) { warnings.push(message); },
+  });
+
+  assert.equal(timer.unrefCalled, true);
+  clock = 180; tick(); // 80ms late
+  clock = 360; tick(); // another 80ms late, inside warning cooldown
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /lag=80ms/);
+  assert.deepEqual(monitor.status(), {
+    lastLagMs: 80,
+    maxLagMs: 80,
+    stallCount: 2,
+    lastStallAt: monitor.status().lastStallAt,
+    warnLagMs: 50,
+  });
+  assert.ok(monitor.status().lastStallAt);
+
+  monitor.stop();
+  assert.equal(cancelled, true);
+});


### PR DESCRIPTION
Part 3 of 3 split out of #301 (author: @nova28), per the review there.

- `src/event-loop-monitor.js`: an event-loop lag watchdog started with the crash handlers and stopped on shutdown, reported as numbers only under `server.eventLoop` in `/teamclaude/status`.
- `teamclaude status` gets a deadline (`TEAMCLAUDE_STATUS_TIMEOUT_MS`, default 5 s) and names the stall instead of hanging.
- Both documented in `docs/configuration.md`.

Supersedes the diagnostics part of #301. The `ingress` counter from #301 no longer exists; `upstreamPool` ships with the admission PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)