### PR TITLE
Fix rolling warmup for multi-org accounts

### DIFF
--- a/src/warmer.js
+++ b/src/warmer.js
@@ -326,11 +326,16 @@ export class Warmer {
   /** The `claude` invocation for one account. Pure/deterministic so tests can
    *  assert the args and env without spawning anything. */
   _spawnSpec(account, signal) {
-    // Pin by accountUuid — a stable identity. The rotation index is NOT usable:
-    // it is array position, so removing an account would repoint this at a
+    // One user can have accounts in several organizations, all sharing the
+    // same accountUuid. Qualify it with orgUuid when possible so each warm-up
+    // reaches the intended subscription. The rotation index is NOT usable: it
+    // is array position, so removing an account would repoint this at a
     // different one. Fall back to the display name when the uuid isn't known
-    // yet (e.g. an API-key account, or before the first profile fetch).
-    const pin = encodePinComponent(account.accountUuid || account.name);
+    // yet (e.g. before the first profile fetch).
+    const identity = account.accountUuid && account.orgUuid
+      ? `${account.accountUuid}/${account.orgUuid}`
+      : account.accountUuid || account.name;
+    const pin = encodePinComponent(identity);
     const baseUrl = `http://127.0.0.1:${this.port}/tc-acct/${pin}`;
     return {
       command: 'claude',

--- a/test/warmer.test.js
+++ b/test/warmer.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { AccountManager } from '../src/account-manager.js';
+import { resolveAccountPin } from '../src/server.js';
 import { Warmer } from '../src/warmer.js';
 
 function oauth(name, extra = {}) {
@@ -73,6 +74,22 @@ test('the spawn invocation is a minimal non-interactive claude pinned to the acc
   assert.deepEqual(spec.args, ['-p', '--bare', '--model', 'haiku', '--output-format', 'text', 'hi']);
   assert.equal(spec.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9999/tc-acct/solo');
   assert.equal(spec.env.ANTHROPIC_API_KEY, 'tc-secret');
+});
+
+test('warm-up pins distinguish one user across multiple organizations', async () => {
+  const am = new AccountManager([
+    oauth('person@example.com (Personal)', { accountUuid: 'account-1', orgUuid: 'org-personal' }),
+    oauth('person@example.com (Work)', { accountUuid: 'account-1', orgUuid: 'org-work' }),
+  ], 0.98);
+  const spawn = fakeSpawner();
+
+  await makeWarmer(am, spawn).warmAll();
+
+  const resolved = spawn.calls.map(({ env }) => {
+    const encodedPin = new URL(env.ANTHROPIC_BASE_URL).pathname.split('/').at(-1);
+    return resolveAccountPin(am, decodeURIComponent(encodedPin));
+  });
+  assert.deepEqual(resolved, [0, 1]);
 });
 
 // ── status ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- qualify rolling warmup pins with both the account UUID and organization UUID
- keep the existing account UUID/display-name fallback for incomplete profiles
- add a regression test covering one Anthropic user with subscriptions in two organizations

## Root cause

Anthropic accounts belonging to the same user share an account UUID across organizations. The warmer pinned each one by that account UUID alone, so the server's first-match resolution routed every warmup to the first organization. The child Claude processes still exited successfully, which made warmup status look healthy while the other organization's five-hour window remained cold.

The server already supports the fully qualified accountUuid/orgUuid pin form, so this change makes the warmer use that stable, organization-specific identity when both fields are available.

## Verification

- npm test — 1645 passed, 0 failed
- npm run lint
- git diff --check upstream/master...HEAD
