### PR TITLE
fix(updater): run npm off the event loop so a headless server keeps serving during an update

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,7 +215,7 @@ The page is a static asset and loads without a key; the data does not — its sc
 
 ## Auto-update
 
-When TeamClaude is installed globally via npm, it self-updates in the background: it checks the npm registry at most once a day, and when a newer version is published it runs `npm install -g @karpeleslab/teamclaude@latest` and applies it on the next launch. The check runs after a `teamclaude run` session ends and when a headless server starts. A git checkout is never touched — update that with `git pull`. Run `teamclaude update` to update on demand.
+When TeamClaude is installed globally via npm, it self-updates in the background: it checks the npm registry at most once a day, and when a newer version is published it runs `npm install -g @karpeleslab/teamclaude@latest` and applies it on the next launch. The check runs after a `teamclaude run` session ends and when a headless server starts. In a headless server the install runs as a background child process, so the proxy keeps serving requests while npm works (a synchronous install used to stall it for the duration). A git checkout is never touched — update that with `git pull`. Run `teamclaude update` to update on demand.
 
 Disable it with `TEAMCLAUDE_DISABLE_AUTOUPDATE=1` or `"autoUpdate": false` in the config.
 

--- a/src/index.js
+++ b/src/index.js
@@ -666,6 +666,9 @@ async function serverCommand() {
   // Background self-update for a backgrounded (headless) server. Skipped under
   // the TUI, where npm's install output would corrupt the display — interactive
   // users update via `teamclaude run` (post-session) or `teamclaude update`.
+  // Not awaited, and nothing inside it is synchronous: the npm probe and the
+  // install are child processes the loop runs beside (#353), so this never
+  // holds up a request.
   if (!tui) autoUpdate({ config }).catch(() => {});
 
   // One idempotent shutdown funnel for BOTH modes and BOTH triggers: POSIX
@@ -1783,7 +1786,7 @@ async function updateCommand() {
   const cur = currentVersion();
   console.log(`Current version: ${cur || 'unknown'}`);
 
-  const kind = installKind();
+  const kind = await installKind();
   if (kind === 'git') {
     console.log('This is a git checkout — update it with `git pull`, not npm.');
     return;
@@ -1801,7 +1804,7 @@ async function updateCommand() {
   }
 
   console.log(`Updating ${info.current} → ${info.latest} …`);
-  const ok = runUpdate(info.latest);
+  const ok = await runUpdate(info.latest);
   if (ok) {
     console.log(`Updated to ${info.latest}. Restart teamclaude to use the new version.`);
   } else {

--- a/src/updater.js
+++ b/src/updater.js
@@ -10,7 +10,7 @@
 // Every side-effecting dependency (fetch, spawn, the clock, the cache path) is
 // injectable so the logic is unit-testable without network or npm.
 
-import { spawnSync } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -46,21 +46,29 @@ export function compareVersions(a, b) {
   return 0;
 }
 
-/** `npm root -g` (the global modules dir), or null if npm is unavailable. */
+/**
+ * `npm root -g` (the global modules dir), or null if npm is unavailable.
+ *
+ * Asynchronous on purpose: this runs inside the headless server, and npm takes
+ * up to a second or two to answer. A synchronous spawn parked the event loop
+ * for that long, with every client connection waiting behind it.
+ */
 function npmGlobalRoot() {
-  try {
-    const r = spawnSync('npm', ['root', '-g'], { encoding: 'utf8', timeout: 5000 });
-    if (r.status === 0 && r.stdout) return r.stdout.trim();
-  } catch { /* npm missing */ }
-  return null;
+  return new Promise((resolve) => {
+    try {
+      execFile('npm', ['root', '-g'], { encoding: 'utf8', timeout: 5000 }, (err, stdout) => {
+        resolve(!err && stdout ? stdout.trim() : null);
+      });
+    } catch { resolve(null); } // npm missing
+  });
 }
 
 /** How this copy was installed: 'git', 'global', 'local', or 'unknown'. */
-export function installKind({ root = packageRoot(), globalRoot = npmGlobalRoot } = {}) {
+export async function installKind({ root = packageRoot(), globalRoot = npmGlobalRoot } = {}) {
   if (existsSync(join(root, '.git'))) return 'git';
   const norm = root.split('\\').join('/');
   if (!norm.includes('/node_modules/')) return 'unknown';
-  const g = typeof globalRoot === 'function' ? globalRoot() : globalRoot;
+  const g = await (typeof globalRoot === 'function' ? globalRoot() : globalRoot);
   if (g && norm.startsWith(g.split('\\').join('/'))) return 'global';
   return 'local';
 }
@@ -135,16 +143,35 @@ export function isReleaseVersion(v) {
 }
 
 /**
- * Install a specific version globally. Returns true on success. `version` must
+ * Install a specific version globally. Resolves true on success. `version` must
  * be a release version (or the literal `latest`), or nothing is spawned.
+ *
+ * The install is a child process the event loop keeps running beside, never a
+ * synchronous wait. `autoUpdate` runs this inside `server --headless`, the one
+ * process every client depends on: a synchronous `npm install -g` blocked it
+ * for the whole install, so the proxy accepted no connections, `teamclaude
+ * status` timed out and `teamclaude run` refused to launch — unattended, on
+ * whichever day the daily check found a new version (#353). The result only
+ * matters for the log line, and the new version applies on the next start
+ * regardless, so nothing is gained by waiting inline.
+ *
+ * `spawnImpl` is injectable and must return a ChildProcess-shaped emitter
+ * ('exit' with a code, or 'error').
  */
-export function runUpdate(version = 'latest', { spawnImpl = spawnSync } = {}) {
-  if (version !== 'latest' && !isReleaseVersion(version)) return false;
-  const r = spawnImpl('npm', ['install', '-g', `${PKG_NAME}@${version}`], {
-    stdio: 'inherit',
-    timeout: 180000,
+export function runUpdate(version = 'latest', { spawnImpl = spawn } = {}) {
+  if (version !== 'latest' && !isReleaseVersion(version)) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnImpl('npm', ['install', '-g', `${PKG_NAME}@${version}`], {
+        stdio: 'inherit',
+        timeout: 180000,
+      });
+    } catch { resolve(false); return; }
+    if (!child || typeof child.once !== 'function') { resolve(false); return; }
+    child.once('error', () => resolve(false));
+    child.once('exit', (code) => resolve(code === 0));
   });
-  return !!r && !r.error && r.status === 0;
 }
 
 // The root warning is printed once per process: autoUpdate runs at startup and
@@ -188,12 +215,12 @@ export async function autoUpdate({
     return { ...info, skipped: 'bad-version' };
   }
 
-  if (kind({ root }) !== 'global') {
+  if (await kind({ root }) !== 'global') {
     log(`[TeamClaude] Update available: ${info.current} → ${info.latest}. Run: teamclaude update`);
     return { ...info, notified: true };
   }
   log(`[TeamClaude] Updating ${info.current} → ${info.latest}…`);
-  const ok = install(info.latest);
+  const ok = await install(info.latest);
   log(ok
     ? `[TeamClaude] Updated to ${info.latest}. Restart teamclaude to use the new version.`
     : `[TeamClaude] Auto-update failed. Run manually: npm install -g ${PKG_NAME}@latest`);

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -20,24 +21,27 @@ test('compareVersions orders x.y.z numerically and ignores pre-release', () => {
 
 // ── installKind ──────────────────────────────────────────────
 
-test('installKind detects a git checkout by a .git dir', () => {
+test('installKind detects a git checkout by a .git dir', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'tc-git-'));
   mkdirSync(join(dir, '.git'));
   try {
-    assert.equal(installKind({ root: dir, globalRoot: () => '/usr/lib/node_modules' }), 'git');
+    assert.equal(await installKind({ root: dir, globalRoot: () => '/usr/lib/node_modules' }), 'git');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
-test('installKind flags a global npm install and distinguishes a local one', () => {
+test('installKind flags a global npm install and distinguishes a local one', async () => {
   const gRoot = '/usr/lib/node_modules';
   const global = `${gRoot}/@karpeleslab/teamclaude`;
   const local = '/home/x/project/node_modules/@karpeleslab/teamclaude';
-  assert.equal(installKind({ root: global, globalRoot: () => gRoot }), 'global');
-  assert.equal(installKind({ root: local, globalRoot: () => gRoot }), 'local');
+  assert.equal(await installKind({ root: global, globalRoot: () => gRoot }), 'global');
+  assert.equal(await installKind({ root: local, globalRoot: () => gRoot }), 'local');
+  // `npm root -g` is asked asynchronously now, so a probe that answers later is
+  // the shape the real one has.
+  assert.equal(await installKind({ root: global, globalRoot: async () => gRoot }), 'global');
 });
 
-test('installKind is unknown outside node_modules (e.g. running from source path)', () => {
-  assert.equal(installKind({ root: '/opt/teamclaude-src', globalRoot: () => null }), 'unknown');
+test('installKind is unknown outside node_modules (e.g. running from source path)', async () => {
+  assert.equal(await installKind({ root: '/opt/teamclaude-src', globalRoot: () => null }), 'unknown');
 });
 
 // ── fetchLatestVersion ───────────────────────────────────────
@@ -99,17 +103,46 @@ test('checkForUpdate reports no update when already on the latest', async () => 
 
 // ── runUpdate ────────────────────────────────────────────────
 
-test('runUpdate invokes the global npm install for the requested version', () => {
+// A fake `spawn`: a ChildProcess-shaped emitter that settles on the next tick
+// with an exit code, or with an 'error' when `error` is given.
+function fakeSpawn(calls, { code = 0, error = null } = {}) {
+  return (cmd, argv, opts) => {
+    calls.push([cmd, argv, opts]);
+    const child = new EventEmitter();
+    setImmediate(() => { if (error) child.emit('error', error); else child.emit('exit', code); });
+    return child;
+  };
+}
+
+test('runUpdate invokes the global npm install for the requested version', async () => {
   const calls = [];
-  const spawnImpl = (cmd, argv) => { calls.push([cmd, argv]); return { status: 0 }; };
-  const ok = runUpdate('2.3.4', { spawnImpl });
+  const ok = await runUpdate('2.3.4', { spawnImpl: fakeSpawn(calls) });
   assert.equal(ok, true);
-  assert.deepEqual(calls[0], ['npm', ['install', '-g', `${PKG_NAME}@2.3.4`]]);
+  assert.deepEqual(calls[0].slice(0, 2), ['npm', ['install', '-g', `${PKG_NAME}@2.3.4`]]);
 });
 
-test('runUpdate returns false when npm fails', () => {
-  assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ status: 1 }) }), false);
-  assert.equal(runUpdate('2.3.4', { spawnImpl: () => ({ error: new Error('ENOENT') }) }), false);
+test('runUpdate resolves false when npm fails', async () => {
+  assert.equal(await runUpdate('2.3.4', { spawnImpl: fakeSpawn([], { code: 1 }) }), false);
+  assert.equal(await runUpdate('2.3.4', { spawnImpl: fakeSpawn([], { error: new Error('ENOENT') }) }), false);
+  assert.equal(await runUpdate('2.3.4', { spawnImpl: () => { throw new Error('ENOENT'); } }), false);
+});
+
+// The install runs inside `server --headless`, the one process every client
+// depends on. A synchronous spawn parked the event loop for the whole install
+// (#353); the child must run beside it.
+test('runUpdate does not block the event loop while npm runs', async () => {
+  const calls = [];
+  let child;
+  const spawnImpl = (cmd, argv, opts) => { calls.push([cmd, argv, opts]); child = new EventEmitter(); return child; };
+  const pending = runUpdate('2.3.4', { spawnImpl });
+  // The install is "running": the loop must still turn.
+  let ticks = 0;
+  await new Promise(r => { const t = setInterval(() => { if (++ticks === 3) { clearInterval(t); r(); } }, 1); });
+  assert.equal(ticks, 3, 'timers ran while the install was in flight');
+  assert.equal(calls[0][2].stdio, 'inherit');
+  assert.equal(calls[0][2].timeout, 180000, 'a hung npm is still bounded');
+  child.emit('exit', 0);
+  assert.equal(await pending, true);
 });
 
 // ── the registry's "latest" is a string from the network ─────
@@ -123,14 +156,14 @@ test('isReleaseVersion accepts only x.y.z', () => {
   }
 });
 
-test('runUpdate spawns nothing for a version that is not a release version', () => {
+test('runUpdate spawns nothing for a version that is not a release version', async () => {
   const calls = [];
-  const spawnImpl = (cmd, argv) => { calls.push([cmd, argv]); return { status: 0 }; };
-  assert.equal(runUpdate('99.0.0 || npm:evil', { spawnImpl }), false);
-  assert.equal(runUpdate('1.2.3-beta.1', { spawnImpl }), false);
+  const spawnImpl = fakeSpawn(calls);
+  assert.equal(await runUpdate('99.0.0 || npm:evil', { spawnImpl }), false);
+  assert.equal(await runUpdate('1.2.3-beta.1', { spawnImpl }), false);
   assert.equal(calls.length, 0);
   // The literal tag the manual fallback uses is still fine.
-  assert.equal(runUpdate('latest', { spawnImpl }), true);
+  assert.equal(await runUpdate('latest', { spawnImpl }), true);
 });
 
 // ── autoUpdate guards ────────────────────────────────────────
@@ -165,8 +198,8 @@ test('autoUpdate still installs a well-formed newer version for a global install
     const res = await autoUpdate({
       root, uid: 1000, log: () => {},
       check: async () => ({ current: '1.0.0', latest: '2.0.0', updateAvailable: true }),
-      kind: () => 'global',
-      install: (v) => { installs.push(v); return true; },
+      kind: async () => 'global',
+      install: async (v) => { installs.push(v); return true; },
     });
     assert.equal(res.updated, true);
     assert.deepEqual(installs, ['2.0.0']);


### PR DESCRIPTION
Fixes #353.

`runUpdate` spawned `npm install -g` through `spawnSync`, and the global-root probe ran `npm root -g` the same way. Both are reached from `autoUpdate` inside `server --headless`, so on the day the daily check found a new version the proxy accepted no connections for the length of the install: `/teamclaude/status` timed out, `teamclaude run` refused to launch, and the event-loop monitor could only report the stall after the fact.

## Changes

- `src/updater.js`: `runUpdate` uses async `spawn` and resolves with the outcome; the 180 s bound is kept as the spawn's `timeout`. `npmGlobalRoot` uses `execFile` and `installKind` is async accordingly. `autoUpdate` awaits both.
- `src/index.js`: `teamclaude update` awaits `installKind` and `runUpdate`; a comment at the headless call site says why nothing there is synchronous.
- `test/updater.test.js`: the fake spawn is now a ChildProcess-shaped emitter; a new case shows timers still fire while the install is in flight.
- `docs/usage.md`: one sentence in Auto-update.

The issue's second finding (`ProcessType=Background` in the LaunchAgent on macOS 15.6) is separate and not touched here.

## Testing

`node --test test/updater.test.js` 18/18, `npm run lint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)