### PR TITLE
feat(tui): move the switch-mode cursor to the targeted family bar

### DIFF
--- a/src/tui.js
+++ b/src/tui.js
@@ -1563,9 +1563,21 @@ export class TUI {
     const isCur = idx === this.am.currentIndex;
     const isSel = this.mode === 'select' && idx === this.selIdx;
 
-    // Prefix: selection marker + current marker
-    const sel = isSel ? cyan('>') : ' ';
+    // Prefix: selection marker + current marker.
+    //
+    // In switch mode with a Fable/Sonnet route as the pin target, the cursor
+    // moves to that family's bar — in front of `F7` / `S7`, where the pin's ►
+    // will land — and the row start keeps a dim `>` so the row stays easy to
+    // find. The move only happens when the row draws that bar; a row without
+    // it keeps the cursor at the start, since there is nothing to point at.
+    const q = a.quota;
+    const selFamily = isSel && this.selAction === 'switch' && this.selRoute ? routeFamily(this.selRoute) : null;
+    const barShown = fam => showBoth && showFamily && q[fam === 'fable' ? 'unified7dFable' : 'unified7dSonnet'] != null;
+    const cursorAt = selFamily && barShown(selFamily) ? selFamily : null;
+    const sel = !isSel ? ' ' : cursorAt ? dim('>') : cyan('>');
     const cur = isCur ? green('►') : ' ';
+    // The column before a family bar's marker: the cursor when it moved here, else the separator space.
+    const famLead = fam => (cursorAt === fam ? cyan('>') : ' ');
 
     // General-route markers: one fixed column per general route (stable order), so
     // the same route always sits in the same slot across accounts. A member shows
@@ -1617,7 +1629,6 @@ export class TUI {
     status = rpad(status, 10);
 
     // Quota ratios — prefer unified (Claude Max), fall back to standard (API key)
-    const q = a.quota;
     let r1 = null, r2 = null, l1 = 'Ses', l2 = 'Wk ', t1 = null, t2 = null, w1 = null, w2 = null;
 
     if (rowCategory(q) === 'unified') {
@@ -1663,11 +1674,11 @@ export class TUI {
       // Sonnet weekly bar — only shown when the usage probe has populated it. A
       // leading ► (in place of a padding space) marks a Sonnet route on this account.
       if (showFamily && q.unified7dSonnet != null) {
-        line += ` ${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, limFor('unified7dSonnet'))}`;
+        line += `${famLead('sonnet')}${familyMark('sonnet')}S7  ${bar(q.unified7dSonnet, bw, q.unified7dSonnetReset, SEVEN_DAY_MS, limFor('unified7dSonnet'))}`;
       }
       // Fable weekly bar — only shown when the usage probe has populated it.
       if (showFamily && q.unified7dFable != null) {
-        line += ` ${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, limFor('unified7dFable'))}`;
+        line += `${famLead('fable')}${familyMark('fable')}F7  ${bar(q.unified7dFable, bw, q.unified7dFableReset, SEVEN_DAY_MS, limFor('unified7dFable'))}`;
       }
     }
     // Explicit "disabled for these models" tag (issue #85): a family the account

--- a/test/tui-routes.test.js
+++ b/test/tui-routes.test.js
@@ -236,3 +236,60 @@ test('TUI routes editor: delete removes the selected route', async () => {
   assert.deepEqual(config.routes, [{ name: 'bulk', match: ['*opus*'] }]);
   assert.deepEqual(applied.routes, config.routes);
 });
+
+// Pressing → in switch mode targets the Fable route; the cursor should say so
+// where the eye is: in front of the F7 bar, where the pin's ► will land. The
+// row start keeps a dim `>` so the row is still easy to find.
+test('TUI: targeting a family route moves the cursor to its bar and dims the row-start one', () => {
+  const future = Date.now() + 7 * 24 * 3600_000;
+  const oauth = n => ({ name: n, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: future });
+  const am = new AccountManager([oauth('a'), oauth('b')], 0.98);
+  for (const acc of am.accounts) {
+    acc.quota.unified5h = 0.1; acc.quota.unified5hReset = future;
+    acc.quota.unified7d = 0.1; acc.quota.unified7dReset = future;
+    acc.quota.unified7dFable = 0.2; acc.quota.unified7dFableReset = future;
+    acc.quota.unified7dSonnet = 0.2; acc.quota.unified7dSonnetReset = future;
+  }
+  const routes = am.getRoutes();
+  const fable = routes.find(r => r.name === 'fable');
+  const sonnet = routes.find(r => r.name === 'sonnet');
+  assert.ok(fable && sonnet, 'auto routes exist');
+
+  const tui = Object.create(TUI.prototype);
+  tui.am = am; tui.mode = 'select'; tui.selAction = 'switch'; tui.selIdx = 1;
+  const render = (i) => tui._renderAcct(i, 8, true, routes, [], { fable: null, sonnet: null });
+  const CYAN_CURSOR = '\x1b[36m>\x1b[0m';
+  const DIM_CURSOR = '\x1b[2m>\x1b[0m';
+
+  // Default target: the bright cursor at the row start, nothing at the bars.
+  tui.selRoute = null;
+  let row = render(1);
+  assert.ok(row.startsWith(` ${CYAN_CURSOR}`), 'bright cursor at the row start');
+  assert.doesNotMatch(stripAnsi(row), />\s*[►]?\s*F7/, 'no cursor at F7');
+  const width = stripAnsi(row).length;
+
+  // Fable target: dim at the start, bright in front of F7, same row width.
+  tui.selRoute = fable;
+  row = render(1);
+  assert.ok(row.startsWith(` ${DIM_CURSOR}`), 'the row-start cursor is dimmed');
+  assert.ok(row.includes(`${CYAN_CURSOR} F7`), `bright cursor in front of F7, got: ${JSON.stringify(stripAnsi(row))}`);
+  assert.equal(stripAnsi(row).length, width, 'the row does not grow');
+  assert.ok(!render(0).includes('>'), 'an unselected row draws no cursor anywhere');
+
+  // Sonnet target: the cursor sits at S7 instead, and F7 is clear again.
+  tui.selRoute = sonnet;
+  row = render(1);
+  assert.ok(row.includes(`${CYAN_CURSOR} S7`), 'bright cursor in front of S7');
+  assert.ok(!row.includes(`${CYAN_CURSOR} F7`), 'not at F7');
+
+  // The pin's own ► keeps its place: the cursor takes the separator column, not the marker's.
+  row = tui._renderAcct(1, 8, true, routes, [], { fable: 1, sonnet: null });
+  tui.selRoute = fable;
+  row = tui._renderAcct(1, 8, true, routes, [], { fable: 1, sonnet: null });
+  assert.match(stripAnsi(row), />►F7/, 'cursor, then the marker, then the label');
+
+  // A row without the F7 bar keeps the bright cursor at the start: nothing to point at.
+  am.accounts[1].quota.unified7dFable = null;
+  row = render(1);
+  assert.ok(row.startsWith(` ${CYAN_CURSOR}`), 'bright cursor stays at the start when the bar is absent');
+});


### PR DESCRIPTION
Pressing → in switch mode targets the Fable route (→ again, Sonnet), but the only sign of it was the footer text: the `>` cursor stayed at the row start, far from the F7/S7 bar where the pin's ► lands.

The bright cursor now moves in front of that family's bar label, taking the separator column so the row keeps its width and the bar's own ► stays visible beside it. The row start keeps a dim `>` so the selected row stays easy to find.

```
-- target default
 >  bob@example.com    oauth   active     Ses   7d    Wk    7d    S7    7d   ►F7    7d
-- target fable          (row-start > is dim)
 >  bob@example.com    oauth   active     Ses   7d    Wk    7d    S7    7d  >►F7    7d
-- target sonnet
 >  bob@example.com    oauth   active     Ses   7d    Wk    7d  > S7    7d   ►F7    7d
```

A row that does not draw the bar keeps the bright cursor at the start, since there is nothing to point at. The default target and general (non-family) routes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
