### PR TITLE
fix(identity): compare organizations field by field, and prefer the org match on upsert

### DIFF
--- a/src/account-pairing.js
+++ b/src/account-pairing.js
@@ -14,7 +14,7 @@
 // evidence and admits no ambiguity: it survives the refresh that rewrites the
 // credential, and it separates two entries that agree on everything else.
 
-import { sameIdentity } from './identity.js';
+import { sameIdentity, sameOrg } from './identity.js';
 
 /**
  * The manager account built from config entry `acct`, or null if it has none.
@@ -107,14 +107,17 @@ export function clearRemovedAccountIds(config) {
  * Which disk row each config entry merges over, as a Map of config index to disk
  * index. A row is claimed by at most one entry.
  *
- * Evidence before guesswork, in three passes: an exact id, then an account uuid
- * both records carry, then the display name. `sameIdentity` collapses the last
- * two — it compares uuids only when both sides have one and falls back to the
- * name otherwise — so calling it alone lets an entry holding a uuid settle for a
- * namesake's row. Claiming consumes, so that row is then taken from the entry it
- * belonged to, and `importFrom` on it names the file an entry reads its
- * credential from at the next start. findUpsertTarget in identity.js puts the
- * same two questions in this order for the login axis.
+ * Evidence before guesswork, in four passes: an exact id, then an account uuid
+ * with an organization both records name, then an account uuid alone, then the
+ * display name. `sameIdentity` collapses the last three — it compares uuids
+ * only when both sides have one, tolerates an organization either side has not
+ * stored, and falls back to the name otherwise — so calling it alone lets an
+ * entry holding a uuid settle for a namesake's row, or an entry with no
+ * organization settle for the row of the same person in another one (#327).
+ * Claiming consumes, so that row is then taken from the entry it belonged to,
+ * and `importFrom` on it names the file an entry reads its credential from at
+ * the next start. findUpsertTarget in identity.js puts the same questions in
+ * this order for the login axis.
  *
  * Ids can disagree with disk — a file written before the field existed, or
  * re-minted by another process — which is why they cannot be the only pass.
@@ -141,6 +144,7 @@ function claimDiskRows(configAccounts, diskAccounts, removedIds) {
     }
   };
   configAccounts.forEach((a, i) => { if (a?.id) claim(i, d => d?.id === a.id); });
+  configAccounts.forEach((a, i) => { if (!rowFor.has(i) && a?.accountUuid) claim(i, d => d?.accountUuid === a.accountUuid && sameOrg(d, a) === true); });
   configAccounts.forEach((a, i) => { if (!rowFor.has(i) && a?.accountUuid) claim(i, d => d?.accountUuid && sameIdentity(d, a)); });
   configAccounts.forEach((a, i) => { if (!rowFor.has(i)) claim(i, d => sameIdentity(d, a)); });
   return rowFor;

--- a/src/identity.js
+++ b/src/identity.js
@@ -17,22 +17,39 @@ export function orgKey(acct) {
 }
 
 /**
+ * Whether two records name the same organization: true, false, or null when
+ * they carry no field in common to compare.
+ *
+ * Compared field by field rather than through orgKey. Which field a record
+ * carries depends on what the profile returned when the account was added, so
+ * one record holding only the uuid and another holding only the name describe
+ * one organization while their keys differ — and comparing those keys called
+ * one account two, which on the save path carried its row over a second time
+ * (#328). The uuid decides when both sides have one; the name decides when
+ * both have one and either lacks a uuid; a uuid against a name is no evidence
+ * either way.
+ */
+export function sameOrg(a, b) {
+  if (a?.orgUuid && b?.orgUuid) return a.orgUuid === b.orgUuid;
+  if (a?.orgName && b?.orgName) return a.orgName === b.orgName;
+  return null;
+}
+
+/**
  * Whether two account records refer to the same account+org.
  *
- * - Both have an accountUuid: it must match. If both org keys are known they
- *   must also match; but if either side's org is still unknown we treat them as
- *   the same. This lets a freshly-profiled login backfill a legacy entry (which
- *   has no stored org) instead of creating a duplicate. Once both sides carry an
- *   org key, a *different* org is correctly seen as a distinct account.
+ * - Both have an accountUuid: it must match. If the organizations can be
+ *   compared (see sameOrg) they must also match; but if either side's org is
+ *   still unknown we treat them as the same. This lets a freshly-profiled login
+ *   backfill a legacy entry (which has no stored org) instead of creating a
+ *   duplicate. Once both sides carry a comparable org field, a *different* org
+ *   is correctly seen as a distinct account.
  * - Otherwise (API-key accounts, or no UUID yet): fall back to matching by name.
  */
 export function sameIdentity(a, b) {
   if (a?.accountUuid && b?.accountUuid) {
     if (a.accountUuid !== b.accountUuid) return false;
-    const ka = orgKey(a);
-    const kb = orgKey(b);
-    if (ka && kb) return ka === kb;
-    return true;
+    return sameOrg(a, b) !== false;
   }
   return a?.name === b?.name;
 }
