### PR TITLE
fix(server): classify a request path on its decoded, separator-folded form

### DIFF
--- a/src/classification-path.js
+++ b/src/classification-path.js
@@ -1,0 +1,81 @@
+// The path a request is CLASSIFIED on.
+//
+// Every routing decision this proxy makes (which pool of accounts is eligible,
+// whether the client's own credential is relayed instead of a pooled one,
+// whether the request is refused outright) is a prefix test on the request
+// path, while the request goes out on the path as it arrived. Two spellings let
+// the test and the destination read that string differently — and they are not
+// the same kind of claim:
+//
+//   backslash    A parser fact. `\` is a separator for http(s) in the WHATWG
+//                URL parser, so the `new URL(upstream + req.url)` that builds
+//                the outgoing target rewrites `/api\oauth\profile` to
+//                `/api/oauth/profile` in THIS process, before anything is sent.
+//                Folding it here only makes the test agree with what we
+//                ourselves are about to send.
+//
+//   percent-     A conservative choice, not a fact. `%2f` and `%61` survive to
+//   encoding     the wire untouched, so whether `/api/oauth%2fprofile` reaches
+//                the same handler as `/api/oauth/profile` is the receiving
+//                server's policy — an RFC-conformant one may keep an encoded
+//                reserved character opaque and route it elsewhere. We decode
+//                anyway because the failure direction is the safe one: matching
+//                the relay where the receiver would not have merely withholds a
+//                pooled token and sends the client's own instead, and refusing a
+//                dot-segment that would not have resolved returns a 400 the
+//                caller can see. Not folding is the direction that puts a pooled
+//                credential on a path nothing here classified.
+//
+// Exactly one decode, never a loop. One decode is the depth a receiving server
+// applies to the target it routes on, so it is the depth that matches the wire.
+// Decoding twice would classify `%252e%252e` as a dot-segment, and that path
+// resolves — everywhere — to a literal segment with no traversal in it at all.
+//
+// BEHAVIOUR CHANGE, from that same conservative direction: hasDotSegment now
+// refuses paths it used to forward. Any path whose one-decode form carries a `.`
+// or `..` segment is a 400, which now includes the spellings that encode the
+// separator itself (`..%2f..%2f`, `.%2f`, `..%5c`) even though nothing in this
+// process folds those. The literal and `%2e` spellings were already refused. No
+// client of ours emits any of them.
+
+// Splits a path into segments AND separators, so a rejoin reproduces it.
+const KEEP_SEPARATORS = /([/\\])/;
+
+function pathOnly(url) {
+  return String(url || '').split('?')[0].split('#')[0];
+}
+
+function decodeOnce(s) {
+  try { return decodeURIComponent(s); } catch { return s; }
+}
+
+/**
+ * `path` percent-decoded exactly one level deep.
+ *
+ * A malformed escape (`%`, `%zz`) has no decoded form, so it is kept as sent —
+ * the receiving server cannot resolve it either. It makes the WHOLE string
+ * undecodable though, while only the one segment is at fault, so the remaining
+ * segments are then decoded individually: a stray `%` must not shield an
+ * encoding in a DIFFERENT segment. Inside its own segment it still shields —
+ * `/a/%zz%2e%2e/b` is classified exactly as sent, as it was before — because
+ * that segment has no decoded form either. Both branches are one decode deep,
+ * so which one runs never changes how deep the decoding goes.
+ */
+function decodeOncePath(path) {
+  try { return decodeURIComponent(path); } catch { /* per-segment below */ }
+  return path.split(KEEP_SEPARATORS).map(decodeOnce).join('');
+}
+
+/**
+ * `url` reduced to the path the proxy should make its routing decisions on:
+ * query and fragment removed, percent-decoded once, backslashes folded to
+ * forward slashes.
+ *
+ * Decode BEFORE folding, not after: `%5c` is only a backslash once it has been
+ * decoded, and folding first would leave it encoded and unseen. The order also
+ * keeps the decoding one level deep — `%255c` decodes to a literal `%5c`, which
+ * stays a character inside a segment rather than becoming a separator.
+ */
+export function classificationPath(url) {
+  return decodeOncePath(pathOnly(url)).replaceAll('\\', '/');
+}

--- a/src/provider.js
+++ b/src/provider.js
@@ -13,6 +13,8 @@
 // re-serialising tool calls, streaming events and cache breakpoints, which is
 // exactly the fidelity loss this proxy exists to avoid.
 
