### PR TITLE
feat(server): report the running version in /teamclaude/status

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,7 +186,7 @@ teamclaude version           # Print the installed version
 teamclaude help              # Show all commands
 ```
 
-`teamclaude status` prints the same picture as the TUI, once, as text. Handy over SSH or in a script; `--json` for machine-readable output.
+`teamclaude status` prints the same picture as the TUI, once, as text. Handy over SSH or in a script; `--json` for machine-readable output. The JSON's `server.version` is the version of the process answering — read once at startup, so right after `teamclaude update` it still names the old code until the restart, where the installed CLI's `teamclaude version` already names the new one.
 
 `teamclaude attach` opens the dashboard itself against a server that is already running, which is how you get interactive control back when the proxy runs as a background service. It polls the same status endpoint every second and can do the two things the control plane exposes: `s` switches account, `R` reloads config. Settings editing, quota probing and the request activity stream stay in the server's own TUI — they need state that only that process has. When contact with the server drops, the header marker turns from `▲` to `▼` and what is on screen is the last snapshot, not the current state.
 

--- a/src/index.js
+++ b/src/index.js
@@ -360,6 +360,10 @@ async function serverCommand() {
   // Opt-in keep-warm scheduler (interval or persisted reset-target schedule).
   let warmer = null;
   const serverStartedAt = Date.now();
+  // Read once here, not per request: `teamclaude update` swaps package.json on
+  // disk while this process keeps running the old code, and status must report
+  // what is running, not what is installed.
+  const serverVersion = currentVersion();
 
   // sx.org proxy (IP-based-429 workaround). Dormant unless an API key is set in
   // config.sx.apiKey; when set we provision a proxy and route upstream through it.
@@ -552,6 +556,7 @@ async function serverCommand() {
     // Per-dimension usage (proxy.usageDimensions) — empty when unconfigured.
     usageDimensions: dimensionUsage.export(),
     server: {
+      version: serverVersion,
       startedAt: new Date(serverStartedAt).toISOString(),
       uptimeSeconds: Math.round((Date.now() - serverStartedAt) / 1000),
       port,

--- a/test/status-server-version.test.js
+++ b/test/status-server-version.test.js
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `GET /teamclaude/status` reports the version of the process that answers
+// under `server.version`. Clients (the remote TUI, a menu bar app) used to
+// infer it from the CLI they were installed with, which is the wrong answer
+// right after `teamclaude update` and before the restart — and the gate for
+// "does this proxy hot-apply key X on reload" needs the running version, not
+// the installed one. This drives the real server as a subprocess against a
+// throwaway TEAMCLAUDE_CONFIG and compares against the package.json it runs.
+
+const cliPath = fileURLToPath(new URL('../src/index.js', import.meta.url));
+const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url));
+
+// A port nothing is listening on: bind one, learn its number, give it back.
+function closedPort() {
+  return new Promise(resolve => {
+    const probe = net.createServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function startServer(configPath) {
+  const child = spawn(process.execPath, [cliPath, 'server', '--headless'], {
+    env: { ...process.env, TEAMCLAUDE_CONFIG: configPath, TEAMCLAUDE_DISABLE_AUTOUPDATE: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', c => { output += c; });
+  child.stderr.on('data', c => { output += c; });
+  const stop = async () => {
+    child.kill('SIGTERM');
+    const killer = setTimeout(() => child.kill('SIGKILL'), 5000);
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise(resolve => child.on('exit', resolve));
+    }
+    clearTimeout(killer);
+  };
+  return { child, stop, output: () => output };
+}
+
+async function waitForStatus(port, childOutput) {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/teamclaude/status`);
+      if (res.ok) return res.json();
+    } catch { /* not up yet */ }
+    if (Date.now() > deadline) throw new Error(`server did not start:\n${childOutput()}`);
+    await new Promise(r => setTimeout(r, 100));
+  }
+}
+
+test('GET /teamclaude/status reports the running package version under server.version', async () => {
+  const deadPort = await closedPort();
+  const proxyPort = await closedPort();
+  const dir = await mkdtemp(join(tmpdir(), 'teamclaude-status-version-'));
+  const configPath = join(dir, 'config.json');
+  await writeFile(configPath, JSON.stringify({
+    proxy: { port: proxyPort, apiKey: 'tc-test' },
+    upstream: `http://127.0.0.1:${deadPort}`,
+    upstreamProxy: false,
+    accounts: [{ name: 'a@example.com', type: 'apikey', apiKey: 'k1' }],
+  }));
+
+  const server = startServer(configPath);
+  try {
+    const status = await waitForStatus(proxyPort, server.output);
+    const { version } = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+    assert.match(version, /^\d+\.\d+\.\d+/, 'package.json carries a version to compare against');
+    assert.equal(status.server.version, version);
+    assert.equal(typeof status.server.startedAt, 'string', 'the rest of the server block is untouched');
+  } finally {
+    await server.stop();
+  }
+});


### PR DESCRIPTION
## Summary

Clients that reach the proxy over HTTP — the CLI's remote TUI, a menu bar app — had no way to learn the server's version except by assuming it matches the CLI they came with. That assumption breaks in the one window where it matters: right after `teamclaude update` and before the restart, the installed package is newer than the process answering, and a client that gates "does this proxy hot-apply key X on `POST /teamclaude/reload`" on the version gets the wrong answer.

`GET /teamclaude/status` (and so `teamclaude status --json`) now carries `server.version`. It reuses `currentVersion()` from `updater.js`, read once at server startup next to `serverStartedAt` rather than per request, so an update that swaps `package.json` on disk does not leak into a process still running the old code.

## Changes

- `src/index.js` — `serverVersion = currentVersion()` captured at startup in `serverCommand`; `hooks.getStatusExtra` emits it as `server.version` ahead of `startedAt`. Nothing else in the block changes.
- `test/status-server-version.test.js` — subprocess test in the style of `reload-account-fields.test.js`: real `server --headless` against a throwaway `TEAMCLAUDE_CONFIG` (dead upstream, `upstreamProxy: false`, one apikey account), `GET /teamclaude/status`, asserts `server.version` equals the `version` in the repo's `package.json`.
- `docs/usage.md` — one sentence after the `teamclaude status` paragraph describing `server.version` and why it can differ from `teamclaude version` after an update.

## Testing

- `node --test test/status-server-version.test.js`: 1 test, 1 pass. With the `src/index.js` change stashed it fails (`server.version` undefined vs `'1.1.19'`).
- `npm test` (whole suite): 1703 tests, 1703 pass, 0 fail, 0 skipped.
- `npm run lint`: clean.
- Not verified by hand: the `teamclaude update` → pre-restart window itself, and no consumer in this repo reads the field yet (the TUI and dashboard are untouched); this PR only adds the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
