### PR TITLE
fix(account-pairing): a removed row is claimed by no surviving entry

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -118,10 +118,20 @@ export function clearRemovedAccountIds(config) {
  *
  * Ids can disagree with disk — a file written before the field existed, or
  * re-minted by another process — which is why they cannot be the only pass.
+ *
+ * A row the operator removed is claimed by nobody. Removal consults `removedIds`
+ * where rows are carried over, so the removed row is not appended as its own
+ * entry; without the same check here, the identity fallback matched that row
+ * to a surviving namesake and merged its fields in — including `importFrom`,
+ * which names the file an entry reads its credential from at the next start, so
+ * the survivor was left pointing at the deleted account's credentials (#329).
  */
-function claimDiskRows(configAccounts, diskAccounts) {
+function claimDiskRows(configAccounts, diskAccounts, removedIds) {
   const rowFor = new Map();
   const taken = new Set();
+  for (const [d, diskAcct] of diskAccounts.entries()) {
+    if (diskAcct?.id && removedIds.has(diskAcct.id)) taken.add(d);
+  }
   const claim = (i, matches) => {
     for (const [d, diskAcct] of diskAccounts.entries()) {
       if (taken.has(d) || !matches(diskAcct)) continue;
@@ -149,7 +159,7 @@ export function mergeAccountsForSave(configAccounts, managerAccounts, diskAccoun
   // loadConfig normalises a missing list, but this is the function that threw
   // on one (#330), so it holds its own contract too: no rows is an empty list.
   if (!Array.isArray(diskAccounts)) diskAccounts = [];
-  const rowFor = claimDiskRows(configAccounts, diskAccounts);
+  const rowFor = claimDiskRows(configAccounts, diskAccounts, removedIds);
 
   const merged = configAccounts.map((a, i) => {
     const am = managerAccountFor(managerAccounts, a);

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -180,3 +180,37 @@ test('a disk config with no accounts list is saved as an empty one', () => {
   markAccountRemoved(config, 'i2');
   assert.deepEqual(mergeAccountsForSave([], [], undefined, removedAccountIds(config)), []);
 });
+
+// The removal set was consulted only where rows are carried over, so the
+// removed row was not appended — but nothing consulted it where rows are
+// claimed, and the identity fallback matched the removed row to a surviving
+// namesake and merged its fields in. `importFrom` names the file an entry reads
+// its credential from at the next start, so the survivor was left pointing at
+// the deleted account's credentials (#329). Reachable with a hand-added entry
+// (no id of its own) sharing the removed account's name.
+test('a removed row hands nothing to a surviving namesake', () => {
+  const config = { accounts: [{ name: 'p@example.com', type: 'oauth' }] };
+  markAccountRemoved(config, 'gone');
+  const disk = [{ id: 'gone', name: 'p@example.com', type: 'oauth', importFrom: '/removed-account-creds' }];
+
+  const out = mergeAccountsForSave(config.accounts, [], disk, removedAccountIds(config));
+
+  assert.equal(out.length, 1);
+  assert.equal(out[0].importFrom, undefined, 'the survivor must not read the deleted account\'s credentials');
+  assert.equal(out[0].id, undefined, 'nor inherit its id');
+});
+
+test('a removed row is not claimed even when the survivor carries the same uuid', () => {
+  const config = { accounts: [{ id: 'new', name: 'p@example.com', type: 'oauth', accountUuid: 'u1' }] };
+  markAccountRemoved(config, 'gone');
+  const disk = [
+    { id: 'gone', name: 'p@example.com', type: 'oauth', accountUuid: 'u1', importFrom: '/removed-account-creds' },
+    { id: 'new', name: 'p@example.com', type: 'oauth', accountUuid: 'u1', refreshToken: 'r-new' },
+  ];
+
+  const out = mergeAccountsForSave(config.accounts, [], disk, removedAccountIds(config));
+
+  assert.deepEqual(out.map(a => a.id), ['new']);
+  assert.equal(out[0].importFrom, undefined);
+  assert.equal(out[0].refreshToken, 'r-new', 'its own row is still merged over');
+});


### PR DESCRIPTION
The removal set was consulted where disk rows are carried over, so a removed account was not appended back as its own entry. Nothing consulted it where rows are *claimed*, so the identity fallback matched the removed row to a surviving namesake and merged its fields in — including `importFrom`, which names the file an entry reads its credential from at the next start. The survivor was left pointing at the deleted account's credentials.

`claimDiskRows` now marks every removed row as taken before any pass runs, so it is neither claimed nor carried over. Tests cover the namesake case from the report and a same-uuid survivor that still merges over its own row.

Follows #331, which touched the same lines.

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
