### PR TITLE
types: annotate the small modules, taking 140 strict-mode diagnostics off the count

### DIFF
--- a/src/account-id.js
+++ b/src/account-id.js
@@ -40,6 +40,7 @@ export function mintAccountId() {
  * copies its id along with it, and two entries answering to one id collapse
  * onto whichever comes first — the later one would be handed the earlier one's
  * credential, which is the crossing this field exists to prevent.
+ * @param {Array<Record<string, any>>} accounts
  */
 export function ensureAccountIds(accounts) {
   const seen = new Set();

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -2476,7 +2476,10 @@ export class AccountManager {
     console.log(`[TeamClaude] Account "${account.name}" rolled over its ${window} window ${this._heldRolloverReason(reason)}`);
   }
 
-  /** The half of the held-rollover line that says which of the two cases it is. */
+  /**
+   * The half of the held-rollover line that says which of the two cases it is.
+   * @param {'none-eligible'|'ranks-best'} reason
+   */
   _heldRolloverReason(reason) {
     switch (reason) {
       case 'none-eligible': return 'but no eligible account can take that traffic — still routing there';
@@ -3736,6 +3739,8 @@ export class AccountManager {
 
   /**
    * Update a specific account's OAuth tokens (e.g. after intercepting a token refresh).
+   * @param {number} accountIndex
+   * @param {{ accessToken?: string, refreshToken?: string, expiresAt?: number }} tokens
    */
   updateAccountTokens(accountIndex, { accessToken, refreshToken, expiresAt }) {
     const account = this.accounts[accountIndex];

--- a/src/account-uuid-rewrite.js
+++ b/src/account-uuid-rewrite.js
@@ -16,12 +16,17 @@
 const PREFIX = Buffer.from('account_uuid\\":\\"', 'latin1');
 
 export class AccountUuidPatcher {
+  /**
+   * @param {unknown} newUuid  a 36-character account uuid; anything else disables the patcher
+   */
   constructor(newUuid) {
     this.newUuid = (typeof newUuid === 'string' && newUuid.length === 36) ? Buffer.from(newUuid, 'latin1') : null;
-    this.frames = [];          // container stack: { container:'obj'|'arr', name, key, awaitingKey }
+    /** @type {Array<{ container: 'obj'|'arr', name: string|null, key: string|null, awaitingKey: boolean }>} */
+    this.frames = [];          // container stack
     this.inStr = false;
     this.esc = false;
     this.readingKey = false;
+    /** @type {number[]} */
     this.keyBuf = [];
     this.target = false;       // inside the metadata.user_id string value
     this.matchPos = 0;         // PREFIX match progress (within target)
@@ -30,7 +35,11 @@ export class AccountUuidPatcher {
     this.changed = false;
   }
 
-  /** Feed a chunk; returns a same-length chunk (patched in place). */
+  /**
+   * Feed a chunk; returns a same-length chunk (patched in place).
+   *
+   * @param {Buffer|Uint8Array} chunk
+   */
   push(chunk) {
     if (!this.newUuid || this.done) return chunk;
     const out = Buffer.from(chunk);
@@ -43,6 +52,9 @@ export class AccountUuidPatcher {
 
   #top() { return this.frames[this.frames.length - 1]; }
 
+  /**
+   * @param {number} b
+   */
   #byte(b) {
     if (this.target) return this.#targetByte(b);
 
@@ -82,9 +94,14 @@ export class AccountUuidPatcher {
 
   // Inside the metadata.user_id string value: stream-match the account_uuid key
   // and overwrite its 36-byte value. Detect the (unescaped) closing quote to exit.
+  /**
+   * @param {number} b
+   */
   #targetByte(b) {
     if (this.uuidRemaining > 0) {
-      const outByte = this.newUuid[this.newUuid.length - this.uuidRemaining];
+      // `push` returns before any byte reaches here while `newUuid` is null.
+      const uuid = /** @type {Buffer} */ (this.newUuid);
+      const outByte = uuid[uuid.length - this.uuidRemaining];
       this.uuidRemaining--;
       if (outByte !== b) this.changed = true;
       if (this.uuidRemaining === 0) this.done = true; // only one account_uuid per body
@@ -97,6 +114,9 @@ export class AccountUuidPatcher {
     return b;
   }
 
+  /**
+   * @param {number} b
+   */
   #match(b) {
     if (b === PREFIX[this.matchPos]) {
       this.matchPos++;
@@ -107,7 +127,12 @@ export class AccountUuidPatcher {
   }
 }
 
-/** One-shot convenience (whole-buffer); returns the same instance if unchanged. */
+/**
+ * One-shot convenience (whole-buffer); returns the same instance if unchanged.
+ *
+ * @param {Buffer} buf
+ * @param {unknown} newUuid
+ */
 export function patchAccountUuid(buf, newUuid) {
   const p = new AccountUuidPatcher(newUuid);
   const out = p.push(buf);

--- a/src/admission-gate.js
+++ b/src/admission-gate.js
@@ -11,10 +11,15 @@ export const DEFAULT_MAX_QUEUE = 64;
 export const DEFAULT_QUEUE_TIMEOUT_MS = 5_000;
 
 export class AdmissionGate {
+  /**
+   * @param {unknown} limit
+   * @param {unknown} [maxQueue]
+   */
   constructor(limit, maxQueue = DEFAULT_MAX_QUEUE) {
     this.limit = positiveInt(limit, 1);
     this.maxQueue = Number.isSafeInteger(Number(maxQueue)) && Number(maxQueue) >= 0 ? Number(maxQueue) : DEFAULT_MAX_QUEUE;
     this.active = 0;
+    /** @type {Array<(admitted: boolean) => void>} */
     this.queue = [];
   }
 
@@ -27,8 +32,9 @@ export class AdmissionGate {
     }
     if (this.queue.length >= this.maxQueue) return Promise.resolve(false);
     return new Promise(resolve => {
+      /** @type {ReturnType<typeof setTimeout>|undefined} */
       let timer;
-      const settle = admitted => {
+      const settle = (/** @type {boolean} */ admitted) => {
         clearTimeout(timer);
         signal?.removeEventListener('abort', cancel);
         const index = this.queue.indexOf(settle);
@@ -54,6 +60,10 @@ export class AdmissionGate {
   }
 }
 
+/**
+ * @param {unknown} value
+ * @param {number} fallback
+ */
 function positiveInt(value, fallback) {
   const n = Number(value);
   return Number.isSafeInteger(n) && n > 0 && n <= 2 ** 31 - 1 ? n : fallback;

--- a/src/alias.js
+++ b/src/alias.js
@@ -21,6 +21,8 @@ const MARKER = '# teamclaude alias';
  * it over. Writing the rc file in place left a truncated .bashrc behind a crash
  * or a full disk, and a truncated .bashrc breaks every new shell. The existing
  * mode is carried over, so a 0600 rc file stays 0600.
+ * @param {string} path
+ * @param {string} text
  */
 function writeFileAtomic(path, text) {
   let mode = null;
@@ -41,7 +43,11 @@ export function detectShell() {
   return (process.env.SHELL || '').split('/').pop() || 'bash';
 }
 
-/** Whether a bare command resolves on the current $PATH. */
+/**
+ * Whether a bare command resolves on the current $PATH.
+ *
+ * @param {string} cmd
+ */
 function commandOnPath(cmd) {
   for (const dir of (process.env.PATH || '').split(':')) {
     if (dir && existsSync(join(dir, cmd))) return true;
@@ -151,6 +157,9 @@ export function uninstallAlias({ shell = detectShell(), rcPath = rcPathForShell(
   console.log(`Removed alias from ${rcPath}`);
 }
 
+/**
+ * @param {string} s
+ */
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/backend-quota.js
+++ b/src/backend-quota.js
@@ -36,7 +36,7 @@ const PROVIDERS = [
     // host keeps working.
     host: 'api.deepseek.com',
     path: '/user/balance',
-    parse(body) {
+    parse(/** @type {any} */ body) {
       const info = Array.isArray(body?.balance_infos) ? body.balance_infos[0] : null;
       if (!info) return null;
       const amount = Number(info.total_balance);
@@ -58,7 +58,11 @@ const PROVIDERS = [
   },
 ];
 
-/** The provider entry for an upstream URL, or null when we know of none. */
+/**
+ * The provider entry for an upstream URL, or null when we know of none.
+ *
+ * @param {string|null|undefined} upstream
+ */
 export function providerFor(upstream) {
   if (!upstream || typeof upstream !== 'string') return null;
   let host;
@@ -66,7 +70,11 @@ export function providerFor(upstream) {
   return PROVIDERS.find(p => host === p.host || host.endsWith(`.${p.host}`)) || null;
 }
 
-/** True when this account has a backend reading we know how to fetch. */
+/**
+ * True when this account has a backend reading we know how to fetch.
+ *
+ * @param {Record<string, any>|null|undefined} account
+ */
 export function hasBackendQuota(account) {
   return !!account?.upstream && !!providerFor(account.upstream);
 }
@@ -77,6 +85,8 @@ export function hasBackendQuota(account) {
  * could not refresh.
  *
  * @returns {Promise<BackendQuota | { error: string } | null>}
+ * @param {Record<string, any>|null|undefined} account
+ * @param {{ fetchImpl?: Function, timeoutMs?: number }} [opts]
  */
 export async function fetchBackendQuota(account, { fetchImpl = proxyFetch, timeoutMs = 10_000 } = {}) {
   const provider = providerFor(account?.upstream);
@@ -94,7 +104,7 @@ export async function fetchBackendQuota(account, { fetchImpl = proxyFetch, timeo
     if (body === undefined) return { error: 'response too large' };
     const reading = provider.parse(body);
     return reading ? { ...reading, at: Date.now() } : { error: 'unrecognized response' };
-  } catch (err) {
+  } catch (/** @type {any} */ err) {
     return { error: err?.message || String(err) };
   }
 }
@@ -103,6 +113,8 @@ export async function fetchBackendQuota(account, { fetchImpl = proxyFetch, timeo
  * Parse a JSON response body of at most `limit` bytes; `undefined` when it is
  * larger (declared or actual). A response without a readable stream (a test
  * double) falls back to `json()`.
+ * @param {any} res
+ * @param {number} limit
  */
 async function readJsonBounded(res, limit) {
   const declared = Number(res.headers?.get?.('content-length'));

--- a/src/band-decision.js
+++ b/src/band-decision.js
@@ -59,6 +59,9 @@ const WEEKLY_WINDOW_SECONDS = 7 * 24 * 3600;
 /**
  * Exhaustiveness enforced at runtime: on plain JS a variant nothing here
  * handles has no other check.
+ * @param {never} value
+ * @param {string} context
+ * @returns {never}
  */
 export function assertNever(value, context) {
   throw new Error(`${context}: unhandled variant ${JSON.stringify(value)}`);
@@ -98,6 +101,7 @@ export function pressureOf(account, now) {
 /** How much of a window is left to spend. Clamped at both ends: above 1 is real
  * overage and leaves nothing, below 0 would read as MORE headroom than the
  * window has. Shared by the measured pressure and the unknown-reset bound so the
+ * @param {number} utilization
  * two cannot disagree about what an account is holding. */
 function spendableFraction(utilization) {
   return 1 - Math.min(1, Math.max(0, utilization));
@@ -110,6 +114,7 @@ function spendableFraction(utilization) {
  * known. `expiry-routing-off` sorts there too and must be constant across the
  * fleet, or the off switch stops being one. A bounded absence sorts by its
  * bound, since `no-reset` knows the utilization and lacks only the clock.
+ * @param {Pressure} pressure
  */
 export function pressureRank(pressure) {
   switch (pressure.kind) {
@@ -126,6 +131,8 @@ export function pressureRank(pressure) {
  * preferred. Lower tiers pass through unfiltered, since they are reached only
  * when the top tier is empty, which banding cannot cause because the maximum
  * always qualifies.
+ * @param {BandSnapshot} snapshot
+ * @returns {BandDecision}
  */
 export function decideBand(snapshot) {
   const { accounts, now, tolerance, enabled } = snapshot;
@@ -147,6 +154,7 @@ export function decideBand(snapshot) {
   const ratio = Number.isFinite(tolerance) && tolerance > 0 ? tolerance : 1;
   const floor = Math.min(maxKnown, maxKnown / ratio);
 
+  /** @type {number[]} */
   const keep = [];
   tier.forEach((account, i) => {
     const pressure = pressures[i];

--- a/src/cache-control-sanitize.js
+++ b/src/cache-control-sanitize.js
@@ -38,6 +38,7 @@ const SUBFIELD_PREFIX = 'cache_control.';
  * The `cache_control` subfields an account's `stripRequestFields` asks to drop:
  * every entry of the form `cache_control.<name>`. Top-level entries are the
  * forwarder's `stripBodyFields` business and are ignored here.
+ * @param {unknown} stripRequestFields
  */
 export function cacheControlSubfieldsToStrip(stripRequestFields) {
   const out = new Set();
@@ -52,12 +53,19 @@ export function cacheControlSubfieldsToStrip(stripRequestFields) {
 
 // Is this a JSON /v1/messages (or /v1/messages/count_tokens) request we can
 // reason about? Everything else (token refreshes, GETs, non-JSON) is left alone.
+/**
+ * @param {unknown} url
+ * @param {string|undefined} contentType
+ */
 function isMessagesRequest(url, contentType) {
   if (typeof url !== 'string' || !url.includes(MESSAGES_PATH)) return false;
   if (contentType && !/json/i.test(contentType)) return false;
   return true;
 }
 
+/**
+ * @param {unknown} v
+ */
 function isPlainObject(v) {
   return !!v && typeof v === 'object' && !Array.isArray(v);
 }
@@ -101,6 +109,10 @@ export function sanitizeCacheControl(body, url, contentType, subfields) {
 // Drop `drop` subfields from `holder.cache_control` (and the key itself when
 // nothing is left — an empty object is itself an extra input to a strict
 // schema). Returns the number of keys removed.
+/**
+ * @param {any} holder
+ * @param {Set<string>} drop
+ */
 function stripOn(holder, drop) {
   if (!isPlainObject(holder) || !isPlainObject(holder.cache_control)) return 0;
   const cc = holder.cache_control;
@@ -113,6 +125,10 @@ function stripOn(holder, drop) {
 }
 
 // The documented breakpoint positions, and nothing else (see the header).
+/**
+ * @param {any} root
+ * @param {Set<string>} drop
+ */
 function stripAtDocumentedPositions(root, drop) {
   let removed = stripOn(root, drop);
   if (Array.isArray(root.system)) for (const block of root.system) removed += stripOn(block, drop);

--- a/src/classification-path.js
+++ b/src/classification-path.js
@@ -41,10 +41,16 @@
 // Splits a path into segments AND separators, so a rejoin reproduces it.
 const KEEP_SEPARATORS = /([/\\])/;
 
+/**
+ * @param {unknown} url
+ */
 function pathOnly(url) {
   return String(url || '').split('?')[0].split('#')[0];
 }
 
+/**
+ * @param {string} s
+ */
 function decodeOnce(s) {
   try { return decodeURIComponent(s); } catch { return s; }
 }
@@ -60,6 +66,7 @@ function decodeOnce(s) {
  * `/a/%zz%2e%2e/b` is classified exactly as sent, as it was before — because
  * that segment has no decoded form either. Both branches are one decode deep,
  * so which one runs never changes how deep the decoding goes.
+ * @param {string} path
  */
 function decodeOncePath(path) {
   try { return decodeURIComponent(path); } catch { /* per-segment below */ }
@@ -75,6 +82,7 @@ function decodeOncePath(path) {
  * decoded, and folding first would leave it encoded and unseen. The order also
  * keeps the decoding one level deep — `%255c` decodes to a literal `%5c`, which
  * stays a character inside a segment rather than becoming a separator.
+ * @param {unknown} url
  */
 export function classificationPath(url) {
   return decodeOncePath(pathOnly(url)).replaceAll('\\', '/');

--- a/src/claude-env.js
+++ b/src/claude-env.js
@@ -4,10 +4,16 @@
 // statements for `eval "$(teamclaude env)"` — a name like "work (Acme)" would be
 // a shell syntax error. Clients percent-decode userinfo before using it
 // (verified against Claude Code 2.1.220), so the extra escaping is transparent.
+/**
+ * @param {string} s
+ */
 export function encodePinComponent(s) {
   return encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
+/**
+ * @param {unknown} value
+ */
 function shellQuote(value) {
   return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
 }
@@ -16,6 +22,7 @@ function shellQuote(value) {
  * `port` as a number in 1..65535, or a throw. Strict on purpose: parseInt alone
  * would turn "3456; touch /tmp/x" into 3456 and hide the bad config value that
  * would otherwise have been eval'd.
+ * @param {unknown} port
  */
 export function validPort(port) {
   const text = String(port ?? '').trim();
@@ -32,7 +39,11 @@ export function validPort(port) {
 // its own dev server.
 export const LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1'];
 
-/** True if `value` names `*` — "proxy nothing" — among its entries. */
+/**
+ * True if `value` names `*` — "proxy nothing" — among its entries.
+ *
+ * @param {unknown} value
+ */
 export function bypassesAllHosts(value) {
   return String(value ?? '').split(',').some((entry) => entry.trim() === '*');
 }
@@ -50,6 +61,7 @@ export function bypassesAllHosts(value) {
  * `*` is the one entry dropped: it routes every host around the proxy,
  * api.anthropic.com included, which silently turns the launch into a direct run
  * — no rotation, the operator's own quota. `--no-mitm` is how that is asked for.
+ * @param {...(string|null|undefined)} inherited
  */
 export function mergeNoProxy(...inherited) {
   const seen = new Set();
@@ -87,6 +99,16 @@ export function mergeNoProxy(...inherited) {
 // `/tc-acct/` prefix. TC_ACCT itself is then unset, so the pin does not leak
 // into claude or anything it spawns — same reasoning as `run` deleting it from
 // the child environment.
+/**
+ * @param {Object} opts
+ * @param {unknown} opts.port
+ * @param {boolean} [opts.useMitm]
+ * @param {string|null} [opts.caPath]
+ * @param {number} [opts.holdSeconds]
+ * @param {string|null} [opts.account]
+ * @param {string} [opts.proxyApiKey]
+ * @param {string|null} [opts.inheritedNoProxy]
+ */
 export function buildClaudeEnvLines({ port, useMitm = true, caPath = null, holdSeconds = 0, account = null, proxyApiKey = '', inheritedNoProxy = null }) {
   const lines = [];
   const pin = (account || '').trim();

--- a/src/codex-usage.js
+++ b/src/codex-usage.js
@@ -8,6 +8,9 @@ import { proxyFetch } from './upstream-fetch.js';
 
 export const CODEX_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
 
+/**
+ * @param {any} window
+ */
 function windowReading(window) {
   if (!window || typeof window !== 'object') return null;
   const used = Number(window.used_percent ?? window.usedPercentage ?? window.utilization);
@@ -21,14 +24,21 @@ function windowReading(window) {
   };
 }
 
+/**
+ * @param {any} rateLimit
+ */
 function classify(rateLimit) {
-  const readings = Object.values(rateLimit || {}).map(windowReading).filter(Boolean);
+  const readings = Object.values(rateLimit || {}).flatMap(w => windowReading(w) ?? []);
   const fiveHour = readings.find(r => r.seconds <= 6 * 60 * 60) || null;
   const sevenDay = readings.find(r => r.seconds >= 6 * 24 * 60 * 60) || null;
   return { fiveHour, sevenDay };
 }
 
-/** Convert the private `/wham/usage` response into TeamClaude quota fields. */
+/**
+ * Convert the private `/wham/usage` response into TeamClaude quota fields.
+ *
+ * @param {any} data
+ */
 export function normalizeCodexUsagePayload(data) {
   const rateLimit = data?.rate_limit || data?.rate_limits;
   const shared = classify(rateLimit);
@@ -52,7 +62,12 @@ export function normalizeCodexUsagePayload(data) {
   };
 }
 
-/** Fetch Codex quota without sending an inference request. */
+/**
+ * Fetch Codex quota without sending an inference request.
+ *
+ * @param {Record<string, any>|null|undefined} account
+ * @param {{ fetchImpl?: Function, timeoutMs?: number, url?: string }} [opts]
+ */
 export async function fetchCodexUsage(account, { fetchImpl = proxyFetch, timeoutMs = 10_000, url = CODEX_USAGE_URL } = {}) {
   if (!account?.credential || !account?.accountId) return { error: 'missing Codex account identity' };
   try {
@@ -66,7 +81,7 @@ export async function fetchCodexUsage(account, { fetchImpl = proxyFetch, timeout
     });
     if (!res.ok) return { error: `HTTP ${res.status}`, status: res.status };
     return normalizeCodexUsagePayload(await res.json());
-  } catch (err) {
+  } catch (/** @type {any} */ err) {
     return { error: err?.message || String(err), status: null };
   }
 }

--- a/src/crash-log.js
+++ b/src/crash-log.js
@@ -11,9 +11,11 @@ import { appendFileSync } from 'node:fs';
  * Handling these events replaces Node's own behaviour, so this must do what
  * Node would: report and exit non-zero. Continuing after an uncaught exception
  * would leave the proxy running on unknown state.
+ * @param {string} path
+ * @param {{ exit?: (code: number) => void, log?: { write: (s: string) => void } }} [opts]
  */
 export function installCrashHandlers(path, { exit = process.exit, log = process.stderr } = {}) {
-  const report = (kind) => (err) => {
+  const report = (/** @type {string} */ kind) => (/** @type {any} */ err) => {
     const stack = err?.stack || String(err);
     const entry = `\n=== ${new Date().toISOString()} ${kind} ===\n${stack}\n`;
     // 0600: a stack can carry request context. A write failure (read-only home,

--- a/src/egress-guard.js
+++ b/src/egress-guard.js
@@ -86,14 +86,22 @@ export class EgressGuard {
     return this._inFlight;
   }
 
-  /** Is `ip` one of the pinned addresses? Unknown (null) counts as allowed. */
+  /**
+   * Is `ip` one of the pinned addresses? Unknown (null) counts as allowed.
+   *
+   * @param {string|null|undefined} ip
+   */
   matches(ip) {
     if (!ip) return true;
     const allowed = this.allowed();
     return allowed.length === 0 || allowed.includes(ip);
   }
 
-  /** One check against the pin: { ok, ip, expected }. */
+  /**
+   * One check against the pin: { ok, ip, expected }.
+   *
+   * @param {{ force?: boolean }} [opts]
+   */
   async check(opts) {
     const ip = await this.currentIp(opts);
     return { ok: this.matches(ip), ip, expected: this.allowed() };
@@ -124,7 +132,12 @@ export class EgressGuard {
   }
 }
 
-/** Build a guard from config, or null when the feature is not configured. */
+/**
+ * Build a guard from config, or null when the feature is not configured.
+ *
+ * @param {Record<string, any>|null|undefined} config
+ * @param {(line: string) => void} log
+ */
 export function createEgressGuard(config, log) {
   const cfg = config?.egress;
   if (!cfg?.pin) return null;

--- a/src/event-loop-monitor.js
+++ b/src/event-loop-monitor.js
@@ -15,12 +15,13 @@ export function startEventLoopMonitor({
   now = () => performance.now(),
   schedule = setInterval,
   cancel = clearInterval,
-  log = (message) => console.error(message),
+  log = (/** @type {string} */ message) => console.error(message),
 } = {}) {
   let expectedAt = now() + intervalMs;
   let lastLagMs = 0;
   let maxLagMs = 0;
   let stallCount = 0;
+  /** @type {string|null} */
   let lastStallAt = null;
   let lastWarningClock = -Infinity;
 

--- a/src/json-format-stream.js
+++ b/src/json-format-stream.js
@@ -20,9 +20,15 @@ export class JsonStreamFormatter {
     this.freshContainer = false; // just opened { or [ — first element needs a newline+indent
   }
 
+  /**
+   * @param {number} depth
+   */
   nl(depth) { return '\n' + this.pad.repeat(depth); }
 
   // Feed a chunk; returns the formatted text for that chunk.
+  /**
+   * @param {Buffer|string} buf
+   */
   push(buf) {
     const text = Buffer.isBuffer(buf) ? buf.toString('latin1') : String(buf);
     let out = '';

--- a/src/request-log.js
+++ b/src/request-log.js
@@ -8,16 +8,22 @@
 
 import { JsonStreamFormatter } from './json-format-stream.js';
 
-export const truncationNote = (bytes) => `... truncated ${bytes} bytes ...`;
+export const truncationNote = (/** @type {number} */ bytes) => `... truncated ${bytes} bytes ...`;
 
 // Tracks how one direction's body is written: decide formatter-vs-raw on the
 // first chunk (event-stream → raw; otherwise pretty-print if it looks like JSON,
 // i.e. the first non-whitespace byte is { or [). Writes the section header once.
 export class BodyWriter {
+  /**
+   * @param {(text: string) => void} write
+   * @param {string} label
+   * @param {string|undefined} contentType
+   * @param {number} [maxBytes]
+   */
   constructor(write, label, contentType, maxBytes = 0) {
     this.write = write;
     this.label = label;
-    this.isStream = /event-stream/.test(contentType);
+    this.isStream = /event-stream/.test(contentType || '');
     this.decided = false;
     this.fmt = null;
     this.headerWritten = false;
@@ -26,6 +32,9 @@ export class BodyWriter {
     this.remaining = maxBytes > 0 ? maxBytes : Infinity;
     this.dropped = 0;
   }
+  /**
+   * @param {Buffer} buf
+   */
   chunk(buf) {
     if (!buf.length) return;
     if (this.remaining <= 0) { this.dropped += buf.length; return; }

--- a/src/resolve-accounts.js
+++ b/src/resolve-accounts.js
@@ -12,6 +12,7 @@ import { providerOf } from './provider.js';
  * used to discard everything else on it (`disabled`, `priority`, `upstream`,
  * `modelMap`, `models`), so an account disabled on disk silently rejoined
  * rotation on every restart and a third-party backend lost its upstream.
+ * @param {{ accounts: Array<Record<string, any>> }} config
  */
 export async function resolveAccounts(config) {
   const accounts = [];
@@ -38,7 +39,7 @@ export async function resolveAccounts(config) {
           }
           accounts.push({ ...acct, ...creds });
           console.log(`Imported "${acct.name}" from ${from}`);
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           console.error(`Failed to import "${acct.name}": ${err.message}`);
         }
       } else if (acct.accessToken) {

--- a/src/rollover.js
+++ b/src/rollover.js
@@ -36,6 +36,7 @@ export function newObservation() {
  *
  * @param {Hold|null} held
  * @returns {Hold|null}
+ * @param {(idx: number) => number|null} mapFn
  */
 export function remapHeld(held, mapFn) {
   if (!held) return null;
@@ -47,6 +48,11 @@ export function remapHeld(held, mapFn) {
 // The roll this observation owes an account, or the one a stay's stamp names.
 // The newest match, since a later escape of the same account was read after the
 // earlier one's window had already rolled.
+/**
+ * @param {Hold|null} held
+ * @param {(h: Hold) => boolean} match
+ * @returns {Hold|null}
+ */
 export function findHeld(held, match) {
   for (let h = held; h; h = h.prev) if (match(h)) return h;
   return null;
@@ -54,6 +60,11 @@ export function findHeld(held, match) {
 
 // The chain without the roll owed to `idx`. Handing a roll back and settling one
 // both remove that account's own, and leave every other escape standing.
+/**
+ * @param {Hold|null} held
+ * @param {number} idx
+ * @returns {Hold|null}
+ */
 export function dropHeld(held, idx) {
   if (!held) return null;
   const rest = dropHeld(held.prev, idx);

--- a/src/safe-text.js
+++ b/src/safe-text.js
@@ -24,12 +24,18 @@ const CONTROL = /\x1b\[[0-?]*[ -/]*[@-~]|\p{C}/gu;
 /**
  * Strip escape sequences and control characters, collapsing the whitespace they
  * leave behind so a stripped value cannot pad a column or split a line.
+ * @param {unknown} value
  */
 export function sanitizeText(value) {
   return String(value).replace(CONTROL, ' ').replace(/\s+/g, ' ').trim();
 }
 
-/** sanitizeText, bounded — for a value rendered into a fixed-width column. */
+/**
+ * sanitizeText, bounded — for a value rendered into a fixed-width column.
+ *
+ * @param {unknown} value
+ * @param {number} [max]
+ */
 export function safeLine(value, max = 120) {
   const cleaned = sanitizeText(value);
   return cleaned.length > max ? cleaned.slice(0, max) : cleaned;

--- a/src/session-titles.js
+++ b/src/session-titles.js
@@ -70,6 +70,7 @@ export class SessionTitles {
   /** Apply a config change in place, so a reload takes effect without a
    *  restart. An absent key returns to its default. Off unless asked for: this
    *  reads the transcripts of every session the proxy sees, which is further
+   * @param {Record<string, any>|null|undefined} cfg
    *  than the proxy reaches for anything else by default. */
   configure(cfg) {
     const { enabled = false, width = DEFAULT_WIDTH, projectsDir = DEFAULT_PROJECTS_DIR } = cfg || {};
@@ -87,6 +88,8 @@ export class SessionTitles {
   }
 
   /** The cached title, or null. Never touches the disk: a miss or a stale entry
+   * @param {string} sessionId
+   * @param {number} [now]
    *  schedules the read and the caller gets the previous answer until it lands. */
   get(sessionId, now = Date.now()) {
     if (!this.enabled || !isSessionId(sessionId)) return null;
@@ -96,7 +99,12 @@ export class SessionTitles {
     return hit ? hit.title : null;
   }
 
-  /** Read the title now. Resolves to null when the session has none. */
+  /**
+   * Read the title now. Resolves to null when the session has none.
+   *
+   * @param {string} sessionId
+   * @param {number} [now]
+   */
   async resolve(sessionId, now = Date.now()) {
     if (!this.enabled || !isSessionId(sessionId)) return null;
     return this._schedule(sessionId, now);
@@ -114,6 +122,7 @@ export class SessionTitles {
 
   /** Drop entries no row has refreshed within the window. A visible session is
    *  re-read every TTL, which keeps its entry young; one that left the screen
+   * @param {number} now
    *  ages out. Runs at most once per TTL, so a frame does not pay for it. */
   _evict(now) {
     if (now - this.sweptAt < this.ttlMs) return;
@@ -123,6 +132,10 @@ export class SessionTitles {
     }
   }
 
+  /**
+   * @param {string} sessionId
+   * @param {number} now
+   */
   _schedule(sessionId, now) {
     const existing = this.inflight.get(sessionId);
     if (existing) return existing;
@@ -140,6 +153,7 @@ export class SessionTitles {
   }
 
   /** The project directory is keyed by the session's cwd, which the proxy does
+   * @param {string} sessionId
    *  not know, so each directory is tried until one holds the session. */
   async _read(sessionId) {
     const entries = await readdir(this.projectsDir, { withFileTypes: true }).catch(() => []);
@@ -154,6 +168,9 @@ export class SessionTitles {
     return null;
   }
 
+  /**
+   * @param {string} path
+   */
   async _fromSidecar(path) {
     const raw = await readFile(path, 'utf8').catch(() => null);
     if (raw == null) return null;
@@ -164,6 +181,9 @@ export class SessionTitles {
     }
   }
 
+  /**
+   * @param {string} path
+   */
   async _fromTranscript(path) {
     const file = await open(path, 'r').catch(() => null);
     if (!file) return null;
@@ -185,6 +205,7 @@ export class SessionTitles {
 
 /** A typed name wins wherever it sits in the file; otherwise the most recent
  *  generated one. Both are re-appended as a session runs, so the scan reads
+ * @param {string[]} lines
  *  backwards and stops at the first match. */
 function lastTitle(lines) {
   let generated = null;
@@ -208,12 +229,16 @@ function lastTitle(lines) {
   return generated;
 }
 
+/**
+ * @param {unknown} value
+ */
 function isSessionId(value) {
   return typeof value === 'string' && SESSION_ID.test(value);
 }
 
 /** A title is printed inside a terminal escape and written to the activity log
  *  file, so a control character in it (an ESC, a newline) is not a title, it
+ * @param {unknown} value
  *  is an injection. Each becomes a space and runs of whitespace collapse. */
 function cleanTitle(value) {
   if (typeof value !== 'string') return null;

--- a/src/sync-accounts.js
+++ b/src/sync-accounts.js
@@ -6,6 +6,9 @@ import { ensureAccountIds } from './account-id.js';
  * Sync accounts from disk config: add new accounts and refresh credentials
  * for existing ones (handles re-imported OAuth tokens, rotated API keys, etc.).
  * Returns the number of new accounts added.
+ * @param {Record<string, any>} diskConfig
+ * @param {Record<string, any>} memConfig
+ * @param {import('./account-manager.js').AccountManager} accountManager
  */
 export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager) {
   let added = 0;
@@ -14,7 +17,7 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
   // same-person/different-org entries pair correctly instead of all matching the
   // first one with that accountUuid.
   const claimed = new Set();
-  const claim = (diskAcct) => {
+  const claim = (/** @type {Record<string, any>} */ diskAcct) => {
     for (let i = 0; i < accountManager.accounts.length; i++) {
       if (!claimed.has(i) && sameIdentity(accountManager.accounts[i], diskAcct)) {
         claimed.add(i);
@@ -30,7 +33,7 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
   // its entries never receive the org backfill below, so a first-match scan
   // pairs an unorged entry with whichever same-uuid disk entry comes first.
   const cfgClaimed = new Set();
-  const claimConfig = (diskAcct) => {
+  const claimConfig = (/** @type {Record<string, any>} */ diskAcct) => {
     for (let i = 0; i < memConfig.accounts.length; i++) {
       if (!cfgClaimed.has(i) && sameIdentity(memConfig.accounts[i], diskAcct)) {
         cfgClaimed.add(i);
@@ -84,7 +87,7 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     // account (e.g. after disk-side org disambiguation or a `priority` change).
     if (diskAcct.orgUuid && !mgr.orgUuid) mgr.orgUuid = diskAcct.orgUuid;
     if (diskAcct.orgName && !mgr.orgName) mgr.orgName = diskAcct.orgName;
-    for (const field of ['organizationType', 'rateLimitTier', 'seatTier', 'hasClaudeMax', 'hasClaudePro']) {
+    for (const field of /** @type {const} */ (['organizationType', 'rateLimitTier', 'seatTier', 'hasClaudeMax', 'hasClaudePro'])) {
       if (diskAcct[field] != null) mgr[field] = diskAcct[field];
     }
     if (diskAcct.name && mgr.name !== diskAcct.name) mgr.name = diskAcct.name;
@@ -116,12 +119,13 @@ export async function syncAccountsFromDisk(diskConfig, memConfig, accountManager
     if (mgr.disabled !== wantDisabled) accountManager.setDisabled(mgr.index, wantDisabled);
 
     // Existing account — resolve fresh credentials from disk
+    /** @type {{ accessToken?: string, refreshToken?: string, expiresAt?: number, apiKey?: string }|null} */
     let freshCred = null;
     if (diskAcct.type === 'oauth' && diskAcct.importFrom) {
       try {
         const creds = await importCredentials(diskAcct.importFrom);
         freshCred = { accessToken: creds.accessToken, refreshToken: creds.refreshToken, expiresAt: creds.expiresAt };
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         console.error(`[TeamClaude] Re-import failed for "${diskAcct.name}": ${err.message}`);
       }
     } else if (diskAcct.type === 'oauth' && diskAcct.accessToken) {

--- a/src/terminal-title.js
+++ b/src/terminal-title.js
@@ -11,6 +11,10 @@ const BEL = '\x07';
 export const TITLE_STACK_PUSH = '\x1b[22;2t';
 export const TITLE_STACK_POP = '\x1b[23;2t';
 
+/**
+ * @param {string} s
+ * @param {number} max
+ */
 function truncate(s, max) {
   s = String(s);
   return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
@@ -25,6 +29,9 @@ export function formatTerminalTitle({ index = 0, total = 0, name = null } = {}) 
 
 // Wrap a title string in the OSC set-title sequence, stripping control chars so a
 // crafted account name can't break out of the escape or move the cursor.
+/**
+ * @param {string} title
+ */
 export function titleSequence(title) {
   const safe = String(title).replace(/[\x00-\x1f\x7f]/g, ' ').trimEnd();
   return `${OSC_TITLE}${safe}${BEL}`;

--- a/src/tool-pair-sanitize.js
+++ b/src/tool-pair-sanitize.js
@@ -37,6 +37,10 @@ const TOOL_RESULT_MARKER = Buffer.from('"tool_result"');
 
 // Is this a JSON /v1/messages (or /v1/messages/count_tokens) request we can
 // reason about? Everything else (token refreshes, GETs, non-JSON) is left alone.
+/**
+ * @param {unknown} url
+ * @param {string|undefined} contentType
+ */
 function isMessagesRequest(url, contentType) {
   if (typeof url !== 'string' || !url.includes(MESSAGES_PATH)) return false;
   if (contentType && !/json/i.test(contentType)) return false;
@@ -44,6 +48,9 @@ function isMessagesRequest(url, contentType) {
 }
 
 // Ids of the tool_use blocks in a message (empty for a non-array / absent message).
+/**
+ * @param {any} msg
+ */
 function toolUseIds(msg) {
   const ids = new Set();
   if (msg && Array.isArray(msg.content)) {
@@ -55,6 +62,9 @@ function toolUseIds(msg) {
 }
 
 // tool_use_ids referenced by the tool_result blocks in a message.
+/**
+ * @param {any} msg
+ */
 function toolResultIds(msg) {
   const ids = new Set();
   if (msg && Array.isArray(msg.content)) {
@@ -69,6 +79,9 @@ function toolResultIds(msg) {
 // merged losslessly. Anthropic accepts a single-text-block array as equivalent
 // to a plain string, so this never changes meaning. Returns null for shapes we
 // don't recognize (caller then declines to merge rather than risk corruption).
+/**
+ * @param {any} content
+ */
 function toBlocks(content) {
   if (Array.isArray(content)) return content;
   if (typeof content === 'string') return [{ type: 'text', text: content }];
@@ -79,7 +92,11 @@ function toBlocks(content) {
 // (a user turn that held only an orphaned tool_result is removed, leaving the
 // assistant turns on either side touching). Anthropic requires roles to alternate,
 // so coalesce same-role neighbors by concatenating their content.
+/**
+ * @param {any[]} messages
+ */
 function coalesceSameRole(messages) {
+  /** @type {any[]} */
   const out = [];
   for (const msg of messages) {
     const prev = out[out.length - 1];
@@ -100,6 +117,9 @@ function coalesceSameRole(messages) {
 // message it empties, and (only when it dropped something) coalesces same-role
 // neighbors so roles still alternate. Returns the possibly-new array plus whether
 // it changed anything. Mutates the `content` arrays of the (already-cloned) input.
+/**
+ * @param {any[]} messages
+ */
 function pruneOnce(messages) {
   let changed = false;
 
@@ -147,6 +167,9 @@ function pruneOnce(messages) {
 // expose a new positional orphan (the cascade), so one pass is not enough. Each
 // pass only removes, so this terminates. Returns the new array, or null if the
 // body was already valid (so the caller can forward the original bytes untouched).
+/**
+ * @param {any[]} messages
+ */
 function pruneOrphans(messages) {
   let current = messages;
   let everChanged = false;

--- a/src/updater.js
+++ b/src/updater.js
@@ -35,9 +35,14 @@ export function currentVersion(root = packageRoot()) {
   }
 }
 
-/** Numeric compare of x.y.z (prerelease/build suffix ignored). >0 if a is newer. */
+/**
+ * Numeric compare of x.y.z (prerelease/build suffix ignored). >0 if a is newer.
+ *
+ * @param {string} a
+ * @param {string} b
+ */
 export function compareVersions(a, b) {
-  const nums = (v) => String(v).split('+')[0].split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const nums = (/** @type {string} */ v) => String(v).split('+')[0].split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
   const pa = nums(a), pb = nums(b);
   for (let i = 0; i < 3; i++) {
     const d = (pa[i] || 0) - (pb[i] || 0);
@@ -95,9 +100,16 @@ export async function fetchLatestVersion({ fetchImpl = fetch, timeoutMs = 5000 }
 function defaultCacheFile() {
   return join(dirname(getConfigPath()), 'update-check.json');
 }
+/**
+ * @param {string} path
+ */
 async function readCache(path) {
   try { return JSON.parse(await readFile(path, 'utf8')); } catch { return {}; }
 }
+/**
+ * @param {string} path
+ * @param {object} obj
+ */
 async function writeCache(path, obj) {
   try { await writeFile(path, JSON.stringify(obj)); } catch { /* best effort */ }
 }
@@ -137,6 +149,7 @@ export async function checkForUpdate({
  * "99.0.0 || npm:evil" reads as newer and would go straight into
  * `npm install -g <name>@<value>`. Only x.y.z is installed; anything else is
  * reported and skipped.
+ * @param {unknown} v
  */
 export function isReleaseVersion(v) {
   return /^\d+\.\d+\.\d+$/.test(String(v));


### PR DESCRIPTION
JSDoc parameter and member types for the twenty-three modules that carried a
dozen or fewer strict diagnostics each, so every one of them is now clean
under tsconfig.strict.json: account-id, json-format-stream, resolve-accounts,
safe-text, crash-log, event-loop-monitor, terminal-title, alias,
classification-path, egress-guard, request-log, claude-env, sync-accounts,
admission-gate, backend-quota, codex-usage, rollover, updater,
cache-control-sanitize, tool-pair-sanitize, account-uuid-rewrite,
band-decision and session-titles. Scalars are typed as what they are, the
config and request shapes that are genuinely open as Record<string, any> or
any, and the catch variables the message is read from as any.

Two things the types turned up, neither a bug: sync-accounts handed
updateAccountTokens a credential that could also be an API key, which the
method's own `type !== 'oauth'` guard already refuses, so its parameter is
now the optional bag it handles; and assertNever's `never` parameter,
which is what makes the band-decision switches exhaustive, needed the
rollover-reason switch in account-manager typed to reach it. Three tiny
code touches: a null-safe regex test on the request log's content type, the
Codex usage readings collected with flatMap instead of a filter the checker
cannot see through, and a local cast where the uuid patcher already knows
its buffer is set.

Strict count 2006 -> 1866; the non-strict check stays at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)