### PR TITLE
build: typecheck the JS sources with tsc in CI, and bring src/ to zero diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # `--ignore-scripts`: eslint (the only devDependency) is needed for lint
-      # only, and neither it nor its transitive packages need lifecycle scripts to
-      # work. Not running them denies a compromised package arbitrary code
+      # `--ignore-scripts`: the devDependencies (eslint, typescript, @types/node)
+      # are needed for lint and typecheck only, and neither they nor their
+      # transitive packages need lifecycle scripts to work. Not running them denies a compromised package arbitrary code
       # execution at install time. Still `npm install` rather than `npm ci`:
       # package-lock.json is deliberately gitignored for this zero-dependency
       # package, so there is no lockfile for `npm ci` to consume.
@@ -39,6 +39,11 @@ jobs:
       - name: Lint
         if: matrix.node == 24
         run: npm run lint
+
+      # tsc over the JS sources, driven by their JSDoc (see tsconfig.json).
+      - name: Typecheck
+        if: matrix.node == 24
+        run: npm run typecheck
 
   nix:
     name: nix package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,8 @@ jobs:
       # Deliberately no `npm install` here. The package has zero runtime
       # dependencies, the tests are plain `node --test` and import nothing from
       # node_modules, and the published tarball is just `files: ["src/"]`. The
