### PR TITLE
fix(config): stop the saved account list doubling when ids disagree

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -44,21 +44,6 @@ export function configIndexFor(configAccounts, managerAccounts, mgrIdx) {
 }
 
 /**
- * The account list to write to disk: in-memory config entries carrying live
- * credentials from the account each was built into, merged over the on-disk
- * entry so disk-only fields (e.g. importFrom) survive. An entry with no account
- * keeps what it has — there is no live credential to write.
- *
- * The config-to-disk lookup is a different axis and stays on identity, which is
- * not claimed one-to-one: two entries identity cannot separate both merge over
- * the same disk record. No credential moves that way, because the live one above
- * overrides whatever the lookup found — but the record's other fields do move,
- * and `importFrom` among them names the file an entry takes its credential from
- * at the next start. An entry can therefore pick up a delegation that was never
- * its own and read another's credential a restart later. Pairing by id does not
- * reach this axis.
- */
-/**
  * Whether this entry's OAuth token belongs in `config.json` at all.
  *
  * The save used to write `accessToken: am.credential` onto EVERY entry, which
@@ -118,8 +103,52 @@ export function clearRemovedAccountIds(config) {
   if (config?.[REMOVED]) config[REMOVED].clear();
 }
 
+/**
+ * Which disk row each config entry merges over, as a Map of config index to disk
+ * index. A row is claimed by at most one entry.
+ *
+ * Evidence before guesswork, in three passes: an exact id, then an account uuid
+ * both records carry, then the display name. `sameIdentity` collapses the last
+ * two — it compares uuids only when both sides have one and falls back to the
+ * name otherwise — so calling it alone lets an entry holding a uuid settle for a
+ * namesake's row. Claiming consumes, so that row is then taken from the entry it
+ * belonged to, and `importFrom` on it names the file an entry reads its
+ * credential from at the next start. findUpsertTarget in identity.js puts the
+ * same two questions in this order for the login axis.
+ *
+ * Ids can disagree with disk — a file written before the field existed, or
+ * re-minted by another process — which is why they cannot be the only pass.
+ */
+function claimDiskRows(configAccounts, diskAccounts) {
+  const rowFor = new Map();
+  const taken = new Set();
+  const claim = (i, matches) => {
+    for (const [d, diskAcct] of diskAccounts.entries()) {
+      if (taken.has(d) || !matches(diskAcct)) continue;
+      taken.add(d);
+      rowFor.set(i, d);
+      return;
+    }
+  };
+  configAccounts.forEach((a, i) => { if (a?.id) claim(i, d => d?.id === a.id); });
+  configAccounts.forEach((a, i) => { if (!rowFor.has(i) && a?.accountUuid) claim(i, d => d?.accountUuid && sameIdentity(d, a)); });
+  configAccounts.forEach((a, i) => { if (!rowFor.has(i)) claim(i, d => sameIdentity(d, a)); });
+  return rowFor;
+}
+
+/**
+ * The account list to write to disk: in-memory config entries carrying live
+ * credentials from the account each was built into, merged over the on-disk
+ * entry so disk-only fields (e.g. importFrom) survive. An entry with no account
+ * keeps what it has — there is no live credential to write.
+ *
+ * The config-to-disk lookup is a different axis from the config-to-manager one,
+ * and claimDiskRows is where it is decided: one row per entry, one entry per row.
+ */
 export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccounts, removedIds = new Set()) {
-  const merged = configAccounts.map(a => {
+  const rowFor = claimDiskRows(configAccounts, diskAccounts);
+
+  const merged = configAccounts.map((a, i) => {
     const am = managerAccountFor(managerAccounts, a);
     const live = am && ownsInlineToken(a) ? {
       ...a,
@@ -127,7 +156,7 @@ export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccoun
       refreshToken: am.refreshToken,
       expiresAt: am.expiresAt,
     } : a;
-    const diskAcct = diskAccounts.find(d => sameIdentity(d, a));
+    const diskAcct = diskAccounts[rowFor.get(i)];
     return diskAcct ? { ...diskAcct, ...live } : live;
   });
 
@@ -137,12 +166,19 @@ export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccoun
   // server runs — was silently dropped by the next save (#205). The refresh
   // handler already re-reads disk for this reason; the save had no equivalent.
   //
+  // A claimed row is one the merge above already folded into an entry, so this
+  // loop and the claim have to agree on what counts as already represented. The
+  // id alone does not agree: two processes mint different ids for the same
+  // pre-id row, so every row would look absent and the whole list would double.
+  //
   // Except the ones the operator removed: removal is itself a save, so without
   // that check this would resurrect the account being deleted, on the very
   // write that was meant to delete it.
+  const claimed = new Set(rowFor.values());
   const keptIds = new Set(merged.map(a => a?.id).filter(Boolean));
-  for (const diskAcct of diskAccounts) {
-    if (!diskAcct?.id) continue;                 // pre-id row; identity above covers it
+  for (const [d, diskAcct] of diskAccounts.entries()) {
+    if (claimed.has(d)) continue;
+    if (!diskAcct?.id) continue;                 // nothing for removedIds to match; adopting it could undo a removal
     if (keptIds.has(diskAcct.id)) continue;
     if (removedIds.has(diskAcct.id)) continue;
     merged.push(diskAcct);

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -75,3 +75,93 @@ test('a disk row with no id is left to the identity merge, not duplicated', () =
   const out = mergeAccountsForSave(cfg, [], disk);
   assert.equal(out.length, 1, 'a pre-id row must not be appended alongside its own entry');
 });
+
+// The carryover used to ask a different question than the merge above it. The
+// merge found an entry's disk row by identity and consumed it; the carryover
+// then asked whether that row's id was among the kept ones, and appended the row
+// the merge had just used. Two processes that minted different ids for one
+// pre-id config made the two answers disagree for every row at once, and the
+// list doubled.
+
+const oauth = (id, name, over = {}) => ({
+  id, name, type: 'oauth', accountUuid: `u-${name}`, orgUuid: 'o-1', accessToken: `disk-${id}`, ...over,
+});
+const mgr = (id, credential) => ({ id, credential, refreshToken: `r-${id}`, expiresAt: 1 });
+
+test('a disk row already merged onto an entry is not appended again under its own id', () => {
+  const cfg = [oauth('x1', 'a'), oauth('x2', 'b')];
+  const disk = [oauth('y1', 'a'), oauth('y2', 'b')];
+  const out = mergeAccountsForSave(cfg, [mgr('x1', 'live-a'), mgr('x2', 'live-b')], disk);
+
+  assert.deepEqual(out.map(a => a.name), ['a', 'b'], 'one row per account, not two');
+  assert.deepEqual(out.map(a => a.id), ['x1', 'x2'], 'and each keeps the id its account is paired by');
+  assert.deepEqual(out.map(a => a.accessToken), ['live-a', 'live-b'], 'carrying the live credential, not the disk copy');
+});
+
+// Identity is not one-to-one: two entries for one person share it, which is the
+// whole reason entries carry an id. Consuming disk rows one apiece is what keeps
+// that pair from leaving a spare row behind for the carryover to append.
+test('two entries sharing one identity consume one disk row each', () => {
+  const cfg = [oauth('x1', 'p'), oauth('x2', 'p')];
+  const disk = [oauth('y1', 'p'), oauth('y2', 'p')];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.id), ['x1', 'x2'], 'neither disk row survives as a third entry');
+});
+
+// Disk order is not entry order — a login rewrites the file from its own list.
+// An exact id is evidence and identity is a fallback, so the id decides first.
+test('an entry merges the disk row carrying its own id, whatever the disk order', () => {
+  const cfg = [oauth('x1', 'p'), oauth('x2', 'p')];
+  const disk = [oauth('x2', 'p', { importFrom: '/second' }), oauth('x1', 'p', { importFrom: '/first' })];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/first', '/second'], 'not the row identity happened to reach first');
+});
+
+// The other half of the carryover contract. The three tests above pin that a
+// claimed row is not appended twice; this one pins that an unclaimed one is
+// still appended, which is what an over-claiming pairing would silently break.
+test('an account another process added survives a save whose ids disagree with disk', () => {
+  const cfg = [oauth('x1', 'a')];
+  const disk = [oauth('y1', 'a'), oauth('y2', 'added-by-login')];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.name), ['a', 'added-by-login'], 'the external addition is not swallowed by the identity claim');
+});
+
+// removedIds is keyed by id, so a row without one can never be recognised as a
+// deletion in progress. Skipping it is what keeps the save that removes an
+// account from writing it straight back.
+test('an id-less disk row is not adopted over the removal it cannot be matched against', () => {
+  const config = { accounts: [entry('i1', 'a'), entry('i2', 'doomed')] };
+  markAccountRemoved(config, 'i2');
+  config.accounts = config.accounts.filter(a => a.id !== 'i2');
+
+  const disk = [{ name: 'a', type: 'apikey', apiKey: 'k' }, { name: 'doomed', type: 'apikey', apiKey: 'k' }];
+  const out = mergeAccountsForSave(config.accounts, [], disk, removedAccountIds(config));
+
+  assert.deepEqual(out.map(a => a.name), ['a'], 'the save that deletes it must not put it back');
+});
+
+// sameIdentity answers two different questions: it compares account uuids when
+// both records carry one, and falls back to the display name when either does
+// not. A claim consumes the row it matches, so an entry holding a uuid that
+// settles for a namesake's row takes it away from the entry it belonged to —
+// and `importFrom` on that row names the credentials file the entry reads at the
+// next start. identity.js already orders these for the login axis (#236); the
+// disk axis needs the same order.
+test('an entry with a uuid claims the row that proves it, not a namesake without one', () => {
+  const cfg = [
+    { id: 'x2', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'o1' },
+    { id: 'x1', name: 'p@example.com', type: 'oauth' },
+  ];
+  const disk = [
+    { id: 'y0', name: 'p@example.com', type: 'oauth', importFrom: '/hand-added' },
+    { id: 'y1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'o1', importFrom: '/logged-in' },
+  ];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/logged-in', '/hand-added'], 'the uuid is evidence; a shared display name is not');
+  assert.equal(out[1].accountUuid, undefined, 'and the namesake does not acquire a uuid from a row that is not its own');
+});


### PR DESCRIPTION
Every account in `config.json` gets a twin. It happened to me today: six accounts became twelve, and five of the copies sat in the running proxy holding tokens that had expired hours earlier.

`mergeAccountsForSave` asks two different questions about the same pair of lists. The field merge finds each entry's disk row with `sameIdentity` and merges it, which is why every twin carries the disk row's fields. The carryover then asks whether that row's `id` appears among the entries it kept, and appends it when it does not. So it re-appends the row the merge just consumed, and the list doubles.

Ids diverge whenever a config that has none is read by more than one process, since each mints its own with `randomUUID`. No race is needed: `teamclaude login` ends in a whole-file save, so it publishes one process's ids and leaves every already-running server holding ids that are no longer on disk. A hand-copied account block does it too, because `ensureAccountIds` re-mints the duplicate differently in each process.

The fix pairs the two lists once. Each entry claims one disk row, by exact id first and `sameIdentity` as the fallback, and a claimed row is never offered again. Both the field merge and the carryover use that pairing, so they can no longer disagree about which rows are spoken for. Id stays the rule for pairing entries to accounts; identity stays where it already was, on the config-to-disk axis, and only gains the discipline it lacked.

Measured on the merge base and on this branch:

| | before | after |
| --- | --- | --- |
| one process, config still without ids | 2 | 2 |
| both sides already migrated | 2 | 2 |
| two processes, ids disagree | 4 | 2 |
| an account added on disk by another process | 3 | 3 |
| added on disk while ids also disagree | 5 | 3 |

A config that is already doubled stays doubled. Nothing here removes an existing twin, and nothing could: the two rows agree on identity, differ in id, and differ in token freshness in whichever direction the last save went, which is also what a deliberate second entry for one person looks like. Deleting the wrong one deletes a working account. `teamclaude accounts` collapses rows sharing an account and organisation, but it keeps the last of them, which may be the stale copy, and it skips API-key rows and rows with no `accountUuid`, so it is a starting point rather than a repair.

Four new tests. Three fail at the merge base: the doubling itself, two entries of one person each consuming their own disk row, and an entry merging the row that carries its own id rather than whichever one identity reached first. That last one reproduces the `importFrom` crossing the module's comment describes, as a value rather than a worry: an entry inherits a delegation belonging to its neighbour and reads that neighbour's credential at the next start. The fourth passes at the merge base and pins the guard whose comment this changes.
