### PR TITLE
Bump to 1.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Multi-account proxy for Claude Code and Codex: pools Claude Max, ChatGPT/Codex, API-key and third-party backend accounts, and rotates on quota",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Sixty-one commits since 1.1.17, most of them a security hardening pass
over every entry point. Several tighten what the proxy accepts, so read
the first section before upgrading a public or shared deployment.

Behaviour changes
  #332 the loopback key exemption is refused to a request carrying
       X-Forwarded-For, X-Real-IP or Forwarded, and `proxy.trustLoopback:
       false` switches it off outright. Behind nginx or Caddy on the same
       host every caller was loopback, so the key gate never ran and an
       anonymous POST /v1/messages spent a pooled credential (issue #324)
  #317 the WebSocket upgrade (Remote Control) passes the same key gate as
       every other entry point; on 1.1.17 a public deployment relayed it
       with no auth at all
  4051e50 a CONNECT tunnel or plain-HTTP relay may no longer target this
       machine: that was an unauthenticated route back into the proxy's own
       control plane, and SSRF to loopback and link-local services
  39f9317 buffered request bodies are capped at 64 MiB (413 past it)
  44f1077 x-claude-code-session-id is honoured only as [A-Za-z0-9._-]{1,128};
       anything else is treated as untagged
  202c988 the quota probe interval is capped at seven days (`teamclaude
       probe` and the settings screen); a larger value overflowed Node's
       timer and probed every millisecond
  fc56396 the auto-updater installs only a plain x.y.z from the registry,
       and never runs as root
  5fd6c91 config and state are written via an fsynced temp file and rename,
       0600, following a symlinked config (1ca6761); a crash mid-write no
       longer leaves an empty file with the credentials gone
  4ccbe02 the quota probe skips disabled accounts and accounts whose refresh
       token upstream already rejected

Security boundary
  ee5328e the client's own Authorization header is dropped before forwarding
       on the API-key path, so it no longer reaches a per-account upstream
  be78434 the proxy's own x-api-key is not relayed on client-credential paths
       (/v1/code/*, /api/oauth/*, the WebSocket)
  925a80a the loopback exemption is closed to web pages: cross-origin
       requests and a rebound Host are refused on every path
  125a138 the dashboard is served with a Content-Security-Policy
  a1527fd internal error detail (config paths, resolved upstream hosts) is
       kept out of client-facing replies
  53b8efb modelMap lookups use own properties only ("constructor" no longer
       resolves to a function)
  d1292d9 the CONNECT authority is parsed strictly, so `[::1]:443`, an empty
       host or an upper-cased api.anthropic.com can no longer slip past the
       intercept into a blind tunnel
  f1b991d TLS handshakes on terminated and tunnelled connections have a
       deadline
  821f95b the browser login callback listens on loopback only, and only a
       state-bearing request may settle it
  9cc0078 token-endpoint replies are checked before being stored (no more
       `Bearer undefined`, no unexpiring garbage expiry)
  bb06590 an https:// upstream proxy URL is refused rather than sending the
       CONNECT and its credentials in cleartext to port 443
  d07a4a7 SX_API_BASE is honoured only over https
  fbf2d5d a third-party backend's balance reply is bounded and its currency
       string stripped before it reaches the terminal
  42e8872 a third-party backend's token is never refreshed against Anthropic
  1812e6e an unrecognised CONNECT username (the slot the proxy key travels
       in) is redacted in the log
  ef99591 systemd unit values are quoted and control characters refused;
       9b2073f the shell alias escapes quotes in the install path and writes
       the rc file atomically; a122a4a `teamclaude env` quotes the CA path
       and validates proxy.port
  28da0bc the session map is bounded (10k entries, ids keyed by their first
       128 characters); 1ad193a upstream rate-limit headers and the client's
       model string are validated and sanitised; 9c2d075 a non-finite
       Retry-After no longer parks an account for ever
  14f221f 151eabd 1a4d1dd beeb772 bb8790a every string the TUI, the attach
       dashboard and `teamclaude status` draw is stripped of escape
       sequences; control-plane replies are size-capped; API keys are masked
       while typed
  771ba54 f16ca13 79abaf4 the publish job installs no dependencies, every
       action is pinned to a commit SHA, and the publishing npm is pinned

Features
  #290 `distributeSessions: "adaptive"`: a third distribution mode that
       concentrates new sessions on the account with the least remaining
       weekly credit, tapering off at the threshold and backing off under
       congestion, learning plan tier and tolerated concurrency live
  #321 bounded per-origin admission in front of the upstream pool, and
       upstream work is cancelled when the client disconnects
  #322 event-loop lag under `server.eventLoop` in the status, and a deadline
       for `teamclaude status`
  #337 a WebSocket channel opened with a client key is booked as a
       `connections` count on that client, and its open/close lines carry the
       `[name]` prefix (issue #325); an upstream-refused handshake is relayed
       back instead of hanging
  #338 in switch mode, targeting the Fable or Sonnet route moves the cursor
       to that family's bar, with a dim cursor left at the row start

Fixes
  #334 the uuid and name forms of one organization compare as one (issue
       #328), and a login for a known organization lands on the entry that
       names it rather than an earlier legacy entry (issue #327)
  #336 a removed account's disk row is no longer merged into a surviving
       namesake, which could leave it reading the deleted account's
       credentials (issue #329)
  #331 a config with no `accounts` key loads and saves as an empty list
       (issue #330)
  #323 the saved account list no longer doubles when two processes mint
       different entry ids for a pre-id config
  a2a7086 a refreshed token is paired to its config row by entry id only,
       never by a name guess that could cross two people's accounts
  f4fd00a `teamclaude accounts`, `login` and `import` write onto a fresh read
       of the config, so a running server's rotated refresh token is not
       clobbered by a stale copy
  cd84152 a refresh outcome is attributed to the token that was sent, so a
       reload during the refresh no longer marks the new token dead
  a56fb97 a tunnelled WebSocket upgrade is routed by its Host header; a Codex
       client's channel no longer goes to api.anthropic.com
  fa7b828 a stored MITM certificate chain is renewed 30 days before expiry
       instead of failing every handshake once expired
  #320 the macOS LaunchAgent runs at Standard process type; the Background
       QoS clamp starved the proxy under host contention
  #297 undocumented cache_control subfields are stripped for strict
       Anthropic-compatible backends
  80d7665 the browser login opens on Windows (`start "" <url>`)
  b46e73d a tracked node_modules symlink is removed and ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
