### PR TITLE
feat(docker): add container image and ghcr.io publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# The image only needs src/, package.json and LICENSE.
+
+# Secrets -- config.json holds account credentials.
+config.json
+*.pem
+*.key
+.env
+.env.*
+
+# VCS and CI
+.git
+.gitignore
+.github
+
+# Dependencies and build noise
+node_modules
+npm-debug.log*
+*.log
+
+# Dev-only tooling and docs
+test
+docs
+screenshots
+nix
+flake.nix
+flake.lock
+eslint.config.js
+.claude
+README.md
+SECURITY.md
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,135 @@
+name: Docker
+
+# Build and publish the container image to ghcr.io.
+#
+# Separate from publish.yml so a GHCR outage cannot fail a run that already
+# published to npm. Auth uses the built-in GITHUB_TOKEN. PRs build but never push.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    name: build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write            # push to ghcr.io
+      id-token: write            # mint the OIDC token Sigstore signs with
+      attestations: write        # write the attestation to the repo's attestations API
+      artifact-metadata: write   # record it on the package page (push-to-registry: true)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Normalise image name
+        id: image
+        run: echo "name=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check whether this version is already in GHCR
+        id: check
+        if: github.event_name == 'push'
+        run: |
+          version='${{ steps.pkg.outputs.version }}'
+          image='${{ steps.image.outputs.name }}'
+          target="${REGISTRY}/${image}:${version}"
+          # An auth or network failure must not read as absent and overwrite a tag.
+          if err=$(docker manifest inspect "$target" 2>&1); then
+            echo "${image}:${version} is already in GHCR — building without pushing."
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$err" | grep -qiE 'manifest unknown|not found|no such manifest'; then
+            echo "${image}:${version} is new — will push."
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Could not determine whether ${version} exists:" >&2
+            printf '%s\n' "$err" >&2
+            exit 1
+          fi
+
+      - name: Resolve push decision
+        id: decide
+        run: |
+          if [ '${{ github.event_name }}' = 'pull_request' ]; then
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          elif [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=${{ steps.check.outputs.push }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.pkg.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.pkg.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.pkg.outputs.version }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=pr
+          labels: |
+            org.opencontainers.image.title=teamclaude
+            org.opencontainers.image.description=Multi-account Claude proxy with automatic quota-based rotation
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.decide.outputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.pkg.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Needs attestations: write to persist, on top of id-token: write to mint the
+      # OIDC token. The digest guard skips the build-without-push case.
+      - name: Attest build provenance
+        if: steps.decide.outputs.push == 'true' && steps.build.outputs.digest != ''
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22
+FROM node:${NODE_VERSION}-alpine
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE
+LABEL org.opencontainers.image.title="teamclaude" \
+      org.opencontainers.image.description="Multi-account Claude proxy with automatic quota-based rotation" \
+      org.opencontainers.image.source="https://github.com/KarpelesLab/teamclaude" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+RUN apk add --no-cache tini su-exec
+
+ENV NODE_ENV=production \
+    TEAMCLAUDE_DISABLE_AUTOUPDATE=1 \
+    TEAMCLAUDE_CONFIG=/data/teamclaude.json \
+    TEAMCLAUDE_HOST=0.0.0.0
+
+WORKDIR /app
+
+COPY --chown=root:root package.json LICENSE ./
+COPY --chown=root:root --chmod=755 src/ ./src/
+
+RUN ln -s /app/src/index.js /usr/local/bin/teamclaude
+
+COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/
+
+RUN mkdir -p /data && chown node:node /data
+
+WORKDIR /data
+
+EXPOSE 3456
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "const c=process.env.TEAMCLAUDE_CONFIG||'/data/teamclaude.json';let p=3456;try{p=require(c).proxy?.port||p}catch{};fetch('http://127.0.0.1:'+p+'/teamclaude/status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["docker-entrypoint.sh", "teamclaude"]
+CMD ["server", "--headless"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -e
+
+if [ -z "$TEAMCLAUDE_SPLIT_STDERR" ]; then
+    exec 2>&1
+fi
+
+log() {
+    echo "[teamclaude] $*"
+}
+
+DEFAULT_UID=1000
+DEFAULT_GID=1000
+CONFIG="${TEAMCLAUDE_CONFIG:-/data/teamclaude.json}"
+
+if [ "$(id -u)" != "0" ]; then
+    exec "$@"
+fi
+
+if [ -n "$TEAMCLAUDE_UID" ]; then
+    TARGET_UID="$TEAMCLAUDE_UID"
+    TARGET_GID="${TEAMCLAUDE_GID:-$TEAMCLAUDE_UID}"
+elif [ -e "$CONFIG" ]; then
+    TARGET_UID="$(stat -c %u "$CONFIG")"
+    TARGET_GID="$(stat -c %g "$CONFIG")"
+elif [ -d /data ] && [ "$(stat -c %u /data)" != "0" ]; then
+    TARGET_UID="$(stat -c %u /data)"
+    TARGET_GID="$(stat -c %g /data)"
+else
+    TARGET_UID="$DEFAULT_UID"
+    TARGET_GID="$DEFAULT_GID"
+fi
+
+if [ "$TARGET_UID" = "0" ]; then
+    log "warning: running as root"
+    exec /sbin/tini -- "$@"
+fi
+
+if [ ! -d /data ]; then
+    mkdir -p /data
+fi
+if [ "$(stat -c %u /data)" != "$TARGET_UID" ]; then
+    chown "$TARGET_UID:$TARGET_GID" /data 2>/dev/null \
+        || log "warning: could not chown /data; relying on mount ownership"
+fi
+
+if [ "$TARGET_UID" = "$DEFAULT_UID" ]; then
+    RUN_AS="node"
+else
+    RUN_AS="$TARGET_UID:$TARGET_GID"
+fi
+
+export HOME=/data
+
+log "starting as uid=$TARGET_UID gid=$TARGET_GID home=$HOME config=$CONFIG"
+
+exec su-exec "$RUN_AS" /sbin/tini -- "$@"


### PR DESCRIPTION
Adds a Dockerfile so teamclaude can run as a container, plus a workflow to publish images to ghcr.io on version bumps. No source changes.

- Dockerfile: node:22-alpine, tini as PID 1, non-root, healthcheck, OCI labels
- docker-entrypoint.sh: matches the runtime UID to the bind-mounted config's owner, then drops privileges via su-exec
- .dockerignore: keeps config.json and keys out of the build context
- .github/workflows/docker.yml: amd64 + arm64, pushes on version bump with build provenance; PRs build but never push

A plain USER node breaks bind mounts, since the host's ownership overlays the image's and the config comes back EACCES unless chowned to 1000:1000 first. The entrypoint reads the mount's actual ownership and drops to that UID instead. TEAMCLAUDE_UID overrides.

The entrypoint also redirects stderr to stdout so everything lands in docker logs as one stream; TEAMCLAUDE_SPLIT_STDERR opts out.

Usage:

```bash
docker run -d --name teamclaude -p 3456:3456 \
  -v ~/.config/teamclaude.json:/data/teamclaude.json \
  ghcr.io/karpeleslab/teamclaude:latest

docker exec -it teamclaude teamclaude login --token
```