### PR TITLE
fix(config): advisory lock file around config read-modify-write

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@ Config is stored at `~/.config/teamclaude.json` (or `$XDG_CONFIG_HOME/teamclaude
 
 Volatile runtime state (observed quota) is written separately to `teamclaude.state.json` alongside the config, so the config file stays clean and hand-editable. The state file is safe to delete — quota is simply re-learned from traffic.
 
+While the config is being rewritten — by the server rotating a refresh token, by a CLI command that saves, or by any other client — the writer holds `teamclaude.json.lock` next to it: a file containing `{"pid":<pid>,"at":<ms epoch>}`. It is an advisory lock so that separate writers wait for one another instead of overwriting each other's edit (a lost write here was typically a freshly rotated refresh token, which cost a re-login). It exists for milliseconds; a lock older than 10 s or whose pid is gone is treated as stale and removed by the next writer, and a writer that cannot get it within 2 s proceeds anyway, with one warning in the log, rather than hang. It is safe to delete by hand if one is left behind.
+
 ## Format
 
 ```json

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 import { readFile, open, mkdir, chmod, rename, unlink, realpath } from 'node:fs/promises';
+import { openSync, writeSync, closeSync, readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -167,36 +168,114 @@ export async function loadOrCreateConfig() {
   return config;
 }
 
-export async function saveConfig(config) {
-  // The proxy apiKey and every account's tokens live here: see writeJsonAtomic
-  // for why this is not a plain writeFile.
-  await writeJsonAtomic(getConfigPath(), config);
+// Every writer of the config — the server rotating a refresh token, a CLI
+// command, a GUI client — does its own read-modify-write with a temp+rename.
+// Two of them racing keep only the later write, and the edit that is lost is
+// as likely as not a freshly rotated refresh token, which costs a re-login.
+// The lock below is the coordination point. It is advisory and file-based so
+// that clients outside this package can honour it with no shared code:
+//
+//   path     <configPath>.lock
+//   acquire  open(O_CREAT|O_EXCL, 0600), then write {"pid":<pid>,"at":<ms epoch>}
+//   stale    `at` older than 10 s, or the pid no longer alive: unlink and retry
+//   busy     poll every 25 ms for at most 2 s, then write WITHOUT the lock
+//   release  unlink
+//
+// The 2 s cap is deliberate: a writer must never hang on a lock, so contention
+// past it degrades to today's behaviour (a possible lost update) plus one
+// warning line, rather than to a stuck server or CLI.
+const LOCK_STALE_MS = 10_000;
+const LOCK_WAIT_MS = 2_000;
+const LOCK_POLL_MS = 25;
+
+function lockIsStale(lockPath) {
+  let pid, at;
+  try {
+    ({ pid, at } = JSON.parse(readFileSync(lockPath, 'utf8')));
+  } catch (err) {
+    if (err.code === 'ENOENT') return false; // released under us; the retry takes it
+    // Empty or garbled: the holder is between its open and its write, or died
+    // there. Only the file's age can tell those apart.
+    try { return Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS; } catch { return false; }
+  }
+  if (Date.now() - at > LOCK_STALE_MS) return true;
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try { process.kill(pid, 0); return false; } catch (err) { return err.code === 'ESRCH'; }
 }
 
-// Serialize config updates. atomicConfigUpdate is a read-modify-write, so two
-// concurrent callers can both read the same config and then save in turn, and
-// the later save silently drops the earlier caller's change. This bites hardest
-// on startup, when several OAuth accounts refresh their tokens at once: only the
-// last writer's rotated refresh token persists, and the other accounts keep a
-// token that was just rotated away, so they fail on the next restart with
-// invalid_grant and need a re-login. Chaining the updates keeps every write.
-let configUpdateChain = Promise.resolve();
+/** True when the lock is ours; false when we gave up and proceed without it. */
+async function acquireConfigLock(lockPath) {
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      const fd = openSync(lockPath, 'wx', 0o600);
+      try { writeSync(fd, JSON.stringify({ pid: process.pid, at: Date.now() })); } finally { closeSync(fd); }
+      return true;
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        console.error(`[TeamClaude] Cannot create ${lockPath} (${err.code || err.message}); writing the config without it`);
+        return false;
+      }
+    }
+    if (lockIsStale(lockPath)) {
+      await unlink(lockPath).catch(() => {});
+      continue;
+    }
+    if (Date.now() >= deadline) {
+      console.error(`[TeamClaude] ${lockPath} is still held by another process after ${LOCK_WAIT_MS}ms; writing the config without it`);
+      return false;
+    }
+    await new Promise(resolve => setTimeout(resolve, LOCK_POLL_MS));
+  }
+}
+
+// One queue per lock path inside this process: same-process callers (the TUI
+// saving while a token refresh runs) would otherwise spin against their own
+// live lock file for the full 2 s.
+const lockQueues = new Map();
+
+/**
+ * Run `fn` while holding the advisory lock for `configPath` (protocol above).
+ * Same-process callers are queued; other processes are held off by the file.
+ * The lock is released whether `fn` resolves or throws.
+ */
+export function withConfigLock(configPath, fn) {
+  const lockPath = `${configPath}.lock`;
+  const run = async () => {
+    await mkdir(dirname(lockPath), { recursive: true });
+    const held = await acquireConfigLock(lockPath);
+    try {
+      return await fn();
+    } finally {
+      if (held) await unlink(lockPath).catch(() => {});
+    }
+  };
+  const prev = lockQueues.get(lockPath) || Promise.resolve();
+  const result = prev.then(run, run);
+  lockQueues.set(lockPath, result.then(() => {}, () => {}));
+  return result;
+}
+
+export async function saveConfig(config) {
+  const path = getConfigPath();
+  // The proxy apiKey and every account's tokens live here: see writeJsonAtomic
+  // for why this is not a plain writeFile.
+  await withConfigLock(path, () => writeJsonAtomic(path, config));
+}
 
 /**
  * Atomically update the config: re-reads from disk, calls updater(config),
  * then saves. Returns the updated config. This prevents overwriting changes
  * made by other processes (e.g. `teamclaude import` while the server runs), and
- * serializes concurrent callers so simultaneous updates queue instead of
- * clobbering one another.
+ * holds the config lock across the read and the write so a concurrent writer —
+ * in this process or another — waits its turn instead of clobbering the update.
  */
 export function atomicConfigUpdate(updater) {
-  const run = async () => {
+  const path = getConfigPath();
+  return withConfigLock(path, async () => {
     const config = await loadConfig() || createDefaultConfig();
     await updater(config);
-    await saveConfig(config);
+    await writeJsonAtomic(path, config);
     return config;
-  };
-  const result = configUpdateChain.then(run, run);
-  configUpdateChain = result.then(() => {}, () => {});
-  return result;
+  });
 }

