### PR TITLE
fix(run): keep the operator's NO_PROXY instead of replacing it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ While the config is being rewritten — by the server rotating a refresh token, 
 | `TEAMCLAUDE_DISABLE_AUTOUPDATE` | Set to `1` to skip the background self-update check |
 | `TEAMCLAUDE_STATUS_TIMEOUT_MS` | How long `teamclaude status` waits for the server's answer before giving up (default `5000`). A connection that is accepted but never answered is reported as a stalled or overloaded server, distinct from a refused one ("Is the server running?") |
 | `HTTPS_PROXY` / `ALL_PROXY` | Outbound proxy used when the config sets no `upstreamProxy` (lowercase forms honoured too) |
-| `NO_PROXY` | Hosts that bypass the outbound proxy, when the config sets no `noProxy` |
+| `NO_PROXY` | Hosts that bypass the outbound proxy, when the config sets no `noProxy`. Also inherited by clients that `teamclaude run`/`env` launch — their loopback entries are added to yours, and `*` is ignored |
 
 ```bash
 TEAMCLAUDE_CONFIG=./my-config.json teamclaude server

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,6 +140,8 @@ claude
 
 Only the export lines go to stdout (so `eval` is safe); a short summary and any hints go to stderr. No `ANTHROPIC_API_KEY` is emitted — loopback clients are exempt from the proxy key gate, and setting it would drop Claude Code out of subscription mode. A remote (non-loopback) client must add the proxy key itself.
 
+**Your own `NO_PROXY` is kept.** `run` and `env` both set `NO_PROXY=localhost,127.0.0.1,::1` and append whatever the launching shell already had. That matters for local development: a dev server on a name like `app.test` resolves to 127.0.0.1 through a local resolver, and a forward to loopback is refused, so a client that proxied it would get a 403 on every retry. `export NO_PROXY=.test` before the eval (or before `run`) and the launched client gets `localhost,127.0.0.1,::1,.test`. The one entry that is dropped is `*` — it would send `api.anthropic.com` around the proxy as well, silently ending rotation; use `--no-mitm` for a direct launch.
+
 **Using an agent multiplexer or a tool that spawns `claude` itself?** Export this environment in the process that launches those `claude` instances — e.g. `eval "$(teamclaude env)"` in the shell you start the multiplexer from. Every spawned `claude` then gets the same routing (and MITM interception of hardcoded endpoints) without going through `teamclaude run`. The trade-off: `run`'s proxy-up/down guard only applies when you launch via `run`, so start the server before the multiplexer.
 
 ### Routing plain `claude` automatically

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -26,11 +26,50 @@ export function validPort(port) {
   return n;
 }
 
+// The loopback entries every launched client gets. They keep the client's own
+// localhost traffic out of the proxy: a forward to loopback is refused
+// (forward-target.js), so a client that proxied it would get a 403 instead of
+// its own dev server.
+export const LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1'];
+
+/** True if `value` names `*` — "proxy nothing" — among its entries. */
+export function bypassesAllHosts(value) {
+  return String(value ?? '').split(',').some((entry) => entry.trim() === '*');
+}
+
+/**
+ * The NO_PROXY a launched client gets: ours, plus whatever the operator had.
+ *
+ * Replacing theirs broke the case the list exists for. A local dev host is
+ * rarely spelled `localhost` — `*.test` and friends resolve to 127.0.0.1
+ * through a local resolver — so with only our three entries the client proxies
+ * it, the proxy refuses the loopback forward, and the client retries the 403 on
+ * a loop. Their entries are kept verbatim (a leading dot or a `host:port` is
+ * theirs to mean), deduped case-insensitively, ours first.
+ *
+ * `*` is the one entry dropped: it routes every host around the proxy,
+ * api.anthropic.com included, which silently turns the launch into a direct run
+ * — no rotation, the operator's own quota. `--no-mitm` is how that is asked for.
+ */
+export function mergeNoProxy(...inherited) {
+  const seen = new Set();
+  const out = [];
+  const entries = inherited.flatMap((value) => String(value ?? '').split(','));
+  for (const entry of [...LOOPBACK_NO_PROXY, ...entries]) {
+    const host = entry.trim();
+    if (!host || host === '*' || seen.has(host.toLowerCase())) continue;
+    seen.add(host.toLowerCase());
+    out.push(host);
+  }
+  return out.join(',');
+}
+
 // Build the shell `export` lines that point Claude Code — or any tool that
 // spawns it, e.g. an agent multiplexer — at the proxy. This is the same
 // environment `teamclaude run` sets up, but emitted for `eval "$(teamclaude
 // env)"` instead of launching claude directly. Pure and side-effect free so it
