### PR TITLE
Bump to 1.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Multi-account proxy for Claude Code and Codex: pools Claude Max, ChatGPT/Codex, API-key and third-party backend accounts, and rotates on quota",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Fourteen commits since 1.1.18: three daemon-robustness fixes from issue
reports, a batch of contributor fixes to Codex support and the CLI, and a
container image.

Behaviour changes
  #342 request paths are classified on their decoded, backslash-folded
       form, so the Codex pool, the client-credential relay and the
       dot-segment refusal read the path the way it will be resolved.
       Encoded dot-segments (`..%2f`, `..%5c`) are now refused with a 400
       like the literal spelling; and the relay runs after the /tc-acct/
       pin is stripped, so a pinned session's /api/oauth/* traffic keeps
       the client's own credential instead of a pooled token
  #349 the provider is part of an account's identity, and a Codex account
       is identified by its ChatGPT account id: one email holding a Claude
       and a ChatGPT subscription no longer reads as one account, and
       quota state saved by older versions no longer restores onto a Codex
       row (it is re-learned from traffic)
  #350 ~/.codex/auth.json is a default for a Codex account with no
       credential of its own, no longer an override of every Codex row
  #357 a WebSocket upgrade is relayed only for an origin-form path pinned
       to the upstream's origin; anything else is answered 400

Fixes
  #355 the auto-updater runs npm off the event loop, so a headless server
       keeps serving while an update installs (issue #353)
  #356 the SSE usage parser reads lines as they arrive and retains one
       bounded partial line, so an upstream stream with no blank line can
       no longer grow the heap until V8 aborts the process (issue #341)
  #357 a crafted upgrade against an upstream with a port no longer throws
       out of the one unguarded listener and exits the daemon; both
       upgrade listeners are now guarded (issue #340)
  #348 x-codex-* response headers reach updateQuota, so Codex accounts
       report their quota instead of "unknown" until a 429
  #352 the Codex CLI's `session-id` header is read, so Codex sessions are
       tracked and distributed; x-claude-code-session-id still wins
  #351 the Models row stays on an account whose dedicated family bucket
       was cleared for revalidation while the learned bucket remains
  #343 rolling warm-up pins are qualified by account and organization
       uuid, so one user's accounts in several orgs are each warmed
  #345 eventLogging and blockedModels hot-apply on reload
  #346 `teamclaude status --json` finishes writing before exit when
       stdout is a pipe
  #347 `login --api` saves onto a fresh read of the config and tells a
       running server to reload

Features
  #354 a container image, published to ghcr.io/karpeleslab/teamclaude on
       every version bump (amd64 and arm64, with build provenance); see
       "Running in a container" in docs/usage.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)