--- a/test/activity-entries.test.js
+++ b/test/activity-entries.test.js
@@ -56,7 +56,10 @@ async function quietly(fn) {
 // A client that announces a body, sends part of it, and hangs up. This is what
 // Ctrl+C in Claude Code does to a request that is still uploading, and it makes
 // the server's `for await (const chunk of req)` reject above the inner try.
-function abortMidBody(port) {
+// The hang-up waits for `opened` — the server's onRequestStart — rather than a
+// timer: destroying on a timer races the header parse under load, and a request
+// the server never opened says nothing about how it closes entries.
+function abortMidBody(port, opened) {
   return new Promise((resolve) => {
     const req = http.request({
       host: '127.0.0.1', port, method: 'POST', path: '/v1/messages',
@@ -64,23 +67,31 @@ function abortMidBody(port) {
     });
     req.on('error', () => {});
     req.write(BODY.slice(0, 24));
-    setTimeout(() => { req.destroy(); resolve(); }, 50);
+    opened.then(() => { req.destroy(); resolve(); });
   });
+}
+
+// Poll `cond` until it holds or `ms` elapse; the caller asserts afterwards.
+async function until(cond, ms = 5000) {
+  const deadline = Date.now() + ms;
+  while (!cond() && Date.now() < deadline) await new Promise(r => setTimeout(r, 10));
 }
 
 test('a request aborted mid-body closes its activity entry', async () => {
   const am = new AccountManager(ACCTS, 0.98);
   const started = [];
   const ended = [];
+  let markOpened;
+  const opened = new Promise(resolve => { markOpened = resolve; });
   const proxy = createProxyServer(am, NO_UPSTREAM, {
-    onRequestStart: (id) => started.push(id),
+    onRequestStart: (id) => { started.push(id); markOpened(); },
     onRequestEnd: (id, info) => ended.push({ id, status: info.status }),
   });
   const port = await listen(proxy);
   try {
     await quietly(async () => {
-      await abortMidBody(port);
-      await new Promise(r => setTimeout(r, 200));   // let the server-side rejection land
+      await abortMidBody(port, opened);
+      await until(() => ended.length >= started.length);   // let the server-side rejection land
     });
   } finally {
     proxy.close();

--- a/test/config-lock-file.test.js
+++ b/test/config-lock-file.test.js
@@ -1,0 +1,142 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// The server (token refresh), the CLI (login/import/priority/...) and a GUI
+// client all rewrite the config with a temp+rename. Two of them racing keep only
+// the later write, and the edit that is lost is as likely as not a freshly
+// rotated refresh token — which costs a re-login. Writers therefore hold an
+// advisory lock file, `<config>.lock`, across the read-modify-write. These pin
+// the protocol other clients interoperate with: exclusive create, a JSON body
+// of {pid, at}, staleness by age or dead pid, a bounded wait, and that the lock
+// is advisory — a writer that cannot get it still writes.
+
+async function withConfigDir(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-lock-'));
+  const prev = process.env.TEAMCLAUDE_CONFIG;
+  const path = join(dir, 'teamclaude.json');
+  process.env.TEAMCLAUDE_CONFIG = path;
+  try {
+    const cfg = await import('../src/config.js');
+    await writeFile(path, JSON.stringify({ proxy: { port: 1, apiKey: 'tc-test' }, upstreamProxy: false, accounts: [] }));
+    await fn({ dir, cfg, path, lockPath: `${path}.lock` });
+  } finally {
+    if (prev === undefined) delete process.env.TEAMCLAUDE_CONFIG;
+    else process.env.TEAMCLAUDE_CONFIG = prev;
+  }
+}
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf-8'));
+
+// A pid that no process has: a child that has already exited.
+async function deadPid() {
+  const child = spawn(process.execPath, ['-e', '']);
+  await new Promise(resolve => child.on('exit', resolve));
+  return child.pid;
+}
+
+test('two concurrent atomicConfigUpdate calls both land', async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    await Promise.all([
+      cfg.atomicConfigUpdate(config => { config.first = 1; }),
+      cfg.atomicConfigUpdate(config => { config.second = 2; }),
+    ]);
+    const on = await readJson(path);
+    assert.equal(on.first, 1);
+    assert.equal(on.second, 2);
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'no lock or temp file remains');
+  });
+});
+
+test('a lock older than 10 s is broken even though its pid is alive', async () => {
+  await withConfigDir(async ({ dir, cfg, path, lockPath }) => {
+    await writeFile(lockPath, JSON.stringify({ pid: process.pid, at: Date.now() - 60_000 }));
+    const started = Date.now();
+    await cfg.saveConfig({ fresh: true });
+    assert.ok(Date.now() - started < 1000, 'a stale lock does not cost the 2 s wait');
+    assert.deepEqual(await readJson(path), { fresh: true });
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'the stale lock is gone');
+  });
+});
+
+test('a fresh lock whose pid is dead is broken', async () => {
+  await withConfigDir(async ({ dir, cfg, path, lockPath }) => {
+    await writeFile(lockPath, JSON.stringify({ pid: await deadPid(), at: Date.now() }));
+    const started = Date.now();
+    await cfg.saveConfig({ fresh: true });
+    assert.ok(Date.now() - started < 1000, 'a dead holder does not cost the 2 s wait');
+    assert.deepEqual(await readJson(path), { fresh: true });
+    assert.deepEqual(await readdir(dir), ['teamclaude.json']);
+  });
+});
+
+test('a live lock held by another process delays the write until it is released', async () => {
+  await withConfigDir(async ({ dir, cfg, path, lockPath }) => {
+    // The other writer: takes the lock exactly as we do, holds it 500 ms, releases.
+    const holder = spawn(process.execPath, ['-e', `
+      const fs = require('node:fs');
+      const fd = fs.openSync(process.argv[1], 'wx', 0o600);
+      fs.writeSync(fd, JSON.stringify({ pid: process.pid, at: Date.now() }));
+      fs.closeSync(fd);
+      process.stdout.write('locked\\n');
+      setTimeout(() => fs.unlinkSync(process.argv[1]), 500);
+    `, lockPath], { stdio: ['ignore', 'pipe', 'inherit'] });
+    const exited = new Promise(resolve => holder.on('exit', resolve));
+    await new Promise((resolve, reject) => {
+      holder.stdout.once('data', resolve);
+      holder.once('error', reject);
+    });
+
+    const started = Date.now();
+    await cfg.saveConfig({ fresh: true });
+    const waited = Date.now() - started;
+    assert.ok(waited >= 400, `the write waited for the holder (waited ${waited}ms)`);
+    assert.ok(waited < 1500, `the write went through as soon as the lock was released, not at the 2 s cap (waited ${waited}ms)`);
+    assert.deepEqual(await readJson(path), { fresh: true });
+    assert.equal(await exited, 0, 'the holder unlinked its own lock; nobody removed it from under it');
+    assert.deepEqual(await readdir(dir), ['teamclaude.json']);
+  });
+});
+
+test('the lock is released after a success and after a throwing mutator', async () => {
+  await withConfigDir(async ({ dir, cfg, path }) => {
+    await cfg.atomicConfigUpdate(config => { config.ok = true; });
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'released after success');
+
+    await assert.rejects(cfg.atomicConfigUpdate(() => { throw new Error('boom'); }), /boom/);
+    assert.deepEqual(await readdir(dir), ['teamclaude.json'], 'released after a throw');
+    assert.equal((await readJson(path)).ok, true, 'the failed update wrote nothing');
+
+    // And the next writer is not held up by anything the failure left behind.
+    const started = Date.now();
+    await cfg.saveConfig({ after: true });
+    assert.ok(Date.now() - started < 1000);
+    assert.deepEqual(await readJson(path), { after: true });
+  });
+});
+
+test('a lock that stays held past the 2 s budget is bypassed with one warning, and left in place', async () => {
+  await withConfigDir(async ({ cfg, path, lockPath }) => {
+    // Fresh, and the pid is alive (ours): nothing lets a writer break it.
+    const body = { pid: process.pid, at: Date.now() };
+    await writeFile(lockPath, JSON.stringify(body));
+    const warnings = [];
+    const origError = console.error;
+    console.error = (...args) => warnings.push(args.join(' '));
+    try {
+      const started = Date.now();
+      await cfg.saveConfig({ fresh: true });
+      const waited = Date.now() - started;
+      assert.ok(waited >= 1900 && waited < 4000, `gave up at the budget, not before and not much after (waited ${waited}ms)`);
+    } finally {
+      console.error = origError;
+    }
+    assert.deepEqual(await readJson(path), { fresh: true }, 'the write still landed');
+    assert.equal(warnings.length, 1, warnings.join('\n'));
+    assert.match(warnings[0], /teamclaude\.json\.lock is still held/);
+    assert.deepEqual(await readJson(lockPath), body, 'the other holder\'s lock was not touched');
+  });
+});