-// can be unit-tested; the caller resolves the port, cert path, and holdSeconds.
+// can be unit-tested; the caller resolves the port, cert path, holdSeconds and
+// the NO_PROXY the invoking shell already had.
 //
 // MITM (forward-proxy) mode is the default, matching `teamclaude run`: it routes
 // ALL of claude's traffic through the proxy — even hardcoded api.anthropic.com
@@ -48,7 +87,7 @@ export function validPort(port) {
 // `/tc-acct/` prefix. TC_ACCT itself is then unset, so the pin does not leak
 // into claude or anything it spawns — same reasoning as `run` deleting it from
 // the child environment.
-export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '' }) {
+export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '', inheritedNoProxy = null }) {
   const lines = [];
   const pin = (account || '').trim();
   // The port is interpolated unquoted into URLs the shell evals, so it has to
@@ -58,13 +97,16 @@ export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdS
   if (useMitm) {
     const userinfo = pin ? `${encodePinComponent(pin)}:${encodePinComponent(proxyApiKey || '')}@` : '';
     const proxyUrl = `http://${userinfo}127.0.0.1:${port}`;
+    const noProxy = mergeNoProxy(inheritedNoProxy);
     lines.push(
       `export HTTPS_PROXY=${proxyUrl}`,
       `export HTTP_PROXY=${proxyUrl}`,
       `export https_proxy=${proxyUrl}`,
       `export http_proxy=${proxyUrl}`,
-      'export NO_PROXY=localhost,127.0.0.1,::1',
-      'export no_proxy=localhost,127.0.0.1,::1',
+      // Quoted like the CA path below: the value now carries whatever the
+      // operator's own NO_PROXY held, and this line is eval'd.
+      `export NO_PROXY=${shellQuote(noProxy)}`,
+      `export no_proxy=${shellQuote(noProxy)}`,
     );
     // Quoted: the path is under $HOME (or XDG_CONFIG_HOME), which can carry a
     // space or a quote, and this line is eval'd.

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ import { autoUpdate, checkForUpdate, currentVersion, runUpdate, installKind, PKG
 import { renderStatus, formatPercent } from './status-renderer.js';
 import { sanitizeText } from './safe-text.js';
 import { ClientUsageTracker, UsageDimensionTracker } from './client-usage.js';
-import { buildClaudeEnvLines, encodePinComponent } from './claude-env.js';
+import { buildClaudeEnvLines, bypassesAllHosts, encodePinComponent, mergeNoProxy } from './claude-env.js';
 import { serviceKind, installService, uninstallService, serviceStatus, renderService, logPath } from './service.js';
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
@@ -940,6 +940,9 @@ async function envCommand() {
     lines = buildClaudeEnvLines({
       port, useMitm, caPath, holdSeconds: config.holdSeconds,
       account, proxyApiKey: config.proxy?.apiKey || '',
+      // The shell doing the eval keeps its own NO_PROXY entries; re-running is
+      // idempotent, since the merged value is what it will have next time.
+      inheritedNoProxy: [process.env.NO_PROXY, process.env.no_proxy].filter(Boolean).join(','),
     });
   } catch (err) {
     // A bad proxy.port. Nothing reaches stdout: the shell is eval'ing it.
@@ -1018,7 +1021,13 @@ async function runCommand() {
         : '';
       const proxyUrl = `http://${userinfo}127.0.0.1:${port}`;
       env.HTTPS_PROXY = env.HTTP_PROXY = env.https_proxy = env.http_proxy = proxyUrl;
-      env.NO_PROXY = env.no_proxy = 'localhost,127.0.0.1,::1';
+      // Keep the operator's own NO_PROXY and add ours — see mergeNoProxy. Both
+      // spellings are read: a tool that set only one still meant it.
+      const inheritedNoProxy = [process.env.NO_PROXY, process.env.no_proxy];
+      env.NO_PROXY = env.no_proxy = mergeNoProxy(...inheritedNoProxy);
+      if (inheritedNoProxy.some(bypassesAllHosts)) {
+        console.error('[TeamClaude] NO_PROXY=* ignored: it would send api.anthropic.com around the proxy (no rotation). Use --no-mitm for a direct launch.');
+      }
       env.NODE_EXTRA_CA_CERTS = caPath;
       if (tcAcct) console.error(`[TeamClaude] Pinned to account "${tcAcct}" (TC_ACCT)`);
       else if (pinnedBase) {

--- a/test/claude-env.test.js
+++ b/test/claude-env.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import { spawnSync } from 'node:child_process';
 import assert from 'node:assert/strict';
-import { buildClaudeEnvLines } from '../src/claude-env.js';
+import { buildClaudeEnvLines, bypassesAllHosts, mergeNoProxy } from '../src/claude-env.js';
 
 test('MITM mode (default) emits proxy vars + CA cert, and clears ANTHROPIC_BASE_URL', () => {
   const lines = buildClaudeEnvLines({ port: 3456, caPath: '/home/u/.config/teamclaude-ca.pem' });
@@ -10,8 +10,8 @@ test('MITM mode (default) emits proxy vars + CA cert, and clears ANTHROPIC_BASE_
     'export HTTP_PROXY=http://127.0.0.1:3456',
     'export https_proxy=http://127.0.0.1:3456',
     'export http_proxy=http://127.0.0.1:3456',
-    'export NO_PROXY=localhost,127.0.0.1,::1',
-    'export no_proxy=localhost,127.0.0.1,::1',
+    "export NO_PROXY='localhost,127.0.0.1,::1'",
+    "export no_proxy='localhost,127.0.0.1,::1'",
     "export NODE_EXTRA_CA_CERTS='/home/u/.config/teamclaude-ca.pem'",
     'unset ANTHROPIC_BASE_URL',
   ]);
@@ -113,10 +113,58 @@ test('a pinned line is shell-safe: no unquoted metacharacters survive', () => {
   for (const name of ["work (Acme)", "o'brien", "a!b", "x*y"]) {
     for (const useMitm of [true, false]) {
       const lines = buildClaudeEnvLines({ port: 3456, useMitm, account: name, caPath: '/x' });
-      // The pin rides unquoted in the URL lines; the CA path line is quoted separately.
-      for (const l of lines.filter(l => !l.startsWith('export NODE_EXTRA_CA_CERTS='))) {
+      // The pin rides unquoted in the URL lines; the CA path and NO_PROXY lines
+      // carry operator-supplied text and are quoted separately.
+      for (const l of lines.filter(l => !/^export (NODE_EXTRA_CA_CERTS|NO_PROXY|no_proxy)=/.test(l))) {
         assert.ok(!/[()'!*]/.test(l), `${l} (from ${name})`);
       }
     }
   }
+});
+
+// ── NO_PROXY ─────────────────────────────────────────────────
+//
+// Replacing the operator's NO_PROXY broke local development: a dev host on a
+// `*.test` name resolves to 127.0.0.1, the client proxied it because the name
+// is not `localhost`, and the proxy refused the loopback forward — a 403 per
+// retry, for as long as the dev server ran.
+test('an inherited NO_PROXY is kept, with ours in front', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, caPath: '/x', inheritedNoProxy: '.test,dev.internal:8080' });
+  assert.ok(lines.includes("export NO_PROXY='localhost,127.0.0.1,::1,.test,dev.internal:8080'"), lines.join('\n'));
+  assert.ok(lines.includes("export no_proxy='localhost,127.0.0.1,::1,.test,dev.internal:8080'"), lines.join('\n'));
+});
+
+test('mergeNoProxy: always emits the loopback trio, trims, and dedupes case-insensitively', () => {
+  assert.equal(mergeNoProxy(null), 'localhost,127.0.0.1,::1');
+  assert.equal(mergeNoProxy(''), 'localhost,127.0.0.1,::1');
+  assert.equal(mergeNoProxy('  .test ,, 127.0.0.1 '), 'localhost,127.0.0.1,::1,.test');
+  assert.equal(mergeNoProxy('LOCALHOST,Dev.Test,dev.test'), 'localhost,127.0.0.1,::1,Dev.Test');
+  // Both spellings of the variable are read; overlap collapses.
+  assert.equal(mergeNoProxy('.test', '.test,.example'), 'localhost,127.0.0.1,::1,.test,.example');
+});
+
+// `*` means "proxy nothing". Honouring it would send api.anthropic.com straight
+// out: no rotation, the operator's own quota, and nothing on screen to say so.
+test('mergeNoProxy drops `*`, keeping the rest of the list', () => {
+  assert.equal(mergeNoProxy('*'), 'localhost,127.0.0.1,::1');
+  assert.equal(mergeNoProxy(' * , .test'), 'localhost,127.0.0.1,::1,.test');
+  assert.ok(bypassesAllHosts('.test, *'));
+  assert.ok(!bypassesAllHosts('.test,*.example'));
+  assert.ok(!bypassesAllHosts(null));
+});
+
+// The value now comes from the environment, and these lines are eval'd — the
+// same hazard the port check exists for.
+test('an inherited NO_PROXY is shell-quoted: a space, a quote and a $ survive eval', () => {
+  for (const inherited of ['.test,a b', ".test,o'brien", '.test,$(touch /tmp/tc-no-proxy-pwn)', '.test;touch /tmp/tc-no-proxy-pwn2']) {
+    const lines = buildClaudeEnvLines({ port: 3456, caPath: '/x', inheritedNoProxy: inherited });
+    const result = spawnSync('/bin/sh', ['-c', `${lines.join('\n')}\nprintf %s "$NO_PROXY"`], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, mergeNoProxy(inherited), inherited);
+  }
+});
+
+test('base-URL mode still emits no NO_PROXY, inherited or not', () => {
+  const lines = buildClaudeEnvLines({ port: 3456, useMitm: false, inheritedNoProxy: '.test' });
+  assert.deepEqual(lines, ['export ANTHROPIC_BASE_URL=http://localhost:3456']);
 });


### PR DESCRIPTION
`teamclaude run` and `teamclaude env` set `NO_PROXY=localhost,127.0.0.1,::1` and discard whatever the launching shell had. `forward-target.js` notes that nothing legitimate is lost on the loopback side because launched clients carry that list — but the list only covers the literal spellings. A local dev server is usually reached by name: `app.test`, `*.localhost`, or anything a local resolver points at 127.0.0.1. The launched client proxies it (the name is not `localhost`), the forward policy refuses the loopback target, and the client retries the 403 for as long as its dev server runs — one `CONNECT … refused: … resolves to 127.0.0.1, a loopback address` per retry in the log, and a dev-time request that never succeeds. There is no way to opt out, because the one standard variable for it is overwritten.

This change:
- merges rather than replaces — `mergeNoProxy()` puts the loopback entries first and appends the operator's, deduped case-insensitively, so `export NO_PROXY=.test` before `run`/`env` reaches the client as `localhost,127.0.0.1,::1,.test`;
- drops `*`: honouring it would route `api.anthropic.com` around the proxy as well and silently end rotation on the operator's own quota, with nothing on screen to say so. `run` prints a line when it ignores one, and `--no-mitm` stays the way to ask for a direct launch;
- shell-quotes the emitted `NO_PROXY` lines, since the value now carries text from the environment into a line the shell evals — the hazard `validPort` already guards for the port.

Tests cover the merge, the trim/dedupe, the `*` drop, and that a space, a quote and a `$` in an inherited value survive `eval`. Docs: the launch environment in `docs/usage.md` and the `NO_PROXY` row in `docs/configuration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
