### PR TITLE
fix(probe): keep Codex tokens off Anthropic usage endpoint

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,6 +165,7 @@ teamclaude alias             # Print/install a `claude` alias that routes via th
 teamclaude accounts          # List accounts with subscription tier and token status
 teamclaude status            # Show live proxy status (requires running server)
 teamclaude attach            # Open the live dashboard against a running server
+teamclaude dashboard         # Start headless mode if needed and open web dashboard
 teamclaude service install   # Run the proxy as a login service (uninstall/status/print)
 teamclaude switch [name]     # Prefer an account; no name lists them (needs server)
 teamclaude remove <name>     # Remove an account (by name or email)
@@ -188,7 +189,7 @@ teamclaude help              # Show all commands
 
 `teamclaude status` prints the same picture as the TUI, once, as text. Handy over SSH or in a script; `--json` for machine-readable output. The JSON's `server.version` is the version of the process answering — read once at startup, so right after `teamclaude update` it still names the old code until the restart, where the installed CLI's `teamclaude version` already names the new one.
 
-`teamclaude attach` opens the dashboard itself against a server that is already running, which is how you get interactive control back when the proxy runs as a background service. It polls the same status endpoint every second and can do the two things the control plane exposes: `s` switches account, `R` reloads config. Settings editing, quota probing and the request activity stream stay in the server's own TUI — they need state that only that process has. When contact with the server drops, the header marker turns from `▲` to `▼` and what is on screen is the last snapshot, not the current state.
+`teamclaude attach` opens the terminal dashboard itself against a server that is already running, which is how you get interactive control back when the proxy runs as a background service. It polls the same status endpoint every second and can do the two things the remote control exposes: `s` switches account, `R` reloads config. The browser dashboard adds the matching **Reload config** action plus a zero-spend **Probe quotas** action; settings editing and the request activity stream still stay in the server's own TUI because they need state that only that process has. When contact with the server drops, the header marker turns from `▲` to `▼` and what is on screen is the last snapshot, not the current state.
 
 `teamclaude service install` registers the proxy as a user service that starts at login and restarts on its own — a LaunchAgent on macOS, a `systemd --user` unit on Linux (`uninstall`, `status` and `print` round it out; `print` writes the unit to stdout without touching anything). On macOS the LaunchAgent runs with `ProcessType` `Standard`: the `Background` class it used before carried a QoS clamp that starved the proxy under host contention (status timeouts, seconds of event-loop lag). The unit is only written at install time, so an existing install keeps whatever it was installed with until you re-run `teamclaude service install`.
 
@@ -197,6 +198,8 @@ teamclaude help              # Show all commands
 ## Status dashboard (browser)
 
 `GET /teamclaude/dashboard` serves a self-contained HTML page rendering the same data as `teamclaude status`: per-account quota bars (session and weekly, plus one bar per model-scoped weekly bucket upstream reports), rotation state, and active sessions — refreshed every few seconds.
+
+Use `teamclaude dashboard` to start a headless server when needed and open this page in the system browser. The page's **Reload config** and **Probe quotas** buttons mirror the corresponding TUI actions without spending message quota.
 
 With `proxy.usageDimensions` configured, each dimension gets its own sortable table. With `proxy.sessionDetail` on, a per-session table shows each session's client, project, serving accounts, and what it actually spent per weekly bucket — cache reads and cache creation included — filterable by project or client. That table is off by default; see [Configuration](configuration.md#usage-dimensions).
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -404,6 +404,10 @@ const PAGE = `<!doctype html>
   .filters label { color: var(--dim); font-size: 12px; display: flex; align-items: center; gap: 6px; }
   .filters select { background: var(--bg); border: 1px solid var(--line); border-radius: 6px; color: var(--text); font: inherit; font-size: 12px; padding: 4px 8px; }
   .hint { color: var(--dim); font-size: 12px; margin-left: auto; }
+  .actions { display: flex; gap: 8px; margin: 8px 0 16px; }
+  .actions button { font: inherit; font-size: 12px; padding: 4px 10px; border-radius: 999px; border: 1px solid var(--line); background: transparent; color: var(--dim); cursor: pointer; }
+  .actions button:hover { color: var(--text); border-color: var(--text); }
+  .actions button:disabled { opacity: .5; cursor: default; }
   th.sortable { cursor: pointer; user-select: none; }
   th.sortable:hover { color: var(--text); }
   td.dim { color: var(--dim); }
@@ -434,6 +438,10 @@ const PAGE = `<!doctype html>
   <div id="app" style="display:none">
     <h1>TeamClaude</h1>
     <p class="sub" id="summary"></p>
+    <div class="actions">
+      <button id="reload" type="button">Reload config</button>
+      <button id="probe" type="button">Probe quotas</button>
+    </div>
     <div id="err"></div>
     <div id="problems"></div>
     <div id="note"></div>
@@ -814,6 +822,10 @@ ${SHARED_HELPERS}
       sum.appendChild(el('b', '', s.currentAccount || 'none'));
     }
     sum.appendChild(el('span', '', ' · ' + (sess.active || 0) + ' active / ' + (sess.known || 0) + ' known sessions' + (up ? ' · ' + up : '')));