+import { classificationPath } from './classification-path.js';
+
 /** Providers keyed by the value used in an account's `provider` field. */
 export const PROVIDERS = {
   anthropic: {
@@ -137,7 +139,14 @@ const CODEX_PATHS = ['/backend-api/codex'];
  * client-supplied hint that could disagree with the body.
  */
 export function providerForPath(url) {
-  const path = String(url || '').split('?')[0];
+  // Read on the classification path, never rewritten: the request goes out with
+  // the path exactly as it arrived, so this test has to read it the way the
+  // parser and the receiving server will. Otherwise
+  // `/backend-api/codex/..%2fconversations` classifies as Codex and lands
+  // somewhere else entirely, and `/backend-api\codex/responses` — which
+  // `new URL()` folds to a Codex path before sending it — does not classify as
+  // Codex at all, so it draws the wrong pool's credential.
+  const path = classificationPath(url);
   return CODEX_PATHS.some(p => path === p || path.startsWith(`${p}/`))
     ? 'codex'
     : DEFAULT_PROVIDER;

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,7 @@ import { safeLine } from './safe-text.js';
 import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-target.js';
 import { renderDashboardHtml, dashboardCsp } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
+import { classificationPath } from './classification-path.js';
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -33,26 +34,24 @@ const PIN_PREFIX = '/tc-acct/';
  * spelling, on either slash)?
  *
  * Every path classification in the listener — the Codex pool, the
- * client-credential relay, the `/tc-acct/` pin — is a prefix test on the path
- * AS SENT, while the upstream URL is normalised afterwards by `new URL()` and
- * fetch. So `/backend-api/codex/../conversations` classifies as Codex and
- * reaches chatgpt.com as `/backend-api/conversations`, pooled token attached;
+ * client-credential relay, the `/tc-acct/` pin — is a prefix test, while the
+ * path itself is forwarded verbatim and resolved elsewhere. So
+ * `/backend-api/codex/../conversations` classifies as Codex and reaches
+ * chatgpt.com as `/backend-api/conversations`, pooled token attached;
  * `/v1/messages/../../api/oauth/profile` does not start with `/api/oauth/`,
  * takes the pool path, and reaches the profile endpoint with a rotated token —
- * the exact thing the relay exists to prevent for the literal path. Backslash
- * counts because the URL parser treats it as a slash for http(s). No client of
- * ours ever sends one; refusing the request is the whole fix.
+ * the exact thing the relay exists to prevent for the literal path. No client
+ * of ours ever sends such a path; refusing the request is the whole fix.
+ *
+ * Read on the classification path, which is decoded once and has its
+ * backslashes folded (the URL parser treats one as a slash for http(s), so
+ * `new URL()` folds it on the way out too). `..%2f..%2f` and `..\..\` are
+ * therefore the same request as `../../` here, as they are to whatever
+ * resolves them — and splitting on `/` alone is enough, since no separator
+ * survives classificationPath in any other spelling.
  */
 export function hasDotSegment(url) {
-  const path = String(url || '').split('?')[0].split('#')[0];
-  for (const seg of path.split(/[\/\\]/)) {
-    let s = seg;
-    // An undecodable segment (`%`) is compared as sent: the URL parser leaves
-    // it alone too, so it cannot become a dot-segment upstream.
-    try { s = decodeURIComponent(seg); } catch { /* keep raw */ }
-    if (s === '.' || s === '..') return true;
-  }
-  return false;
+  return classificationPath(url).split('/').some((s) => s === '.' || s === '..');
 }
 const INLINE_RETRY_AFTER_MAX_SECONDS = 15;
 // How long the proxy will absorb a rate-limit 429's retry-after inline (waiting
@@ -843,15 +842,6 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
       // Client token refresh: pass through untouched (the proxy manages its own
       // tokens via ensureTokenFresh; rewriting client refreshes would conflict).
       if (req.method === 'POST' && req.url === '/v1/oauth/token') { await relayRaw(req, res, upstream, sx, resolveMaxBodyBytes(config)); return; }
-      // Remote Control (/v1/code/*) is bound to the session's paired claude.ai
-      // identity — forward with the client's OWN credential (streamed), never a
-      // rotated account token, which would 403 the worker event stream.
-      // Attachment transfers (/api/oauth/files/*, /api/oauth/file_upload) are
-      // likewise account-bound: files uploaded from claude.ai belong to the
-      // paired identity, so fetching them with a rotated token 403s and Claude
-      // Code silently drops the image from the message.
-      if (CLIENT_CREDENTIAL_PATHS.some((p) => (req.url || '').startsWith(p))) { await relayStream(req, res, upstream, sx); return; }
-
       // Account pin: a request to `/tc-acct/<name-or-index>/...` (e.g. via
       // ANTHROPIC_BASE_URL=http://host:port/tc-acct/deepseek) is forced onto that
       // one account, bypassing rotation. Used by the keep-warm scheduler and for
@@ -891,6 +881,30 @@ export function createProxyRequestListener({ accountManager, upstream, logDir = 
         }
         req.url = afterPrefix.slice(tokenEnd);
       }
+
+      // Remote Control (/v1/code/*) is bound to the session's paired claude.ai
+      // identity — forward with the client's OWN credential (streamed), never a
+      // rotated account token, which would 403 the worker event stream.
+      // Attachment transfers (/api/oauth/files/*, /api/oauth/file_upload) are
+      // likewise account-bound: files uploaded from claude.ai belong to the
+      // paired identity, so fetching them with a rotated token 403s and Claude
+      // Code silently drops the image from the message.
+      //
+      // Below the pin strip, so this reads the path that will actually be sent,
+      // and on its classification form: `/%61pi/oauth/…`, `/api/oauth%2fprofile`,
+      // `/api\oauth\profile` and `/tc-acct/<acct>/api/oauth/profile` all leave
+      // here as the identity plane, so all of them take the relay. A pinned
+      // account's token is a rotated token like any other — the pin says which
+      // account serves INFERENCE, and no version of it should put a fleet
+      // identity on /api/oauth/*. Above the strip this test still saw the
+      // prefix and matched nothing, while `provider` further down is built from
+      // the stripped url: the two disagreed about the same request.
+      //
+      // Still ABOVE the TC_ACCT branch below, which does not touch req.url —
+      // moving past it would turn an unknown TC_ACCT pin on an identity-plane
+      // request into a 404 that it does not return today.
+      const classifiedPath = classificationPath(req.url);
+      if (CLIENT_CREDENTIAL_PATHS.some((p) => classifiedPath.startsWith(p))) { await relayStream(req, res, upstream, sx); return; }
 
       // MITM-mode pin. A CONNECT carrying `Proxy-Authorization: Basic <acct>:…`
       // has no URL to hang a `/tc-acct/` prefix on — the path inside the tunnel

--- a/test/oauth-client-credential.test.js
+++ b/test/oauth-client-credential.test.js
@@ -86,3 +86,147 @@ test('an inference request still gets the account token injected', async () => {
     upstream.close();
   }
 });
+
+// ── the same endpoints, spelled with percent-encoding ────────────────────────
+//
+// The path is forwarded verbatim — this proxy rewrites nothing on the wire — so
+// a prefix test on the raw string and the endpoint that actually resolves it
+// can disagree. `/%61pi/oauth/profile` and `/api/oauth%2fprofile` are the
+// profile endpoint to the server that answers them, and neither one starts with
+// `/api/oauth/`. Classified on the decoded path, they take the same relay as the
+// literal spelling.
+//
+// The account manager here holds a real fleet token rather than throwing, so the
+// assertion is on WHICH credential arrived: a request that fell through to
+// rotation reaches upstream with the fleet token, and that is what must not
+// happen.
+
+// http.request, not fetch: the raw path is the whole point of these cases and
+// has to reach the listener exactly as written.
+function rawGet(port, path, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method: 'GET', path, headers }, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function fleetManager() {
+  return new AccountManager([
+    { name: 'a', type: 'oauth', accessToken: 'fleet-token', refreshToken: 'r', expiresAt: Date.now() + 3600_000 },
+  ], 0.98);
+}
+
+for (const path of [
+  '/%61pi/oauth/profile',
+  '/api/oauth%2fprofile',
+  '/api/oauth%2Fprofile',
+  '/%76%31/code/sessions/abc/worker/events/stream',
+]) {
+  test(`${path} keeps the client's own credential`, async () => {
+    const { server: upstream, port, seen } = await echoAuthUpstream();
+    const listener = createProxyRequestListener({ accountManager: fleetManager(), upstream: `http://127.0.0.1:${port}` });
+    const { server: proxy, port: proxyPort } = await listen(listener);
+    try {
+      assert.equal(await rawGet(proxyPort, path, { authorization: 'Bearer client-own-token' }), 200);
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].authorization, 'Bearer client-own-token',
+        'a fleet token was attached to the client identity plane');
+      assert.equal(seen[0].url, path, 'the path must be forwarded exactly as sent');
+    } finally {
+      proxy.closeAllConnections?.(); proxy.close();
+      upstream.close();
+    }
+  });
+}
+
+// Decoding is one level deep, matching what the receiving server applies to the
+// target it routes on. `/api/oauth%252fprofile` resolves to a literal segment
+// under `/api/`, not to the identity plane, so it rotates like any other path —
+// widening the relay to cover it would relay requests nobody asked to relay.
+test('a double-encoded separator is not the identity plane and still rotates', async () => {
+  const { server: upstream, port, seen } = await echoAuthUpstream();
+  const listener = createProxyRequestListener({ accountManager: fleetManager(), upstream: `http://127.0.0.1:${port}` });
+  const { server: proxy, port: proxyPort } = await listen(listener);
+  try {
+    assert.equal(await rawGet(proxyPort, '/api/oauth%252fprofile', { authorization: 'Bearer client-own-token' }), 200);
+    assert.equal(seen[0].authorization, 'Bearer fleet-token');
+  } finally {
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.close();
+  }
+});
+
+// ── the same endpoints, spelled with a backslash ─────────────────────────────
+//
+// A backslash is a separator to the WHATWG URL parser for http(s), so the
+// `new URL()` that builds the outgoing target folds it HERE, in this process,
+// before the request is sent. `/api\oauth\profile` therefore always arrives at
+// the identity plane, while a prefix test on the raw string reads one segment
+// and sees nothing of the sort.
+//
+// That is also why `onWire` differs per spelling below, and the difference is
+// the point: a folded backslash is rewritten by our own URL construction, while
+// percent-encoding survives untouched and is resolved by the receiving server.
+
+for (const [path, onWire] of [
+  ['/api\\oauth\\profile', '/api/oauth/profile'],
+  ['/api/oauth\\profile', '/api/oauth/profile'],
+  ['/v1\\code/sessions/abc/worker/events/stream', '/v1/code/sessions/abc/worker/events/stream'],
+  ['/%61pi%5coauth/profile', '/%61pi%5coauth/profile'],
+]) {
+  test(`${path} keeps the client's own credential`, async () => {
+    const { server: upstream, port, seen } = await echoAuthUpstream();
+    const listener = createProxyRequestListener({ accountManager: fleetManager(), upstream: `http://127.0.0.1:${port}` });
+    const { server: proxy, port: proxyPort } = await listen(listener);
+    try {
+      assert.equal(await rawGet(proxyPort, path, { authorization: 'Bearer client-own-token' }), 200);
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].authorization, 'Bearer client-own-token',
+        'a fleet token was attached to the client identity plane');
+      assert.equal(seen[0].url, onWire, 'the request went out on a path this test did not predict');
+    } finally {
+      proxy.closeAllConnections?.(); proxy.close();
+      upstream.close();
+    }
+  });
+}
+
+// ── the same endpoints, reached under a /tc-acct/ pin ────────────────────────
+//
+// A pinned session sends EVERY request under the prefix: claude-env.js and
+// index.js both emit `ANTHROPIC_BASE_URL=http://localhost:<port>/tc-acct/<acct>`,
+// so `/api/oauth/*` and `/v1/code/*` arrive carrying it too. This is ordinary
+// traffic from a supported configuration, not a probe.
+//
+// The prefix is stripped before forwarding, so the identity plane is exactly
+// where these leave for — while a prefix test run before the strip sees
+// `/tc-acct/...` and matches nothing. A pinned account's token is a rotated
+// token like any other: the pin chooses which account serves INFERENCE, and no
+// version of it should put a fleet identity on the client's own control plane.
+
+for (const [path, onWire] of [
+  ['/tc-acct/a/api/oauth/profile', '/api/oauth/profile'],
+  ['/tc-acct/a/api/oauth/file_upload', '/api/oauth/file_upload'],
+  ['/tc-acct/a/v1/code/sessions/abc/worker/events/stream', '/v1/code/sessions/abc/worker/events/stream'],
+  ['/tc-acct/a/%61pi/oauth/profile', '/%61pi/oauth/profile'],
+]) {
+  test(`${path} keeps the client's own credential`, async () => {
+    const { server: upstream, port, seen } = await echoAuthUpstream();
+    const listener = createProxyRequestListener({ accountManager: fleetManager(), upstream: `http://127.0.0.1:${port}` });
+    const { server: proxy, port: proxyPort } = await listen(listener);
+    try {
+      assert.equal(await rawGet(proxyPort, path, { authorization: 'Bearer client-own-token' }), 200);
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].authorization, 'Bearer client-own-token',
+        'the pinned account\'s token was attached to the client identity plane');
+      assert.equal(seen[0].url, onWire, 'the pin prefix must be stripped and nothing else changed');
+    } finally {
+      proxy.closeAllConnections?.(); proxy.close();
+      upstream.close();
+    }
+  });
+}

