### PR TITLE
fix(account-pairing): claim a disk row on org evidence, not a partial identity match

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -14,7 +14,7 @@
 // evidence and admits no ambiguity: it survives the refresh that rewrites the
 // credential, and it separates two entries that agree on everything else.
 
-import { sameIdentity } from './identity.js';
+import { orgKey, sameIdentity } from './identity.js';
 
 /**
  * The manager account built from config entry `acct`, or null if it has none.
@@ -107,14 +107,16 @@ export function clearRemovedAccountIds(config) {
  * Which disk row each config entry merges over, as a Map of config index to disk
  * index. A row is claimed by at most one entry.
  *
- * Evidence before guesswork, in three passes: an exact id, then an account uuid
- * both records carry, then the display name. `sameIdentity` collapses the last
- * two — it compares uuids only when both sides have one and falls back to the
- * name otherwise — so calling it alone lets an entry holding a uuid settle for a
- * namesake's row. Claiming consumes, so that row is then taken from the entry it
- * belonged to, and `importFrom` on it names the file an entry reads its
- * credential from at the next start. findUpsertTarget in identity.js puts the
- * same two questions in this order for the login axis.
+ * Evidence before guesswork, strongest first, because a claim consumes: a row
+ * taken on weak grounds is taken away from the entry that could have proved it,
+ * and `importFrom` on that row names the file an entry reads its credential from
+ * at the next start.
+ *
+ * `sameIdentity` returns true three ways, and they are not equally strong — uuid
+ * with both organizations known and equal, uuid with an organization missing on
+ * either side, and a bare name match when either record lacks a uuid. One boolean
+ * hides which one answered, so each gets a pass of its own here, behind the exact
+ * id that outranks them all.
  *
  * Ids can disagree with disk — a file written before the field existed, or
  * re-minted by another process — which is why they cannot be the only pass.
@@ -131,6 +133,7 @@ function claimDiskRows(configAccounts, diskAccounts) {
     }
   };
   configAccounts.forEach((a, i) => { if (a?.id) claim(i, d => d?.id === a.id); });
+  configAccounts.forEach((a, i) => { if (!rowFor.has(i) && a?.accountUuid && orgKey(a)) claim(i, d => d?.accountUuid === a.accountUuid && orgKey(d) === orgKey(a)); });
   configAccounts.forEach((a, i) => { if (!rowFor.has(i) && a?.accountUuid) claim(i, d => d?.accountUuid && sameIdentity(d, a)); });
   configAccounts.forEach((a, i) => { if (!rowFor.has(i)) claim(i, d => sameIdentity(d, a)); });
   return rowFor;

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -165,3 +165,75 @@ test('an entry with a uuid claims the row that proves it, not a namesake without
   assert.deepEqual(out.map(a => a.importFrom), ['/logged-in', '/hand-added'], 'the uuid is evidence; a shared display name is not');
   assert.equal(out[1].accountUuid, undefined, 'and the namesake does not acquire a uuid from a row that is not its own');
 });
+
+// The third rung of the same ladder. With uuids equal on both sides,
+// sameIdentity compares organizations only when both are known and returns true
+// when either is missing — so a legacy entry, whose org was never stored, matches
+// any organization of that person. Claiming consumes, so it takes the row from
+// the entry whose org actually names it.
+test('an entry whose org is stored keeps its own row against a legacy namesake', () => {
+  const cfg = [
+    { id: 'x1', name: 'p@example.com', type: 'oauth', accountUuid: 'U' },
+    { id: 'x2', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O2' },
+  ];
+  const disk = [
+    { id: 'y2', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O2', importFrom: '/second-org' },
+    { id: 'y1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', importFrom: '/legacy' },
+  ];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/legacy', '/second-org'], 'a known org outranks an unknown one');
+});
+
+// The other side of the same rung. Matching the person is not matching the
+// account: one uuid spans every organization that person belongs to, so a claim
+// made on a known organization has to match that organization and not merely
+// its owner. This pass runs earliest of the three and consumes, so accepting the
+// person alone here crosses two organizations' rows before any later pass can
+// object.
+test('two organizations of one person keep their own rows, whatever the disk order', () => {
+  const cfg = [
+    { id: 'x1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O1' },
+    { id: 'x2', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O2' },
+  ];
+  const disk = [
+    { id: 'y2', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O2', importFrom: '/org-two' },
+    { id: 'y1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O1', importFrom: '/org-one' },
+  ];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/org-one', '/org-two'], 'a claim on a known org must match that org, not merely the person');
+});
+
+// One organization is not one account. Colleagues share an org key, so matching
+// the organization alone pairs two different people — and this pass consumes,
+// so it would hand each of them the other's credentials file.
+test('colleagues in one organization keep their own rows', () => {
+  const cfg = [
+    { id: 'x1', name: 'a@example.com', type: 'oauth', accountUuid: 'U1', orgUuid: 'O' },
+    { id: 'x2', name: 'b@example.com', type: 'oauth', accountUuid: 'U2', orgUuid: 'O' },
+  ];
+  const disk = [
+    { id: 'y2', name: 'b@example.com', type: 'oauth', accountUuid: 'U2', orgUuid: 'O', importFrom: '/person-b' },
+    { id: 'y1', name: 'a@example.com', type: 'oauth', accountUuid: 'U1', orgUuid: 'O', importFrom: '/person-a' },
+  ];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/person-a', '/person-b'], 'a shared organization must not pair different people');
+});
+
+// An entry that already claimed its row by id must not claim a second one. A
+// later pass that re-claims overwrites the record of the first, and the row it
+// abandons is then suppressed by the keptIds guard rather than carried, because
+// the entry still holds that row's id. So the row is not duplicated, it is lost —
+// and the entry is left holding a credentials path that belongs to another row.
+test('an entry that claimed its row by id does not claim a second one', () => {
+  const cfg = [{ id: 'y1', name: 'a@example.com', type: 'oauth', accountUuid: 'U1', orgUuid: 'O' }];
+  const disk = [
+    { id: 'y1', name: 'a@example.com', type: 'oauth', accountUuid: 'U1', orgUuid: 'O', importFrom: '/its-own' },
+    { id: 'y9', name: 'a@example.com', type: 'oauth', accountUuid: 'U1', orgUuid: 'O', importFrom: '/twin' },
+  ];
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.deepEqual(out.map(a => a.importFrom), ['/its-own', '/twin'], 'its own row merged, the twin carried over once');
+});


### PR DESCRIPTION
**Please do not merge this until the title says it is ready.** It is up early because the bug it describes is live on master and you should see it now, not because it is finished.

`#323` shipped a regression on the `importFrom` path, and it needs a conjunction rather than any two accounts: one person with entries in two organizations, the earlier entry's organization never stored, and the organization-bearing disk row written ahead of the organization-less one. Disk order is whatever the last writer left, so this is reachable rather than contrived. When it holds, the two entries merge each other's disk row, and `importFrom` names the credentials file an entry reads at the next start. Measured against the file on master:

```
config [ A: uuid U, no org ]  [ B: uuid U, org O2 ]
disk   [ row: org O2, importFrom /second-org ]  [ row: no org, importFrom /legacy ]

on 8bb99d6   ["/second-org", "/legacy"]     A and B hold each other's file
on b46e73d   B kept its own "/second-org"
correct      ["/legacy", "/second-org"]
```

So for this input master is worse than it was before `#323`. That is on me.

`sameIdentity` returns true three ways, not two: an account uuid with both organizations known and equal, an account uuid with the organization missing on either side, and a bare name match. `#323` split off the name case and left the middle one collapsed, so an entry whose organization was never stored matches a row belonging to any organization of that person. Claiming consumes, so the row is then gone from the entry it named.

The fix adds a strict pass ahead of the uuid pass, using `orgKey`, so the ladder is exhaustive by construction rather than by anyone having enumerated the cases correctly. Six tests in the suite plus one new one, mutation-checked: reverting the strict pass reddens the new test alone.

Two things about `#323` worth recording, since both are permanent.

Its commit message says "one entry can no longer inherit another's `importFrom` and read its credential at the next start". The regression above disproves it. A universal claim about a credential path should have rested on what the code guarantees by construction, and that sentence rested on my enumeration being complete. It was not, twice.

It was merged from draft while a review round was still open, and that round is what found this. I published the draft to make the work visible, so the half-finished state was mine to put where it could be merged, not yours to guess about. Hence the shouting in this title: the signal that failed was implicit, so this one is not.