+    var probe = s.probe || {};
+    var probeBtn = document.getElementById('probe');
+    probeBtn.textContent = probe.running ? 'Probe running…' : 'Probe quotas';
+    probeBtn.disabled = !!probe.running;
     var acc = document.getElementById('accounts');
     acc.textContent = '';
     (s.accounts || []).forEach(function (a) { acc.appendChild(renderAccount(a, s.currentAccount, currentAccounts)); });
@@ -853,6 +865,23 @@ ${SHARED_HELPERS}
         poll();
       })
       .catch(function (e) { note('error', 'switch failed: ' + e.message); btn.disabled = false; });
+  }
+
+  function doControl(path, label, btn) {
+    btn.disabled = true;
+    fetch(path, { method: 'POST', headers: { 'x-api-key': localStorage.getItem(KEY) || '' } })
+      .then(function (res) {
+        if (res.status === 401) { localStorage.removeItem(KEY); showKeybox(); return null; }
+        return res.json().catch(function () { return { ok: false, error: 'status ' + res.status }; });
+      })
+      .then(function (json) {
+        if (!json) return;
+        if (json.ok !== true) { note('error', label + ' failed' + (json.error ? ': ' + json.error : '')); return; }
+        note('ok', label + ' complete');
+        poll();
+      })
+      .catch(function (e) { note('error', label + ' failed: ' + e.message); })
+      .finally(function () { btn.disabled = false; });
   }
 
   function showKeybox() {
@@ -897,6 +926,8 @@ ${SHARED_HELPERS}
   document.getElementById('key').addEventListener('keydown', function (e) {
     if (e.key === 'Enter') document.getElementById('go').click();
   });
+  document.getElementById('reload').addEventListener('click', function () { doControl('/teamclaude/reload', 'config reload', this); });
+  document.getElementById('probe').addEventListener('click', function () { doControl('/teamclaude/probe', 'quota probe', this); });
 
   ['fProject', 'fClient'].forEach(function (id) {
     document.getElementById(id).addEventListener('change', function () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { createWriteStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
@@ -128,6 +128,10 @@ switch (command) {
     break;
   case 'attach':
     await attachCommand();
+    process.exit(0);
+    break;
+  case 'dashboard':
+    await dashboardCommand();
     process.exit(0);
     break;
   case 'accounts':
@@ -656,6 +660,10 @@ async function serverCommand() {
     intervalMs: (config.quotaProbeSeconds || 0) * 1000,
     profileFn: fetchProfile,
   });
+  // The web dashboard's one-shot probe button uses the same zero-spend action
+  // as the TUI's `p` key. Assigned after construction because the hook object
+  // is already shared with the server created above.
+  hooks.probeQuota = () => prober?.probeAll();
   prober.start();
 
   // Start the opt-in keep-warm scheduler. Interval mode runs relative to server
@@ -1182,6 +1190,57 @@ async function attachCommand() {
     session.am.applyStatus(first);
     session.start();
   });
+}
+
+// Open the browser dashboard, starting a headless proxy when no server is
+// reachable. This keeps the common background-service workflow one command,
+// while preserving `attach` as the terminal-only remote TUI.
+async function dashboardCommand() {
+  const config = await loadOrCreateConfig();
+  const port = config.proxy.port;
+  const bound = process.env.TEAMCLAUDE_HOST || config.proxy.host || '127.0.0.1';
+  const host = (bound === '0.0.0.0' || bound === '::') ? '127.0.0.1' : bound;
+  const statusUrl = `http://${host}:${port}/teamclaude/status`;
+  const dashboardUrl = `http://${host}:${port}/teamclaude/dashboard`;
+  const canReach = async () => {
+    try {
+      const res = await fetch(statusUrl, {
+        headers: { 'x-api-key': config.proxy.apiKey },
+        signal: AbortSignal.timeout(750),
+      });
+      return res.ok;
+    } catch { return false; }
+  };
+
+  if (!(await canReach())) {
+    const child = spawn(process.argv[1], ['server', '--headless'], {
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    child.unref();
+    let ready = false;
+    for (let i = 0; i < 20; i++) {
+      await new Promise(resolve => setTimeout(resolve, 250));
+      if (await canReach()) { ready = true; break; }
+    }
+    if (!ready) {
+      console.error(`Started headless server, but it did not answer at ${host}:${port}.`);
+      console.error(`Check the service log: ${logPath()}`);
+      process.exit(1);
+    }
+    console.log(`Started headless server at ${host}:${port}`);
+  }
+
+  const opener = process.platform === 'darwin' ? 'open'
+    : process.platform === 'win32' ? 'start'
+    : 'xdg-open';
+  const opened = spawnSync(opener, [dashboardUrl], { stdio: 'ignore', shell: process.platform === 'win32' });
+  if (opened.error || opened.status !== 0) {
+    console.log(`Dashboard: ${dashboardUrl}`);
+    return;
+  }
+  console.log(`Dashboard: ${dashboardUrl}`);
 }
 
 // ── switch ──────────────────────────────────────────────────
@@ -2030,6 +2089,7 @@ Commands:
                       Use --color=always|never to control ANSI colors
   attach              Open the live dashboard against a running server; s
                       switches account, R reloads config, q leaves it running
+  dashboard           Start a headless server if needed and open the web dashboard
   accounts            List configured accounts
   switch [NAME]       Make the running server prefer one account (as 's' in the
                       TUI does); with no NAME, list accounts and mark the current

--- a/src/prober.js
+++ b/src/prober.js
@@ -9,6 +9,7 @@
 
 import { fetchUsage } from './oauth.js';
 import { fetchBackendQuota, hasBackendQuota } from './backend-quota.js';
+import { providerOf } from './provider.js';
 
 // Node's timers take a 32-bit signed delay: anything above 2^31-1 ms is
 // coerced to 1 ms, so an interval large enough to mean "practically never"
@@ -95,7 +96,8 @@ export class Prober {
    * this line (warmer.js `_isWarmTarget`); the probe did not.
    */
   _isProbeTarget(account) {
-    return !!account && account.type === 'oauth' && !!account.credential && !account.upstream;
+    return !!account && providerOf(account) === 'anthropic'
+      && account.type === 'oauth' && !!account.credential && !account.upstream;
   }
 
   /** A third-party backend that publishes a quota of its own. The provider

--- a/src/server.js
+++ b/src/server.js
@@ -387,6 +387,26 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
         return;
       }
 
+      // One-shot quota probe — the web equivalent of the TUI's `p` key. It is
+      // zero-spend and only available when the running server has a prober.
+      if (req.method === 'POST' && req.url === '/teamclaude/probe') {
+        if (!hooks.probeQuota) {
+          res.writeHead(501, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'quota probe not supported' }));
+          return;
+        }
+        try {
+          await hooks.probeQuota();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+        } catch (err) {
+          console.error('[TeamClaude] Quota probe failed:', err.message);
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'quota probe failed; see the proxy log' }));
+        }
+        return;
+      }
+
       // Switch endpoint — make one account the preferred one, the headless
       // equivalent of picking it with 's' in the TUI. Both do the same single
       // thing: move currentIndex. That is a preference, and a weak one: _select

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -192,6 +192,32 @@ test('the switch button\'s request passes the same-origin gate and moves the cur
   }
 });
 
+test('the dashboard exposes reload and one-shot probe controls', () => {
+  const html = renderDashboardHtml();
+  assert.match(html, /id="reload"/);
+  assert.match(html, /id="probe"/);
+  assert.match(html, /\/teamclaude\/reload/);
+  assert.match(html, /\/teamclaude\/probe/);
+});
+
+test('the probe control invokes the server hook', async () => {
+  let calls = 0;
+  const am = new AccountManager([{ name: 'a', type: 'api_key', apiKey: 'sk-x' }], 0.98);
+  const proxy = createProxyServer(am, { proxy: { apiKey: 'secret' }, upstream: 'http://127.0.0.1:9' }, {
+    probeQuota: async () => { calls++; },
+  });
+  const port = await listen(proxy);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/teamclaude/probe`, {
+      method: 'POST', headers: { origin: `http://127.0.0.1:${port}`, 'sec-fetch-site': 'same-origin' },
+    });
+    assert.deepEqual(await res.json(), { ok: true });
+    assert.equal(calls, 1);
+  } finally {
+    proxy.close();
+  }
+});
+
 // The shape /teamclaude/status reports per route: the server's own target for
 // the family, and every account with whether it could serve it.
 const ROUTED = {

--- a/test/quota-probe.test.js
+++ b/test/quota-probe.test.js
@@ -344,6 +344,19 @@ test('prober skips API-key accounts', async () => {
   assert.equal(calls, 0);
 });
 
+test('prober does not send a Codex token to the Anthropic usage endpoint', async () => {
+  const am = new AccountManager([oauth('codex', { provider: 'codex', accountId: 'acct-codex' })], 0.98);
+  let calls = 0;
+  const prober = new Prober(am, {
+    intervalMs: 0,
+    probeFn: async () => { calls++; return { error: 'HTTP 401', status: 401 }; },
+    log: () => {},
+  });
+  await prober.probeAll();
+  assert.equal(calls, 0);
+  assert.equal(prober.getStatus().accounts[0].status, 'not-applicable');
+});
+
 test('prober retries once on a 401', async () => {
   const am = new AccountManager([oauth('a')], 0.98); // no refreshToken → ensureTokenFresh is a no-op
   let calls = 0;


### PR DESCRIPTION
The background OAuth quota prober previously treated every OAuth account without an upstream as an Anthropic target. Codex OAuth accounts also match that shape, so their ChatGPT token was sent to Anthropic /api/oauth/usage and returned HTTP 401.

Gate the target through the account provider and add a regression test asserting Codex accounts are not probed and report not-applicable. This branch is based on the current master and also carries the dashboard reload/probe controls and launcher that were not part of the merged dashboard PR.