### PR DESCRIPTION
## Summary

The server (token refresh through `atomicConfigUpdate`), the CLI (`login`, `import`, `priority`, …) and now a GUI client all rewrite `~/.config/teamclaude.json` with a temp+rename. Each write is atomic on its own, but two writers racing keep only the later document, and the edit that is lost is as likely as not a freshly rotated refresh token — the account then fails with `invalid_grant` on the next restart and needs a re-login. The in-process promise chain covered only `atomicConfigUpdate` callers inside one process; nothing coordinated the server with a CLI or a GUI.

Writers now hold an advisory lock across the read-modify-write. It is a plain file, no new dependency, so a client outside this package can honour it with no shared code:

- **path**: `<configPath>.lock` (so `~/.config/teamclaude.json.lock`), next to the config path as configured, not the symlink target
- **acquire**: `open(O_CREAT|O_EXCL, 0600)`, then write `{"pid":<pid>,"at":<ms epoch>}`
- **stale**: `at` older than 10 000 ms, or the pid not alive (`kill(pid, 0)` → `ESRCH`): unlink and retry. An empty or unparsable lock (a holder between its open and its write, or dead there) is judged by the file's mtime against the same 10 s
- **busy**: poll every 25 ms for at most 2 000 ms, then proceed **without** the lock and log one `[TeamClaude] … is still held by another process after 2000ms; writing the config without it` line on stderr — a writer must never hang on an advisory lock, so contention past the budget degrades to today's behaviour (a possible lost update) rather than to a stuck server or CLI. The other holder's file is left alone
- **release**: unlink, in a `finally`, so a throwing updater leaves nothing behind