-      # only devDependency is eslint, which is linted in ci.yml, not here. This
+      # devDependencies (eslint, typescript, @types/node) serve ci.yml's lint and
+      # typecheck steps, not this job. This
       # job holds `id-token: write` + `contents: write` and ends in `npm publish`,
       # so pulling ~90 unpinned transitive packages from the registry (and
       # running their lifecycle scripts) in the same job would hand any one of

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "node --test --test-timeout=120000",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.json"
   },
   "keywords": [
     "claude",
@@ -43,6 +44,8 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "eslint": "^9.0.0"
+    "@types/node": "20.19.43",
+    "eslint": "^9.0.0",
+    "typescript": "5.9.2"
   }
 }

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -262,6 +262,23 @@ function sampleModelFor(route) {
 }
 
 export class AccountManager {
+  /**
+   * @param {Array<Object>} accounts  config entries, credentials resolved
+   * @param {number|Object<string, number>} [switchThreshold]  one number, or per bucket with a `default`
+   * @param {Object} [opts]
+   * @param {Function} [opts.refreshFn]
+   * @param {Function} [opts.codexRefreshFn]
+   * @param {number} [opts.throttleProbeFloorMs]
+   * @param {number} [opts.familyStaleMs]
+   * @param {number} [opts.statusStaleMs]
+   * @param {number} [opts.forcedRefreshFloorMs]
+   * @param {Array<Object>} [opts.routes]
+   * @param {Object} [opts.ramp]
+   * @param {boolean|string} [opts.distributeSessions]
+   * @param {Object} [opts.adaptive]
+   * @param {Object} [opts.sessionTracker]
+   * @param {Object} [opts.expiryRouting]
+   */
   constructor(accounts, switchThreshold = 0.98, { refreshFn = refreshAccessToken, codexRefreshFn = refreshCodexToken, throttleProbeFloorMs, familyStaleMs, statusStaleMs, forcedRefreshFloorMs = FORCED_REFRESH_FLOOR_MS, routes, ramp, distributeSessions = false, adaptive, sessionTracker, expiryRouting } = {}) {
     // How long a just-minted token is trusted against a forced refresh.
     this._forcedRefreshFloorMs = forcedRefreshFloorMs;

--- a/src/admission-gate.js
+++ b/src/admission-gate.js
@@ -18,6 +18,7 @@ export class AdmissionGate {
     this.queue = [];
   }
 
+  /** @param {{ signal?: AbortSignal, timeoutMs?: number }} [opts] */
   enter({ signal, timeoutMs = DEFAULT_QUEUE_TIMEOUT_MS } = {}) {
     if (signal?.aborted) return Promise.resolve(false);
     if (this.active < this.limit) {

--- a/src/cache-control-sanitize.js
+++ b/src/cache-control-sanitize.js
@@ -67,7 +67,7 @@ function isPlainObject(v) {
  *
  * @param {Buffer} body fully-buffered request body
  * @param {string} url req.url (only /v1/messages bodies are inspected)
- * @param {string} [contentType] the request's content-type header
+ * @param {string|undefined} contentType the request's content-type header
  * @param {Iterable<string>} subfields subfield names to drop (e.g. `scope`)
  * @returns {Buffer} the original buffer when nothing needed stripping (or on any
  *   parse / shape surprise), else a re-serialized buffer with those subfields

--- a/src/codex-auth.js
+++ b/src/codex-auth.js
@@ -17,6 +17,7 @@ import { exec } from 'node:child_process';
 import http from 'node:http';
 import { proxyFetch } from './upstream-fetch.js';
 import { tokenPairFromResponse } from './oauth.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 export const DEFAULT_CODEX_CREDENTIALS_PATH = '~/.codex/auth.json';
 
@@ -98,7 +99,7 @@ export async function refreshCodexToken(refreshToken, endpoint = TOKEN_ENDPOINT)
 
   if (!res.ok) {
     const text = await res.text();
-    const err = new Error(`Codex token refresh failed (${res.status}): ${text}`);
+    const err = /** @type {CodedError} */ (new Error(`Codex token refresh failed (${res.status}): ${text}`));
     // Surfaced so callers can tell a dead refresh token (re-login needed) from
     // a transient server error, exactly as the Anthropic path does.
     err.status = res.status;
@@ -238,7 +239,7 @@ export async function loginCodex({ noBrowser = false, timeoutMs = 120_000 } = {}
   const code = await new Promise((resolve, reject) => {
     server = http.createServer(codexCallbackHandler(state, { resolve, reject }));
 
-    server.on('error', (e) => reject(e.code === 'EADDRINUSE'
+    server.on('error', (/** @type {CodedError} */ e) => reject(e.code === 'EADDRINUSE'
       ? new Error(`Port ${CALLBACK_PORT} is in use. OpenAI only accepts ${REDIRECT_URI} for this client, so close whatever holds it (a running \`codex login\`) and retry.`)
       : e));
 

--- a/src/egress-guard.js
+++ b/src/egress-guard.js
@@ -19,8 +19,14 @@ const POLL_MS = 3_000;
 
 export class EgressGuard {
   /**
-   * @param {object} opts
-   * @param {string|string[]} opts.pin  'auto' (pin whatever is seen first), or one or more allowed IPs
+   * @param {Object} [opts]
+   * @param {string|string[]} [opts.pin]  'auto' (pin whatever is seen first), or one or more allowed IPs
+   * @param {string} [opts.checkUrl]  what to ask for the egress address
+   * @param {number} [opts.ttlMs]
+   * @param {number} [opts.holdMs]
+   * @param {Function} [opts.fetchImpl]
+   * @param {number} [opts.pollMs]
+   * @param {(line: string) => void} [opts.log]
    */
   constructor({ pin, checkUrl = DEFAULT_CHECK_URL, ttlMs = DEFAULT_TTL_MS, holdMs = DEFAULT_HOLD_MS,
     fetchImpl = fetch, pollMs = POLL_MS, log = () => {} } = {}) {

--- a/src/forward-target.js
+++ b/src/forward-target.js
@@ -24,6 +24,7 @@
 
 import dns from 'node:dns';
 import net from 'node:net';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 /** Error code carried by a lookup refused by this policy. */
 export const FORBIDDEN_FORWARD = 'EFORBIDDENFORWARD';
@@ -171,7 +172,7 @@ export function guardedLookup(socket, { lookup = dns.lookup } = {}) {
       for (const { address } of list) {
         const why = forwardRefusal(hostname, address, socket);
         if (why) {
-          const e = new Error(`forward to ${hostname} refused: ${why}`);
+          const e = /** @type {CodedError} */ (new Error(`forward to ${hostname} refused: ${why}`));
           e.code = FORBIDDEN_FORWARD;
           return callback(e);
         }

--- a/src/identity.js
+++ b/src/identity.js
@@ -179,6 +179,7 @@ export function canUpsertOAuthAccount(profile, userNamed) {
  * Copy only known profile identity fields. Omitting unavailable fields keeps a
  * named re-import from erasing identity already stored on the account.
  */
+/** @returns {{ accountUuid?: string, orgUuid?: string, orgName?: string }} */
 export function oauthIdentityFields(profile) {
   if (!profile || profile.error) return {};
   return Object.fromEntries(

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ import { serviceKind, installService, uninstallService, serviceStatus, renderSer
 import { formatTerminalTitle, titleSequence, TITLE_STACK_PUSH, TITLE_STACK_POP } from './terminal-title.js';
 import { getUpstreamProxy, describeProxy, describeSelfProxy } from './upstream-proxy.js';
 import { startEventLoopMonitor } from './event-loop-monitor.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 // These constants are referenced by routeCommand, which the dispatch below
 // reaches through a top-level `await`. The await suspends module evaluation at
@@ -460,6 +461,7 @@ async function serverCommand() {
   };
 
   let tui = null;
+  /** @type {Object} */
   let hooks = {};
 
   if (useTUI) {
@@ -1087,7 +1089,7 @@ async function runCommand() {
   });
 
   if (result.error) {
-    if (result.error.code === 'ENOENT') {
+    if (/** @type {CodedError} */ (result.error).code === 'ENOENT') {
       console.error('Claude Code not found in PATH. Install it first.');
     } else {
       console.error(`Failed to start claude: ${result.error.message}`);

--- a/src/mitm.js
+++ b/src/mitm.js
@@ -24,6 +24,7 @@ import { createProxyRequestListener, resolveClientAuth, loopbackExempt, relayUpg
 import { interceptHostsFor, isNeverIntercepted } from './provider.js';
 import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-target.js';
 import { safeLine } from './safe-text.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 const CA_CERT = 'teamclaude-ca.pem';
 const LEAF_CERT = 'teamclaude-leaf.pem';
@@ -191,7 +192,17 @@ export function upgradeUpstreamFor(hostHeader, config, upstream) {
 /**
  * Build a `connect` event handler implementing the terminating MITM described at
  * the top of this file.
- * @param ensureLeaf async () => { key, cert }   // current leaf PEMs
+ * @param {Object} opts
+ * @param {Object} opts.config
+ * @param {Object} opts.accountManager
+ * @param {() => Promise<{ key: string, cert: string }>} opts.ensureLeaf  current leaf PEMs
+ * @param {string|null} [opts.logDir]
+ * @param {Object} [opts.hooks]
+ * @param {(line: string) => void} [opts.log]
+ * @param {Object|null} [opts.sx]
+ * @param {Object|null} [opts.egress]
+ * @param {Object|null} [opts.clientUsage]
+ * @param {Object|null} [opts.dimensionUsage]
  */
 export function createConnectHandler({ config, accountManager, ensureLeaf, logDir = null, hooks = {}, log = () => {}, sx = null, egress = null, clientUsage = null, dimensionUsage = null }) {
   const upstream = config.upstream || 'https://api.anthropic.com';
@@ -364,7 +375,7 @@ export function createConnectHandler({ config, accountManager, ensureLeaf, logDi
         if (head && head.length) up.write(head);
         up.pipe(clientSocket); clientSocket.pipe(up);
       });
-      up.on('error', (err) => {
+      up.on('error', (/** @type {CodedError} */ err) => {
         if (err.code === FORBIDDEN_FORWARD) {
           log(`[TeamClaude] CONNECT ${host}:${port} refused: ${err.message}`);
           teardown('403 Forbidden');

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 import { createInterface } from 'node:readline';
 import http from 'node:http';
 import { proxyFetch } from './upstream-fetch.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 const execFileAsync = promisify(execFile);
 
@@ -173,7 +174,7 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
           continue;
         }
         const text = await res.text();
-        const err = new Error(`Token refresh failed (${res.status}): ${text}`);
+        const err = /** @type {CodedError} */ (new Error(`Token refresh failed (${res.status}): ${text}`));
         // Surface the HTTP status so callers can distinguish a genuine auth
         // rejection (the refresh token is dead — re-login needed) from a
         // transient server error. 5xx is retried above; reaching here with a 5xx
@@ -187,8 +188,8 @@ export async function refreshAccessToken(refreshToken, endpoint = DEFAULT_TOKEN_
       const isNetworkError = err instanceof Error &&
         (err.name === 'TimeoutError' || err.name === 'AbortError' ||
           err.message.includes('fetch failed') ||
-          (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED' ||
-           err.code === 'ETIMEDOUT' || err.code === 'UND_ERR_CONNECT_TIMEOUT'));
+          ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT']
+            .includes(/** @type {CodedError} */ (err).code));
 
       if (attempt < maxRetries && isNetworkError) {
         continue;
@@ -784,7 +785,7 @@ export function startCallbackServer(expectedState) {
     // Loopback only: the redirect URI is http://localhost:<port>/callback, so
     // nothing off this machine ever has a reason to reach the listener.
     server.listen(0, '127.0.0.1', () => {
-      resolve({ port: server.address().port, codePromise, server });
+      resolve({ port: /** @type {import('node:net').AddressInfo} */ (server.address()).port, codePromise, server });
     });
     server.on('error', reject);
 

--- a/src/prober.js
+++ b/src/prober.js
@@ -209,11 +209,12 @@ export class Prober {
     const reading = await this.backendFn(account, { timeoutMs: this.timeoutMs })
       .catch(err => ({ error: err?.message || String(err) }));
     const finishedAt = Date.now();
-    const failed = !reading || reading.error;
+    const failure = reading && 'error' in reading ? reading.error : null;
+    const failed = !reading || !!failure;
     if (!failed) this.am.applyBackendQuota(account.index, reading);
     this._recordAccount(account, {
       status: failed ? 'error' : 'ok',
-      error: failed ? (reading?.error || 'no reading') : null,
+      error: failed ? (failure || 'no reading') : null,
       startedAt, finishedAt, durationMs: finishedAt - startedAt,
     });
   }

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,7 @@ import { forwardRefusal, guardedLookup, FORBIDDEN_FORWARD } from './forward-targ
 import { renderDashboardHtml, dashboardCsp } from './dashboard.js';
 import { createUsageRecorder, resolveUsageDimensions, usageDimensionHeaderNames } from './client-usage.js';
 import { classificationPath } from './classification-path.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 
 export const HOP_BY_HOP_HEADERS = new Set([
@@ -537,7 +538,7 @@ export function createProxyServer(accountManager, config, hooks = {}, sx = null,
         // line, so the 401 alone leaves an operator with a channel that is
         // silently dead — the same shape as the outage this gate could cause if
         // a client turns out not to send the key.
-        console.log(`[TeamClaude] WebSocket upgrade refused (no proxy key) from ${safeLine(socket?.remoteAddress || 'unknown')} for ${safeLine(req.url)}`);
+        console.log(`[TeamClaude] WebSocket upgrade refused (no proxy key) from ${safeLine(/** @type {import('node:net').Socket} */ (socket)?.remoteAddress || 'unknown')} for ${safeLine(req.url)}`);
         try { socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'); } catch { /* already gone */ }
         socket.destroy();
         return;
@@ -747,6 +748,7 @@ export function relayHttpForward(req, res) {
   if (refused) { refuse(refused); return; }
 
   const transport = target.protocol === 'http:' ? http : https;
+  /** @type {import('node:http').OutgoingHttpHeaders} */
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -764,7 +766,7 @@ export function relayHttpForward(req, res) {
     res.writeHead(upstreamRes.statusCode, responseHeaders);
     upstreamRes.pipe(res);
   });
-  upstreamReq.on('error', (err) => {
+  upstreamReq.on('error', (/** @type {CodedError} */ err) => {
     if (err.code === FORBIDDEN_FORWARD) { refuse(err.message); return; }
     console.error(`[TeamClaude] HTTP forward to ${target.host} failed:`, describeConnectError(err));
     if (!res.headersSent) {
@@ -815,6 +817,21 @@ export function clientSessionId(headers) {
  * the MITM's terminating h2/h1 server, so both get identical buffering, model-
  * aware routing, and retry-on-quota behavior. Control endpoints (status/reload)
  * and the proxy-API-key gate live in the base server's wrapper, not here.
+ */
+/**
+ * @param {Object} opts
+ * @param {Object} opts.accountManager
+ * @param {string} opts.upstream
+ * @param {string|null} [opts.logDir]
+ * @param {Object} [opts.hooks]  activity callbacks (onRequestStart, onRequestEnd, ...), all optional
+ * @param {Object|null} [opts.sx]
+ * @param {number} [opts.holdMs]
+ * @param {Object} [opts.config]  the live config object; read per request, never copied
+ * @param {string|null} [opts.forcedPin]
+ * @param {Object|null} [opts.egress]
+ * @param {Object|null} [opts.clientUsage]
+ * @param {string|null} [opts.forcedClient]
+ * @param {Object|null} [opts.dimensionUsage]
  */
 export function createProxyRequestListener({ accountManager, upstream, logDir = null, hooks = {}, sx = null, holdMs = 0, config = {}, forcedPin = null, egress = null, clientUsage = null, forcedClient = null, dimensionUsage = null }) {
   let counter = 0;
@@ -1226,7 +1243,7 @@ function recordEarlyOutcome(accountManager, sessionId, url, usable) {
 // wait in forwardRequest either resolves to a clientGone check or rejects with
 // this, and the catch recognises it by code.
 function clientGoneError() {
-  const err = new Error('client disconnected');
+  const err = /** @type {CodedError} */ (new Error('client disconnected'));
   err.code = 'TEAMCLAUDE_CLIENT_GONE';
   return err;
 }
@@ -1276,7 +1293,7 @@ function sxAgent(sx, targetHost) {
   agent.createConnection = (_options, cb) => {
     tunnelTls({ proxy, targetHost, targetPort: 443, tlsOptions: sx.tlsOptions || {} })
       .then((sock) => cb(null, sock))
-      .catch((err) => cb(err));
+      .catch((err) => cb(err, null));
     return undefined;
   };
   return agent;
@@ -1292,6 +1309,7 @@ function sxAgent(sx, targetHost) {
  */
 function relayStream(req, res, upstream, sx) {
   const target = new URL(`${upstream}${req.url}`);
+  /** @type {import('node:http').OutgoingHttpHeaders} */
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -1442,6 +1460,7 @@ export function relayUpgrade(req, socket, head, upstream, sx, { client = null, c
   // accepts: a handshake it refuses opened nothing.
   const tag = client ? `[${safeLine(client, 64)}] ` : '';
   const path = safeLine(req.url);
+  /** @type {import('node:http').OutgoingHttpHeaders} */
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -1455,7 +1474,10 @@ export function relayUpgrade(req, socket, head, upstream, sx, { client = null, c
 
   const useProxy = !!(sx?.useByDefault() && sx.isProvisioned());
   const agent = useProxy ? sxAgent(sx, target.hostname) : undefined;
-  const transport = target.protocol === 'http:' ? http : https;
+  // One module's signature stands for both: the options this call passes are
+  // the same for http and https, and a union of the two `request` overload sets
+  // is not callable as such.
+  const transport = /** @type {typeof https} */ (target.protocol === 'http:' ? http : https);
 
   const upstreamReq = transport.request(target, { method: req.method, headers, agent });
 
@@ -2100,6 +2122,7 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
   }
 
   // Build upstream request headers
+  /** @type {import('node:http').OutgoingHttpHeaders} */
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     const lk = key.toLowerCase();
@@ -2152,8 +2175,8 @@ export async function forwardRequest(req, res, body, accountManager, upstream, r
     if (!l || reqLogged) return;
     reqLogged = true;
     const safeHeaders = { ...headers };
-    if (safeHeaders['x-api-key']) safeHeaders['x-api-key'] = safeHeaders['x-api-key'].slice(0, 15) + '...';
-    if (safeHeaders['authorization']) safeHeaders['authorization'] = safeHeaders['authorization'].slice(0, 20) + '...';
+    if (safeHeaders['x-api-key']) safeHeaders['x-api-key'] = String(safeHeaders['x-api-key']).slice(0, 15) + '...';
+    if (safeHeaders['authorization']) safeHeaders['authorization'] = String(safeHeaders['authorization']).slice(0, 20) + '...';
     l.write(`=== REQUEST (account: ${account.name}, retry: ${retryCount}) ===\n${method} ${upstreamUrl}\n${formatHeaders(safeHeaders)}`);
     // The body that went upstream, not the one the client sent: they differ
     // exactly when the proxy rewrote it (tool-pair sanitising, account_uuid,
@@ -2691,7 +2714,7 @@ export function readWithIdleTimeout(reader, ms) {
   let timer;
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => {
-      const err = new Error(`upstream stream idle for ${ms}ms`);
+      const err = /** @type {CodedError} */ (new Error(`upstream stream idle for ${ms}ms`));
       err.code = 'TEAMCLAUDE_BODY_TIMEOUT';
       reject(err);
     }, ms);

--- a/src/sx.js
+++ b/src/sx.js
@@ -164,6 +164,7 @@ export async function tunnelTls({ proxy, targetHost, targetPort = 443, tlsOption
  * reverse proxy, the MITM handler, and the TUI so a key change applies live.
  */
 export class SxManager {
+  /** @param {{ log?: (line: string) => void }} [opts] */
   constructor({ log = () => {} } = {}) {
     this.log = log;
     this.apiKey = null;

--- a/src/tui-remote.js
+++ b/src/tui-remote.js
@@ -2,6 +2,7 @@ import { TUI } from './tui.js';
 import { SessionTitles } from './session-titles.js';
 import { modelGlobMatches } from './model.js';
 import { safeLine } from './safe-text.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 // Attach mode — the dashboard against a server running somewhere else (a
 // background service, another terminal). The renderer is the same one the
@@ -96,6 +97,7 @@ export class RemoteControl {
 
   async _call(method, path, body) {
     const deadline = this.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    /** @type {Record<string, string>} */
     const headers = {};
     if (this.apiKey) headers['x-api-key'] = this.apiKey;
     if (body !== undefined) headers['content-type'] = 'application/json';
@@ -130,11 +132,11 @@ export class RemoteControl {
       // clients from the key gate, so a 401 from there cannot be about the key
       // and blaming it would send the operator to edit a config that is fine.
       const auth = !answered && (res.status === 401 || res.status === 403);
-      const err = new Error(auth
+      const err = /** @type {CodedError} */ (new Error(auth
         ? (LOOPBACK_HOSTS.has(this.host)
           ? `something other than teamclaude is answering on port ${this.port} (HTTP ${res.status})`
           : `the server rejected the proxy API key (HTTP ${res.status})`)
-        : answered ? text(payload.error, 200, `HTTP ${res.status}`) : `HTTP ${res.status}`);
+        : answered ? text(payload.error, 200, `HTTP ${res.status}`) : `HTTP ${res.status}`));
       err.status = res.status;
       err.answered = answered;
       throw err;

--- a/src/tui.js
+++ b/src/tui.js
@@ -1198,6 +1198,7 @@ export class TUI {
         name = `account-${n}`;
       }
 
+      /** @type {Object<string, any>} */
       const entry = {
         name, type: 'oauth', source: 'import',
         ...oauthIdentityFields(profile),

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,14 @@
+// JSDoc typedefs shared across modules. Nothing here runs: `npm run typecheck`
+// (tsc over the plain-JS sources, see tsconfig.json) reads these through
+// `@typedef {import('./types.js').Name} Name` in the modules that use them.
+
+/**
+ * An Error carrying the fields Node and this codebase hang on one: `code` (an
+ * errno such as ECONNRESET, or one of the TEAMCLAUDE_* codes the proxy mints),
+ * `status` (the HTTP status a refused request was answered with) and
+ * `answered` (whether that status came from a teamclaude control plane).
+ *
+ * @typedef {Error & { code?: string, status?: number, answered?: boolean }} CodedError
+ */
+
+export {};

--- a/src/updater.js
+++ b/src/updater.js
@@ -190,6 +190,16 @@ let rootWarned = false;
  * from the network — the operator can run `teamclaude update` deliberately.
  *
  * `root`, `uid`, `check`, `kind` and `install` are injectable for tests.
+ *
+ * @param {Object} [opts]
+ * @param {{ autoUpdate?: boolean }} [opts.config]
+ * @param {boolean} [opts.force]
+ * @param {(line: string) => void} [opts.log]
+ * @param {string} [opts.root]
+ * @param {number|undefined} [opts.uid]
+ * @param {Function} [opts.check]
+ * @param {Function} [opts.kind]
+ * @param {Function} [opts.install]
  */
 export async function autoUpdate({
   config = {}, force = false, log = console.error,

--- a/src/upstream-fetch.js
+++ b/src/upstream-fetch.js
@@ -15,6 +15,7 @@ import { ReadableStream } from 'node:stream/web';
 import { tunnelTls } from './sx.js';
 import { proxyForHost, proxyAgent } from './upstream-proxy.js';
 import { AdmissionGate, DEFAULT_MAX_QUEUE, DEFAULT_QUEUE_TIMEOUT_MS } from './admission-gate.js';
+/** @typedef {import('./types.js').CodedError} CodedError */
 
 // Pooled keep-alive agents for the direct (non-sx) path. Node's global fetch
 // multiplexes ALL requests to an origin over a SINGLE HTTP/2 connection; under
@@ -111,7 +112,7 @@ function resolveHeadersTimeout(perCall) {
 }
 
 function headersTimeoutError(ms) {
-  const err = new Error(`upstream response headers timed out after ${ms}ms`);
+  const err = /** @type {CodedError} */ (new Error(`upstream response headers timed out after ${ms}ms`));
   // Recognized by server.js isTransient → fail fast + let the client retry, so
   // Node's fetch pool evicts the stale connection instead of wedging.
   err.code = 'TEAMCLAUDE_HEADERS_TIMEOUT';
@@ -208,7 +209,7 @@ function proxiedFetch(url, opts, sx, timeoutMs) {
     // tests inject a CA here to reach a self-signed upstream.
     tunnelTls({ proxy, targetHost: u.hostname, targetPort: Number(u.port) || 443, tlsOptions: sx.tlsOptions || {} })
       .then((sock) => cb(null, sock))
-      .catch((err) => cb(err));
+      .catch((err) => cb(err, null));
     return undefined; // socket delivered asynchronously via cb
   };
   return nodeRequest(u, opts, timeoutMs, { transport: https, agent });
@@ -234,7 +235,7 @@ async function nodeRequest(u, opts, timeoutMs, { transport, agent }) {
   if (!admitted) {
     forget();
     if (opts.signal?.aborted) throw opts.signal.reason ?? new Error('aborted');
-    const err = new Error(`upstream admission queue for ${u.origin} is full or its wait deadline passed`);
+    const err = /** @type {CodedError} */ (new Error(`upstream admission queue for ${u.origin} is full or its wait deadline passed`));
     err.code = 'TEAMCLAUDE_UPSTREAM_OVERLOADED';
     throw err;
   }

--- a/src/upstream-proxy.js
+++ b/src/upstream-proxy.js
@@ -284,9 +284,9 @@ export function proxyAgent(proxy, { targetHost, targetPort, tls: useTls = true, 
         // TLS is established end-to-end over the tunnel, so the proxy sees only
         // ciphertext and cert verification stays at its secure default.
         handshakeOverTunnel(sock, { servername: targetHost, tlsOptions })
-          .then((tlsSock) => cb(null, tlsSock), (err) => cb(err));
+          .then((tlsSock) => cb(null, tlsSock), (err) => cb(err, null));
       })
-      .catch((err) => cb(err));
+      .catch((err) => cb(err, null));
     return undefined; // socket is delivered asynchronously through cb
   };
   return agent;

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -29,6 +29,22 @@ import {
 const SCHEDULE_TIMER_GRACE_MS = 60_000;
 
 export class Warmer {
+  /**
+   * @param {Object} accountManager
+   * @param {Object} opts
+   * @param {number} [opts.intervalMs]
+   * @param {Object|null} [opts.schedule]
+   * @param {number} [opts.port]
+   * @param {string|null} [opts.apiKey]
+   * @param {string} [opts.model]
+   * @param {string} [opts.prompt]
+   * @param {Function} [opts.spawnFn]
+   * @param {number} [opts.timeoutMs]
+   * @param {Function} [opts.log]
+   * @param {Function} [opts.nowFn]
+   * @param {Function} [opts.setTimeoutFn]
+   * @param {Function} [opts.clearTimeoutFn]
+   */
   constructor(accountManager, {
     intervalMs = 0,
     schedule = null,
@@ -219,7 +235,8 @@ export class Warmer {
     if (generation !== this._scheduleGeneration || this._stopped) return false;
     if (deadline !== null && this.nowFn() >= deadline) return false;
     this._running = true;
-    let finishRun;
+    /** @type {(value?: unknown) => void} */
+    let finishRun = () => {};
     const runFinished = new Promise(resolve => { finishRun = resolve; });
     this._runFinished = runFinished;
     const abort = this._abort = new AbortController();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  // `npm run typecheck`: TypeScript's checker over the plain-JS sources, driven
+  // by the JSDoc already in them. Nothing is compiled and no .ts file exists;
+  // this only reads. Non-strict on purpose for now — strict mode reports about
+  // two thousand implicit-any diagnostics on this tree — so what it catches is
+  // drift between a signature and its callers, a misspelled option, a property
+  // read off the wrong shape. Widening towards `strict` is the intended
+  // direction; each notch should land with the annotations that make it green.
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}


### PR DESCRIPTION
`npm run typecheck` runs TypeScript's checker over the plain-JS sources under
`allowJs` + `checkJs`, driven by the JSDoc already in them (tsconfig.json).
Nothing is compiled and no .ts file exists. It runs in ci.yml beside test and
lint, with `typescript` and `@types/node` pinned as dev dependencies. The
publish job still installs nothing.

Non-strict for now: strict mode reports about two thousand implicit-any
diagnostics on this tree, so it is the direction rather than the first step,
to be tightened one option at a time with the annotations that make each
notch green.

The 91 diagnostics the non-strict config reported on master are gone, almost
all through annotations: typedefs for the option bags whose `= {}` default
had the checker read them as empty (AccountManager, Warmer, EgressGuard,
createProxyRequestListener, createConnectHandler, autoUpdate), a shared
`CodedError` typedef (src/types.js) for the `code`/`status` fields Node and
this codebase hang on an Error, a typed return for oauthIdentityFields, and
`(line) => void` for the injectable loggers whose `() => {}` default read as
zero-argument. Three code touches, none a behaviour change: the Node-style
`cb(err)` calls pass an explicit null socket, the backend probe reads its
error through an `in` narrowing, and the logged header excerpt goes through
String(). One real finding fixed on the way: sanitizeCacheControl declared a
required parameter after an optional one.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)