@@ -45,9 +62,7 @@ export function sameIdentity(a, b) {
 export function distinctAccounts(a, b) {
   if (!a?.accountUuid || !b?.accountUuid) return false;
   if (a.accountUuid !== b.accountUuid) return true;
-  const ka = orgKey(a);
-  const kb = orgKey(b);
-  return !!(ka && kb && ka !== kb);
+  return sameOrg(a, b) === false;
 }
 
 /**
@@ -72,8 +87,16 @@ export function findUpsertTarget(accounts, incoming) {
   // UUID is just a hand-added entry beside a logged-in one, or an account added
   // before its first probe.
   //
-  // So look for the evidence before accepting the guess.
+  // So look for the evidence before accepting the guess — and the strongest
+  // evidence first. The uuid pass below still takes sameIdentity's tolerant
+  // answer, which says yes to an entry that never stored an organization, so a
+  // legacy entry sitting earlier in the list won over the one whose
+  // organization actually matched (#327). An entry with no organization ahead
+  // of one that has it is a hand-added entry beside a logged-in one, or any
+  // account before its first probe.
   if (incoming?.accountUuid) {
+    const exact = accounts.findIndex(a => a?.accountUuid === incoming.accountUuid && sameOrg(a, incoming) === true);
+    if (exact >= 0) return exact;
     const byUuid = accounts.findIndex(a => a?.accountUuid && sameIdentity(a, incoming));
     if (byUuid >= 0) return byUuid;
   }

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   orgKey,
+  sameOrg,
   sameIdentity,
   emailOf,
   matchAccounts,
@@ -239,6 +240,55 @@ test('findUpsertTarget does not let a UUID match cross organizations', () => {
     { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' },
   ];
   assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-acme' }), 1);
+});
+
+// Which org field a record carries depends on what the profile returned when
+// the account was added, so the uuid form and the name form of one organization
+// are both in circulation. Keyed through orgKey they compared unequal, and on
+// the config-to-disk axis neither record claimed the other's row, so the row
+// was carried over and the account appeared twice after an upgrade (#328).
+test('sameOrg: the uuid and name forms of one organization agree', () => {
+  const byUuid = { accountUuid: 'u1', orgUuid: 'O' };
+  const byName = { accountUuid: 'u1', orgName: 'Acme' };
+  assert.equal(sameOrg(byUuid, byName), null, 'a uuid against a name is no evidence either way');
+  assert.equal(sameIdentity(byUuid, byName), true);
+  assert.equal(distinctAccounts(byUuid, byName), false);
+});
+
+test('sameOrg: the uuid decides when both sides carry one, the name only when they do not', () => {
+  assert.equal(sameOrg({ orgUuid: 'O', orgName: 'Acme' }, { orgUuid: 'O', orgName: 'Acme Renamed' }), true);
+  assert.equal(sameOrg({ orgUuid: 'O1', orgName: 'Acme' }, { orgUuid: 'O2', orgName: 'Acme' }), false);
+  assert.equal(sameOrg({ orgUuid: 'O', orgName: 'Acme' }, { orgName: 'Acme' }), true);
+  assert.equal(sameOrg({ orgUuid: 'O', orgName: 'Acme' }, { orgName: 'Other' }), false);
+  assert.equal(sameOrg({}, { orgUuid: 'O' }), null);
+  assert.equal(sameOrg(null, undefined), null);
+});
+
+// findUpsertTarget's uuid pass takes sameIdentity's tolerant answer, which says
+// yes to an entry that never stored an organization — so a legacy entry sitting
+// earlier in the list won over the one whose organization actually matched, and
+// a login for a known organization landed its credential on the legacy row
+// (#327).
+test('findUpsertTarget prefers the entry whose organization matches over an earlier legacy entry', () => {
+  const accounts = [
+    { name: 'a@x.com', accountUuid: 'u1' },                 // no org stored: hand-added, or never probed
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o2' },  // the one this login is for
+  ];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o2' }), 1);
+  // The same organization under its name form is still the exact match.
+  const named = [
+    { name: 'a@x.com', accountUuid: 'u1' },
+    { name: 'a@x.com', accountUuid: 'u1', orgName: 'Acme' },
+  ];
+  assert.equal(findUpsertTarget(named, { name: 'a@x.com', accountUuid: 'u1', orgName: 'Acme' }), 1);
+});
+
+test('findUpsertTarget still backfills the legacy entry when no entry names the organization', () => {
+  const accounts = [
+    { name: 'a@x.com', accountUuid: 'u1' },
+    { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o-other' },
+  ];
+  assert.equal(findUpsertTarget(accounts, { name: 'a@x.com', accountUuid: 'u1', orgUuid: 'o2' }), 0);
 });
 
 test('findUpsertTarget still adds a genuinely new account', () => {

--- a/test/save-disk-entries.test.js
+++ b/test/save-disk-entries.test.js
@@ -214,3 +214,39 @@ test('a removed row is not claimed even when the survivor carries the same uuid'
   assert.equal(out[0].importFrom, undefined);
   assert.equal(out[0].refreshToken, 'r-new', 'its own row is still merged over');
 });
+
+// The uuid and name forms of one organization compared unequal through orgKey,
+// so on this axis neither record claimed the other's row: the row was carried
+// over and the account appeared twice after an upgrade that changed which field
+// the profile handed back (#328).
+test('an entry naming its organization by uuid claims the disk row naming it by name', () => {
+  const cfg = [{ id: 'x1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgUuid: 'O', accessToken: 't' }];
+  const disk = [{ id: 'y1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', orgName: 'Acme', importFrom: '/creds' }];
+
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.equal(out.length, 1, 'one account, not two');
+  assert.equal(out[0].importFrom, '/creds', 'merged over its own row');
+});
+
+// The uuid pass took sameIdentity's tolerant answer, so an entry that never
+// stored an organization could claim the row of the same person in another
+// one, taking it away from the entry it belonged to (#327, on the disk axis).
+test('an entry with no organization does not claim the row of the same person in a known one', () => {
+  const cfg = [
+    { id: 'x1', name: 'p@example.com', type: 'oauth', accountUuid: 'U', accessToken: 't-legacy' },
+    { id: 'x2', name: 'p@example.com (Acme)', type: 'oauth', accountUuid: 'U', orgUuid: 'O', accessToken: 't-acme' },
+  ];
+  const disk = [
+    { id: 'y1', name: 'p@example.com (Acme)', type: 'oauth', accountUuid: 'U', orgUuid: 'O', importFrom: '/acme-creds' },
+    { id: 'y2', name: 'p@example.com', type: 'oauth', accountUuid: 'U' },
+  ];
+
+  const out = mergeAccountsForSave(cfg, [], disk);
+
+  assert.equal(out.length, 2);
+  const acme = out.find(a => a.id === 'x2');
+  const legacy = out.find(a => a.id === 'x1');
+  assert.equal(acme.importFrom, '/acme-creds', 'the Acme entry keeps the Acme row');
+  assert.equal(legacy.importFrom, undefined, 'the legacy entry does not take it');
+});


### PR DESCRIPTION
Two related gaps in how one account in one organization is recognised, fixed together because the second needs the first's comparison.

**#328** — `orgKey` returned the org uuid or else the org name, so the uuid form and the name form of one organization compared unequal, and which form a record carries depends on what the profile returned when the account was added. On the config-to-disk axis neither record claimed the other's row, the row was carried over, and the account appeared twice after an upgrade. A new `sameOrg` compares uuids when both sides have one, names when both have one and either lacks a uuid, and reports "cannot tell" for a uuid against a name. `sameIdentity` and `distinctAccounts` use it.

**#327** — `findUpsertTarget` took the tolerant identity match before looking for the exact one, so a login for a known organization landed on a legacy entry that never stored an organization whenever that entry came first. A rung requiring both sides to name the organization, and agree, now runs ahead of the uuid pass. `claimDiskRows` gets the same rung on the disk axis.

Stacked on #333; merge that first.

Fixes #327
Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