No behaviour change when the lock is free beyond the create/unlink of the lock file around each save.

## Changes

- `src/config.js` — `withConfigLock(configPath, fn)` (exported) implements the protocol above; `saveConfig` wraps its write in it, and `atomicConfigUpdate` holds it across load → updater → write (writing through `writeJsonAtomic` directly, so it does not queue on its own lock). Same-process callers are queued per lock path, which is what the old `configUpdateChain` did for `atomicConfigUpdate` and now also covers `saveConfig`, so a TUI save during a token refresh does not spin against the process's own lock file for 2 s. The chain variable goes away. Every CLI path that calls `saveConfig` gets the lock without changes.
- `docs/configuration.md` — one paragraph under *Where it lives*, after the state-file paragraph: what `teamclaude.json.lock` is, its content, the 10 s / 2 s rules, and that it is safe to delete by hand when left behind.
- `test/config-lock-file.test.js` — six cases: (a) two concurrent `atomicConfigUpdate` calls in one process both land; (b) a lock older than 10 s with a live pid is broken, and a fresh lock with a dead pid (an exited child's pid) is broken, both without paying the 2 s wait; (c) a live lock held by another process (`node -e` that takes the lock the same way, holds it 500 ms, unlinks) delays `saveConfig` until released — the write waits ≥ 400 ms, lands, and the holder exits 0 having unlinked its own file; (d) the lock is gone after a success and after a throwing mutator, and the next write is not held up; plus the fallback: a fresh live lock nobody releases is bypassed at the 2 s budget with exactly one warning, the write lands, and the foreign lock file is untouched.
- `test/activity-entries.test.js` (separate commit) — `a request aborted mid-body closes its activity entry` destroyed its client on a 50 ms timer, racing the server's header parse; under load it failed on its own guard twice while this branch was being validated, on a path that never touches `config.js`. The hang-up now waits for the test's `onRequestStart` hook, and the fixed 200 ms settle is a bounded wait for `onRequestEnd` to catch up.

## Testing

- `node --test test/config-lock-file.test.js`: 6 tests, 6 pass (2.9 s, the budget case accounts for 2 s). With `src/config.js` reverted to `master`, 4 of the 6 fail — the two that still pass are the pre-existing in-process serialization (a) and the no-leftover-files half of (d).
- `npm test` (whole suite, final state of the branch): 1708 tests, 1708 pass, 0 fail, 0 skipped. Three further clean full runs (1708/1708) of the lock change before the activity-entries fix; the two runs that failed on that test both happened under system memory pressure, and `test/activity-entries.test.js` alone passed 3/3 before and 3/3 after the change.
- `npm run lint`: clean.
- Not verified: an actual external client (GUI/other language) honouring the protocol — only the `node -e` stand-in in (c); Windows (`'wx'` and `process.kill(pid, 0)` semantics there were not exercised, macOS only); a symlinked config path (the lock sits next to the link, the write follows it — consistent with the protocol's `<configPath>.lock`, but not covered by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
