### PR TITLE
ci: a strict-mode ratchet — per-file tsc strict diagnostics may not grow past the pre-merge commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,22 @@ jobs:
         if: matrix.node == 24
         run: npm run typecheck
 
+      # The strict-mode ratchet (scripts/typecheck-strict.mjs): strict
+      # diagnostics per file may not grow against the pre-merge commit. For a
+      # pull request the checkout is the merge of the branch into master and
+      # the base is master's tip; for a push to master it is the previous tip.
+      # The base commit is fetched on its own, since the checkout is shallow.
+      - name: Strict typecheck ratchet
+        if: matrix.node == 24 && (github.event_name == 'pull_request' || github.event_name == 'push')
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base commit for this event; skipping."; exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "$BASE"
+          npm run typecheck:strict -- --base "$BASE"
+
   nix:
     name: nix package
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "node src/index.js",
     "test": "node --test --test-timeout=120000",
     "lint": "eslint .",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "typecheck:strict": "node scripts/typecheck-strict.mjs"
   },
   "keywords": [
     "claude",

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// The strict-mode ratchet.
+//
+// tsconfig.json checks src/ non-strict and must be clean; `strict: true` is the
+// destination, and on this tree it reports a few thousand diagnostics, nearly
+// all implicit `any`. This script keeps that number from growing while it is
+// worked down, without a baseline file to maintain: it counts the strict
+// diagnostics PER FILE on the current tree and on a base commit, and fails when
+// any file has more now than it had there, or when a file the base did not
+// have carries any at all.
+//
+//   npm run typecheck:strict                  base = merge-base with origin/master
+//   npm run typecheck:strict -- --base <ref>  base = that commit
+//
+// CI passes the pre-merge commit: for a pull request the checkout is already
+// the merge of the branch into master and the base is master's tip, so the two
+// counts are exactly "before this merge" and "after it"; for a push to master
+// the base is the previous tip. Per file rather than one total, so a change
+// cannot add diagnostics in one place by removing some in another. A rename is
+// followed (`git diff -M`), so a file carries its count to its new name.
+//
+// The base is checked out into a throwaway git worktree with this tree's
+// node_modules linked in, so the same pinned `typescript` and `@types/node`
+// judge both sides. A base that predates tsconfig.strict.json borrows this
+// tree's copy.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, copyFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = process.cwd();
+const args = process.argv.slice(2);
+const baseArg = args.includes('--base') ? args[args.indexOf('--base') + 1] : null;
+
+function git(...argv) {
+  const r = spawnSync('git', argv, { encoding: 'utf8', cwd: root });
+  if (r.status !== 0) throw new Error(`git ${argv.join(' ')} failed: ${r.stderr.trim()}`);
+  return r.stdout.trim();
+}
+
+/** Strict diagnostics per file for the tree at `dir`, keyed by `src/...` path. */
+function countAt(dir) {
+  const tsc = spawnSync(process.execPath, [join(root, 'node_modules/typescript/bin/tsc'), '-p', join(dir, 'tsconfig.strict.json'), '--pretty', 'false'], {
+    encoding: 'utf8', cwd: dir, maxBuffer: 64 * 1024 * 1024,
+  });
+  // 2 is "there were diagnostics", the expected outcome. Anything else is tsc
+  // itself failing (a bad config, a missing install), which must not read as
+  // zero diagnostics.
+  if (tsc.error || (tsc.status !== 0 && tsc.status !== 2)) {
+    console.error(tsc.stderr || tsc.stdout || String(tsc.error));
+    throw new Error(`tsc did not run in ${dir} (status ${tsc.status ?? tsc.error?.code})`);
+  }
+  /** @type {Record<string, number>} */
+  const counts = {};
+  for (const line of tsc.stdout.split('\n')) {
+    const m = /^(src\/\S+?)\(\d+,\d+\): error TS\d+:/.exec(line);
+    if (m) counts[m[1]] = (counts[m[1]] || 0) + 1;
+  }
+  return counts;
+}
+
+const base = baseArg || git('merge-base', 'HEAD', 'origin/master');
+const baseSha = git('rev-parse', '--verify', `${base}^{commit}`);
+
+// Renames between base and now, old path -> new path, so a moved file is
+// compared with itself rather than read as one deletion and one new file.
+/** @type {Record<string, string>} */
+const renamed = {};
+for (const line of git('diff', '--name-status', '-M', baseSha, 'HEAD', '--', 'src').split('\n')) {
+  const m = /^R\d*\t(\S+)\t(\S+)$/.exec(line);
+  if (m) renamed[m[1]] = m[2];
+}
+
+const work = mkdtempSync(join(tmpdir(), 'tc-strict-base-'));
+let before;
+try {
+  git('worktree', 'add', '--detach', '--quiet', work, baseSha);
+  symlinkSync(join(root, 'node_modules'), join(work, 'node_modules'), 'dir');
+  for (const f of ['tsconfig.json', 'tsconfig.strict.json']) {
+    if (!existsSync(join(work, f))) copyFileSync(join(root, f), join(work, f));
+  }
+  before = countAt(work);
+} finally {
+  try { git('worktree', 'remove', '--force', work); } catch { rmSync(work, { recursive: true, force: true }); }
+}
+const after = countAt(resolve(root));
+
+/** @type {Record<string, number>} */
+const was = {};
+for (const [file, n] of Object.entries(before)) was[renamed[file] || file] = (was[renamed[file] || file] || 0) + n;
+
+const sum = (o) => Object.values(o).reduce((a, b) => a + b, 0);
+const worse = [];
+let dropped = 0;
+for (const file of new Set([...Object.keys(was), ...Object.keys(after)])) {
+  const b = was[file] || 0;
+  const a = after[file] || 0;
+  if (a > b) worse.push({ file, b, a });
+  else dropped += b - a;
+}
+
+console.log(`typecheck-strict: ${sum(after)} strict-mode diagnostics (base ${baseSha.slice(0, 8)}: ${sum(before)})`);
+if (worse.length === 0) {
+  if (dropped) console.log(`typecheck-strict: ${dropped} fewer than the base. Nice.`);
+  process.exit(0);
+}
+console.error('typecheck-strict: strict-mode diagnostics GREW in:');
+for (const { file, b, a } of worse) console.error(`  ${file}: ${b} -> ${a}`);
+console.error('');
+console.error('Fix the new ones (see: npx tsc -p tsconfig.strict.json). The count per file');
+console.error('may only stay or go down; a new file starts at zero.');
+process.exit(1);

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,11 @@
+{
+  // The strict-mode view of the same sources, for the ratchet in
+  // scripts/typecheck-strict.mjs: `npm run typecheck:strict` counts strict
+  // diagnostics per file here and on the pre-merge commit, and fails when any
+  // file's count grew. `strict: true` in tsconfig.json is where this ends,
+  // with this file deleted.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
Follows #371. `npm run typecheck` keeps `src/` clean under the non-strict config; this keeps the road to `strict: true` from getting longer.

`npm run typecheck:strict` runs `tsc` under `tsconfig.strict.json` (the base config plus `strict: true`), counts diagnostics **per file**, does the same for a base commit checked out into a temporary git worktree with this tree's `node_modules` linked in, and fails when any file has more now than it had at the base, or when a file the base did not have carries any. There is no baseline file to maintain: the base is the commit being merged onto. In CI that is `github.event.pull_request.base.sha` for a pull request (the checkout is already the merge of the branch into master, so the two counts are exactly before and after the merge) and `github.event.before` for a push to master.

- Per file rather than one total, so a change cannot add diagnostics in one place by removing some elsewhere. Running it against the commit before #371 shows why: that PR lowered the total from 2015 to 2006 while raising `account-manager.js`, `index.js` and `warmer.js`.
- A rename is followed with `git diff -M`, so a moved file keeps its count.
- A base that predates `tsconfig.strict.json` borrows this tree's copy, so the first comparison works.
- tsc failing to run (bad config, missing install) is an error, never read as zero diagnostics.
- About three seconds on this tree.

Verified locally: equal counts against master pass; an added untyped function fails with the file named and its counts; the temporary worktree is removed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)