### PR TITLE
fix(server): read SSE usage line by line with a bounded partial, instead of buffering the response

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2653,10 +2653,10 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
   if (clientGone(res)) onClose();
   const idleMs = resolveBodyIdleTimeout();
   const decoder = new TextDecoder();
-  let sseBuffer = '';
   let errored = false;
   // The message's usage, merged across its two reports and recorded once below.
   const merged = {};
+  const usage = createSseLineScanner(line => parseSSEDataLine(line, accountIndex, accountManager, onUsage, merged));
 
   try {
     while (true) {
@@ -2677,16 +2677,10 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
       const logPending = bodyWriter?.drain?.();
       if (logPending) await logPending;
 
-      const text = decoder.decode(value, { stream: true });
-
-      // Parse SSE events for usage tracking
-      sseBuffer += text;
-      const events = sseBuffer.split('\n\n');
-      sseBuffer = events.pop(); // keep incomplete event
-
-      for (const event of events) {
-        parseSSEUsage(event, accountIndex, accountManager, onUsage, merged);
-      }
+      // Parse the SSE data lines for usage tracking, as they arrive. The relay
+      // above is done with the chunk by now; this reads it and retains at most
+      // one bounded partial line, never the response.
+      usage.push(decoder.decode(value, { stream: true }));
 
       // Handle backpressure — also bail out if client disconnects,
       // because 'drain' will never fire on a destroyed socket
@@ -2703,10 +2697,9 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
       }
     }
 
-    // Parse any remaining buffer
-    if (sseBuffer.trim()) {
-      parseSSEUsage(sseBuffer, accountIndex, accountManager, onUsage, merged);
-    }
+    // A final data line without a trailing newline.
+    usage.push(decoder.decode());
+    usage.flush();
   } catch (err) {
     // A mid-stream idle timeout (or any read error) means the upstream went
     // silent after headers. Rethrow to the caller's transient handler, which
@@ -2733,6 +2726,61 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
   }
 }
 
+// The longest line the usage scanner will hold while waiting for its newline.
+// A real Anthropic SSE line is a single JSON event of at most a few kilobytes,
+// so this sits three orders of magnitude above anything legitimate.
+export const SSE_MAX_LINE_CHARS = 1 << 20;
+
+/**
+ * A line scanner for the usage parser: `push(text)` hands every complete line
+ * to `onLine` as it arrives and retains only the trailing partial one; `flush()`
+ * delivers that partial at end of stream.
+ *
+ * The parser used to accumulate the whole response into one string and drain
+ * it on the `\n\n` event boundary. An upstream that sends
+ * `text/event-stream` and never a blank line — a stuck or garbage stream, a
+ * misbehaving third-party backend — therefore grew that string for the whole
+ * response, re-split on every chunk, until V8 aborted the process on its heap
+ * limit: uncatchable, and it took every account and every session down with
+ * it (#341). The relay never needed the buffer; only the accounting did, and
+ * the accounting reads single lines.
+ *
+ * So the retained state is one line, and even that is bounded: a partial line
+ * that outgrows `maxChars` is dropped, and the rest of that line is discarded
+ * up to its newline. Only that line's usage figure is lost, which the caller
+ * already tolerates; the bytes themselves were relayed before they came here.
+ */
+export function createSseLineScanner(onLine, maxChars = SSE_MAX_LINE_CHARS) {
+  let partial = '';
+  let dropping = false; // inside a line already judged too long
+  return {
+    push(text) {
+      let start = 0;
+      for (;;) {
+        const nl = text.indexOf('\n', start);
+        if (nl < 0) break;
+        if (!dropping) {
+          const line = partial + text.slice(start, nl);
+          if (line.length <= maxChars) onLine(line);
+        }
+        partial = '';
+        dropping = false;
+        start = nl + 1;
+      }
+      if (dropping) return;
+      partial += text.slice(start);
+      if (partial.length > maxChars) { partial = ''; dropping = true; }
+    },
+    flush() {
+      if (!dropping && partial.trim()) onLine(partial);
+      partial = '';
+      dropping = false;
+    },
+    /** Characters currently retained, for tests that pin the bound. */
+    pending() { return partial.length; },
+  };
+}
+
 // A streaming response reports its usage twice. `message_start` carries the
 // input side, including the two cache fields, with an output figure that is only
 // a placeholder. `message_delta` then reports figures that are cumulative for
