### PR TITLE
Bump to 1.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karpeleslab/teamclaude",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Multi-account proxy for Claude Code and Codex: pools Claude Max, ChatGPT/Codex, API-key and third-party backend accounts, and rotates on quota",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Eight commits since 1.1.19: Codex quota probing, a provider-aware
dashboard, a lock file around config writes, and the next round of
expiry-pressure routing follow-ups.

Behaviour changes
  #360 writers of the config hold `teamclaude.json.lock` next to it
       across their read-modify-write: a plain file holding
       {"pid","at"}, stale after 10 s or a dead pid, waited on for at
       most 2 s before the write proceeds with a warning. The server,
       every CLI command and any outside client coordinate through it
  #365 `teamclaude run` and `env` keep the operator's own NO_PROXY and
       add the loopback entries to it, so a dev host on a `.test` name
       reaches its own server instead of a 403 from the loopback-forward
       refusal; `*` is dropped with a warning, since it would send
       api.anthropic.com around the proxy
  #368 the quota probe reads Codex accounts from ChatGPT's read-only
       usage endpoint, and no longer sends a Codex token to Anthropic's
       usage endpoint; the endpoint is internal and may change
  #367 a walk records where it left the slot as the provider's cursor,
       and a cursor move inside a walk writes no provider cursor of its
       own, so a Codex request served by a shared API key no longer
       moves the Anthropic fleet's cursor

Features
  #359 `server.version` in /teamclaude/status (and `status --json`),
       read once at startup, so a client can tell the running version
       from the installed one after an update
  #361 the dashboard tells Claude and Codex accounts apart, marks the
       current account within each provider's pool, and renders one
       default routing row per provider; status carries
       `currentAccounts` and `defaultTargets` keyed by provider, plus
       `provider` and `knownSessions` per account
  #368 the web dashboard gains Reload config and Probe quotas buttons
       (`POST /teamclaude/probe`), and `teamclaude dashboard` opens the
       page of a running server in the browser

Fixes
  #362 expiry-pressure routing (opt-in) holds one rolled-over reading per
       escaped account and per fleet, hands a roll back once per window,
       and bounds the session-reset switch to the fleet the cursor serves
  #366 the session-reset switch admits an advisor request on both of its
       models, by the same test selection applies, so a reset is never
       spent onto an account the request is then diverted away from

🤖 Generated with [Claude Code](https://claude.com/claude-code)