### PR TITLE
fix(config): a config with no accounts key loads and saves as an empty list

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -146,6 +146,9 @@ function claimDiskRows(configAccounts, diskAccounts) {
  * and claimDiskRows is where it is decided: one row per entry, one entry per row.
  */
 export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccounts, removedIds = new Set()) {
+  // loadConfig normalises a missing list, but this is the function that threw
+  // on one (#330), so it holds its own contract too: no rows is an empty list.
+  if (!Array.isArray(diskAccounts)) diskAccounts = [];
   const rowFor = claimDiskRows(configAccounts, diskAccounts);
 
   const merged = configAccounts.map((a, i) => {

--- a/src/config.js
+++ b/src/config.js
@@ -108,6 +108,12 @@ export async function loadConfig() {
   const path = getConfigPath();
   try {
     const config = JSON.parse(await readFile(path, 'utf-8'));
+    // A file with no `accounts` key is what an empty or hand-trimmed config
+    // looks like. Every reader treats the list as always present, and the first
+    // one to trip was the save path — so the failure arrived while writing,
+    // long after the read that could have explained it (#330). A missing list
+    // is an empty one.
+    if (!Array.isArray(config.accounts)) config.accounts = [];
     // Everything downstream pairs config entries to running accounts by entry id,
     // so a config written before the field existed — or edited by hand — is given
     // ids here, before anything can read one. The next save persists them.

--- a/test/config-missing-accounts.test.js
+++ b/test/config-missing-accounts.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig, atomicConfigUpdate } from '../src/config.js';
+import { mergeAccountsForSave } from '../src/account-pairing.js';
+
+// A config.json without an `accounts` key is what an empty or hand-trimmed
+// file looks like. The load is where it first enters memory, so the load is
+// where a missing list becomes an empty one — every reader downstream, the
+// save path included, assumes the list exists (#330).
+
+async function withConfig(raw, fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-config-'));
+  const path = join(dir, 'config.json');
+  await writeFile(path, JSON.stringify(raw));
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  process.env.TEAMCLAUDE_CONFIG = path;
+  try {
+    await fn(path);
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG; else process.env.TEAMCLAUDE_CONFIG = prev;
+  }
+}
+
+test('a config with no accounts key loads with an empty list', async () => {
+  await withConfig({ proxy: { port: 3456 } }, async () => {
+    const config = await loadConfig();
+    assert.deepEqual(config.accounts, []);
+    assert.equal(config.proxy.port, 3456, 'the rest of the file is untouched');
+  });
+});
+
+test('an accounts key that is not a list is treated as empty rather than crashing', async () => {
+  await withConfig({ accounts: null }, async () => {
+    assert.deepEqual((await loadConfig()).accounts, []);
+  });
+  await withConfig({ accounts: { name: 'not-a-list' } }, async () => {
+    assert.deepEqual((await loadConfig()).accounts, []);
+  });
+});
+
+test('the save path survives a config with no accounts key', async () => {
+  await withConfig({ proxy: { port: 3456 } }, async (path) => {
+    const inMemory = [{ id: 'i1', name: 'a', type: 'apikey', apiKey: 'k' }];
+    await atomicConfigUpdate(disk => {
+      disk.accounts = mergeAccountsForSave(inMemory, [], disk.accounts);
+    });
+    const written = JSON.parse(await readFile(path, 'utf-8'));
+    assert.deepEqual(written.accounts.map(a => a.name), ['a']);
+    assert.equal(written.proxy.port, 3456);
+  });
+});

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -165,3 +165,18 @@ test('an entry with a uuid claims the row that proves it, not a namesake without
   assert.deepEqual(out.map(a => a.importFrom), ['/logged-in', '/hand-added'], 'the uuid is evidence; a shared display name is not');
   assert.equal(out[1].accountUuid, undefined, 'and the namesake does not acquire a uuid from a row that is not its own');
 });
+
+// A config.json with no `accounts` key at all is what an empty or hand-trimmed
+// file looks like. Every reader treated the list as always present, and the
+// first to trip was this save — a TypeError while writing, long after the read
+// that could have explained it (#330). A missing list is an empty one.
+test('a disk config with no accounts list is saved as an empty one', () => {
+  const cfg = [entry('i1', 'a')];
+  for (const disk of [undefined, null, 'not a list']) {
+    const out = mergeAccountsForSave(cfg, [], disk);
+    assert.deepEqual(out.map(a => a.name), ['a'], `disk accounts = ${String(disk)}`);
+  }
+  const config = { accounts: [] };
+  markAccountRemoved(config, 'i2');
+  assert.deepEqual(mergeAccountsForSave([], [], undefined, removedAccountIds(config)), []);
+});


### PR DESCRIPTION
A `config.json` without an `accounts` key is what an empty or hand-trimmed file looks like. Every reader assumed the list was present, and the first to trip was `mergeAccountsForSave` on the save path, so the failure arrived while writing rather than at the read that could have explained it.

- `loadConfig` normalises a missing or non-list `accounts` to `[]`, covering every reader at once.
- `mergeAccountsForSave` defaults its own argument, so the function that threw holds its own contract too.
- Tests for the load, the save through `atomicConfigUpdate`, and the merge with no rows.

Fixes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
