### PR TITLE
feat(tui): draw locally-served accounts last

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -199,3 +199,25 @@ export function upstreamFor(account, configuredUpstream) {
 export function rewritesBody(account) {
   return PROVIDERS[providerOf(account)].rewritesBody;
 }
+
+/** Whether `account` is served by a process on this machine rather than by a
+ *  vendor endpoint — typically a local translating proxy in front of another
+ *  backend.
+ *
+ *  Keyed on the upstream resolving to loopback. Pairing the account against a
+ *  declared local process does not generalise: such a declaration carries a
+ *  COMMAND rather than a port, and the port sits inside its argv, where every
+ *  program spells it differently. A loopback upstream says the same thing
+ *  directly, and says it for a hand-started process too. A remote third-party
+ *  backend (DeepSeek, GLM) keeps a public host and is not caught.
+ *
+ * @param {any} account
+ */
+export function isLocalUpstream(account) {
+  if (!account?.upstream) return false;
+  let hostname;
+  try { hostname = new URL(account.upstream).hostname; }
+  catch { return false; } // not a URL we can judge — treat it as a normal account
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase(); // URL brackets IPv6
+  return host === 'localhost' || host === '::1' || /^127\./.test(host);
+}

--- a/src/tui.js
+++ b/src/tui.js
@@ -14,6 +14,7 @@ import { formatPercent } from './status-renderer.js';
 import { resolveMaxUsage } from './model.js';
 import { parseProxyUrl, proxyToUrl, describeProxy, describeSelfProxy, resolveUpstreamProxy, setUpstreamProxy, getUpstreamProxy } from './upstream-proxy.js';
 import { sanitizeText, safeLine } from './safe-text.js';
+import { isLocalUpstream } from './provider.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────
 
@@ -756,7 +757,7 @@ export class TUI {
         label: 'Remove account',
         hint: 'Enter to pick',
         value: () => dim('—'),
-        enter: () => { this.mode = 'select'; this.selAction = 'remove'; this.selIdx = 0; this.selReturn = 'settings'; },
+        enter: () => { this.mode = 'select'; this.selAction = 'remove'; this.selIdx = this._displayOrder()[0] ?? 0; this.selReturn = 'settings'; },
       });
     }
 
