### PR TITLE
fix(server): a crafted WebSocket upgrade answers 400 instead of exiting the daemon

### DIFF
--- a/src/mitm.js
+++ b/src/mitm.js
@@ -241,17 +241,25 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
     // which never fires 'request' — only 'upgrade', with a raw socket instead
     // of a response object (h1-only; falls back to blind h2 passthrough is not
     // needed since WS clients negotiate h1 for the handshake).
+    // Guarded for the same reason the listener in server.js is: an uncaught
+    // throw here exits the process (#340).
     srv.on('upgrade', (req, socket, head) => {
-      const target = upgradeUpstreamFor(req.headers.host, config, upstream);
-      if (!target) {
-        log(`[TeamClaude] MITM: refusing a WebSocket Upgrade for host ${JSON.stringify(safeLine(req.headers.host, 64))}, which this proxy does not intercept`);
-        try { socket.write('HTTP/1.1 421 Misdirected Request\r\nConnection: close\r\n\r\n'); } catch { /* client already gone */ }
+      try {
+        const target = upgradeUpstreamFor(req.headers.host, config, upstream);
+        if (!target) {
+          log(`[TeamClaude] MITM: refusing a WebSocket Upgrade for host ${JSON.stringify(safeLine(req.headers.host, 64))}, which this proxy does not intercept`);
+          try { socket.write('HTTP/1.1 421 Misdirected Request\r\nConnection: close\r\n\r\n'); } catch { /* client already gone */ }
+          socket.destroy();
+          return;
+        }
+        // The CONNECT's client identity is bound to this listener (see getServer),
+        // so the channel is attributed the way the requests in the tunnel are.
+        relayUpgrade(req, socket, head, target, sx, { client, clientUsage, log });
+      } catch (err) {
+        log(`[TeamClaude] MITM: WebSocket upgrade handler failed for ${safeLine(req?.url)}: ${err?.message || err}`);
+        try { socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'); } catch { /* client already gone */ }
         socket.destroy();
-        return;
       }
-      // The CONNECT's client identity is bound to this listener (see getServer),
-      // so the channel is attributed the way the requests in the tunnel are.
-      relayUpgrade(req, socket, head, target, sx, { client, clientUsage, log });
     });
     // Make the h2-WebSocket dead end audible. Without this the only evidence is
     // a message that never arrives, which is what made #164 cost a day to

--- a/src/server.js
+++ b/src/server.js
@@ -499,30 +499,39 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
   // call — Node fires 'upgrade' for that handshake, never 'request', so it
   // needs its own listener (base-URL routing path; the MITM path wires the
   // same relayUpgrade onto its own terminating server in mitm.js).
+  // Guarded like requestHandler and the connect handler are: this process
+  // exits on any uncaught throw (see crash-log.js), and a listener handed a raw
+  // socket has nothing else standing between a bad handshake and that exit.
   server.on('upgrade', (req, socket, head) => {
-    // The upgrade handshake never reaches requestHandler, so it does not
-    // inherit the key gate above — it has to ask for itself. Without this a
-    // WebSocket handshake is an unauthenticated relay to `upstream`: the
-    // handshake carries no pooled credential (relayUpgrade forwards the
-    // client's own headers), so it is not a way to spend the fleet's quota,
-    // but it is a way to reach the upstream on this host's address and
-    // bandwidth. A deployment on a public hostname hands that to anyone.
-    const auth = resolveUpgradeAuth(req, socket, config.proxy);
-    if (!auth.ok) {
-      // Logged as well as answered: a WebSocket client discards the status
-      // line, so the 401 alone leaves an operator with a channel that is
-      // silently dead — the same shape as the outage this gate could cause if
-      // a client turns out not to send the key.
-      console.log(`[TeamClaude] WebSocket upgrade refused (no proxy key) from ${safeLine(socket?.remoteAddress || 'unknown')} for ${safeLine(req.url)}`);
-      try { socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
+    try {
+      // The upgrade handshake never reaches requestHandler, so it does not
+      // inherit the key gate above — it has to ask for itself. Without this a
+      // WebSocket handshake is an unauthenticated relay to `upstream`: the
+      // handshake carries no pooled credential (relayUpgrade forwards the
+      // client's own headers), so it is not a way to spend the fleet's quota,
+      // but it is a way to reach the upstream on this host's address and
+      // bandwidth. A deployment on a public hostname hands that to anyone.
+      const auth = resolveUpgradeAuth(req, socket, config.proxy);
+      if (!auth.ok) {
+        // Logged as well as answered: a WebSocket client discards the status
+        // line, so the 401 alone leaves an operator with a channel that is
+        // silently dead — the same shape as the outage this gate could cause if
+        // a client turns out not to send the key.
+        console.log(`[TeamClaude] WebSocket upgrade refused (no proxy key) from ${safeLine(socket?.remoteAddress || 'unknown')} for ${safeLine(req.url)}`);
+        try { socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
+        socket.destroy();
+        return;
+      }
+      // The identity the gate resolved rides along, as it does on the request
+      // path (req.tcClient): a handshake authenticated with a client key is
+      // attributed to that client, or it is a channel the operator cannot see
+      // under `clients` at all (#325).
+      relayUpgrade(req, socket, head, upstream, sx, { client: auth.client, clientUsage });
+    } catch (err) {
+      console.error(`[TeamClaude] WebSocket upgrade handler failed for ${safeLine(req?.url)}: ${err?.message || err}`);
+      try { socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
       socket.destroy();
-      return;
     }
-    // The identity the gate resolved rides along, as it does on the request
-    // path (req.tcClient): a handshake authenticated with a client key is
-    // attributed to that client, or it is a channel the operator cannot see
-    // under `clients` at all (#325).
-    relayUpgrade(req, socket, head, upstream, sx, { client: auth.client, clientUsage });
   });
 
   return server;
@@ -1367,8 +1376,46 @@ export function resolveUpgradeAuth(req, socket, proxyConfig) {
  * handshake (emits its own 'upgrade' event on a 101); once that fires it's
  * just two raw sockets spliced together.
  */
+/**
+ * The URL a WebSocket upgrade for `url` is relayed to on `upstream`, or null
+ * when it cannot be — an answer, never a throw.
+ *
+ * This was `new URL(upstream + req.url)`. With an upstream that carries a port
+ * (`http://127.0.0.1:4000`, or a redundant `:443`) and a request target that
+ * is not a plain path — the absolute form `GET http://x/ HTTP/1.1`, ordinary
+ * proxy traffic — the concatenation ran straight on from the port digits and
+ * `new URL()` threw. The upgrade listener was the one entry point with no
+ * try/catch around it, so the throw was an uncaughtException and the daemon
+ * exited: one crafted handshake, every session gone (#340).
+ *
+ * Only the origin form is relayed, and the result is pinned to the upstream's
+ * origin: resolving the target against the upstream as a base would turn
+ * `http://x/` or `//evil.example/p` into a relay to that host instead. The
+ * concatenation itself is kept for an origin-form path, because an upstream
+ * may carry a path prefix of its own (`https://gateway.example/anthropic`)
+ * that resolution would discard.
+ */
+export function upgradeTarget(upstream, url) {
+  // Origin form: a single leading slash. `//host` is scheme-relative, and the
+  // URL parser reads a backslash as a slash for http(s), so `/\host` is too.
+  if (typeof url !== 'string' || !/^\/(?![\/\\])/.test(url)) return null;
+  let base, target;
+  try {
+    base = new URL(upstream);
+    target = new URL(`${upstream}${url}`);
+  } catch { return null; }
+  if (target.origin !== base.origin) return null;
+  return target;
+}
+
 export function relayUpgrade(req, socket, head, upstream, sx, { client = null, clientUsage = null, log = console.log } = {}) {
-  const target = new URL(`${upstream}${req.url}`);
+  const target = upgradeTarget(upstream, req.url);
+  if (!target) {
+    log(`[TeamClaude] WebSocket upgrade refused: request target ${JSON.stringify(safeLine(req.url, 128))} is not a path on the upstream`);
+    try { socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
+    socket.destroy();
+    return;
+  }
   // The channel's log lines, prefixed `[name]` like a request line when a
   // client key authenticated the handshake, so an operator reading per-client
   // activity sees the channel beside the requests. Booked only once upstream

--- a/test/upgrade-target.test.js
+++ b/test/upgrade-target.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { AccountManager } from '../src/account-manager.js';
+import { createProxyServer, upgradeTarget } from '../src/server.js';
+
+// relayUpgrade built its target as `new URL(upstream + req.url)`. With an
+// upstream that carries a port and a request target that is not a plain path
+// — the absolute form `GET http://x/ HTTP/1.1`, ordinary proxy traffic — the
+// concatenation ran on from the port digits and `new URL()` threw. The
+// upgrade listener was the one entry point with no try/catch, so the throw was
+// an uncaughtException and the daemon exited: one handshake, every session
+// gone (#340). The target is now an answer or null, never a throw, and both
+// upgrade listeners are guarded like the request and connect handlers are.
+
+const listen = (s) => new Promise(r => s.listen(0, '127.0.0.1', () => r(s.address().port)));
+
+test('upgradeTarget relays only an origin-form path, pinned to the upstream origin', () => {
+  const ported = 'http://127.0.0.1:4999';
+  assert.equal(upgradeTarget(ported, '/v1/session_ingress/ws/abc').href, 'http://127.0.0.1:4999/v1/session_ingress/ws/abc');
+  assert.equal(upgradeTarget(ported, '/ws?x=1').search, '?x=1');
+  // The crash: absolute form after a port.
+  assert.equal(upgradeTarget(ported, 'http://x/'), null);
+  assert.equal(upgradeTarget('https://api.anthropic.com:443', 'http://x/'), null);
+  // The SSRF a naive `new URL(url, base)` would have traded it for.
+  assert.equal(upgradeTarget(ported, '//evil.example/p'), null);
+  assert.equal(upgradeTarget(ported, '/\\evil.example/p'), null);
+  assert.equal(upgradeTarget(ported, '\\\\evil.example/p'), null);
+  assert.equal(upgradeTarget(ported, 'evil.example/p'), null);
+  assert.equal(upgradeTarget(ported, '*'), null);
+  assert.equal(upgradeTarget(ported, ''), null);
+  assert.equal(upgradeTarget(ported, undefined), null);
+  // An upstream with a path prefix keeps it, which resolution would discard.
+  assert.equal(upgradeTarget('https://gateway.example/anthropic', '/v1/ws').href, 'https://gateway.example/anthropic/v1/ws');
+  // A bad upstream is an answer too.
+  assert.equal(upgradeTarget('not a url', '/v1/ws'), null);
+});
+
+// Drive the real listener against a ported upstream: the handshake that used to
+// exit the process is answered 400, and the proxy goes on to relay a good one.
+test('a crafted upgrade against a ported upstream is refused, and the proxy survives it', async () => {
+  const open = [];
+  let relayed = 0;
+  const upstream = http.createServer(() => {});
+  upstream.on('upgrade', (req, socket) => {
+    relayed++;
+    open.push(socket);
+    socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n');
+  });
+  const upstreamPort = await listen(upstream);
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'sk-a' }], 0.98);
+  // No key configured, so the gate is open and the target is what decides.
+  const proxy = createProxyServer(am, { proxy: {}, upstream: `http://127.0.0.1:${upstreamPort}` });
+  const port = await listen(proxy);
+
+  const handshake = (requestLine) => new Promise((resolve, reject) => {
+    const c = net.createConnection({ port, host: '127.0.0.1' }, () => {
+      open.push(c);
+      c.write(`${requestLine}\r\nHost: 127.0.0.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n`);
+    });
+    c.once('data', (d) => resolve(d.toString()));
+    c.once('error', reject);
+    c.once('close', () => resolve(''));
+  });
+
+  try {
+    assert.match(await handshake('GET http://x/ HTTP/1.1'), /^HTTP\/1\.1 400 /);
+    assert.match(await handshake('GET //evil.example/p HTTP/1.1'), /^HTTP\/1\.1 400 /);
+    assert.equal(relayed, 0, 'nothing reached the upstream');
+    // The process is still here, and a plain path is still relayed.
+    assert.match(await handshake('GET /v1/session_ingress/ws/abc HTTP/1.1'), /^HTTP\/1\.1 101 /);
+    assert.equal(relayed, 1);
+  } finally {
+    for (const s of open) s.destroy();
+    proxy.closeAllConnections?.(); proxy.close();
+    upstream.closeAllConnections(); upstream.close();
+  }
+});
+
+// The guard itself: a listener that throws for any other reason answers the
+// socket instead of taking the process down. Forced by a proxy config the
+// gate cannot read: the listener reads `config.proxy` on every handshake.
+test('a throw inside the upgrade listener tears down the socket, not the process', async () => {
+  const am = new AccountManager([{ name: 'a', type: 'apikey', apiKey: 'sk-a' }], 0.98);
+  const config = { proxy: {}, upstream: 'http://127.0.0.1:4999' };
+  const proxy = createProxyServer(am, config);
+  const port = await listen(proxy);
+  Object.defineProperty(config, 'proxy', { get() { throw new Error('boom'); } });
+  const errors = [];
+  const orig = console.error;
+  console.error = (...a) => errors.push(a.join(' '));
+  try {
+    const answer = await new Promise((resolve, reject) => {
+      const c = net.createConnection({ port, host: '127.0.0.1' }, () => {
+        c.write('GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n');
+      });
+      let got = '';
+      c.on('data', (d) => { got += d; });
+      c.once('close', () => resolve(got));
+      c.once('error', reject);
+    });
+    assert.match(answer, /^HTTP\/1\.1 400 /);
+    assert.ok(errors.some(e => /upgrade handler failed/.test(e)), errors.join('\n'));
+  } finally {
+    console.error = orig;
+    proxy.closeAllConnections?.(); proxy.close();
+  }
+});


### PR DESCRIPTION
Fixes #340.

`relayUpgrade` built its target as `new URL(upstream + req.url)`. With an upstream carrying a port (`http://127.0.0.1:4000`, or a redundant `https://api.anthropic.com:443`) and a request target that is not a plain path, such as the absolute form `GET http://x/ HTTP/1.1`, the concatenation ran on from the port digits and `new URL()` threw. The upgrade listener was the one entry point with no try/catch, so the throw became an `uncaughtException` and the daemon exited with every session.

## Changes

- `src/server.js`: `upgradeTarget(upstream, url)` (exported) returns the relay URL or null, never throws. Only an origin-form path (a single leading slash, so neither `//host` nor `/\host`) is relayed, and the result must share the upstream's origin, which is what keeps a naive `new URL(url, base)` from trading the crash for an SSRF. Concatenation is kept for the origin form because an upstream may carry a path prefix that resolution would discard. `relayUpgrade` answers 400 and closes the socket on null.
- `src/server.js`, `src/mitm.js`: both `upgrade` listeners are wrapped in try/catch, answering 400 and destroying the socket on any other throw, as the request and connect handlers already are.
- `test/upgrade-target.test.js`: the resolver's table (the crash, the SSRF spellings, the path-prefix upstream); the real listener against a ported upstream, where the crafted handshakes get 400 and a plain path is still relayed afterwards; and a forced throw inside the listener that tears down the socket, not the process.

## Testing

The new file plus `upgrade-auth`, `upgrade-attribution`, `remote-control-relay`, `mitm-upgrade-host`, `mitm-integration`: 27/27. `npm run lint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)