--- a/test/path-dot-segments.test.js
+++ b/test/path-dot-segments.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import { once } from 'node:events';
 import { createProxyRequestListener, hasDotSegment } from '../src/server.js';
+import { classificationPath } from '../src/classification-path.js';
 
 // Every path classification in the listener is a prefix test on the path as
 // sent, while the upstream URL is normalised afterwards — so a dot-segment
@@ -82,4 +83,111 @@ test('a dot-segment path is refused before the Codex or relay boundary is classi
     proxy.closeAllConnections?.(); proxy.close();
     upstream.closeAllConnections?.(); upstream.close();
   }
+});
+
+// ── percent-encoded spellings ────────────────────────────────────────────────
+//
+// Splitting the path on its literal separators and decoding the pieces
+// afterwards can promote a segment to `..`, but it can never re-split one. So a
+// traversal that hides its own separator behind `%2f` passed the guard as a
+// single ordinary segment, while the server that resolved the forwarded path
+// saw two. Classification reads the decoded path instead.
+
+test('a dot-segment hidden behind an encoded separator is still a dot-segment', () => {
+  for (const p of [
+    '/v1/messages/..%2f..%2fapi/oauth/profile',
+    '/v1/messages/..%2F..%2Fapi/oauth/profile',   // the escape is case-insensitive
+    '/backend-api/codex/..%2fconversations',
+    '/v1/messages/.%2fcount_tokens',
+    '/a/%2e%2e%2fb',
+    '/v1/..%2f',
+  ]) assert.equal(hasDotSegment(p), true, p);
+});
+
+// One decode deep, which is the depth a receiving server applies to the target
+// it routes on. `%252e%252e` decodes to the literal `%2e%2e` — an ordinary
+// segment that traverses nothing — so refusing it would reject a path that is
+// perfectly well formed.
+test('a double-encoded dot-segment is a literal segment, not a traversal', () => {
+  for (const p of [
+    '/a/%252e%252e/b',
+    '/v1/messages/..%252f..%252fapi/oauth/profile',
+    '/backend-api/codex/%252e%252e/conversations',
+    '/a/%255c..%255cb',                            // a literal `%5c`, not a separator
+  ]) assert.equal(hasDotSegment(p), false, p);
+});
+
+// A malformed escape has no decoded form and leaves the WHOLE path undecodable,
+// though only the one segment is at fault. The rest are still read decoded, so a
+// stray '%' cannot shield an encoding sitting beside it.
+test('an undecodable segment does not hide an encoded dot-segment beside it', () => {
+  assert.equal(hasDotSegment('/tc-acct/%zz/..%2fapi/oauth/profile'), true);
+  assert.equal(hasDotSegment('/tc-acct/%/a/%2e%2e/b'), true);
+});
+
+test('classificationPath decodes exactly once and drops query and fragment', () => {
+  assert.equal(classificationPath('/%61pi/oauth/profile'), '/api/oauth/profile');
+  assert.equal(classificationPath('/api/oauth%2fprofile'), '/api/oauth/profile');
+  assert.equal(classificationPath('/v1/messages?model=%2e%2e'), '/v1/messages');
+  assert.equal(classificationPath('/v1/messages#%2e%2e'), '/v1/messages');
+  assert.equal(classificationPath('/a/%252e%252e/b'), '/a/%2e%2e/b');
+  // Undecodable as sent, and the segments around it decoded anyway.
+  assert.equal(classificationPath('/tc-acct/%/v1/messages'), '/tc-acct/%/v1/messages');
+  assert.equal(classificationPath('/tc-acct/%/%61pi'), '/tc-acct/%/api');
+  assert.equal(classificationPath(''), '');
+  assert.equal(classificationPath(null), '');
+  assert.equal(classificationPath(undefined), '');
+});
+
+// The same oracle as the literal-spelling refusal above, for the spellings that
+// encode the separator: the listener answers 400 itself, so no account is
+// selected and nothing is forwarded on either boundary.
+test('an encoded dot-segment is refused before any classification runs', async () => {
+  let upstreamHits = 0;
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => { upstreamHits++; res.writeHead(200); res.end('{}'); });
+  const accountManager = { getActiveAccount() { throw new Error('must not select an account'); } };
+  const listener = createProxyRequestListener({ accountManager, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const { server: proxy, port } = await listen(listener);
+  try {
+    for (const path of [
+      '/v1/messages/..%2f..%2fapi/oauth/profile',
+      '/backend-api/codex/..%2fconversations',
+      '/v1/messages/.%2fcount_tokens',
+    ]) {
+      const { status, body } = await rawRequest(port, path);
+      assert.equal(status, 400, path);
+      assert.equal(JSON.parse(body).error.type, 'invalid_request_error', path);
+    }
+    assert.equal(upstreamHits, 0, 'upstream never saw a dot-segment request');
+  } finally {
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.closeAllConnections?.(); upstream.close();
+  }
+});
+
+// ── the separator spelling ───────────────────────────────────────────────────
+//
+// A backslash is a separator to the WHATWG URL parser for http(s), so
+// `new URL()` folds it while building the outgoing target — in this process,
+// before anything is sent. A literal one was already caught here; an encoded
+// one was not, because it only becomes a separator once it is decoded.
+
+test('an encoded backslash separator carries a dot-segment like a literal one', () => {
+  for (const p of [
+    '/backend-api/codex/..%5cconversations',
+    '/backend-api/codex/..%5Cconversations',
+    '/v1/messages%5c..%5c..%5capi/oauth/profile',
+    '/v1/messages/.%5ccount_tokens',
+    '/a/%5c..%5cb',
+  ]) assert.equal(hasDotSegment(p), true, p);
+});
+
+// Decode first, then fold: `%5c` is only a backslash once decoded, so folding
+// first would leave it encoded and unseen. The order also keeps the decoding one
+// level deep — `%255c` decodes to a literal `%5c` and stays inside its segment.
+test('classificationPath folds a backslash separator after decoding, not before', () => {
+  assert.equal(classificationPath('/api\\oauth\\profile'), '/api/oauth/profile');
+  assert.equal(classificationPath('/%61pi%5coauth/profile'), '/api/oauth/profile');
+  assert.equal(classificationPath('/backend-api%5Ccodex/responses'), '/backend-api/codex/responses');
+  assert.equal(classificationPath('/api/%255coauth/profile'), '/api/%5coauth/profile');
 });

--- a/test/provider-routing.test.js
+++ b/test/provider-routing.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
 import { AccountManager } from '../src/account-manager.js';
+import { createProxyRequestListener } from '../src/server.js';
 
 const oauth = (name, extra = {}) => ({
   name, type: 'oauth', accessToken: 't-' + name, refreshToken: 'r',
@@ -98,4 +101,83 @@ test('a response with no quota headers leaves a known reading intact', () => {
   am.updateQuota(0, codexHeaders(77));
   am.updateQuota(0, { 'content-type': 'application/json' });
   assert.equal(am.accounts[0].quota.unified7d, 0.77);
+});
+
+// ── the partition is decided on the classification path ─────────────────────
+//
+// The tests above prove selection never crosses the partition once the provider
+// is known. This proves the provider is read from the path the request will
+// actually be resolved on: `providerForPath` matched the raw string, while the
+// `new URL()` that builds the outgoing target folds a backslash to a slash
+// first. So `/backend-api\codex/conversations` classified as Anthropic and then
+// went out as a Codex path — drawing its credential from the wrong pool.
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { server, port: server.address().port };
+}
+
+// http.request, not fetch: fetch normalises the path client-side, and the raw
+// path is the whole point of these cases.
+function rawGet(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method: 'GET', path }, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function withBothPools(run) {
+  const seen = [];
+  const { server: upstream, port: upstreamPort } = await listen((req, res) => {
+    seen.push({ url: req.url, auth: req.headers.authorization });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  // A Codex account's default upstream is chatgpt.com; the per-account override
+  // points both pools at the one local recorder, so the credential that arrives
+  // is what says which pool was chosen.
+  const am = new AccountManager([
+    oauth('claude-1'),
+    { ...codex('codex-1'), upstream: `http://127.0.0.1:${upstreamPort}` },
+  ], 0.98);
+  const listener = createProxyRequestListener({ accountManager: am, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const { server: proxy, port } = await listen(listener);
+  try {
+    return await run({ port, seen });
+  } finally {
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.close();
+  }
+}
+
+for (const [path, onWire] of [
+  ['/backend-api\\codex/conversations', '/backend-api/codex/conversations'],
+  ['/backend-api/codex\\responses', '/backend-api/codex/responses'],
+  ['/backend-api%5ccodex/responses', '/backend-api%5ccodex/responses'],
+  ['/backend-api%2fcodex/responses', '/backend-api%2fcodex/responses'],
+]) {
+  test(`${path} draws on the Codex pool`, async () => {
+    await withBothPools(async ({ port, seen }) => {
+      assert.equal(await rawGet(port, path), 200);
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].auth, 'Bearer t-codex-1',
+        "an Anthropic account's credential was attached to a Codex path");
+      assert.equal(seen[0].url, onWire, 'the request went out on a path this test did not predict');
+    });
+  });
+}
+
+// The counterpart: an Anthropic path must not be pulled across by the folding.
+test('an ordinary Anthropic path still draws on the Anthropic pool', async () => {
+  await withBothPools(async ({ port, seen }) => {
+    assert.equal(await rawGet(port, '/v1/messages'), 200);
+    assert.equal(seen[0].auth, 'Bearer t-claude-1');
+    assert.equal(seen[0].url, '/v1/messages');
+  });
 });

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -39,6 +39,37 @@ test('the request path selects the provider', () => {
   assert.equal(providerForPath(undefined), 'anthropic');
 });
 
+// The path goes upstream verbatim, so this prefix test has to read it the way
+// the server that resolves it will. Otherwise the two disagree about which pool
+// of accounts is eligible, and therefore about which credential is attached.
+test('the provider is selected on the decoded path', () => {
+  assert.equal(providerForPath('/backend-api%2fcodex/responses'), 'codex');
+  assert.equal(providerForPath('/backend-api/codex%2fresponses'), 'codex');
+  assert.equal(providerForPath('/backend-api/codex%2Fmodels?client_version=0.150.1'), 'codex');
+  assert.equal(providerForPath('/%62ackend-api/codex/responses'), 'codex');
+});
+
+// A backslash is a separator to the URL parser, so `new URL()` folds it while
+// building the outgoing target. The prefix test has to fold it too, or the
+// request goes out as a Codex path having been classified as an Anthropic one.
+test('the provider is selected on the separator-folded path', () => {
+  assert.equal(providerForPath('/backend-api\\codex/responses'), 'codex');
+  assert.equal(providerForPath('/backend-api/codex\\responses'), 'codex');
+  assert.equal(providerForPath('/backend-api\\codex'), 'codex');
+  assert.equal(providerForPath('/backend-api%5ccodex/responses'), 'codex');
+});
+
+// One decode deep: `%252f` resolves to a literal `%2f` inside a segment, so
+// `/backend-api%252fcodex/…` is a path under `/backend-api%2fcodex`, not a Codex
+// one. A malformed escape has no decoded form and is read as sent.
+test('a double-encoded or undecodable path is classified as it resolves', () => {
+  assert.equal(providerForPath('/backend-api%252fcodex/responses'), 'anthropic');
+  assert.equal(providerForPath('/backend-api/codex%252fresponses'), 'anthropic');
+  assert.equal(providerForPath('/backend-api/%/responses'), 'anthropic');
+  assert.equal(providerForPath('/backend-api/codex/%/responses'), 'codex');
+  assert.equal(providerForPath('/backend-api%255ccodex/responses'), 'anthropic');
+});
+
 test('Anthropic OAuth sends a bearer token, an API key sends x-api-key', () => {
   const oauth = {};
   applyAuthHeaders(oauth, { type: 'oauth', credential: 'tok' });


### PR DESCRIPTION
Path classification — the Codex path pool, the client-credential relay, the dot-segment refusal — is a prefix test on the request path, while the request goes out on a path the test never saw in that form. Three members of that class, all pre-existing:

**Percent-encoding.** `/%61pi/oauth/profile` and `/api/oauth%2fprofile` do not start with `/api/oauth/`, so they missed the client-credential relay and took a pooled token. `hasDotSegment` had the narrower form of it — it split the path on its literal separators and decoded the pieces afterwards, which can promote a segment to `..` but can never re-split one, so `..%2f..%2f` read as a single ordinary segment.

**Backslash.** It is a separator for http(s) in the WHATWG URL parser, so the `new URL(upstream + req.url)` that builds the outgoing target folds it here, in this process, before anything is sent. `/api\oauth\profile` therefore always left as the identity plane while the prefix test read one segment, and `/backend-api\codex/conversations` left as a Codex path having been classified Anthropic — drawing its credential from the other pool.

**The `/tc-acct/` pin.** The relay was tested before the pin prefix was stripped, while `provider` is built from the stripped url, so the two disagreed about the same request: `/tc-acct/<acct>/api/oauth/profile` matched nothing, took a pooled token, and left as `/api/oauth/profile`. This one is not a probe — `claude-env.js` and `index.js` both emit `ANTHROPIC_BASE_URL=…/tc-acct/<acct>` for a pinned session, so every such session's identity-plane traffic carried the prefix and missed the relay. Found while closing the other two.

## The change

`classificationPath()`: query and fragment stripped, then exactly one `decodeURIComponent`, then backslashes folded to forward slashes; the decode falls back to per-segment when a malformed escape leaves the whole string undecodable, so a stray `%` cannot shield an encoding in a different segment. Classified on in `hasDotSegment`, in `providerForPath`, and in the `CLIENT_CREDENTIAL_PATHS` match — which also moves below the pin strip, so it reads the path that will be sent.

Forwarding is untouched: `req.url` is still what is handed to `new URL()`.

**The two spellings are not the same kind of claim, and the code says so.** Folding a backslash only makes the test agree with a rewrite this process performs itself. Decoding `%2f` and `%61` does not: they survive to the wire, and whether the receiver treats `/api/oauth%2fprofile` as the profile endpoint is its own policy — an RFC-conformant server may keep an encoded reserved character opaque. It is a conservative choice, taken because the failure direction is the safe one: matching the relay where the receiver would not have merely withholds a pooled token and sends the client's own instead.

**BEHAVIOUR CHANGE:** `hasDotSegment` now refuses paths that used to be forwarded. Any path whose one-decode form carries a `.` or `..` segment is a 400, which now includes the spellings that encode the separator (`..%2f..%2f`, `.%2f`, `..%5c`) even though nothing in this process folds those. The literal and `%2e` spellings were already refused.

Decode before folding, not after — `%5c` is only a backslash once it has been decoded. One decode, never a loop: that is the depth a receiving server applies to the target it routes on, so `%252e%252e` and `%255c` stay the literal segments they resolve to. `hasDotSegment` now splits on `/` alone, since no separator survives `classificationPath` in any other spelling.

## Deliberately unchanged

The pin **token** is still found on the raw path and decoded on its own: its boundary is the next literal `/`, and decoding the path first would split `/tc-acct/AAA%2FO2/…` — the qualified form `encodePinComponent` emits — at the wrong place and resolve a different account. That question is separate from what happens to the path *after* the token, which is now classified post-strip like any other.

The `/teamclaude/*` control plane keeps matching raw: those routes are exact-match and terminate here rather than being forwarded, so both halves read the same string and there is no receiver to disagree with.

## Tests

28 added, driving real requests with `http.request` (`fetch` normalises dot-segments client-side) against a fake upstream that records the `Authorization` it received — so the assertion is which credential arrived, not what a helper returned. Both the credential and provider boundaries, with both pools live for the latter. Covers the literal, `%2e`, `%2f`, backslash and `%5c` spellings, the pin forms, and the double-encoded and undecodable negatives; each test also asserts the exact path that went on the wire, which is what makes the "forwarding is untouched" claim checkable.

`npm test` 1672 passing, `npm run lint` clean.