@@ -909,9 +910,13 @@ export class TUI {
   }
 
   _keySelect(k) {
-    const len = this.am.accounts.length;
-    if (k === 'up' || k === 'k') this.selIdx = Math.max(0, this.selIdx - 1);
-    else if (k === 'down' || k === 'j') this.selIdx = Math.min(len - 1, this.selIdx + 1);
+    // Step through the rows AS DRAWN (_displayOrder), while selIdx itself stays
+    // a manager index — everything it feeds (switch, toggle, remove, route pins)
+    // addresses an account by that index, not by its position on screen.
+    const order = this._displayOrder();
+    const pos = order.indexOf(this.selIdx);
+    if (k === 'up' || k === 'k') this.selIdx = order[Math.max(0, pos - 1)] ?? this.selIdx;
+    else if (k === 'down' || k === 'j') this.selIdx = order[Math.min(order.length - 1, pos + 1)] ?? this.selIdx;
     // Tab / ←→ (switch only): cycle which route the pick applies to. null = the
     // global default account; each getRoutes() entry = a per-route manual pin.
     // ↑↓ move within the account list, so ←→ are free to move across targets.
@@ -1504,7 +1509,7 @@ export class TUI {
         fable: anyFable ? this.am.previewRouteIndex('claude-fable-5') : null,
         sonnet: anySonnet ? this.am.previewRouteIndex('claude-sonnet-4-6') : null,
       };
-      for (let i = 0; i < this.am.accounts.length; i++) {
+      for (const i of this._displayOrder()) {
         const b = budgets.get(categoryOf(this.am.accounts[i]));
         lines.push(this._renderAcct(i, b.bw, b.showBoth, routes, genRoutes, familyTarget, b.showFamily, nameW));
       }
@@ -1557,6 +1562,29 @@ export class TUI {
     // Show cursor only in input mode
     buf += this.mode === 'input' ? `${ESC}?25h` : `${ESC}?25l`;
     this._paint(buf, force);
+  }
+
+  /** Manager indices in the order the rows are drawn: accounts served by a
+   *  local process last, every other account left where it is.
+   *
+   *  A local backend (a translating proxy in front of another vendor, say) is
+   *  infrastructure rather than a seat to rotate between, so it reads as noise
+   *  wedged among the accounts that do rotate. Config order cannot keep it out
+   *  of the way on its own, because a newly added account is appended AFTER it
+   *  and puts it back in the middle.
+   *
+   *  Display only. `selIdx`, `currentIndex`, session pins and route entries all
+   *  stay manager indices, so nothing about selection or routing moves with the
+   *  rows — see _keySelect, which walks this order but still stores an index.
+   */
+  _displayOrder() {
+    return this.am.accounts
+      .map((/** @type {any} */ _, /** @type {number} */ i) => i)
+      .sort((/** @type {number} */ x, /** @type {number} */ y) => {
+        const sx = isLocalUpstream(this.am.accounts[x]) ? 1 : 0;
+        const sy = isLocalUpstream(this.am.accounts[y]) ? 1 : 0;
+        return sx - sy || x - y; // ties keep list order, so the sort is stable
+      });
   }
 
   _renderAcct(idx, bw, showBoth, routes = this.am.getRoutes(), genRoutes = routes.filter(r => routeFamily(r) === null), familyTarget = {}, showFamily = true, nameW = NAME_MIN) {

--- a/test/tui-account-order.test.js
+++ b/test/tui-account-order.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountManager } from '../src/account-manager.js';
+import { TUI } from '../src/tui.js';
+import { isLocalUpstream } from '../src/provider.js';
+
+// An account served by a local process (a translating proxy in front of another
+// vendor, say) is infrastructure, not a seat the fleet rotates between, so it
+// belongs at the end of the table instead of wedged among the accounts that do
+// rotate. Config order cannot hold that on its own: a newly added account is
+// appended after it and puts it back in the middle.
+//
+// Rendered rather than unit-tested, in the shape tui-name-column.test.js uses —
+// the order rows are DRAWN in is the property, and only render() decides it.
+
+function oauth(name, extra = {}) {
+  return { name, type: 'oauth', accessToken: 't', refreshToken: 'r', expiresAt: Date.now() + 3600_000, ...extra };
+}
+
+const LOCAL = { upstream: 'http://127.0.0.1:18765' };
+
+function makeTUI(entries) {
+  const am = new AccountManager(entries, 0.98);
+  const tui = new TUI({
+    accountManager: am, config: { proxy: { port: 1 }, accounts: [], routes: [] }, sx: null,
+    saveConfig: async () => {}, syncAccounts: async () => 0, onQuit: () => {}, probeQuota: () => {},
+  });
+  tui.render = () => {};
+  return { tui, am };
+}
+
+/** The manager indices render() actually asked _renderAcct to draw, in order. */
+function drawOrder(tui) {
+  const drawn = [];
+  const cols = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+  const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+  Object.defineProperty(process.stdout, 'columns', { value: 120, configurable: true });
+  Object.defineProperty(process.stdout, 'rows', { value: 40, configurable: true });
+  try {
+    const real = tui._renderAcct.bind(tui);
+    tui._renderAcct = (...args) => { drawn.push(args[0]); return real(...args); };
+    tui._paint = () => {};
+    tui.running = true;
+    delete tui.render; // use the real one for this call
+    TUI.prototype.render.call(tui, true);
+  } finally {
+    if (cols) Object.defineProperty(process.stdout, 'columns', cols);
+    if (rows) Object.defineProperty(process.stdout, 'rows', rows);
+  }
+  return drawn;
+}
+
+test('a loopback upstream marks a locally-served account', () => {
+  for (const upstream of ['http://127.0.0.1:18765', 'http://localhost:1234', 'http://[::1]:9', 'http://127.5.5.5']) {
+    assert.equal(isLocalUpstream({ upstream }), true, upstream);
+  }
+});
+
+test('a remote third-party backend is not local', () => {
+  // The DeepSeek/GLM fallback case: a real upstream, just not Anthropic's.
+  assert.equal(isLocalUpstream({ upstream: 'https://api.deepseek.com' }), false);
+  assert.equal(isLocalUpstream({ upstream: 'https://open.bigmodel.cn/api/paas/v4' }), false);
+  assert.equal(isLocalUpstream({}), false);
+  assert.equal(isLocalUpstream(null), false);
+  assert.equal(isLocalUpstream({ upstream: 'not a url' }), false);
+});
+
+test('the local-upstream row is drawn last, not in the middle', () => {
+  const { tui } = makeTUI([oauth('claude-a'), oauth('codex', LOCAL), oauth('claude-b')]);
+  assert.deepEqual(drawOrder(tui), [0, 2, 1]);
+});
+
+test('accounts added after it still sort above it', () => {
+  // The case config order cannot fix by hand: the new account is appended last.
+  const { tui } = makeTUI([oauth('claude-a'), oauth('codex', LOCAL), oauth('claude-b'), oauth('claude-c')]);
+  assert.deepEqual(drawOrder(tui), [0, 2, 3, 1]);
+});
+
+test('a fleet with no local upstream keeps its list order untouched', () => {
+  const { tui } = makeTUI([oauth('a'), oauth('b'), oauth('c')]);
+  assert.deepEqual(drawOrder(tui), [0, 1, 2]);
+});
+
+test('selection walks the rows as drawn but stores a manager index', () => {
+  const { tui, am } = makeTUI([oauth('claude-a'), oauth('codex', LOCAL), oauth('claude-b')]);
+  tui.mode = 'select';
+  tui.selAction = 'switch';
+  tui.selIdx = 0;
+
+  // Down from the first row lands on the SECOND ROW DRAWN (claude-b, index 2),
+  // skipping the local account that now sits below it.
+  tui._key('down');
+  assert.equal(tui.selIdx, 2);
+  assert.equal(am.accounts[tui.selIdx].name, 'claude-b');
+
+  tui._key('down');
+  assert.equal(tui.selIdx, 1);
+  assert.equal(am.accounts[tui.selIdx].name, 'codex'); // last row
+
+  tui._key('down'); // already at the bottom
+  assert.equal(tui.selIdx, 1);
+
+  tui._key('up');
+  assert.equal(am.accounts[tui.selIdx].name, 'claude-b');
+  tui._key('up');
+  assert.equal(am.accounts[tui.selIdx].name, 'claude-a');
+  tui._key('up'); // already at the top
+  assert.equal(tui.selIdx, 0);
+});


### PR DESCRIPTION
An account whose upstream is a process on this machine — a local translating proxy in front of another vendor — is infrastructure rather than a seat the fleet rotates between, so it reads as noise wedged among the accounts that do rotate. Config order cannot hold it at the end on its own, because a newly added account is appended *after* it and puts it back in the middle.

`isLocalUpstream` (provider.js, next to `upstreamFor`) keys on the account's upstream resolving to loopback. A remote third-party backend — DeepSeek, GLM — keeps a public host and is not caught, so only a genuinely local backend moves.

**Display only.** `selIdx`, `currentIndex`, session pins and route entries all stay manager indices, so nothing about selection or routing moves with the rows. `_keySelect` walks the order as drawn while still *storing* an index, and there is a test pinning exactly that: with a local account in the middle, pressing down from the first row lands on the account below it, not on the one that moved.

Alternatives considered: pairing accounts against a declared local process does not generalise, since such a declaration carries a command rather than a port, and the port sits inside its argv where every program spells it differently. A loopback upstream says the same thing directly, and says it for a hand-started process too.

Tests: 6 new in `test/tui-account-order.test.js`, rendered rather than unit-tested — the order rows are drawn in is the property, and only `render()` decides it. Full suite green; `npm run typecheck` clean; strict-mode diagnostics unchanged against master for both touched files (provider.js 16, tui.js 225), so the ratchet stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)