@@ -2745,12 +2793,14 @@ export async function streamResponse(webStream, res, accountIndex, accountManage
 // message's final figures for a single `recordTokenUsage` once the stream is
 // over. One record per message is what makes double counting unrepresentable
 // rather than merely avoided.
-function parseSSEUsage(event, accountIndex, accountManager, onUsage = null, merged = null) {
-  const dataLine = event.split('\n').find(l => l.startsWith('data: '));
-  if (!dataLine) return;
+//
+// Reads one `data:` line. Anthropic's events carry exactly one, so a line is an
+// event for this purpose, and the scanner above never has to hold more.
+function parseSSEDataLine(line, accountIndex, accountManager, onUsage = null, merged = null) {
+  if (!line.startsWith('data: ')) return;
 
   try {
-    const data = JSON.parse(dataLine.slice(6));
+    const data = JSON.parse(line.slice(6));
     if (data.type === 'message_start' && data.message?.usage) {
       accountManager.updateUsage(accountIndex, data.message.usage.input_tokens, 0);
       onUsage?.(data.message.usage.input_tokens || 0, 0);

--- a/test/sse-parse-bounds.test.js
+++ b/test/sse-parse-bounds.test.js
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TextEncoder } from 'node:util';
+import { ReadableStream } from 'node:stream/web';
+import { createSseLineScanner, streamResponse, SSE_MAX_LINE_CHARS } from '../src/server.js';
+
+// The SSE usage parser used to accumulate the whole relayed body into one
+// string and drain it on the `\n\n` event boundary. An upstream that never
+// sent a blank line grew that string for the entire response — re-split on
+// every chunk — until V8 aborted the process on its heap limit, which no
+// handler can catch (#341). The relay never needed the buffer: the bytes go
+// to the client before the parser sees them, and the accounting reads single
+// lines. So the parser keeps one line, bounded, and nothing else.
+
+// ── the scanner ──────────────────────────────────────────────────────────────
+
+test('complete lines are delivered as they arrive, split across chunks or not', () => {
+  const lines = [];
+  const s = createSseLineScanner(l => lines.push(l));
+  s.push('event: ping\ndata: {}\n\nda');
+  s.push('ta: {"a":1}\n');
+  s.push('\nevent: x\ndata: {"b":2}');
+  assert.deepEqual(lines, ['event: ping', 'data: {}', '', 'data: {"a":1}', '', 'event: x']);
+  s.flush();
+  assert.deepEqual(lines.at(-1), 'data: {"b":2}', 'the final unterminated line is delivered on flush');
+  assert.equal(s.pending(), 0);
+});
+
+test('a line with no newline never retains more than the bound', () => {
+  const lines = [];
+  const max = 1024;
+  const s = createSseLineScanner(l => lines.push(l), max);
+  const chunk = 'a'.repeat(300);
+  let peak = 0;
+  for (let i = 0; i < 100; i++) { s.push(chunk); peak = Math.max(peak, s.pending()); }
+  assert.ok(peak <= max, `retained ${peak} chars against a bound of ${max}`);
+  assert.equal(s.pending(), 0, 'once over the bound the partial line is dropped, not kept');
+  assert.deepEqual(lines, [], 'nothing was delivered: there was no line');
+  // The rest of that line is discarded up to its newline; the next line is
+  // read normally, so one oversized line costs only its own figure.
+  s.push('tail-of-the-long-line\ndata: {"after":true}\n');
+  assert.deepEqual(lines, ['data: {"after":true}']);
+  s.flush();
+  assert.deepEqual(lines, ['data: {"after":true}'], 'flush delivers nothing extra');
+});
+
+test('a line that arrives whole but over the bound is skipped, not delivered', () => {
+  const lines = [];
+  const s = createSseLineScanner(l => lines.push(l), 16);
+  s.push('x'.repeat(40) + '\nshort\n');
+  assert.deepEqual(lines, ['short']);
+});
+
+test('the default bound sits far above any real SSE line', () => {
+  assert.ok(SSE_MAX_LINE_CHARS >= 1 << 20);
+});
+
+// ── streamResponse, end to end ───────────────────────────────────────────────
+
+// The issue's shape: `text/event-stream` with no blank line ever, in 1 MiB
+// chunks. Every byte must still reach the client, and the usage that follows
+// the garbage must still be read. The retained state is asserted through the
+// scanner above; here the proof is that the stream is relayed in full and the
+// accounting survives it.
+test('a stream with no blank line is relayed in full and does not accumulate', async () => {
+  const written = [];
+  let total = 0;
+  const res = {
+    destroyed: false, writableEnded: false, headersSent: true,
+    write(c) { total += c.length; written.push(c.length); return true; },
+    end() { this.writableEnded = true; },
+    once() {}, off() {}, on() {},
+  };
+  const recorded = [];
+  const am = {
+    updateUsage() {},
+    recordTokenUsage(_i, _s, _m, usage) { recorded.push(usage); },
+  };
+  const enc = new TextEncoder();
+  const junk = enc.encode('a'.repeat(1 << 20)); // 1 MiB, no newline at all
+  const N = 48;                                  // 48 MiB of one unterminated line
+  const tail = enc.encode('\ndata: {"type":"message_delta","usage":{"output_tokens":7}}\n\n');
+  let i = 0;
+  const stream = new ReadableStream({
+    pull(c) {
+      if (i < N) { c.enqueue(junk.slice()); i++; } else if (i === N) { c.enqueue(tail); i++; } else c.close();
+    },
+  });
+
+  await streamResponse(stream, res, 0, am, null, null, null, null);
+
+  assert.equal(total, N * (1 << 20) + tail.length, 'every byte was relayed');
+  assert.equal(written.length, N + 1, 'relayed chunk by chunk, never re-buffered');
+  assert.equal(res.writableEnded, true);
+  assert.deepEqual(recorded, [{ output_tokens: 7 }], 'usage after the oversized line was still read');
+});
+
+test('well-formed events still yield their usage line by line', async () => {
+  const res = {
+    destroyed: false, writableEnded: false, headersSent: true,
+    write() { return true; }, end() { this.writableEnded = true; },
+    once() {}, off() {}, on() {},
+  };
+  const calls = [];
+  const recorded = [];
+  const am = {
+    updateUsage(_i, input, output) { calls.push([input, output]); },
+    recordTokenUsage(_i, _s, _m, usage) { recorded.push(usage); },
+  };
+  const enc = new TextEncoder();
+  const body = [
+    'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":12,"output_tokens":1}}}\n\n',
+    'event: ping\ndata: {"type":"ping"}\n\n',
+    'event: message_delta\ndata: {"type":"message_delta","usage":{"output_tokens":500}}\n\n',
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+  ].join('');
+  // Split at awkward places so lines straddle chunks.
+  const parts = [body.slice(0, 37), body.slice(37, 90), body.slice(90)];
+  let i = 0;
+  const stream = new ReadableStream({ pull(c) { if (i < parts.length) c.enqueue(enc.encode(parts[i++])); else c.close(); } });
+
+  await streamResponse(stream, res, 0, am, null, null, null, null);
+
+  assert.deepEqual(calls, [[12, 0], [0, 500]]);
+  assert.deepEqual(recorded, [{ input_tokens: 12, output_tokens: 500 }]);
+});


### PR DESCRIPTION
Fixes #341.

`streamResponse` accumulated every relayed chunk into one string and drained it on the `\n\n` event boundary. An upstream that sends `text/event-stream` and never a blank line grew that string for the whole response, re-split on every chunk, until V8 aborted the process on its heap limit, which no handler can catch.

The relay never needed the buffer: bytes go to the client before the parser sees them, and the accounting only reads single `data:` lines. So the parser now processes lines as chunks arrive and retains at most one partial line, capped at 1 MiB (`SSE_MAX_LINE_CHARS`). A line that outgrows the cap is dropped through its newline, costing only that line's usage figure, which the caller already tolerates ("an empty merge is written nowhere"). Every byte is still relayed unchanged.

## Changes

- `src/server.js`: `createSseLineScanner(onLine, maxChars)` (exported for tests) replaces the `sseBuffer` accumulation; `parseSSEUsage(event)` becomes `parseSSEDataLine(line)`. Anthropic events carry exactly one `data:` line, so a line is an event for this purpose.
- `test/sse-parse-bounds.test.js`: the scanner's bound (peak retained chars never exceeds the cap on a 30 KB unterminated line, and the next line after it is read normally), and `streamResponse` end to end with 48 MiB of one unterminated line followed by a `message_delta`: every byte relayed chunk by chunk, and the usage after the garbage still recorded. Plus a well-formed stream split at awkward chunk boundaries.

## Testing

The new file plus the streaming-related suites (`streaming-usage-merge`, `upstream-timeout`, `request-log-bounds`, `server-error-paths`, `session-starved`, `remote-control-relay`, `upstream-credential-hygiene`, `json-format-stream`): 59/59. `npm run lint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)